### PR TITLE
Simplify viewer cache to Float32 arrays

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -151,11 +151,11 @@
     const defaultDt = 0.002;
     const PREFETCH_WIDTH = 3;   // ±10
     const FALLBACK_MAX = 8;  // API 無い場合
-    const HARD_LIMIT_BYTES = 1000 * 1024 * 1024; // 800MB
+    const HARD_LIMIT_BYTES = 512 * 1024 * 1024; // 512MB
 
-    const cache = new Map(); // key -> {scale, buf:Int8Array}
+    const cache = new Map(); // key -> { f32: Float32Array }
     const inflight = new Map();
-    const CACHE_LIMIT = 32;
+    const CACHE_LIMIT = 12;
     function cacheKey(val, mode) { return `${val}|${mode}`; }
     let sectionShape = null;
     let renderedStart = null;
@@ -395,7 +395,8 @@
         const bin = new Uint8Array(await res.arrayBuffer());
         const obj = msgpack.decode(bin);
         const int8 = new Int8Array(obj.data.buffer);
-        putCache(cacheKey(key1Val, 'den'), obj.scale, int8);
+        const f32  = Float32Array.from(int8, v => v / obj.scale);
+        putCacheF32(cacheKey(key1Val, 'den'), f32);
         sectionShape = obj.shape;
         await fetchAndPlot();
       } else {
@@ -448,7 +449,8 @@
       const bin = new Uint8Array(await res.arrayBuffer());
       const obj = msgpack.decode(bin);
       const int8 = new Int8Array(obj.data.buffer);
-      putCache(cacheKey(key1Val, 'filt'), obj.scale, int8);
+      const f32  = Float32Array.from(int8, v => v / obj.scale);
+      putCacheF32(cacheKey(key1Val, 'filt'), f32);
       sectionShape = obj.shape;
       await fetchAndPlot();
     }
@@ -499,19 +501,14 @@
       }
     }
 
-  function toFloat32(buf, scale) {
-    return Float32Array.from(buf, v => v / scale);
-  }
-  function putCache(key, scale, buf) {
+  function putCacheF32(key, f32) {
     if (cache.size >= CACHE_LIMIT) {
       const oldestKey = cache.keys().next().value;
       const old = cache.get(oldestKey);
-      if (old) { old.f32 = null; old.buf = null; }
+      if (old) old.f32 = null;
       cache.delete(oldestKey);
     }
-    const f32 = Float32Array.from(buf, v => v / scale);
-    cache.set(key, { scale, buf, f32 });
-    //cache.set(key, { scale, buf });
+    cache.set(key, { f32 });
 
     const canCheckMemory =
       performance.memory &&
@@ -532,7 +529,7 @@
     }
 
     if (used > HARD_LIMIT_BYTES) {
-      console.warn(`⚠ Memory limit exceeded! (${(used / 1024 / 1024).toFixed(1)} MB > 800 MB)`);
+      console.warn(`⚠ Memory limit exceeded! (${(used / 1024 / 1024).toFixed(1)} MB > 512 MB)`);
       let removed = 0;
       while (cache.size > 1) {
         const removedKey = cache.keys().next().value;
@@ -541,7 +538,6 @@
         // 🔽 メモリ解放を促すために参照を切る
         if (entry) {
           entry.f32 = null;
-          entry.buf = null;
         }
 
         cache.delete(removedKey);
@@ -557,7 +553,7 @@
       if (!cache.has(key)) return null;
       const entry = cache.get(key);
       cache.delete(key); cache.set(key, entry); // refresh LRU
-      return entry.f32;
+      return entry;
     }
 
     function updateKey1Display() {
@@ -602,6 +598,7 @@
       }
 
       function prefetchAround(centerIdx, mode) {
+        if (mode === 'denoised') return;
         for (const ctrl of inflight.values()) ctrl.abort();
         inflight.clear();
         const start = Math.max(0, centerIdx - PREFETCH_WIDTH);
@@ -674,7 +671,8 @@
               const bin = new Uint8Array(await res.arrayBuffer());
               const obj = msgpack.decode(bin);
               const int8 = new Int8Array(obj.data.buffer);
-              putCache(cacheKey(key1Val, fetchedMode), obj.scale, int8);
+              const f32  = Float32Array.from(int8, v => v / obj.scale);
+              putCacheF32(cacheKey(key1Val, fetchedMode), f32);
               if (!sectionShape) sectionShape = obj.shape;
             } catch (err) {
               if (err.name !== 'AbortError') {
@@ -753,21 +751,22 @@
     await fetchPicks();
 
     console.time('Cache lookup');
-    let f32 = null;
+    let hit = null;
     if (mode === 'raw') {
-      f32 = getCacheF32(cacheKey(key1Val, 'raw'));
+      hit = getCacheF32(cacheKey(key1Val, 'raw'));
     } else if (mode === 'denoised') {
-      f32 = getCacheF32(cacheKey(key1Val, 'den'));
+      hit = getCacheF32(cacheKey(key1Val, 'den'));
     } else if (mode === 'filtered') {
-      f32 = getCacheF32(cacheKey(key1Val, 'filt'));
+      hit = getCacheF32(cacheKey(key1Val, 'filt'));
     } else {
-      f32 = getCacheF32(cacheKey(key1Val, 'den')) ||
+      hit = getCacheF32(cacheKey(key1Val, 'den')) ||
             getCacheF32(cacheKey(key1Val, 'filt')) ||
             getCacheF32(cacheKey(key1Val, 'raw'));
     }
     console.timeEnd('Cache lookup');
 
     let traces;
+    let f32 = hit ? hit.f32 : null;
 
     if (f32) {
       console.time('Decode from cache');
@@ -843,13 +842,13 @@
       console.time('Decode & cache');
       const obj = msgpack.decode(bin);
       const int8 = new Int8Array(obj.data.buffer);
-      putCache(cacheKey(key1Val, fetchedMode), obj.scale, int8);
+      f32 = Float32Array.from(int8, v => v / obj.scale);
+      putCacheF32(cacheKey(key1Val, fetchedMode), f32);
       sectionShape = obj.shape;
-      const tmp = toFloat32(int8, obj.scale);
       const [nTraces, nSamples] = sectionShape;
       traces = new Array(nTraces);
       for (let i = 0; i < nTraces; i++) {
-        traces[i] = tmp.subarray(i * nSamples, (i + 1) * nSamples);
+        traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
       }
       console.timeEnd('Decode & cache');
       latestSeismicData = traces;

--- a/app/static/upload.html
+++ b/app/static/upload.html
@@ -92,7 +92,73 @@
     <span id="progress_text">0%</span>
   </div>
   <script>
-    document.getElementById('upload_btn').addEventListener('click', () => {
+    const progressBar = document.getElementById('upload_progress');
+    const progressText = document.getElementById('progress_text');
+
+    function handleSuccess(fileId, key1Byte, key2Byte) {
+      localStorage.setItem('file_id', fileId);
+      localStorage.setItem('key1_byte', key1Byte);
+      localStorage.setItem('key2_byte', key2Byte);
+      const params = new URLSearchParams({ file_id: fileId, key1_byte: key1Byte, key2_byte: key2Byte });
+      window.location.href = `/?${params.toString()}`;
+    }
+
+    async function openAfterConflict(originalName, key1Byte, key2Byte) {
+      const fd = new FormData();
+      fd.append('original_name', originalName);
+      fd.append('key1_byte', key1Byte);
+      fd.append('key2_byte', key2Byte);
+      try {
+        const res = await fetch('/open_segy', { method: 'POST', body: fd });
+        if (res.ok) {
+          const result = await res.json();
+          handleSuccess(result.file_id, key1Byte, key2Byte);
+        } else {
+          const text = await res.text().catch(() => '');
+          alert(text || 'Open failed');
+        }
+      } catch (err) {
+        alert('Open error occurred');
+      }
+    }
+
+    async function doUpload(file, key1Byte, key2Byte) {
+      return new Promise((resolve) => {
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('key1_byte', key1Byte);
+        formData.append('key2_byte', key2Byte);
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', '/upload_segy', true);
+        xhr.upload.onprogress = function (e) {
+          if (e.lengthComputable) {
+            const percent = (e.loaded / e.total) * 100;
+            progressBar.value = percent;
+            progressText.innerText = `${percent.toFixed(1)}%`;
+          }
+        };
+        xhr.onload = async function () {
+          if (xhr.status === 200) {
+            const result = JSON.parse(xhr.responseText);
+            handleSuccess(result.file_id, key1Byte, key2Byte);
+            resolve();
+          } else if (xhr.status === 409) {
+            await openAfterConflict(file.name, key1Byte, key2Byte);
+            resolve();
+          } else {
+            alert('Upload failed');
+            resolve();
+          }
+        };
+        xhr.onerror = function () {
+          alert('Upload error occurred');
+          resolve();
+        };
+        xhr.send(formData);
+      });
+    }
+
+    document.getElementById('upload_btn').addEventListener('click', async () => {
       const fileInput = document.getElementById('upload_segy');
       const file = fileInput.files[0];
       if (!file) {
@@ -101,35 +167,26 @@
       }
       const key1Byte = document.getElementById('key1_byte').value;
       const key2Byte = document.getElementById('key2_byte').value;
-      const formData = new FormData();
-      formData.append('file', file);
-      formData.append('key1_byte', key1Byte);  // ✅ 追加
-      formData.append('key2_byte', key2Byte);  // ✅ 追加
-      const xhr = new XMLHttpRequest();
-      xhr.open('POST', '/upload_segy', true);
-      xhr.upload.onprogress = function (e) {
-        if (e.lengthComputable) {
-          const percent = (e.loaded / e.total) * 100;
-          document.getElementById('upload_progress').value = percent;
-          document.getElementById('progress_text').innerText = `${percent.toFixed(1)}%`;
-        }
-      };
-      xhr.onload = function () {
-        if (xhr.status === 200) {
-          const result = JSON.parse(xhr.responseText);
-          localStorage.setItem('file_id', result.file_id);
-          localStorage.setItem('key1_byte', key1Byte);
-          localStorage.setItem('key2_byte', key2Byte);
-          const params = new URLSearchParams({ file_id: result.file_id, key1_byte: key1Byte, key2_byte: key2Byte });
-          window.location.href = `/?${params.toString()}`;
+      progressBar.value = 0;
+      progressText.innerText = '0%';
+      const fdOpen = new FormData();
+      fdOpen.append('original_name', file.name);
+      fdOpen.append('key1_byte', key1Byte);
+      fdOpen.append('key2_byte', key2Byte);
+      try {
+        const res = await fetch('/open_segy', { method: 'POST', body: fdOpen });
+        if (res.ok) {
+          const result = await res.json();
+          handleSuccess(result.file_id, key1Byte, key2Byte);
+        } else if (res.status === 404) {
+          await doUpload(file, key1Byte, key2Byte);
         } else {
-          alert('Upload failed');
+          const text = await res.text().catch(() => '');
+          alert(text || 'Open failed');
         }
-      };
-      xhr.onerror = function () {
-        alert('Upload error occurred');
-      };
-      xhr.send(formData);
+      } catch (err) {
+        alert('Open error occurred');
+      }
     });
   </script>
 </body>

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -1,4 +1,6 @@
+import json
 import os
+from pathlib import Path
 
 import numpy as np
 import segyio
@@ -62,3 +64,59 @@ class SegySectionReader:
 	def preload_all_sections(self):
 		for key1_val in self.unique_key1:
 			self.get_section(key1_val)
+
+
+class TraceStoreSectionReader:
+	def __init__(
+		self, store_dir: str | Path, key1_byte: int = 189, key2_byte: int = 193
+	):
+		self.store_dir = Path(store_dir)
+		self.key1_byte = key1_byte
+		self.key2_byte = key2_byte
+		meta_path = self.store_dir / 'meta.json'
+		self.meta = json.loads(meta_path.read_text())
+		self.traces = np.load(self.store_dir / 'traces.npy', mmap_mode='r')
+		self.section_cache: dict[int, list[list[float]]] = {}
+
+	def _header_path(self, byte: int) -> Path:
+		return self.store_dir / f'headers_byte_{byte}.npy'
+
+	def ensure_header(self, byte: int) -> np.ndarray:
+		p = self._header_path(byte)
+		if p.exists():
+			return np.load(p, mmap_mode='r')
+		print(f'Extracting header byte {byte} for {self.store_dir}')
+		with segyio.open(
+			self.meta['original_segy_path'], 'r', ignore_geometry=True
+		) as f:
+			f.mmap()
+			vals = f.attributes(byte)[:].astype(np.int32)
+		tmp = p.with_name(p.stem + '_tmp.npy')
+		np.save(tmp, vals)
+		os.replace(tmp, p)
+		return np.load(p, mmap_mode='r')
+
+	def _get_header(self, byte: int) -> np.ndarray:
+		return self.ensure_header(byte)
+
+	def get_key1_values(self):
+		key1s = self._get_header(self.key1_byte)
+		return np.unique(key1s)
+
+	def get_section(self, key1_val: int):
+		if key1_val in self.section_cache:
+			return self.section_cache[key1_val]
+		key1s = self._get_header(self.key1_byte)
+		indices = np.where(key1s == key1_val)[0]
+		print(len(indices), 'indices found for key1_val:', key1_val)
+		if len(indices) == 0:
+			raise ValueError(f'Key1 value {key1_val} not found')
+		key2s = self._get_header(self.key2_byte)[indices]
+		sorted_indices = indices[np.argsort(key2s, kind='stable')]
+		section = self.traces[sorted_indices].tolist()
+		self.section_cache[key1_val] = section
+		return section
+
+	def preload_all_sections(self):
+		self._get_header(self.key1_byte)
+		self._get_header(self.key2_byte)


### PR DESCRIPTION
## Summary
- Replace Int8-based cache with Float32-only `putCacheF32`/`getCacheF32`
- Convert Int8 → Float32 once per fetch and reuse cached data
- Skip prefetch in denoised mode and tighten cache limits to 12 entries / 512 MB

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10ba2a538832bb774e3da8a2d517f