### PR TITLE
feat: add pick storage with JSON persistence

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,29 @@
+"""FastAPI application entry point."""
+
 from pathlib import Path
 
 from api import endpoints
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from utils.picks import store
 
 app = FastAPI()
 
-# 静的ファイル（HTML, JS）
+
+@app.on_event('startup')
+async def load_picks() -> None:
+	"""Load picks from disk at startup."""
+	store.load()
+
+
+@app.on_event('shutdown')
+async def save_picks() -> None:
+	"""Save picks to disk when shutting down."""
+	store.save()
+
+
+# 静的ファイル (HTML, JS)
 app.mount(
 	'/static',  # ← URLパス
 	StaticFiles(directory='/workspace/app/static'),  # ← ローカルパス
@@ -18,12 +34,14 @@ app.include_router(endpoints.router)
 
 
 @app.get('/', response_class=HTMLResponse)
-async def index():
+async def index() -> str:
+	"""Return the main page."""
 	index_path = Path('/workspace/app/static/index.html')
 	return index_path.read_text(encoding='utf-8')
 
 
 @app.get('/upload', response_class=HTMLResponse)
-async def upload():
+async def upload() -> str:
+	"""Return the upload page."""
 	upload_path = Path('/workspace/app/static/upload.html')
 	return upload_path.read_text(encoding='utf-8')

--- a/app/utils/picks.py
+++ b/app/utils/picks.py
@@ -1,0 +1,50 @@
+"""Utility module for persisting seismic picks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class PickStore:
+	"""In-memory store with JSON persistence for pick data."""
+
+	def __init__(self, path: str | Path) -> None:
+		"""Initialize the store with a file path."""
+		self.path = Path(path)
+		self.picks: dict[str, list[dict[str, int | float]]] = {}
+
+	def load(self) -> None:
+		"""Load picks from the JSON file if it exists."""
+		if self.path.exists():
+			self.picks = json.loads(self.path.read_text(encoding='utf-8'))
+		else:
+			self.picks = {}
+
+	def save(self) -> None:
+		"""Write the current picks to the JSON file."""
+		self.path.write_text(
+			json.dumps(self.picks, ensure_ascii=False, indent=2),
+			encoding='utf-8',
+		)
+
+	def add_pick(self, file_id: str, trace: int, time: float) -> None:
+		"""Record a pick for a trace."""
+		self.picks.setdefault(file_id, []).append({'trace': trace, 'time': time})
+
+	def list_picks(self, file_id: str) -> list[dict[str, int | float]]:
+		"""Return all picks for ``file_id``."""
+		return self.picks.get(file_id, [])
+
+
+store = PickStore(Path(__file__).with_name('picks.json'))
+
+
+def add_pick(file_id: str, trace: int, time: float) -> None:
+	"""Add a pick to the global store."""
+	store.add_pick(file_id, trace, time)
+
+
+def list_picks(file_id: str) -> list[dict[str, int | float]]:
+	"""List picks for ``file_id`` from the global store."""
+	return store.list_picks(file_id)


### PR DESCRIPTION
## Summary
- add PickStore for in-memory pick management with JSON persistence
- load and save picks on app startup and shutdown

## Testing
- `python -m ruff format app/main.py app/utils/picks.py`
- `python -m ruff check app/main.py app/utils/picks.py`
- `python -m ruff check .` (fails: missing docstrings and type annotations in existing modules)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68928fca82e8832b9a4e67c74951b33f