### PR TITLE
Add gain slider to adjust seismic amplitude

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -851,7 +851,7 @@
       const density = visibleTraces / widthPx;
 
       let traces = [];
-      const gain = parseFloat(document.getElementById('gain').value);
+      const gain = parseFloat(document.getElementById('gain').value) || 1.0;
 
       if (density < 0.1) {
         downsampleFactor = 1;
@@ -893,15 +893,17 @@
         }
 
         const zData = Array.from({ length: nSamplesDS }, () => new Float32Array(nTracesDS));
-        let zMin = Infinity;
-        let zMax = -Infinity;
+        // カラースケールはゲイン前の値で固定する（自己正規化を避ける）
+        let baseMin = Infinity;
+        let baseMax = -Infinity;
         for (let i = startTrace, col = 0; col < nTracesDS; i += factor, col++) {
           const trace = seismic[i];
           for (let j = 0, row = 0; row < nSamplesDS; j += factor, row++) {
-            const val = trace[j] * gain;
+            const raw = trace[j];
+            const val = raw * gain;
             zData[row][col] = val;
-            if (val < zMin) zMin = val;
-            if (val > zMax) zMax = val;
+            if (raw < baseMin) baseMin = raw;
+            if (raw > baseMax) baseMax = raw;
           }
         }
         const xVals = new Float32Array(nTracesDS);
@@ -913,8 +915,9 @@
           y: time,
           z: zData,
           colorscale: 'Greys',
-          zmin: zMin,
-          zmax: zMax,
+          // ゲイン前のベース範囲を使うことで、ゲイン変更が可視的なコントラスト変化になる
+          zmin: baseMin,
+          zmax: baseMax,
           showscale: false,
           hoverinfo: 'x+y',
           hovertemplate: '',


### PR DESCRIPTION
## Summary
- Add Gain slider to control seismic amplitude with live display and persistence in localStorage
- Re-render plots on slider input and apply gain during drawing

## Testing
- `python -m pytest`
- `ruff check app`

------
https://chatgpt.com/codex/tasks/task_e_68afff229b9c832bb066bb666fed130e