### PR TITLE
feat: preload seismic sections

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -43,6 +43,7 @@
     <input type="range" id="key1_idx_slider" min="0" max="10000" value="0" step="1" oninput="updateKey1Display(); fetchAndPlot()" />
     <input type="number" id="key1_idx_display" value="0" min="0" max="10000" step="1" style="width: 60px;" onchange="syncSliderWithInput(); fetchAndPlot()" />
     <button onclick="fetchAndPlot()">Plot</button>
+    <progress id="preload_progress" value="0" max="0" style="width: 150px;"></progress>
   </div>
   <div id="plot" style="width: 100vw; height: calc(100vh - 100px);"></div>
   <script src="/static/plotly-2.29.1.min.js"></script>
@@ -100,6 +101,36 @@
       }
     }
 
+    async function preloadSections() {
+      const progress = document.getElementById('preload_progress');
+      progress.max = key1Values.length;
+      let loaded = 0;
+      for (const key1Val of key1Values) {
+        if (sectionCache[key1Val]) {
+          loaded++;
+          progress.value = loaded;
+          console.log(`Preloaded ${loaded}/${key1Values.length}`);
+          continue;
+        }
+        try {
+          const url = `/get_section?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
+          const res = await fetch(url);
+          if (res.ok) {
+            const json = await res.json();
+            sectionCache[key1Val] = json.section;
+          } else {
+            console.warn(`Failed to preload section for key1 ${key1Val}`);
+          }
+        } catch (err) {
+          console.warn(`Error preloading section for key1 ${key1Val}`, err);
+        }
+        loaded++;
+        progress.value = loaded;
+        console.log(`Preloaded ${loaded}/${key1Values.length}`);
+      }
+      console.log('Finished preloading sections');
+    }
+
     async function loadSettings() {
       const params = new URLSearchParams(window.location.search);
       currentFileId = params.get('file_id') || localStorage.getItem('file_id') || '';
@@ -112,6 +143,7 @@
         localStorage.setItem('key2_byte', currentKey2Byte);
         await fetchKey1Values();
         await fetchAndPlot();
+        preloadSections();
       }
     }
 


### PR DESCRIPTION
## Summary
- preload all seismic sections in background to populate client cache
- show progress via HTML progress bar and log

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6890377cb9b0832b8d86bd2f0dc16b96