### PR TITLE
Preload SEG-Y sections in background

### DIFF
--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -44,3 +44,7 @@ class SegySectionReader:
 		# キャッシュに保存
 		self.section_cache[key1_val] = section
 		return section
+
+	def preload_all_sections(self):
+		for key1_val in self.unique_key1:
+			self.get_section(key1_val)


### PR DESCRIPTION
## Summary
- add `preload_all_sections` to `SegySectionReader` for caching all key1 slices
- start background thread in `upload_segy` to preload sections with default key1/key2 bytes

## Testing
- `pytest -q`
- `ruff check .` (fails: Missing docstring and type annotation warnings)


------
https://chatgpt.com/codex/tasks/task_e_68901dfe8dcc832bb8488079eea22c37