### PR TITLE
Refactor FastAPI modules

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package."""

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API submodule."""

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,5 @@
+"""FastAPI application entrypoint."""
+
 from pathlib import Path
 
 from api import endpoints
@@ -7,18 +9,16 @@ from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
 
-# 静的ファイル（HTML, JS）
-app.mount(
-	'/workspace/app/static',
-	StaticFiles(directory='/workspace/app/static'),
-	name='static',
-)
+STATIC_DIR = Path(__file__).parent / 'static'
+
+app.mount('/workspace/app/static', StaticFiles(directory=STATIC_DIR), name='static')
 
 # エンドポイント登録
 app.include_router(endpoints.router)
 
 
 @app.get('/', response_class=HTMLResponse)
-async def index():
-	index_path = Path('/workspace/app/static/index.html')
+async def index() -> str:
+	"""Serve the main HTML page."""
+	index_path = STATIC_DIR / 'index.html'
 	return index_path.read_text(encoding='utf-8')

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility submodule."""


### PR DESCRIPTION
## Summary
- refactor endpoints to encapsulate cache logic
- improve path handling and add docstrings
- restructure `SegySectionReader` with typing and docstrings
- clean up main app entrypoint

## Testing
- `ruff check --fix .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68899f85ea8c832b8771288076e2bf61