### PR TITLE
Add render update on zoom

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -215,26 +215,38 @@
 
 
       plotDiv.on('plotly_relayout', ev => {
-              let xChanged = false;
-              if ('xaxis.range[0]' in ev && 'xaxis.range[1]' in ev) {
-                const newRange = [ev['xaxis.range[0]'], ev['xaxis.range[1]']];
-                xChanged = !savedXRange || savedXRange[0] !== newRange[0] || savedXRange[1] !== newRange[1];
-                savedXRange = newRange;
-              } else if ('xaxis.autorange' in ev && ev['xaxis.autorange'] === true) {
-                xChanged = savedXRange !== null;
-                savedXRange = null;
-                savedYRange = null;
-              }
+        let shouldRedraw = false;
 
-              if ('yaxis.range[0]' in ev && 'yaxis.range[1]' in ev) {
-                savedYRange = [ev['yaxis.range[0]'], ev['yaxis.range[1]']];
-              }
+        if ('xaxis.range[0]' in ev && 'xaxis.range[1]' in ev) {
+          const newRange = [ev['xaxis.range[0]'], ev['xaxis.range[1]']];
 
-              if (xChanged && latestSeismicData) {
-                plotSeismicData(latestSeismicData, defaultDt);
-              }
+          // 旧範囲と比較してズームかどうかを判断（パンなら再描画不要）
+          const prevWidth = savedXRange ? Math.abs(savedXRange[1] - savedXRange[0]) : null;
+          const newWidth = Math.abs(newRange[1] - newRange[0]);
 
-            });
+          // ズームインまたはズームアウト
+          if (prevWidth === null || Math.abs(newWidth - prevWidth) > 2) {
+            savedXRange = newRange;
+            shouldRedraw = true;
+          } else {
+            savedXRange = newRange;  // パンだが範囲更新のみ
+          }
+        }
+
+        if ('xaxis.autorange' in ev && ev['xaxis.autorange'] === true) {
+          savedXRange = null;
+          savedYRange = null;
+          shouldRedraw = true;
+        }
+
+        if ('yaxis.range[0]' in ev && 'yaxis.range[1]' in ev) {
+          savedYRange = [ev['yaxis.range[0]'], ev['yaxis.range[1]']];
+        }
+
+        if (shouldRedraw && latestSeismicData) {
+          plotSeismicData(latestSeismicData, 0.004);
+        }
+      });
     }
 
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -53,6 +53,8 @@
     let currentKey2Byte = 193;
     let savedXRange = null;
     let savedYRange = null;
+    let latestSeismicData = null;
+    const defaultDt = 0.004;
 
     function updateKey1Display() {
       const slider = document.getElementById('key1_idx_slider');
@@ -120,7 +122,8 @@
         return;
       }
       const json = await res.json();
-      plotSeismicData(json.section, 0.004);
+      latestSeismicData = json.section;
+      plotSeismicData(latestSeismicData, defaultDt);
     }
 
     function plotSeismicData(seismic, dt) {
@@ -212,15 +215,23 @@
 
 
       plotDiv.on('plotly_relayout', ev => {
+              let xChanged = false;
               if ('xaxis.range[0]' in ev && 'xaxis.range[1]' in ev) {
-                savedXRange = [ev['xaxis.range[0]'], ev['xaxis.range[1]']];
+                const newRange = [ev['xaxis.range[0]'], ev['xaxis.range[1]']];
+                xChanged = !savedXRange || savedXRange[0] !== newRange[0] || savedXRange[1] !== newRange[1];
+                savedXRange = newRange;
               } else if ('xaxis.autorange' in ev && ev['xaxis.autorange'] === true) {
+                xChanged = savedXRange !== null;
                 savedXRange = null;
                 savedYRange = null;
               }
 
               if ('yaxis.range[0]' in ev && 'yaxis.range[1]' in ev) {
                 savedYRange = [ev['yaxis.range[0]'], ev['yaxis.range[1]']];
+              }
+
+              if (xChanged && latestSeismicData) {
+                plotSeismicData(latestSeismicData, defaultDt);
               }
 
             });


### PR DESCRIPTION
## Summary
- update JS to re-render plot after zoom/pan
- keep the latest seismic section cached for redraws

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_688b228b4d50832b8a665c94a1e699b5