### PR TITLE
Enable dynamic key1 slider

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -14,6 +14,21 @@ UPLOAD_DIR.mkdir(exist_ok=True)
 cached_readers: dict[str, SegySectionReader] = {}
 SEGYS: dict[str, str] = {}
 
+@router.get('/get_key1_values')
+def get_key1_values(
+	file_id: str = Query(...),
+	key1_byte: int = Query(189),
+	key2_byte: int = Query(193),
+):
+	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
+	if cache_key not in cached_readers:
+		if file_id not in SEGYS:
+			raise HTTPException(status_code=404, detail='File ID not found')
+		path = SEGYS[file_id]
+		cached_readers[cache_key] = SegySectionReader(path, key1_byte, key2_byte)
+	reader = cached_readers[cache_key]
+	return JSONResponse(content={'values': reader.get_key1_values().tolist()})
+
 
 @router.post('/upload_segy')
 async def upload_segy(file: UploadFile = File(...)):

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -118,34 +118,34 @@
 
   <script src="https://cdn.plot.ly/plotly-2.29.1.min.js"></script>
 <script>
+    let key1Values = [];
     function updateKey1Display() {
       const slider = document.getElementById('key1_idx_slider');
       const display = document.getElementById('key1_idx_display');
-      display.value = slider.value;
+      const idx = parseInt(slider.value);
+      display.value = key1Values[idx] ?? '';
     }
 
     function syncSliderWithInput() {
       const slider = document.getElementById('key1_idx_slider');
       const display = document.getElementById('key1_idx_display');
-      let value = parseInt(display.value);
-      value = Math.max(slider.min, Math.min(slider.max, value));
-      slider.value = value;
-      display.value = value;
+      const val = parseInt(display.value);
+      const idx = key1Values.indexOf(val);
+      slider.value = idx >= 0 ? idx : 0;
+      display.value = key1Values[slider.value] ?? '';
     }
 
     function stepKey1(delta) {
       const slider = document.getElementById('key1_idx_slider');
-      const display = document.getElementById('key1_idx_display');
       let value = parseInt(slider.value) + delta;
       value = Math.max(slider.min, Math.min(slider.max, value));
       slider.value = value;
-      display.value = value;
+      updateKey1Display();
     }
 
     // 必要に応じて max を動的に設定（例: 取得した key1 値の長さ - 1）
     function setKey1SliderMax(max) {
       document.getElementById('key1_idx_slider').max = max;
-      document.getElementById('key1_idx_display').max = max;
     }
 
     // 呼び出し例: setKey1SliderMax(58);
@@ -169,11 +169,24 @@
       }
     };
 
-    xhr.onload = function () {
+    xhr.onload = async function () {
       if (xhr.status === 200) {
         const result = JSON.parse(xhr.responseText);
         document.getElementById('file_id').value = result.file_id;
         alert(`Upload successful. File ID: ${result.file_id}`);
+
+        const key1Byte = document.getElementById('key1_byte').value;
+        const key2Byte = document.getElementById('key2_byte').value;
+        const res = await fetch(`/get_key1_values?file_id=${result.file_id}&key1_byte=${key1Byte}&key2_byte=${key2Byte}`);
+        if (res.ok) {
+          const data = await res.json();
+          key1Values = data.values;
+          setKey1SliderMax(key1Values.length - 1);
+          document.getElementById('key1_idx_display').min = key1Values[0];
+          document.getElementById('key1_idx_display').max = key1Values[key1Values.length - 1];
+          document.getElementById('key1_idx_slider').value = 0;
+          updateKey1Display();
+        }
       } else {
         alert('Upload failed');
       }
@@ -188,11 +201,12 @@
 
   async function fetchAndPlot() {
     const file_id = document.getElementById('file_id').value;
-    const key1_idx = document.getElementById('key1_idx_display').value;
+    const index = parseInt(document.getElementById('key1_idx_slider').value);
     const key1_byte = document.getElementById('key1_byte').value;
     const key2_byte = document.getElementById('key2_byte').value;
+    const key1_val = key1Values[index];
 
-    const url = `/get_section?file_id=${file_id}&key1_idx=${key1_idx}&key1_byte=${key1_byte}&key2_byte=${key2_byte}`;
+    const url = `/get_section?file_id=${file_id}&key1_idx=${key1_val}&key1_byte=${key1_byte}&key2_byte=${key2_byte}`;
     const res = await fetch(url);
     if (!res.ok) {
       alert("Failed to load section");

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -16,6 +16,8 @@ class SegySectionReader:
 			self.key1s = f.attributes(self.key1_byte)[:]
 			self.key2s = f.attributes(self.key2_byte)[:]
 		self.unique_key1 = np.unique(self.key1s)
+	def get_key1_values(self):
+		return self.unique_key1
 
 	def get_section(self, key1_val):
 		# キャッシュにあれば返す


### PR DESCRIPTION
## Summary
- add `get_key1_values` endpoint
- expose unique key1 values from `SegySectionReader`
- fetch key1 values after upload and map slider index to real key1

## Testing
- `ruff check .`
- `python3 -m py_compile app/api/endpoints.py app/utils/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6889cd17d688832b80ceef1e38d66af0