### PR TITLE
Persist normalized SEG-Y traces and reuse trace stores

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -3,7 +3,9 @@ import asyncio
 import gzip
 import hashlib
 import json
+import os
 import pathlib
+import re
 import shutil
 import threading
 from pathlib import Path
@@ -12,6 +14,7 @@ from uuid import uuid4
 
 import msgpack
 import numpy as np
+import segyio
 import torch
 from fastapi import (
 	APIRouter,
@@ -26,7 +29,11 @@ from pydantic import BaseModel
 from utils.bandpass import bandpass_np
 from utils.denoise import denoise_tensor
 from utils.picks import add_pick, delete_pick, list_picks, store
-from utils.utils import SegySectionReader, quantize_float32
+from utils.utils import (
+        SegySectionReader,
+        TraceStoreSectionReader,
+        quantize_float32,
+)
 
 router = APIRouter()
 
@@ -36,6 +43,9 @@ UPLOAD_DIR.mkdir(exist_ok=True)
 PROCESSED_DIR = UPLOAD_DIR / 'processed'
 DENOISE_DIR = PROCESSED_DIR / 'denoise'
 DENOISE_DIR.mkdir(parents=True, exist_ok=True)
+
+TRACE_DIR = PROCESSED_DIR / 'traces'
+TRACE_DIR.mkdir(parents=True, exist_ok=True)
 
 LATEST_DIR = DENOISE_DIR / 'latest'
 LATEST_DIR.mkdir(parents=True, exist_ok=True)
@@ -51,7 +61,7 @@ def _denoise_latest_path(file_id: str, key1_idx: int) -> Path:
 	return LATEST_DIR / safe_id / f'{key1_idx}.bin.gz'
 
 
-cached_readers: dict[str, SegySectionReader] = {}
+cached_readers: dict[str, SegySectionReader | TraceStoreSectionReader] = {}
 SEGYS: dict[str, str] = {}
 
 # Private caches for denoised sections, band-passed sections and asynchronous jobs
@@ -60,14 +70,21 @@ bandpass_cache: dict[tuple[str, int, str], bytes] = {}
 jobs: dict[str, dict[str, float | str]] = {}
 
 
-def get_reader(file_id: str, key1_byte: int, key2_byte: int) -> SegySectionReader:
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	if cache_key not in cached_readers:
-		if file_id not in SEGYS:
-			raise HTTPException(status_code=404, detail='File ID not found')
-		path = SEGYS[file_id]
-		cached_readers[cache_key] = SegySectionReader(path, key1_byte, key2_byte)
-	return cached_readers[cache_key]
+def get_reader(
+        file_id: str, key1_byte: int, key2_byte: int
+) -> SegySectionReader | TraceStoreSectionReader:
+        cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
+        if cache_key not in cached_readers:
+                if file_id not in SEGYS:
+                        raise HTTPException(status_code=404, detail='File ID not found')
+                path = SEGYS[file_id]
+                p = Path(path)
+                if p.is_dir():
+                        reader = TraceStoreSectionReader(p, key1_byte, key2_byte)
+                else:
+                        reader = SegySectionReader(path, key1_byte, key2_byte)
+                cached_readers[cache_key] = reader
+        return cached_readers[cache_key]
 
 
 class Pick(BaseModel):
@@ -271,32 +288,76 @@ def get_key1_values(
 
 @router.post('/upload_segy')
 async def upload_segy(
-	file: UploadFile = File(...),
-	key1_byte: int = Form(189),
-	key2_byte: int = Form(193),
+        file: UploadFile = File(...),
+        key1_byte: int = Form(189),
+        key2_byte: int = Form(193),
 ):
-	if not file.filename:
-		raise HTTPException(
-			status_code=400, detail='Uploaded file must have a filename'
-		)
-	print(f'Uploading file: {file.filename}')
-	ext = pathlib.Path(file.filename).suffix.lower()
-	file_id = str(uuid4())
-	dest_path = UPLOAD_DIR / f'{file_id}{ext}'
-	with open(dest_path, 'wb') as f:
-		f.write(await file.read())
+        if not file.filename:
+                raise HTTPException(
+                        status_code=400, detail='Uploaded file must have a filename'
+                )
+        print(f'Uploading file: {file.filename}')
+        safe_name = re.sub(r'[^A-Za-z0-9_.-]', '_', file.filename)
+        store_dir = TRACE_DIR / safe_name
+        meta_path = store_dir / 'meta.json'
+        file_id = str(uuid4())
 
-	SEGYS[file_id] = str(dest_path)
+        if meta_path.exists():
+                print(f'Reusing trace store for {file.filename}')
+                reader = TraceStoreSectionReader(store_dir, key1_byte, key2_byte)
+                SEGYS[file_id] = str(store_dir)
+                cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
+                cached_readers[cache_key] = reader
+                threading.Thread(target=reader.preload_all_sections, daemon=True).start()
+                for b in {key1_byte, key2_byte}:
+                        threading.Thread(
+                                target=reader.ensure_header, args=(b,), daemon=True
+                        ).start()
+                return {'file_id': file_id, 'reused_trace_store': True}
 
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	print(f'Creating cache key: {cache_key}')
+        raw_path = UPLOAD_DIR / safe_name
+        with open(raw_path, 'wb') as f:
+                f.write(await file.read())
+        store_dir.mkdir(parents=True, exist_ok=True)
+        traces_tmp = store_dir / 'traces.npy.tmp'
+        with segyio.open(raw_path, 'r', ignore_geometry=True) as segy:
+                segy.mmap()
+                n_traces = segy.tracecount
+                n_samples = len(segy.trace[0])
+                mm = np.lib.format.open_memmap(
+                        traces_tmp,
+                        mode='w+',
+                        dtype=np.float32,
+                        shape=(n_traces, n_samples),
+                )
+                for i in range(n_traces):
+                        tr = segy.trace[i].astype(np.float32)
+                        mean = tr.mean()
+                        std = tr.std()
+                        if std == 0:
+                                std = 1.0
+                        mm[i] = (tr - mean) / std
+                del mm
+        os.replace(traces_tmp, store_dir / 'traces.npy')
+        meta = {
+                'n_traces': int(n_traces),
+                'n_samples': int(n_samples),
+                'original_segy_path': str(raw_path),
+                'version': 1,
+                'normalized': True,
+        }
+        tmp_meta = store_dir / 'meta.json.tmp'
+        tmp_meta.write_text(json.dumps(meta))
+        os.replace(tmp_meta, meta_path)
 
-	reader = SegySectionReader(str(dest_path), key1_byte, key2_byte)
-	cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-	cached_readers[cache_key] = reader
-
-	threading.Thread(target=reader.preload_all_sections, daemon=True).start()
-	return {'file_id': file_id}
+        reader = TraceStoreSectionReader(store_dir, key1_byte, key2_byte)
+        SEGYS[file_id] = str(store_dir)
+        cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
+        cached_readers[cache_key] = reader
+        threading.Thread(target=reader.preload_all_sections, daemon=True).start()
+        for b in {key1_byte, key2_byte}:
+                threading.Thread(target=reader.ensure_header, args=(b,), daemon=True).start()
+        return {'file_id': file_id, 'reused_trace_store': False}
 
 
 @router.get('/get_section')

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -1,4 +1,6 @@
+import json
 import os
+from pathlib import Path
 
 import numpy as np
 import segyio
@@ -62,3 +64,59 @@ class SegySectionReader:
 	def preload_all_sections(self):
 		for key1_val in self.unique_key1:
 			self.get_section(key1_val)
+
+
+class TraceStoreSectionReader:
+        def __init__(
+                self, store_dir: str | Path, key1_byte: int = 189, key2_byte: int = 193
+        ):
+                self.store_dir = Path(store_dir)
+                self.key1_byte = key1_byte
+                self.key2_byte = key2_byte
+                meta_path = self.store_dir / 'meta.json'
+                self.meta = json.loads(meta_path.read_text())
+                self.traces = np.load(self.store_dir / 'traces.npy', mmap_mode='r')
+                self.section_cache: dict[int, list[list[float]]] = {}
+
+        def _header_path(self, byte: int) -> Path:
+                return self.store_dir / f'headers_byte_{byte}.npy'
+
+        def ensure_header(self, byte: int) -> np.ndarray:
+                p = self._header_path(byte)
+                if p.exists():
+                        return np.load(p, mmap_mode='r')
+                print(f'Extracting header byte {byte} for {self.store_dir}')
+                with segyio.open(
+                        self.meta['original_segy_path'], 'r', ignore_geometry=True
+                ) as f:
+                        f.mmap()
+                        vals = f.attributes(byte)[:].astype(np.int32)
+                tmp = p.with_suffix('.tmp')
+                np.save(tmp, vals)
+                os.replace(tmp, p)
+                return np.load(p, mmap_mode='r')
+
+        def _get_header(self, byte: int) -> np.ndarray:
+                return self.ensure_header(byte)
+
+        def get_key1_values(self):
+                key1s = self._get_header(self.key1_byte)
+                return np.unique(key1s)
+
+        def get_section(self, key1_val: int):
+                if key1_val in self.section_cache:
+                        return self.section_cache[key1_val]
+                key1s = self._get_header(self.key1_byte)
+                indices = np.where(key1s == key1_val)[0]
+                print(len(indices), 'indices found for key1_val:', key1_val)
+                if len(indices) == 0:
+                        raise ValueError(f'Key1 value {key1_val} not found')
+                key2s = self._get_header(self.key2_byte)[indices]
+                sorted_indices = indices[np.argsort(key2s, kind='stable')]
+                section = self.traces[sorted_indices].tolist()
+                self.section_cache[key1_val] = section
+                return section
+
+        def preload_all_sections(self):
+                self._get_header(self.key1_byte)
+                self._get_header(self.key2_byte)


### PR DESCRIPTION
## Summary
- add TraceStoreSectionReader for cached normalized traces and lazy header loading
- reuse or build trace stores in /upload_segy and return reuse flag
- extend reader cache to handle trace store directories

## Testing
- `python -m py_compile app/utils/utils.py`
- `python -m py_compile app/api/endpoints.py`
- `ruff check app/utils/utils.py` *(fails: Missing docstring in public module)*


------
https://chatgpt.com/codex/tasks/task_e_68b4ded54fb8832b871a5175aa3e3a6f