### PR TITLE
feat: parameterize upload endpoint key bytes

### DIFF
--- a/app/static/upload.html
+++ b/app/static/upload.html
@@ -103,6 +103,8 @@
       const key2Byte = document.getElementById('key2_byte').value;
       const formData = new FormData();
       formData.append('file', file);
+      formData.append('key1_byte', key1Byte);  // ✅ 追加
+      formData.append('key2_byte', key2Byte);  // ✅ 追加
       const xhr = new XMLHttpRequest();
       xhr.open('POST', '/upload_segy', true);
       xhr.upload.onprogress = function (e) {

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -16,6 +16,7 @@ class SegySectionReader:
 			self.key1s = f.attributes(self.key1_byte)[:]
 			self.key2s = f.attributes(self.key2_byte)[:]
 		self.unique_key1 = np.unique(self.key1s)
+
 	def get_key1_values(self):
 		return self.unique_key1
 
@@ -44,3 +45,7 @@ class SegySectionReader:
 		# キャッシュに保存
 		self.section_cache[key1_val] = section
 		return section
+
+	def preload_all_sections(self):
+		for key1_val in self.unique_key1:
+			self.get_section(key1_val)


### PR DESCRIPTION
## Summary
- allow `upload_segy` to accept `key1_byte` and `key2_byte` query params
- preload uploaded SEG-Y file in background using the provided key bytes

## Testing
- `python -m py_compile app/api/endpoints.py`
- `ruff check app/api/endpoints.py` *(fails: D100 Missing docstring in public module, ANN201 Missing return type annotation for public function `get_key1_values`, D103 Missing docstring in public function, FAST002 FastAPI dependency without `Annotated`, ANN201 Missing return type annotation for public function `upload_segy`, D103 Missing docstring in public function, FAST002 FastAPI dependency without `Annotated`, B008 Do not perform function call `File` in argument defaults, FAST002 FastAPI dependency without `Annotated`, FAST002 FastAPI dependency without `Annotated`, ASYNC230 Async functions should not open files with blocking methods like `open`, ANN202 Missing return type annotation for private function `preload_reader`, ANN201 Missing return type annotation for public function `get_section`, D103 Missing docstring in public function, FAST002 FastAPI dependency without `Annotated`, FAST002 FastAPI dependency without `Annotated`, FAST002 FastAPI dependency without `Annotated`, FAST002 FastAPI dependency without `Annotated`, RUF003 Comment contains ambiguous `（` (FULLWIDTH LEFT PARENTHESIS). Did you mean `(` (LEFT PARENTHESIS)?, RUF003 Comment contains ambiguous `）` (FULLWIDTH RIGHT PARENTHESIS). Did you mean `)` (RIGHT PARENTHESIS)?, TRY301 Abstract `raise` to an inner function, BLE001 Do not catch blind exception: `Exception`, B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling)*

------
https://chatgpt.com/codex/tasks/task_e_68902240b06c832bae17a4fd0e851104