### PR TITLE
Enable line-based picking in seismic viewer

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -77,6 +77,7 @@
     let downsampleFactor = 1;
     let selectedPickIndex = null;
     let isPickMode = false;
+    let linePickStart = null;
 
     function showCacheKeys() {
         const currentKeys = Array.from(cache.keys());
@@ -88,7 +89,9 @@
       const btn = document.getElementById('pickModeBtn');
       btn.textContent = isPickMode ? 'Pick Mode: ON' : 'Pick Mode: OFF';
       btn.classList.toggle('active', isPickMode);
-      document.getElementById('deletePickBtn').disabled = !isPickMode || selectedPickIndex === null;
+      linePickStart = null;
+      selectedPickIndex = null;
+      document.getElementById('deletePickBtn').disabled = true;
       if (latestSeismicData) {
         plotSeismicData(latestSeismicData, defaultDt, renderedStart, renderedEnd);
       }
@@ -532,24 +535,41 @@
       console.log('Snapped trace:', trace);
       console.log('Snapped time:', time);
       console.groupEnd();
-
-      // 既存ピックとの近接確認
-      const existing = pickNear(trace, time);
-      if (existing >= 0) {
-        selectedPickIndex = existing;
-        document.getElementById('deletePickBtn').disabled = false;
-      } else {
-        const traceIdx = pickOnTrace(trace);
-        if (traceIdx >= 0) {
-          await deletePick(trace);
-          picks.splice(traceIdx, 1);
+      if (!linePickStart) {
+        const existing = pickNear(trace, time);
+        if (existing >= 0) {
+          selectedPickIndex = existing;
+          document.getElementById('deletePickBtn').disabled = false;
+          return;
         }
+        linePickStart = { trace, time };
         selectedPickIndex = null;
         document.getElementById('deletePickBtn').disabled = true;
-        picks.push({ trace, time });
-        await postPick(trace, time);
+        return;
       }
 
+      const { trace: x0, time: y0 } = linePickStart;
+      linePickStart = null;
+      const x1 = trace;
+      const y1 = time;
+      const xStart = Math.round(Math.min(x0, x1));
+      const xEnd = Math.round(Math.max(x0, x1));
+      const slope = x1 === x0 ? 0 : (y1 - y0) / (x1 - x0);
+      const promises = [];
+      for (let x = xStart; x <= xEnd; x++) {
+        const y = x1 === x0 ? y1 : y0 + slope * (x - x0);
+        const snapped = Math.round(y / dt) * dt;
+        const idx = pickOnTrace(x);
+        if (idx >= 0) {
+          promises.push(deletePick(x));
+          picks.splice(idx, 1);
+        }
+        picks.push({ trace: x, time: snapped });
+        promises.push(postPick(x, snapped));
+      }
+      await Promise.all(promises);
+      selectedPickIndex = null;
+      document.getElementById('deletePickBtn').disabled = true;
       plotSeismicData(latestSeismicData, defaultDt, renderedStart, renderedEnd);
     }
 


### PR DESCRIPTION
## Summary
- add stateful two-click line picking that registers interpolated picks across traces
- reset pick mode state on toggle

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892f33b316c832bb5769da4fabe77b9