### PR TITLE
feat: add bandpass filtering to viewer

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -37,6 +37,9 @@
     .denoiseParam {
       display: none;
     }
+    .bpfParam {
+      display: none;
+    }
     #denoiseSettingsDialog {
       padding: 1em;
       border: 1px solid #888;
@@ -63,6 +66,7 @@
       <option value="auto" selected>auto</option>
       <option value="raw">raw</option>
       <option value="denoised">denoised</option>
+      <option value="filtered">表示: フィルタ</option>
     </select>
     <select id="denoiseScope">
       <option value="display">表示セクション</option>
@@ -82,6 +86,13 @@
     <button id="denoiseBtn" onclick="handleDenoise()">ノイズ抑制</button>
     <progress id="denoiseProgress" value="0" max="1" style="display:none; width:150px;"></progress>
     <span id="denoiseProgressText"></span>
+    <button id="openBpfDlgBtn" onclick="openBpfSettings()">BPFパラメータ設定</button>
+    <label class="bpfParam">low_hz:<input type="number" id="low_hz" value="5" step="0.1" style="width:70px;"></label>
+    <label class="bpfParam">high_hz:<input type="number" id="high_hz" value="60" step="0.1" style="width:70px;"></label>
+    <label class="bpfParam">dt:<input type="number" id="dt" value="0.002" step="0.0001" style="width:70px;"></label>
+    <label class="bpfParam">taper:<input type="number" id="taper" value="0.1" step="0.1" style="width:70px;"></label>
+    <button id="bpfBtn" onclick="handleBandpass()">BPF（表示セクション）</button>
+    <button id="bpfApplyBtn" onclick="applyBandpassBatch()">BPF（全体/共通）</button>
   </div>
   <div id="plot" style="width: 100vw; height: calc(100vh - 100px);"></div>
   <dialog id="denoiseSettingsDialog">
@@ -99,6 +110,18 @@
       <div style="margin-top:1em;text-align:right;">
         <button type="button" onclick="saveDenoiseSettings()">保存</button>
         <button type="button" onclick="closeDenoiseSettings()">キャンセル</button>
+      </div>
+    </form>
+  </dialog>
+  <dialog id="bpfSettingsDialog">
+    <form method="dialog">
+      <label>low_hz:<input type="number" id="dlg_low_hz" required step="0.1"></label>
+      <label>high_hz:<input type="number" id="dlg_high_hz" required step="0.1"></label>
+      <label>dt:<input type="number" id="dlg_dt" required step="0.0001"></label>
+      <label>taper:<input type="number" id="dlg_taper" required step="0.1"></label>
+      <div style="margin-top:1em;text-align:right;">
+        <button type="button" onclick="saveBpfSettings()">保存</button>
+        <button type="button" onclick="closeBpfSettings()">キャンセル</button>
       </div>
     </form>
   </dialog>
@@ -145,6 +168,19 @@
       }
     })();
 
+    (function() {
+      const saved = localStorage.getItem('bpf_params');
+      if (saved) {
+        try {
+          const p = JSON.parse(saved);
+          if (p.low_hz !== undefined) document.getElementById('low_hz').value = p.low_hz;
+          if (p.high_hz !== undefined) document.getElementById('high_hz').value = p.high_hz;
+          if (p.dt !== undefined) document.getElementById('dt').value = p.dt;
+          if (p.taper !== undefined) document.getElementById('taper').value = p.taper;
+        } catch(e){}
+      }
+    })();
+
     function getDenoiseParams() {
       return {
         mask_ratio: parseFloat(document.getElementById('mask_ratio').value),
@@ -152,6 +188,15 @@
         chunk_h: parseInt(document.getElementById('chunk_h').value),
         overlap: parseInt(document.getElementById('overlap').value),
         mask_noise_mode: document.getElementById('mask_noise_mode').value,
+      };
+    }
+
+    function getBpfParams() {
+      return {
+        low_hz: parseFloat(document.getElementById('low_hz').value),
+        high_hz: parseFloat(document.getElementById('high_hz').value),
+        dt: parseFloat(document.getElementById('dt').value),
+        taper: parseFloat(document.getElementById('taper').value),
       };
     }
 
@@ -183,6 +228,32 @@
       }
     }
 
+    function openBpfSettings() {
+      document.getElementById('dlg_low_hz').value = document.getElementById('low_hz').value;
+      document.getElementById('dlg_high_hz').value = document.getElementById('high_hz').value;
+      document.getElementById('dlg_dt').value = document.getElementById('dt').value;
+      document.getElementById('dlg_taper').value = document.getElementById('taper').value;
+      const dlg = document.getElementById('bpfSettingsDialog');
+      if (dlg.showModal) dlg.showModal(); else dlg.style.display = 'block';
+    }
+
+    function closeBpfSettings() {
+      const dlg = document.getElementById('bpfSettingsDialog');
+      if (dlg.close) dlg.close(); else dlg.style.display = 'none';
+    }
+
+    function saveBpfSettings() {
+      document.getElementById('low_hz').value = document.getElementById('dlg_low_hz').value;
+      document.getElementById('high_hz').value = document.getElementById('dlg_high_hz').value;
+      document.getElementById('dt').value = document.getElementById('dlg_dt').value;
+      document.getElementById('taper').value = document.getElementById('dlg_taper').value;
+      localStorage.setItem('bpf_params', JSON.stringify(getBpfParams()));
+      closeBpfSettings();
+      if (typeof fetchAndPlot === 'function') {
+        try { fetchAndPlot(); } catch (e) {}
+      }
+    }
+
     async function pollDenoiseJob(jobId) {
       const bar = document.getElementById('denoiseProgress');
       const txt = document.getElementById('denoiseProgressText');
@@ -206,6 +277,33 @@
         } else if (data.status === 'error') {
           clearInterval(timer);
           txt.textContent = `error`;
+        }
+      }, 1000);
+    }
+
+    async function pollBpfJob(jobId) {
+      const bar = document.getElementById('denoiseProgress');
+      const txt = document.getElementById('denoiseProgressText');
+      bar.style.display = 'inline-block';
+      bar.value = 0;
+      txt.textContent = 'BPF 0%';
+      const timer = setInterval(async () => {
+        const res = await fetch(`/bandpass_job_status?job_id=${jobId}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        bar.value = data.progress;
+        txt.textContent = `BPF ${Math.round(data.progress * 100)}%`;
+        if (data.status === 'done') {
+          clearInterval(timer);
+          cache.clear();
+          await fetchAndPlot();
+          setTimeout(() => {
+            bar.style.display = 'none';
+            txt.textContent = '';
+          }, 1000);
+        } else if (data.status === 'error') {
+          clearInterval(timer);
+          txt.textContent = 'BPF error';
         }
       }, 1000);
     }
@@ -262,6 +360,68 @@
         }
         const data = await res.json();
         pollDenoiseJob(data.job_id);
+      }
+    }
+
+    async function handleBandpass() {
+      const params = getBpfParams();
+      const index = parseInt(document.getElementById('key1_idx_slider').value);
+      const key1Val = key1Values[index];
+      const body = {
+        file_id: currentFileId,
+        key1_idx: key1Val,
+        key1_byte: currentKey1Byte,
+        key2_byte: currentKey2Byte,
+        ...params,
+      };
+      const res = await fetch('/bandpass_section_bin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        alert('bandpass failed');
+        return;
+      }
+      const bin = new Uint8Array(await res.arrayBuffer());
+      const obj = msgpack.decode(bin);
+      const int8 = new Int8Array(obj.data.buffer);
+      putCache(cacheKey(key1Val, 'filt'), obj.scale, int8);
+      sectionShape = obj.shape;
+      await fetchAndPlot();
+    }
+
+    async function applyBandpassBatch() {
+      const scope = document.getElementById('denoiseScope').value;
+      const params = getBpfParams();
+      const index = parseInt(document.getElementById('key1_idx_slider').value);
+      const key1Val = key1Values[index];
+      if (scope === 'display') {
+        await handleBandpass();
+      } else {
+        const body = {
+          file_id: currentFileId,
+          scope: scope === 'all_key1' ? 'all_key1' : 'by_header',
+          key1_byte: currentKey1Byte,
+          key2_byte: currentKey2Byte,
+          ...params,
+        };
+        if (scope !== 'all_key1') {
+          body.key1_idx = key1Val;
+          body.group_header_byte =
+            scope === 'common_shot' ? currentKey1Byte : currentKey2Byte;
+        }
+        const res = await fetch('/bandpass_apply', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          alert('bandpass apply failed');
+          return;
+        }
+        const data = await res.json();
+        pollBpfJob(data.job_id);
       }
     }
 
@@ -395,32 +555,58 @@
           if (i === centerIdx) continue;
           const key1Val = key1Values[i];
           if (mode === 'auto') {
-            if (cache.has(cacheKey(key1Val, 'den')) || cache.has(cacheKey(key1Val, 'raw')) ||
-                inflight.has(cacheKey(key1Val, 'den')) || inflight.has(cacheKey(key1Val, 'raw'))) continue;
+            if (cache.has(cacheKey(key1Val, 'den')) || cache.has(cacheKey(key1Val, 'filt')) || cache.has(cacheKey(key1Val, 'raw')) ||
+                inflight.has(cacheKey(key1Val, 'den')) || inflight.has(cacheKey(key1Val, 'filt')) || inflight.has(cacheKey(key1Val, 'raw'))) continue;
           } else {
-            const ck = cacheKey(key1Val, mode === 'denoised' ? 'den' : 'raw');
+            const ck = cacheKey(key1Val, mode === 'denoised' ? 'den' : mode === 'filtered' ? 'filt' : 'raw');
             if (cache.has(ck) || inflight.has(ck)) continue;
           }
           const controller = new AbortController();
-          const inflightKey = mode === 'raw' ? cacheKey(key1Val, 'raw') : cacheKey(key1Val, 'den');
+          const inflightKey = mode === 'raw' ? cacheKey(key1Val, 'raw') :
+                              mode === 'denoised' ? cacheKey(key1Val, 'den') :
+                              mode === 'filtered' ? cacheKey(key1Val, 'filt') :
+                              cacheKey(key1Val, 'den');
           inflight.set(inflightKey, controller);
           scheduler(async () => {
             try {
               const denoiseParams = getDenoiseParams();
+              const bpfParams = getBpfParams();
               const urlDen = `/get_denoised_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&chunk_h=${denoiseParams.chunk_h}&overlap=${denoiseParams.overlap}&mask_ratio=${denoiseParams.mask_ratio}&noise_std=${denoiseParams.noise_std}&mask_noise_mode=${denoiseParams.mask_noise_mode}`;
+              const urlFilt = `/get_bandpassed_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&low_hz=${bpfParams.low_hz}&high_hz=${bpfParams.high_hz}&dt=${bpfParams.dt}&taper=${bpfParams.taper}`;
               const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
               let res;
               let fetchedMode = 'raw';
               if (mode === 'raw') {
                 res = await fetch(urlRaw, { signal: controller.signal });
                 if (!res.ok) return;
-              } else {
+              } else if (mode === 'denoised') {
                 res = await fetch(urlDen, { signal: controller.signal });
                 if (res.ok) {
                   fetchedMode = 'den';
                 } else {
                   res = await fetch(urlRaw, { signal: controller.signal });
                   if (!res.ok) return;
+                }
+              } else if (mode === 'filtered') {
+                res = await fetch(urlFilt, { signal: controller.signal });
+                if (res.ok) {
+                  fetchedMode = 'filt';
+                } else {
+                  res = await fetch(urlRaw, { signal: controller.signal });
+                  if (!res.ok) return;
+                }
+              } else {
+                res = await fetch(urlDen, { signal: controller.signal });
+                if (res.ok) {
+                  fetchedMode = 'den';
+                } else {
+                  res = await fetch(urlFilt, { signal: controller.signal });
+                  if (res.ok) {
+                    fetchedMode = 'filt';
+                  } else {
+                    res = await fetch(urlRaw, { signal: controller.signal });
+                    if (!res.ok) return;
+                  }
                 }
               }
               const bin = new Uint8Array(await res.arrayBuffer());
@@ -510,8 +696,12 @@
       f32 = getCacheF32(cacheKey(key1Val, 'raw'));
     } else if (mode === 'denoised') {
       f32 = getCacheF32(cacheKey(key1Val, 'den'));
+    } else if (mode === 'filtered') {
+      f32 = getCacheF32(cacheKey(key1Val, 'filt'));
     } else {
-      f32 = getCacheF32(cacheKey(key1Val, 'den')) || getCacheF32(cacheKey(key1Val, 'raw'));
+      f32 = getCacheF32(cacheKey(key1Val, 'den')) ||
+            getCacheF32(cacheKey(key1Val, 'filt')) ||
+            getCacheF32(cacheKey(key1Val, 'raw'));
     }
     console.timeEnd('Cache lookup');
 
@@ -529,7 +719,9 @@
     } else {
       console.time('Fetch binary');
       const denoiseParams = getDenoiseParams();
+      const bpfParams = getBpfParams();
       const urlDen = `/get_denoised_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&chunk_h=${denoiseParams.chunk_h}&overlap=${denoiseParams.overlap}&mask_ratio=${denoiseParams.mask_ratio}&noise_std=${denoiseParams.noise_std}&mask_noise_mode=${denoiseParams.mask_noise_mode}`;
+      const urlFilt = `/get_bandpassed_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&low_hz=${bpfParams.low_hz}&high_hz=${bpfParams.high_hz}&dt=${bpfParams.dt}&taper=${bpfParams.taper}`;
       const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
       let res;
       let fetchedMode = 'raw';
@@ -540,19 +732,46 @@
           alert('Failed to load section');
           return;
         }
-      } else {
+      } else if (mode === 'denoised') {
         res = await fetch(urlDen);
         if (res.ok) {
           fetchedMode = 'den';
         } else {
-          if (mode === 'denoised') {
-            alert('denoised section not available, showing raw');
-          }
+          alert('denoised section not available, showing raw');
           res = await fetch(urlRaw);
           if (!res.ok) {
             console.timeEnd('Fetch binary');
             alert('Failed to load section');
             return;
+          }
+        }
+      } else if (mode === 'filtered') {
+        res = await fetch(urlFilt);
+        if (res.ok) {
+          fetchedMode = 'filt';
+        } else {
+          res = await fetch(urlRaw);
+          if (!res.ok) {
+            console.timeEnd('Fetch binary');
+            alert('Failed to load section');
+            return;
+          }
+        }
+      } else {
+        res = await fetch(urlDen);
+        if (res.ok) {
+          fetchedMode = 'den';
+        } else {
+          res = await fetch(urlFilt);
+          if (res.ok) {
+            fetchedMode = 'filt';
+          } else {
+            res = await fetch(urlRaw);
+            if (!res.ok) {
+              console.timeEnd('Fetch binary');
+              alert('Failed to load section');
+              return;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- add 'filtered' display mode and band-pass controls
- support bandpass processing and caching in frontend

## Testing
- `ruff check .` (fails: Found 260 errors)


------
https://chatgpt.com/codex/tasks/task_e_68aff05c47e8832b917d69ad171a8f24