### PR TITLE
feat: add automatic picking

### DIFF
--- a/app/utils/picking.py
+++ b/app/utils/picking.py
@@ -1,0 +1,29 @@
+"""Picking utilities."""
+
+import numpy as np
+
+
+def sta_lta(trace: np.ndarray, win_sta: int, win_lta: int) -> np.ndarray:
+	"""Compute classic STA/LTA ratio for a trace."""
+	trace = np.asarray(trace, dtype=np.float32)
+	if win_sta <= 0 or win_lta <= 0 or win_sta >= win_lta:
+		msg = "invalid window lengths"
+		raise ValueError(msg)
+	pow_trace = trace ** 2
+	sta = np.convolve(pow_trace, np.ones(win_sta) / win_sta, "valid")
+	lta = np.convolve(pow_trace, np.ones(win_lta) / win_lta, "valid")
+	return sta[win_lta - win_sta:] / (lta + 1e-12)
+
+
+def pick_first_arrival(
+	trace: np.ndarray,
+	win_sta: int = 20,
+	win_lta: int = 100,
+	threshold: float = 3.0,
+) -> int | None:
+	"""Return the index of the first arrival based on STA/LTA."""
+	ratio = sta_lta(trace, win_sta, win_lta)
+	indices = np.where(ratio > threshold)[0]
+	if len(indices) == 0:
+		return None
+	return int(indices[0] + win_lta)


### PR DESCRIPTION
## Summary
- implement STA/LTA picker utilities
- add background auto-pick endpoint storing results

## Testing
- `ruff check app/api/endpoints.py app/utils/picking.py | head -n 50` (fails: D100, ANN201, FAST002, D103, etc.)
- `ruff check app/utils/picking.py`
- `python -m py_compile app/api/endpoints.py app/utils/picking.py`


------
https://chatgpt.com/codex/tasks/task_e_68929488ca98832bba824c84a1ea4097