### PR TITLE
Add picks API endpoints

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -1,4 +1,5 @@
 # endpoint.py
+import asyncio
 import gzip
 import pathlib
 import threading
@@ -15,6 +16,8 @@ from fastapi import (
         UploadFile,
 )
 from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+from utils.picks import add_pick, delete_pick, list_picks, store
 from utils.utils import SegySectionReader, quantize_float32
 
 router = APIRouter()
@@ -24,6 +27,12 @@ UPLOAD_DIR.mkdir(exist_ok=True)
 
 cached_readers: dict[str, SegySectionReader] = {}
 SEGYS: dict[str, str] = {}
+
+
+class Pick(BaseModel):
+        file_id: str
+        trace: int
+        time: float
 
 
 @router.get('/get_key1_values')
@@ -127,3 +136,25 @@ def get_section_bin(
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post('/picks')
+async def post_pick(pick: Pick) -> dict[str, str]:
+        add_pick(pick.file_id, pick.trace, pick.time)
+        await asyncio.to_thread(store.save)
+        return {'status': 'ok'}
+
+
+@router.get('/picks')
+async def get_pick(file_id: str = Query(...)) -> dict[str, list[dict[str, int | float]]]:
+        return {'picks': list_picks(file_id)}
+
+
+@router.delete('/picks')
+async def delete_pick_route(
+        file_id: str = Query(...),
+        trace: int | None = Query(None),
+) -> dict[str, str]:
+        delete_pick(file_id, trace)
+        await asyncio.to_thread(store.save)
+        return {'status': 'ok'}

--- a/app/utils/picks.py
+++ b/app/utils/picks.py
@@ -29,12 +29,34 @@ class PickStore:
 		)
 
 	def add_pick(self, file_id: str, trace: int, time: float) -> None:
-		"""Record a pick for a trace."""
-		self.picks.setdefault(file_id, []).append({'trace': trace, 'time': time})
+		"""Record or update a pick for a trace."""
+		picks = self.picks.setdefault(file_id, [])
+		for pick in picks:
+			if pick['trace'] == trace:
+				pick['time'] = time
+				break
+		else:
+			picks.append({'trace': trace, 'time': time})
 
 	def list_picks(self, file_id: str) -> list[dict[str, int | float]]:
 		"""Return all picks for ``file_id``."""
 		return self.picks.get(file_id, [])
+
+	def delete_pick(self, file_id: str, trace: int | None = None) -> None:
+		"""Remove picks for ``file_id``.
+
+		If ``trace`` is provided, only that pick is removed; otherwise, all
+		picks for ``file_id`` are deleted.
+		"""
+		if trace is None:
+			self.picks.pop(file_id, None)
+			return
+		picks = self.picks.get(file_id)
+		if picks is None:
+			return
+		self.picks[file_id] = [p for p in picks if p['trace'] != trace]
+		if not self.picks[file_id]:
+			del self.picks[file_id]
 
 
 store = PickStore(Path(__file__).with_name('picks.json'))
@@ -48,3 +70,9 @@ def add_pick(file_id: str, trace: int, time: float) -> None:
 def list_picks(file_id: str) -> list[dict[str, int | float]]:
 	"""List picks for ``file_id`` from the global store."""
 	return store.list_picks(file_id)
+
+
+
+def delete_pick(file_id: str, trace: int | None = None) -> None:
+	"""Delete pick(s) for ``file_id`` from the global store."""
+	store.delete_pick(file_id, trace)


### PR DESCRIPTION
## Summary
- add CRUD endpoints for picks backed by PickStore
- extend PickStore with update and delete capabilities

## Testing
- `ruff check app/utils/picks.py`
- `ruff check app/api/endpoints.py` *(fails: 42 errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892aea3a050832bb2d47ac69a785e3b