### PR TITLE
Ensure only one pick per trace

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -477,6 +477,10 @@
       );
     }
 
+    function pickOnTrace(trace) {
+      return picks.findIndex(p => Math.round(p.trace) === trace);
+    }
+
     async function handlePlotClick(ev) {
       console.log('🔥 plotly_click fired', ev);
       const plotDiv = document.getElementById('plot');
@@ -515,6 +519,11 @@
         selectedPickIndex = existing;
         document.getElementById('deletePickBtn').disabled = false;
       } else {
+        const traceIdx = pickOnTrace(trace);
+        if (traceIdx >= 0) {
+          await deletePick(trace);
+          picks.splice(traceIdx, 1);
+        }
         selectedPickIndex = null;
         document.getElementById('deletePickBtn').disabled = true;
         picks.push({ trace, time });


### PR DESCRIPTION
## Summary
- ensure each trace retains at most one pick
- replace existing pick when new one is added for the same trace

## Testing
- `pytest`
- `ruff check .` *(fails: found 67 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6892e14f968c832ba0bb8b608f876855