### PR TITLE
Persist key1 info with picks

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -33,6 +33,8 @@ class Pick(BaseModel):
         file_id: str
         trace: int
         time: float
+        key1_idx: int
+        key1_byte: int
 
 
 @router.get('/get_key1_values')
@@ -140,21 +142,27 @@ def get_section_bin(
 
 @router.post('/picks')
 async def post_pick(pick: Pick) -> dict[str, str]:
-        add_pick(pick.file_id, pick.trace, pick.time)
+        add_pick(pick.file_id, pick.trace, pick.time, pick.key1_idx, pick.key1_byte)
         await asyncio.to_thread(store.save)
         return {'status': 'ok'}
 
 
 @router.get('/picks')
-async def get_pick(file_id: str = Query(...)) -> dict[str, list[dict[str, int | float]]]:
-        return {'picks': list_picks(file_id)}
+async def get_pick(
+        file_id: str = Query(...),
+        key1_idx: int = Query(...),
+        key1_byte: int = Query(...),
+) -> dict[str, list[dict[str, int | float]]]:
+        return {'picks': list_picks(file_id, key1_idx, key1_byte)}
 
 
 @router.delete('/picks')
 async def delete_pick_route(
         file_id: str = Query(...),
         trace: int | None = Query(None),
+        key1_idx: int = Query(...),
+        key1_byte: int = Query(...),
 ) -> dict[str, str]:
-        delete_pick(file_id, trace)
+        delete_pick(file_id, trace, key1_idx, key1_byte)
         await asyncio.to_thread(store.save)
         return {'status': 'ok'}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -231,11 +231,13 @@
 
   async function fetchPicks() {
     if (!currentFileId) return;
+    const idx = parseInt(document.getElementById('key1_idx_slider').value);
+    const key1Val = key1Values[idx];
     try {
-      const res = await fetch(`/picks?file_id=${currentFileId}`);
+      const res = await fetch(`/picks?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}`);
       if (res.ok) {
         const data = await res.json();
-        picks = data.picks || [];
+        picks = (data.picks || []).map(p => ({ trace: p.trace, time: p.time }));
       }
     } catch (e) {
       console.error('Failed to fetch picks', e);
@@ -243,11 +245,13 @@
   }
 
   async function postPick(trace, time) {
+    const idx = parseInt(document.getElementById('key1_idx_slider').value);
+    const key1Val = key1Values[idx];
     try {
       await fetch('/picks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ file_id: currentFileId, trace, time })
+        body: JSON.stringify({ file_id: currentFileId, trace, time, key1_idx: key1Val, key1_byte: currentKey1Byte })
       });
     } catch (e) {
       console.error('Failed to post pick', e);
@@ -255,8 +259,10 @@
   }
 
   async function deletePick(trace) {
+    const idx = parseInt(document.getElementById('key1_idx_slider').value);
+    const key1Val = key1Values[idx];
     try {
-      await fetch(`/picks?file_id=${currentFileId}&trace=${trace}`, { method: 'DELETE' });
+      await fetch(`/picks?file_id=${currentFileId}&trace=${trace}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}`, { method: 'DELETE' });
     } catch (e) {
       console.error('Failed to delete pick', e);
     }
@@ -268,6 +274,8 @@
 
     const index = parseInt(document.getElementById('key1_idx_slider').value);
     const key1Val = key1Values[index];
+
+    await fetchPicks();
 
     console.time('Cache lookup');
     let f32 = getCacheF32(key1Val);

--- a/app/utils/picks.py
+++ b/app/utils/picks.py
@@ -28,33 +28,84 @@ class PickStore:
 			encoding='utf-8',
 		)
 
-	def add_pick(self, file_id: str, trace: int, time: float) -> None:
-		"""Record or update a pick for a trace."""
+	def add_pick(
+		self,
+		file_id: str,
+		trace: int,
+		time: float,
+		key1_idx: int,
+		key1_byte: int,
+	) -> None:
+		"""Record or update a pick for a trace.
+
+		Picks are uniquely identified by ``trace``, ``key1_idx`` and
+		``key1_byte``.
+		"""
 		picks = self.picks.setdefault(file_id, [])
 		for pick in picks:
-			if pick['trace'] == trace:
+			if (
+				pick.get('trace') == trace
+				and pick.get('key1_idx') == key1_idx
+				and pick.get('key1_byte') == key1_byte
+			):
 				pick['time'] = time
 				break
 		else:
-			picks.append({'trace': trace, 'time': time})
+			picks.append(
+				{
+					'trace': trace,
+					'time': time,
+					'key1_idx': key1_idx,
+					'key1_byte': key1_byte,
+				}
+			)
 
-	def list_picks(self, file_id: str) -> list[dict[str, int | float]]:
-		"""Return all picks for ``file_id``."""
-		return self.picks.get(file_id, [])
+	def list_picks(
+		self, file_id: str, key1_idx: int | None = None, key1_byte: int | None = None
+	) -> list[dict[str, int | float]]:
+		"""Return picks for ``file_id`` filtered by key information."""
+		picks = self.picks.get(file_id, [])
+		if key1_idx is None and key1_byte is None:
+			return picks
+		return [
+			p
+			for p in picks
+			if (
+				(key1_idx is None or p.get('key1_idx') == key1_idx)
+				and (key1_byte is None or p.get('key1_byte') == key1_byte)
+			)
+		]
 
-	def delete_pick(self, file_id: str, trace: int | None = None) -> None:
+	def delete_pick(
+		self,
+		file_id: str,
+		trace: int | None = None,
+		key1_idx: int | None = None,
+		key1_byte: int | None = None,
+	) -> None:
 		"""Remove picks for ``file_id``.
 
-		If ``trace`` is provided, only that pick is removed; otherwise, all
-		picks for ``file_id`` are deleted.
+		If no filters are provided, all picks for ``file_id`` are removed.
+		Otherwise, picks matching the provided ``trace``, ``key1_idx`` and
+		``key1_byte`` are deleted.
 		"""
-		if trace is None:
-			self.picks.pop(file_id, None)
-			return
 		picks = self.picks.get(file_id)
-		if picks is None:
+		if not picks:
 			return
-		self.picks[file_id] = [p for p in picks if p['trace'] != trace]
+
+		if trace is None and key1_idx is None and key1_byte is None:
+			del self.picks[file_id]
+			return
+
+		self.picks[file_id] = [
+			p
+			for p in picks
+			if not (
+				(trace is None or p.get('trace') == trace)
+				and (key1_idx is None or p.get('key1_idx') == key1_idx)
+				and (key1_byte is None or p.get('key1_byte') == key1_byte)
+			)
+		]
 		if not self.picks[file_id]:
 			del self.picks[file_id]
 
@@ -62,17 +113,30 @@ class PickStore:
 store = PickStore(Path(__file__).with_name('picks.json'))
 
 
-def add_pick(file_id: str, trace: int, time: float) -> None:
+def add_pick(
+	file_id: str,
+	trace: int,
+	time: float,
+	key1_idx: int,
+	key1_byte: int,
+) -> None:
 	"""Add a pick to the global store."""
-	store.add_pick(file_id, trace, time)
+	store.add_pick(file_id, trace, time, key1_idx, key1_byte)
 
 
-def list_picks(file_id: str) -> list[dict[str, int | float]]:
+def list_picks(
+	file_id: str, key1_idx: int | None = None, key1_byte: int | None = None
+) -> list[dict[str, int | float]]:
 	"""List picks for ``file_id`` from the global store."""
-	return store.list_picks(file_id)
+	return store.list_picks(file_id, key1_idx, key1_byte)
 
 
 
-def delete_pick(file_id: str, trace: int | None = None) -> None:
+def delete_pick(
+	file_id: str,
+	trace: int | None = None,
+	key1_idx: int | None = None,
+	key1_byte: int | None = None,
+) -> None:
 	"""Delete pick(s) for ``file_id`` from the global store."""
-	store.delete_pick(file_id, trace)
+	store.delete_pick(file_id, trace, key1_idx, key1_byte)


### PR DESCRIPTION
## Summary
- include `key1_idx` and `key1_byte` with saved picks
- extend pick API to read/write the new fields
- update frontend to send and filter picks by the key1 context

## Testing
- `ruff check app/api/endpoints.py app/utils/picks.py --select=E,F`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6892d76982fc832b80f149de1d5bea77