### PR TITLE
Implement zoom reset handling

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -147,7 +147,7 @@
       const plotDiv = document.getElementById('plot');
       Plotly.newPlot(plotDiv, traces, {
         yaxis: { autorange: 'reversed', title: 'Time (s)', showgrid: false, tickfont: { color: '#000' }, titlefont: { color: '#000' } },
-        xaxis: { visible: false, range: [-1, nTraces + 1] },
+        xaxis: {  },
         paper_bgcolor: '#fff',
         plot_bgcolor: '#fff',
         margin: { t: 10, r: 10, l: 60, b: 40 },
@@ -162,19 +162,20 @@
       });
 
       plotDiv.on('plotly_relayout', ev => {
-        if ('xaxis.range[0]' in ev && 'xaxis.range[1]' in ev) {
-          savedXRange = [ev['xaxis.range[0]'], ev['xaxis.range[1]']];
-        } else if ('xaxis.autorange' in ev) {
-          savedXRange = null;
-        }
+              if ('xaxis.range[0]' in ev && 'xaxis.range[1]' in ev) {
+                savedXRange = [ev['xaxis.range[0]'], ev['xaxis.range[1]']];
+              } else if ('xaxis.autorange' in ev && ev['xaxis.autorange'] === true) {
+                savedXRange = null;
+              }
 
-        if ('yaxis.range[0]' in ev && 'yaxis.range[1]' in ev) {
-          savedYRange = [ev['yaxis.range[0]'], ev['yaxis.range[1]']];
-        } else if ('yaxis.autorange' in ev) {
-          savedYRange = null;
-        }
-      });
+              if ('yaxis.range[0]' in ev && 'yaxis.range[1]' in ev) {
+                savedYRange = [ev['yaxis.range[0]'], ev['yaxis.range[1]']];
+              } else if ('yaxis.autorange' in ev && ev['yaxis.autorange'] === true) {
+                savedYRange = null;
+              }
+            });
     }
+
 
     window.addEventListener('DOMContentLoaded', loadSettings);
   </script>


### PR DESCRIPTION
## Summary
- preserve manual zoom when plotting new data
- detect autorange events and clear saved axis ranges

## Testing
- `ruff check` *(fails: Found 48 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e4fc28b4832bb7b2666960f3db70