### PR TITLE
Move section caching to Redis

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -1,15 +1,17 @@
 # endpoint.py
+import json
 import pathlib
 import threading
 from uuid import uuid4
 
+import redis
 from fastapi import (
-	APIRouter,
-	File,
-	Form,  # 忘れずにインポート
-	HTTPException,
-	Query,
-	UploadFile,
+        APIRouter,
+        File,
+        Form,  # 忘れずにインポート
+        HTTPException,
+        Query,
+        UploadFile,
 )
 from fastapi.responses import JSONResponse
 from utils.utils import SegySectionReader
@@ -19,77 +21,71 @@ router = APIRouter()
 UPLOAD_DIR = pathlib.Path(__file__).parent / 'uploads'
 UPLOAD_DIR.mkdir(exist_ok=True)
 
-cached_readers: dict[str, SegySectionReader] = {}
-SEGYS: dict[str, str] = {}
+redis_client = redis.Redis(host='localhost', port=6379, decode_responses=True)
 
 
 @router.get('/get_key1_values')
 def get_key1_values(
-	file_id: str = Query(...),
-	key1_byte: int = Query(189),
-	key2_byte: int = Query(193),
+        file_id: str = Query(...),
+        key1_byte: int = Query(189),
+        key2_byte: int = Query(193),
 ):
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	if cache_key not in cached_readers:
-		if file_id not in SEGYS:
-			raise HTTPException(status_code=404, detail='File ID not found')
-		path = SEGYS[file_id]
-		cached_readers[cache_key] = SegySectionReader(path, key1_byte, key2_byte)
-	reader = cached_readers[cache_key]
-	return JSONResponse(content={'values': reader.get_key1_values().tolist()})
+        try:
+                raw = redis_client.get(f'{file_id}:key1_values')
+                if raw is None:
+                        raise HTTPException(status_code=404, detail='File ID not found')
+                values = json.loads(raw)
+                return JSONResponse(content={'values': values})
+        except Exception as e:
+                raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post('/upload_segy')
 async def upload_segy(
-	file: UploadFile = File(...),
-	key1_byte: int = Form(189),
-	key2_byte: int = Form(193),
+        file: UploadFile = File(...),
+        key1_byte: int = Form(189),
+        key2_byte: int = Form(193),
 ):
-	if not file.filename:
-		raise HTTPException(
-			status_code=400, detail='Uploaded file must have a filename'
-		)
-	print(f'Uploading file: {file.filename}')
-	ext = pathlib.Path(file.filename).suffix.lower()
-	file_id = str(uuid4())
-	dest_path = UPLOAD_DIR / f'{file_id}{ext}'
-	with open(dest_path, 'wb') as f:
-		f.write(await file.read())
+        if not file.filename:
+                raise HTTPException(
+                        status_code=400, detail='Uploaded file must have a filename'
+                )
+        print(f'Uploading file: {file.filename}')
+        ext = pathlib.Path(file.filename).suffix.lower()
+        file_id = str(uuid4())
+        dest_path = UPLOAD_DIR / f'{file_id}{ext}'
+        with open(dest_path, 'wb') as f:
+                f.write(await file.read())
 
-	SEGYS[file_id] = str(dest_path)
+        reader = SegySectionReader(str(dest_path), key1_byte, key2_byte)
 
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	print(f'Creating cache key: {cache_key}')
+        def preload():
+                key1_vals = reader.get_key1_values()
+                redis_client.set(
+                        f'{file_id}:key1_values', json.dumps(key1_vals.tolist())
+                )
+                for key1_val in key1_vals:
+                        section = reader.get_section(key1_val)
+                        redis_client.set(
+                                f'{file_id}:{key1_val}', json.dumps(section)
+                        )
 
-	reader = SegySectionReader(str(dest_path), key1_byte, key2_byte)
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	cached_readers[cache_key] = reader
-
-	threading.Thread(target=reader.preload_all_sections, daemon=True).start()
-	return {'file_id': file_id}
+        threading.Thread(target=preload, daemon=True).start()
+        return {'file_id': file_id}
 
 
 @router.get('/get_section')
 def get_section(
-	file_id: str = Query(...),
-	key1_byte: int = Query(189),  # デフォルト設定
-	key2_byte: int = Query(193),
-	key1_idx: int = Query(...),
+        file_id: str = Query(...),
+        key1_idx: int = Query(...),
+        key1_byte: int = Query(189),  # 未使用
+        key2_byte: int = Query(193),  # 未使用
 ):
-	try:
-		# 複合キーを作る（file_id, key1_byte, key2_byte）
-		cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-
-		# キャッシュにreaderがなければ初期化
-		if cache_key not in cached_readers:
-			if file_id not in SEGYS:
-				raise HTTPException(status_code=404, detail='File ID not found')
-			path = SEGYS[file_id]
-			cached_readers[cache_key] = SegySectionReader(path, key1_byte, key2_byte)
-
-		reader = cached_readers[cache_key]
-		section = reader.get_section(key1_idx)
-		return JSONResponse(content={'section': section})
-
-	except Exception as e:
-		raise HTTPException(status_code=500, detail=str(e))
+        try:
+                raw = redis_client.get(f'{file_id}:{key1_idx}')
+                if raw is None:
+                        raise HTTPException(status_code=404, detail='Section not found')
+                section = json.loads(raw)
+                return JSONResponse(content={'section': section})
+        except Exception as e:
+                raise HTTPException(status_code=500, detail=str(e))

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -43,7 +43,6 @@
     <input type="range" id="key1_idx_slider" min="0" max="10000" value="0" step="1" oninput="updateKey1Display(); fetchAndPlot()" />
     <input type="number" id="key1_idx_display" value="0" min="0" max="10000" step="1" style="width: 60px;" onchange="syncSliderWithInput(); fetchAndPlot()" />
     <button onclick="fetchAndPlot()">Plot</button>
-    <progress id="preload_progress" value="0" max="0" style="width: 150px;"></progress>
   </div>
   <div id="plot" style="width: 100vw; height: calc(100vh - 100px);"></div>
   <script src="/static/plotly-2.29.1.min.js"></script>
@@ -56,7 +55,6 @@
     let savedYRange = null;
     let latestSeismicData = null;
     const defaultDt = 0.004;
-    const sectionCache = {};
     let renderedStart = null;
     let renderedEnd = null;
 
@@ -101,36 +99,6 @@
       }
     }
 
-    async function preloadSections() {
-      const progress = document.getElementById('preload_progress');
-      progress.max = key1Values.length;
-      let loaded = 0;
-      for (const key1Val of key1Values) {
-        if (sectionCache[key1Val]) {
-          loaded++;
-          progress.value = loaded;
-          console.log(`Preloaded ${loaded}/${key1Values.length}`);
-          continue;
-        }
-        try {
-          const url = `/get_section?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
-          const res = await fetch(url);
-          if (res.ok) {
-            const json = await res.json();
-            sectionCache[key1Val] = json.section;
-          } else {
-            console.warn(`Failed to preload section for key1 ${key1Val}`);
-          }
-        } catch (err) {
-          console.warn(`Error preloading section for key1 ${key1Val}`, err);
-        }
-        loaded++;
-        progress.value = loaded;
-        console.log(`Preloaded ${loaded}/${key1Values.length}`);
-      }
-      console.log('Finished preloading sections');
-    }
-
     async function loadSettings() {
       const params = new URLSearchParams(window.location.search);
       currentFileId = params.get('file_id') || localStorage.getItem('file_id') || '';
@@ -143,16 +111,12 @@
         localStorage.setItem('key2_byte', currentKey2Byte);
         await fetchKey1Values();
         await fetchAndPlot();
-        preloadSections();
       }
     }
 
-    async function fetchAndPlot() {
-      const index = parseInt(document.getElementById('key1_idx_slider').value);
-      const key1Val = key1Values[index];
-      if (sectionCache[key1Val]) {
-        latestSeismicData = sectionCache[key1Val];
-      } else {
+      async function fetchAndPlot() {
+        const index = parseInt(document.getElementById('key1_idx_slider').value);
+        const key1Val = key1Values[index];
         const url = `/get_section?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
         const res = await fetch(url);
         if (!res.ok) {
@@ -161,11 +125,9 @@
         }
         const json = await res.json();
         latestSeismicData = json.section;
-        sectionCache[key1Val] = latestSeismicData;
+        const [s, e] = savedXRange ? visibleTraceIndices(savedXRange, latestSeismicData.length) : [0, latestSeismicData.length - 1];
+        plotSeismicData(latestSeismicData, defaultDt, s, e);
       }
-      const [s, e] = savedXRange ? visibleTraceIndices(savedXRange, latestSeismicData.length) : [0, latestSeismicData.length - 1];
-      plotSeismicData(latestSeismicData, defaultDt, s, e);
-    }
 
     function visibleTraceIndices(range, total) {
       let start = Math.floor(range[0]);

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -3,49 +3,38 @@ import segyio
 
 
 class SegySectionReader:
-	def __init__(self, path, key1_byte=189, key2_byte=193):
-		self.path = path
-		self.key1_byte = key1_byte
-		self.key2_byte = key2_byte
-		self.section_cache = {}  # ← sectionごとのキャッシュ
-		self._initialize_metadata()
+        def __init__(self, path, key1_byte=189, key2_byte=193):
+                self.path = path
+                self.key1_byte = key1_byte
+                self.key2_byte = key2_byte
+                self._initialize_metadata()
 
-	def _initialize_metadata(self):
-		with segyio.open(self.path, 'r', ignore_geometry=True) as f:
-			f.mmap()
-			self.key1s = f.attributes(self.key1_byte)[:]
-			self.key2s = f.attributes(self.key2_byte)[:]
-		self.unique_key1 = np.unique(self.key1s)
+        def _initialize_metadata(self):
+                with segyio.open(self.path, 'r', ignore_geometry=True) as f:
+                        f.mmap()
+                        self.key1s = f.attributes(self.key1_byte)[:]
+                        self.key2s = f.attributes(self.key2_byte)[:]
+                self.unique_key1 = np.unique(self.key1s)
 
-	def get_key1_values(self):
-		return self.unique_key1
+        def get_key1_values(self):
+                return self.unique_key1
 
-	def get_section(self, key1_val):
-		# キャッシュにあれば返す
-		if key1_val in self.section_cache:
-			return self.section_cache[key1_val]
+        def get_section(self, key1_val):
+                # SEG-Yから読み込む
+                indices = np.where(self.key1s == key1_val)[0]
+                print(len(indices), 'indices found for key1_val:', key1_val)
+                if len(indices) == 0:
+                        raise ValueError(f'Key1 value {key1_val} not found')
 
-		# なければSEGYから読み込む
-		indices = np.where(self.key1s == key1_val)[0]
-		print(len(indices), 'indices found for key1_val:', key1_val)
-		if len(indices) == 0:
-			raise ValueError(f'Key1 value {key1_val} not found')
+                # key2でソート
+                key2_vals = self.key2s[indices]
+                sorted_indices = indices[np.argsort(key2_vals)]
 
-		# key2でソート
-		key2_vals = self.key2s[indices]
-		sorted_indices = indices[np.argsort(key2_vals)]
+                with segyio.open(self.path, 'r', ignore_geometry=True) as f:
+                        f.mmap()
+                        traces = np.array([f.trace[i] for i in sorted_indices], dtype='float32')
+                        max_abs = np.max(np.abs(traces), axis=1, keepdims=True)
+                        max_abs[max_abs == 0] = 1.0
+                        section = (traces / max_abs).tolist()
 
-		with segyio.open(self.path, 'r', ignore_geometry=True) as f:
-			f.mmap()
-			traces = np.array([f.trace[i] for i in sorted_indices], dtype='float32')
-			max_abs = np.max(np.abs(traces), axis=1, keepdims=True)
-			max_abs[max_abs == 0] = 1.0
-			section = (traces / max_abs).tolist()
-
-		# キャッシュに保存
-		self.section_cache[key1_val] = section
-		return section
-
-	def preload_all_sections(self):
-		for key1_val in self.unique_key1:
-			self.get_section(key1_val)
+                return section


### PR DESCRIPTION
## Summary
- cache sections and key1 values in Redis during upload
- drop all client-side caching
- serve sections directly from Redis

## Testing
- `python -m pip install redis` (failed: Could not find a version that satisfies the requirement redis)
- `ruff check app` (fails: Missing docstring in public package, SyntaxError: Unexpected indentation, etc.)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68905bbf1d34832bbeda57788c5206e3