### PR TITLE
feat: support interactive picks

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -44,6 +44,7 @@
     <input type="number" id="key1_idx_display" value="0" min="0" max="10000" step="1" style="width: 60px;" onchange="syncSliderWithInput(); fetchAndPlot()" />
     <button onclick="fetchAndPlot()">Plot</button>
     <button onclick="showCacheKeys()">Show Cache Keys</button>
+    <button id="deletePickBtn" onclick="deleteSelectedPick()" disabled>Delete Pick</button>
   </div>
   <div id="plot" style="width: 100vw; height: calc(100vh - 100px);"></div>
   <script src="/static/plotly-2.29.1.min.js"></script>
@@ -67,6 +68,9 @@
     let sectionShape = null;
     let renderedStart = null;
     let renderedEnd = null;
+    let picks = [];
+    let downsampleFactor = 1;
+    let selectedPickIndex = null;
 
     function showCacheKeys() {
         const currentKeys = Array.from(cache.keys());
@@ -220,9 +224,43 @@
         localStorage.setItem('key1_byte', currentKey1Byte);
         localStorage.setItem('key2_byte', currentKey2Byte);
         await fetchKey1Values();
+        await fetchPicks();
         await fetchAndPlot();
       }
     }
+
+  async function fetchPicks() {
+    if (!currentFileId) return;
+    try {
+      const res = await fetch(`/picks?file_id=${currentFileId}`);
+      if (res.ok) {
+        const data = await res.json();
+        picks = data.picks || [];
+      }
+    } catch (e) {
+      console.error('Failed to fetch picks', e);
+    }
+  }
+
+  async function postPick(trace, time) {
+    try {
+      await fetch('/picks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file_id: currentFileId, trace, time })
+      });
+    } catch (e) {
+      console.error('Failed to post pick', e);
+    }
+  }
+
+  async function deletePick(trace) {
+    try {
+      await fetch(`/picks?file_id=${currentFileId}&trace=${trace}`, { method: 'DELETE' });
+    } catch (e) {
+      console.error('Failed to delete pick', e);
+    }
+  }
 
   async function fetchAndPlot() {
     console.log('--- fetchAndPlot start ---');
@@ -310,6 +348,7 @@
       const gain = 1.0;
 
       if (density < 0.1) {
+        downsampleFactor = 1;
         const time = new Float32Array(nSamples);
         for (let t = 0; t < nSamples; t++) {
           time[t] = t * dt;
@@ -361,6 +400,7 @@
         }
         const xVals = new Float32Array(nTracesDS);
         for (let i = 0; i < nTracesDS; i++) xVals[i] = startTrace + i * factor;
+        downsampleFactor = factor;
         traces = [{
           type: 'heatmap',
           x: xVals,
@@ -396,37 +436,120 @@
         margin: { t: 10, r: 10, l: 60, b: 40 },
         dragmode: false
       };
+      layout.shapes = picks.map((p, i) => ({
+        type: 'line',
+        x0: p.trace - 0.4,
+        x1: p.trace + 0.4,
+        y0: p.time,
+        y1: p.time,
+        line: { color: i === selectedPickIndex ? 'blue' : 'red', width: 2 }
+      }));
 
-      Plotly.react(plotDiv, traces, layout, { responsive: true });
+      Plotly.react(plotDiv, traces, layout, {
+        responsive: true,
+        editable: true,
+        modeBarButtonsToAdd: ['eraseshape']
+      });
       setTimeout(() => Plotly.Plots.resize(plotDiv), 50);
       renderedStart = startTrace;
       renderedEnd = endTrace;
       console.log(`Rendered traces ${startTrace}-${endTrace}`);
 
       plotDiv.removeAllListeners('plotly_relayout');
-      plotDiv.on('plotly_relayout', ev => {
-        if ('xaxis.range[0]' in ev && 'xaxis.range[1]' in ev) {
-          savedXRange = [ev['xaxis.range[0]'], ev['xaxis.range[1]']];
-        } else if ('xaxis.autorange' in ev && ev['xaxis.autorange'] === true) {
-          savedXRange = null;
-          savedYRange = null;
-        }
-
-        if ('yaxis.range[0]' in ev && 'yaxis.range[1]' in ev) {
-          const y0 = ev['yaxis.range[0]'];
-          const y1 = ev['yaxis.range[1]'];
-          savedYRange = y0 > y1 ? [y0, y1] : [y1, y0]; // 大きい方を上に（逆順）
-        }
-
-        if (latestSeismicData) {
-          const [s, e] = savedXRange ? visibleTraceIndices(savedXRange, latestSeismicData.length) : [0, latestSeismicData.length - 1];
-          if (s !== renderedStart || e !== renderedEnd) {
-            plotSeismicData(latestSeismicData, defaultDt, s, e);
-          }
-        }
-      });
+      plotDiv.removeAllListeners('plotly_click');
+      plotDiv.on('plotly_relayout', handleRelayout);
+      plotDiv.on('plotly_click', handlePlotClick);
     }
 
+    function pickNear(trace, time) {
+      return picks.findIndex(
+        p => Math.abs(p.trace - trace) < 0.5 && Math.abs(p.time - time) < defaultDt * downsampleFactor * 2
+      );
+    }
+
+    async function handlePlotClick(ev) {
+      if (!ev.points.length) return;
+      const point = ev.points[0];
+      let trace = Math.round(point.x);
+      let time = point.y;
+      if (downsampleFactor > 1) {
+        const dt = defaultDt * downsampleFactor;
+        const idx = point.y / dt;
+        const lower = Math.floor(idx);
+        const frac = idx - lower;
+        const lowerTime = lower * dt;
+        const upperTime = (lower + 1) * dt;
+        time = lowerTime + (upperTime - lowerTime) * frac;
+      }
+      const existing = pickNear(trace, time);
+      if (existing >= 0) {
+        selectedPickIndex = existing;
+        document.getElementById('deletePickBtn').disabled = false;
+      } else {
+        selectedPickIndex = null;
+        document.getElementById('deletePickBtn').disabled = true;
+        picks.push({ trace, time });
+        await postPick(trace, time);
+      }
+      plotSeismicData(latestSeismicData, defaultDt, renderedStart, renderedEnd);
+    }
+
+    async function handleRelayout(ev) {
+      const plotDiv = document.getElementById('plot');
+      if ('xaxis.range[0]' in ev && 'xaxis.range[1]' in ev) {
+        savedXRange = [ev['xaxis.range[0]'], ev['xaxis.range[1]']];
+      } else if ('xaxis.autorange' in ev && ev['xaxis.autorange'] === true) {
+        savedXRange = null;
+        savedYRange = null;
+      }
+
+      if ('yaxis.range[0]' in ev && 'yaxis.range[1]' in ev) {
+        const y0 = ev['yaxis.range[0]'];
+        const y1 = ev['yaxis.range[1]'];
+        savedYRange = y0 > y1 ? [y0, y1] : [y1, y0];
+      }
+
+      if (latestSeismicData) {
+        const [s, e] = savedXRange
+          ? visibleTraceIndices(savedXRange, latestSeismicData.length)
+          : [0, latestSeismicData.length - 1];
+        if (s !== renderedStart || e !== renderedEnd) {
+          plotSeismicData(latestSeismicData, defaultDt, s, e);
+        }
+      }
+
+      const shapeKey = Object.keys(ev).find(k => k.startsWith('shapes['));
+      if (shapeKey) {
+        const idx = parseInt(shapeKey.match(/shapes\[(\d+)\]/)[1], 10);
+        const shape = plotDiv.layout.shapes[idx];
+        const trace = (shape.x0 + shape.x1) / 2;
+        const time = (shape.y0 + shape.y1) / 2;
+        picks[idx] = { trace, time };
+        await postPick(Math.round(trace), time);
+      } else if (Array.isArray(ev.shapes)) {
+        const newPicks = ev.shapes.map(s => ({ trace: (s.x0 + s.x1) / 2, time: (s.y0 + s.y1) / 2 }));
+        const oldTraces = new Set(picks.map(p => Math.round(p.trace)));
+        const newTraces = new Set(newPicks.map(p => Math.round(p.trace)));
+        for (const t of oldTraces) {
+          if (!newTraces.has(t)) {
+            await deletePick(t);
+          }
+        }
+        picks = newPicks;
+        selectedPickIndex = null;
+        document.getElementById('deletePickBtn').disabled = true;
+      }
+    }
+
+    async function deleteSelectedPick() {
+      if (selectedPickIndex === null) return;
+      const trace = Math.round(picks[selectedPickIndex].trace);
+      await deletePick(trace);
+      picks.splice(selectedPickIndex, 1);
+      selectedPickIndex = null;
+      document.getElementById('deletePickBtn').disabled = true;
+      plotSeismicData(latestSeismicData, defaultDt, renderedStart, renderedEnd);
+    }
 
     window.addEventListener('DOMContentLoaded', loadSettings);
   </script>


### PR DESCRIPTION
## Summary
- capture click events to create seismic picks with interpolation for downsampled data
- overlay picks as draggable shapes and enable delete controls

## Testing
- `pytest`
- `ruff check` *(fails: Missing docstring in public package, ANN201, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6892b780db38832b8ca33722459c1a3c