### PR TITLE
Use Redis for section cache

### DIFF
--- a/.devcontainer/compose-dev.yaml
+++ b/.devcontainer/compose-dev.yaml
@@ -1,3 +1,5 @@
+version: "3.9"
+
 services:
   seisview:
     image: nvidia-pytorch:24.09
@@ -17,6 +19,11 @@ services:
       HTTPS_PROXY: ${HTTPS_PROXY}
       NO_PROXY: ${NO_PROXY}
       NVIDIA_VISIBLE_DEVICES: all
+
+      # Redis接続のための環境変数
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+
     logging:
       driver: local
       options:
@@ -40,3 +47,11 @@ services:
       - "8000:8000"
     stdin_open: true
     tty: true
+    depends_on:
+      - redis  # Redisが先に起動するように
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    restart: unless-stopped

--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -32,4 +32,5 @@ pyproj
 fastapi
 uvicorn[standard]
 python-multipart
+redis
 plotly

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -1,16 +1,13 @@
-# endpoint.py
+"""FastAPI endpoints for working with SEG-Y files."""
+
+from __future__ import annotations
+
 import pathlib
 import threading
+from typing import Annotated
 from uuid import uuid4
 
-from fastapi import (
-    APIRouter,
-    File,
-    Form,  # 忘れずにインポート
-    HTTPException,
-    Query,
-    UploadFile,
-)
+from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse
 from utils.utils import SegySectionReader
 
@@ -25,10 +22,11 @@ SEGYS: dict[str, str] = {}
 
 @router.get("/get_key1_values")
 def get_key1_values(
-    file_id: str = Query(...),
-    key1_byte: int = Query(189),
-    key2_byte: int = Query(193),
-):
+    file_id: Annotated[str, Query(...)],
+    key1_byte: Annotated[int, Query(189)],
+    key2_byte: Annotated[int, Query(193)],
+) -> JSONResponse:
+    """Return all unique key1 values for the given file."""
     cache_key = f"{file_id}_{key1_byte}_{key2_byte}"
     if cache_key not in cached_readers:
         if file_id not in SEGYS:
@@ -43,56 +41,44 @@ def get_key1_values(
 
 @router.post("/upload_segy")
 async def upload_segy(
-    file: UploadFile = File(...),
-    key1_byte: int = Form(189),
-    key2_byte: int = Form(193),
-):
+    file: Annotated[UploadFile, File(...)],
+    key1_byte: Annotated[int, Form(189)],
+    key2_byte: Annotated[int, Form(193)],
+) -> dict[str, str]:
+    """Upload a SEG-Y file and begin preloading its sections."""
     if not file.filename:
         raise HTTPException(
             status_code=400, detail="Uploaded file must have a filename"
         )
-    print(f"Uploading file: {file.filename}")
     ext = pathlib.Path(file.filename).suffix.lower()
     file_id = str(uuid4())
     dest_path = UPLOAD_DIR / f"{file_id}{ext}"
-    with open(dest_path, "wb") as f:
-        f.write(await file.read())
+    dest_path.write_bytes(await file.read())
 
     SEGYS[file_id] = str(dest_path)
-
     cache_key = f"{file_id}_{key1_byte}_{key2_byte}"
-    print(f"Creating cache key: {cache_key}")
-
     reader = SegySectionReader(str(dest_path), file_id, key1_byte, key2_byte)
     cached_readers[cache_key] = reader
-
     threading.Thread(target=reader.preload_all_sections, daemon=True).start()
     return {"file_id": file_id}
 
 
 @router.get("/get_section")
 def get_section(
-    file_id: str = Query(...),
-    key1_byte: int = Query(189),  # デフォルト設定
-    key2_byte: int = Query(193),
-    key1_idx: int = Query(...),
-):
-    try:
-        # 複合キーを作る(file_id, key1_byte, key2_byte)
-        cache_key = f"{file_id}_{key1_byte}_{key2_byte}"
-
-        # キャッシュにreaderがなければ初期化
-        if cache_key not in cached_readers:
-            if file_id not in SEGYS:
-                raise HTTPException(status_code=404, detail="File ID not found")
-            path = SEGYS[file_id]
-            cached_readers[cache_key] = SegySectionReader(
-                path, file_id, key1_byte, key2_byte
-            )
-
-        reader = cached_readers[cache_key]
-        section = reader.get_section(key1_idx)
-        return JSONResponse(content={"section": section})
-
-    except Exception as e:  # pragma: no cover - Simple error passthrough
-        raise HTTPException(status_code=500, detail=str(e))
+    file_id: Annotated[str, Query(...)],
+    key1_byte: Annotated[int, Query(189)],
+    key2_byte: Annotated[int, Query(193)],
+    key1_idx: Annotated[int, Query(...)],
+) -> JSONResponse:
+    """Return a cached or freshly read section for the given index."""
+    cache_key = f"{file_id}_{key1_byte}_{key2_byte}"
+    if cache_key not in cached_readers:
+        if file_id not in SEGYS:
+            raise HTTPException(status_code=404, detail="File ID not found")
+        path = SEGYS[file_id]
+        cached_readers[cache_key] = SegySectionReader(
+            path, file_id, key1_byte, key2_byte
+        )
+    reader = cached_readers[cache_key]
+    section = reader.get_section(key1_idx)
+    return JSONResponse(content={"section": section})

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -4,92 +4,95 @@ import threading
 from uuid import uuid4
 
 from fastapi import (
-	APIRouter,
-	File,
-	Form,  # 忘れずにインポート
-	HTTPException,
-	Query,
-	UploadFile,
+    APIRouter,
+    File,
+    Form,  # 忘れずにインポート
+    HTTPException,
+    Query,
+    UploadFile,
 )
 from fastapi.responses import JSONResponse
 from utils.utils import SegySectionReader
 
 router = APIRouter()
 
-UPLOAD_DIR = pathlib.Path(__file__).parent / 'uploads'
+UPLOAD_DIR = pathlib.Path(__file__).parent / "uploads"
 UPLOAD_DIR.mkdir(exist_ok=True)
 
 cached_readers: dict[str, SegySectionReader] = {}
 SEGYS: dict[str, str] = {}
 
 
-@router.get('/get_key1_values')
+@router.get("/get_key1_values")
 def get_key1_values(
-	file_id: str = Query(...),
-	key1_byte: int = Query(189),
-	key2_byte: int = Query(193),
+    file_id: str = Query(...),
+    key1_byte: int = Query(189),
+    key2_byte: int = Query(193),
 ):
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	if cache_key not in cached_readers:
-		if file_id not in SEGYS:
-			raise HTTPException(status_code=404, detail='File ID not found')
-		path = SEGYS[file_id]
-		cached_readers[cache_key] = SegySectionReader(path, key1_byte, key2_byte)
-	reader = cached_readers[cache_key]
-	return JSONResponse(content={'values': reader.get_key1_values().tolist()})
+    cache_key = f"{file_id}_{key1_byte}_{key2_byte}"
+    if cache_key not in cached_readers:
+        if file_id not in SEGYS:
+            raise HTTPException(status_code=404, detail="File ID not found")
+        path = SEGYS[file_id]
+        cached_readers[cache_key] = SegySectionReader(
+            path, file_id, key1_byte, key2_byte
+        )
+    reader = cached_readers[cache_key]
+    return JSONResponse(content={"values": reader.get_key1_values().tolist()})
 
 
-@router.post('/upload_segy')
+@router.post("/upload_segy")
 async def upload_segy(
-	file: UploadFile = File(...),
-	key1_byte: int = Form(189),
-	key2_byte: int = Form(193),
+    file: UploadFile = File(...),
+    key1_byte: int = Form(189),
+    key2_byte: int = Form(193),
 ):
-	if not file.filename:
-		raise HTTPException(
-			status_code=400, detail='Uploaded file must have a filename'
-		)
-	print(f'Uploading file: {file.filename}')
-	ext = pathlib.Path(file.filename).suffix.lower()
-	file_id = str(uuid4())
-	dest_path = UPLOAD_DIR / f'{file_id}{ext}'
-	with open(dest_path, 'wb') as f:
-		f.write(await file.read())
+    if not file.filename:
+        raise HTTPException(
+            status_code=400, detail="Uploaded file must have a filename"
+        )
+    print(f"Uploading file: {file.filename}")
+    ext = pathlib.Path(file.filename).suffix.lower()
+    file_id = str(uuid4())
+    dest_path = UPLOAD_DIR / f"{file_id}{ext}"
+    with open(dest_path, "wb") as f:
+        f.write(await file.read())
 
-	SEGYS[file_id] = str(dest_path)
+    SEGYS[file_id] = str(dest_path)
 
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	print(f'Creating cache key: {cache_key}')
+    cache_key = f"{file_id}_{key1_byte}_{key2_byte}"
+    print(f"Creating cache key: {cache_key}")
 
-	reader = SegySectionReader(str(dest_path), key1_byte, key2_byte)
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	cached_readers[cache_key] = reader
+    reader = SegySectionReader(str(dest_path), file_id, key1_byte, key2_byte)
+    cached_readers[cache_key] = reader
 
-	threading.Thread(target=reader.preload_all_sections, daemon=True).start()
-	return {'file_id': file_id}
+    threading.Thread(target=reader.preload_all_sections, daemon=True).start()
+    return {"file_id": file_id}
 
 
-@router.get('/get_section')
+@router.get("/get_section")
 def get_section(
-	file_id: str = Query(...),
-	key1_byte: int = Query(189),  # デフォルト設定
-	key2_byte: int = Query(193),
-	key1_idx: int = Query(...),
+    file_id: str = Query(...),
+    key1_byte: int = Query(189),  # デフォルト設定
+    key2_byte: int = Query(193),
+    key1_idx: int = Query(...),
 ):
-	try:
-		# 複合キーを作る（file_id, key1_byte, key2_byte）
-		cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
+    try:
+        # 複合キーを作る(file_id, key1_byte, key2_byte)
+        cache_key = f"{file_id}_{key1_byte}_{key2_byte}"
 
-		# キャッシュにreaderがなければ初期化
-		if cache_key not in cached_readers:
-			if file_id not in SEGYS:
-				raise HTTPException(status_code=404, detail='File ID not found')
-			path = SEGYS[file_id]
-			cached_readers[cache_key] = SegySectionReader(path, key1_byte, key2_byte)
+        # キャッシュにreaderがなければ初期化
+        if cache_key not in cached_readers:
+            if file_id not in SEGYS:
+                raise HTTPException(status_code=404, detail="File ID not found")
+            path = SEGYS[file_id]
+            cached_readers[cache_key] = SegySectionReader(
+                path, file_id, key1_byte, key2_byte
+            )
 
-		reader = cached_readers[cache_key]
-		section = reader.get_section(key1_idx)
-		return JSONResponse(content={'section': section})
+        reader = cached_readers[cache_key]
+        section = reader.get_section(key1_idx)
+        return JSONResponse(content={"section": section})
 
-	except Exception as e:
-		raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:  # pragma: no cover - Simple error passthrough
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -43,7 +43,6 @@
     <input type="range" id="key1_idx_slider" min="0" max="10000" value="0" step="1" oninput="updateKey1Display(); fetchAndPlot()" />
     <input type="number" id="key1_idx_display" value="0" min="0" max="10000" step="1" style="width: 60px;" onchange="syncSliderWithInput(); fetchAndPlot()" />
     <button onclick="fetchAndPlot()">Plot</button>
-    <progress id="preload_progress" value="0" max="0" style="width: 150px;"></progress>
   </div>
   <div id="plot" style="width: 100vw; height: calc(100vh - 100px);"></div>
   <script src="/static/plotly-2.29.1.min.js"></script>
@@ -56,7 +55,6 @@
     let savedYRange = null;
     let latestSeismicData = null;
     const defaultDt = 0.004;
-    const sectionCache = {};
     let renderedStart = null;
     let renderedEnd = null;
 
@@ -101,36 +99,6 @@
       }
     }
 
-    async function preloadSections() {
-      const progress = document.getElementById('preload_progress');
-      progress.max = key1Values.length;
-      let loaded = 0;
-      for (const key1Val of key1Values) {
-        if (sectionCache[key1Val]) {
-          loaded++;
-          progress.value = loaded;
-          console.log(`Preloaded ${loaded}/${key1Values.length}`);
-          continue;
-        }
-        try {
-          const url = `/get_section?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
-          const res = await fetch(url);
-          if (res.ok) {
-            const json = await res.json();
-            sectionCache[key1Val] = json.section;
-          } else {
-            console.warn(`Failed to preload section for key1 ${key1Val}`);
-          }
-        } catch (err) {
-          console.warn(`Error preloading section for key1 ${key1Val}`, err);
-        }
-        loaded++;
-        progress.value = loaded;
-        console.log(`Preloaded ${loaded}/${key1Values.length}`);
-      }
-      console.log('Finished preloading sections');
-    }
-
     async function loadSettings() {
       const params = new URLSearchParams(window.location.search);
       currentFileId = params.get('file_id') || localStorage.getItem('file_id') || '';
@@ -143,26 +111,20 @@
         localStorage.setItem('key2_byte', currentKey2Byte);
         await fetchKey1Values();
         await fetchAndPlot();
-        preloadSections();
       }
     }
 
     async function fetchAndPlot() {
       const index = parseInt(document.getElementById('key1_idx_slider').value);
       const key1Val = key1Values[index];
-      if (sectionCache[key1Val]) {
-        latestSeismicData = sectionCache[key1Val];
-      } else {
-        const url = `/get_section?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
-        const res = await fetch(url);
-        if (!res.ok) {
-          alert('Failed to load section');
-          return;
-        }
-        const json = await res.json();
-        latestSeismicData = json.section;
-        sectionCache[key1Val] = latestSeismicData;
+      const url = `/get_section?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
+      const res = await fetch(url);
+      if (!res.ok) {
+        alert('Failed to load section');
+        return;
       }
+      const json = await res.json();
+      latestSeismicData = json.section;
       const [s, e] = savedXRange ? visibleTraceIndices(savedXRange, latestSeismicData.length) : [0, latestSeismicData.length - 1];
       plotSeismicData(latestSeismicData, defaultDt, s, e);
     }

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -1,51 +1,72 @@
+"""Utility helpers for working with SEG-Y sections."""
+
+import json
+
 import numpy as np
+import redis
 import segyio
 
 
 class SegySectionReader:
-	def __init__(self, path, key1_byte=189, key2_byte=193):
-		self.path = path
-		self.key1_byte = key1_byte
-		self.key2_byte = key2_byte
-		self.section_cache = {}  # ← sectionごとのキャッシュ
-		self._initialize_metadata()
+    """Read SEG-Y sections and cache them in Redis."""
 
-	def _initialize_metadata(self):
-		with segyio.open(self.path, 'r', ignore_geometry=True) as f:
-			f.mmap()
-			self.key1s = f.attributes(self.key1_byte)[:]
-			self.key2s = f.attributes(self.key2_byte)[:]
-		self.unique_key1 = np.unique(self.key1s)
+    def __init__(
+        self,
+        path: str,
+        file_id: str,
+        key1_byte: int = 189,
+        key2_byte: int = 193,
+    ) -> None:
+        """Initialize the reader and pre-load header metadata."""
+        self.path = path
+        self.file_id = file_id
+        self.key1_byte = key1_byte
+        self.key2_byte = key2_byte
+        self.redis = redis.Redis(
+            host="localhost", port=6379, db=0, decode_responses=True
+        )
+        self._initialize_metadata()
 
-	def get_key1_values(self):
-		return self.unique_key1
+    def _initialize_metadata(self) -> None:
+        with segyio.open(self.path, "r", ignore_geometry=True) as f:
+            f.mmap()
+            self.key1s = f.attributes(self.key1_byte)[:]
+            self.key2s = f.attributes(self.key2_byte)[:]
+        self.unique_key1 = np.unique(self.key1s)
 
-	def get_section(self, key1_val):
-		# キャッシュにあれば返す
-		if key1_val in self.section_cache:
-			return self.section_cache[key1_val]
+    def get_key1_values(self) -> np.ndarray:
+        """Return available key1 values."""
+        return self.unique_key1
 
-		# なければSEGYから読み込む
-		indices = np.where(self.key1s == key1_val)[0]
-		print(len(indices), 'indices found for key1_val:', key1_val)
-		if len(indices) == 0:
-			raise ValueError(f'Key1 value {key1_val} not found')
+    def get_section(self, key1_val: int) -> list[list[float]]:
+        """Return a normalized section for the given key1 value."""
+        cache_key = f"section:{self.file_id}:{key1_val}"
+        cached = self.redis.get(cache_key)
+        if cached is not None:
+            return json.loads(cached)
 
-		# key2でソート
-		key2_vals = self.key2s[indices]
-		sorted_indices = indices[np.argsort(key2_vals)]
+        indices = np.where(self.key1s == key1_val)[0]
+        print(len(indices), "indices found for key1_val:", key1_val)
+        if len(indices) == 0:
+            message = f"Key1 value {key1_val} not found"
+            raise ValueError(message)
 
-		with segyio.open(self.path, 'r', ignore_geometry=True) as f:
-			f.mmap()
-			traces = np.array([f.trace[i] for i in sorted_indices], dtype='float32')
-			max_abs = np.max(np.abs(traces), axis=1, keepdims=True)
-			max_abs[max_abs == 0] = 1.0
-			section = (traces / max_abs).tolist()
+        key2_vals = self.key2s[indices]
+        sorted_indices = indices[np.argsort(key2_vals)]
 
-		# キャッシュに保存
-		self.section_cache[key1_val] = section
-		return section
+        with segyio.open(self.path, "r", ignore_geometry=True) as f:
+            f.mmap()
+            traces = np.array(
+                [f.trace[i] for i in sorted_indices], dtype="float32"
+            )
+            max_abs = np.max(np.abs(traces), axis=1, keepdims=True)
+            max_abs[max_abs == 0] = 1.0
+            section = (traces / max_abs).tolist()
 
-	def preload_all_sections(self):
-		for key1_val in self.unique_key1:
-			self.get_section(key1_val)
+        self.redis.set(cache_key, json.dumps(section))
+        return section
+
+    def preload_all_sections(self) -> None:
+        """Eagerly load all sections into the Redis cache."""
+        for key1_val in self.unique_key1:
+            self.get_section(key1_val)

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -8,65 +8,61 @@ import segyio
 
 
 class SegySectionReader:
-    """Read SEG-Y sections and cache them in Redis."""
+	"""Read SEG-Y sections and cache them in Redis."""
 
-    def __init__(
-        self,
-        path: str,
-        file_id: str,
-        key1_byte: int = 189,
-        key2_byte: int = 193,
-    ) -> None:
-        """Initialize the reader and pre-load header metadata."""
-        self.path = path
-        self.file_id = file_id
-        self.key1_byte = key1_byte
-        self.key2_byte = key2_byte
-        self.redis = redis.Redis(
-            host="localhost", port=6379, db=0, decode_responses=True
-        )
-        self._initialize_metadata()
+	def __init__(
+		self,
+		path: str,
+		file_id: str,
+		key1_byte: int = 189,
+		key2_byte: int = 193,
+	) -> None:
+		"""Initialize the reader and pre-load header metadata."""
+		self.path = path
+		self.file_id = file_id
+		self.key1_byte = key1_byte
+		self.key2_byte = key2_byte
+		self.redis = redis.Redis(host='redis', port=6379, db=0, decode_responses=True)
+		self._initialize_metadata()
 
-    def _initialize_metadata(self) -> None:
-        with segyio.open(self.path, "r", ignore_geometry=True) as f:
-            f.mmap()
-            self.key1s = f.attributes(self.key1_byte)[:]
-            self.key2s = f.attributes(self.key2_byte)[:]
-        self.unique_key1 = np.unique(self.key1s)
+	def _initialize_metadata(self) -> None:
+		with segyio.open(self.path, 'r', ignore_geometry=True) as f:
+			f.mmap()
+			self.key1s = f.attributes(self.key1_byte)[:]
+			self.key2s = f.attributes(self.key2_byte)[:]
+		self.unique_key1 = np.unique(self.key1s)
 
-    def get_key1_values(self) -> np.ndarray:
-        """Return available key1 values."""
-        return self.unique_key1
+	def get_key1_values(self) -> np.ndarray:
+		"""Return available key1 values."""
+		return self.unique_key1
 
-    def get_section(self, key1_val: int) -> list[list[float]]:
-        """Return a normalized section for the given key1 value."""
-        cache_key = f"section:{self.file_id}:{key1_val}"
-        cached = self.redis.get(cache_key)
-        if cached is not None:
-            return json.loads(cached)
+	def get_section(self, key1_val: int) -> list[list[float]]:
+		"""Return a normalized section for the given key1 value."""
+		cache_key = f'section:{self.file_id}:{key1_val}'
+		cached = self.redis.get(cache_key)
+		if cached is not None:
+			return json.loads(cached)
 
-        indices = np.where(self.key1s == key1_val)[0]
-        print(len(indices), "indices found for key1_val:", key1_val)
-        if len(indices) == 0:
-            message = f"Key1 value {key1_val} not found"
-            raise ValueError(message)
+		indices = np.where(self.key1s == key1_val)[0]
+		print(len(indices), 'indices found for key1_val:', key1_val)
+		if len(indices) == 0:
+			message = f'Key1 value {key1_val} not found'
+			raise ValueError(message)
 
-        key2_vals = self.key2s[indices]
-        sorted_indices = indices[np.argsort(key2_vals)]
+		key2_vals = self.key2s[indices]
+		sorted_indices = indices[np.argsort(key2_vals)]
 
-        with segyio.open(self.path, "r", ignore_geometry=True) as f:
-            f.mmap()
-            traces = np.array(
-                [f.trace[i] for i in sorted_indices], dtype="float32"
-            )
-            max_abs = np.max(np.abs(traces), axis=1, keepdims=True)
-            max_abs[max_abs == 0] = 1.0
-            section = (traces / max_abs).tolist()
+		with segyio.open(self.path, 'r', ignore_geometry=True) as f:
+			f.mmap()
+			traces = np.array([f.trace[i] for i in sorted_indices], dtype='float32')
+			max_abs = np.max(np.abs(traces), axis=1, keepdims=True)
+			max_abs[max_abs == 0] = 1.0
+			section = (traces / max_abs).tolist()
 
-        self.redis.set(cache_key, json.dumps(section))
-        return section
+		self.redis.set(cache_key, json.dumps(section))
+		return section
 
-    def preload_all_sections(self) -> None:
-        """Eagerly load all sections into the Redis cache."""
-        for key1_val in self.unique_key1:
-            self.get_section(key1_val)
+	def preload_all_sections(self) -> None:
+		"""Eagerly load all sections into the Redis cache."""
+		for key1_val in self.unique_key1:
+			self.get_section(key1_val)


### PR DESCRIPTION
## Summary
- Replace in-memory section caching with Redis and add `file_id` support to `SegySectionReader`
- Pass `file_id` to `SegySectionReader` instances in FastAPI endpoints

## Testing
- `ruff check app/utils/utils.py app/api/endpoints.py` *(fails: missing docstrings and type annotations)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68904015c8ac832bab3a83b4bbe15b1c