### PR TITLE
Add shortcut to toggle denoised view

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ ruff.toml            # Ruff linter settings
 - `GET /get_key1_values`: list available values for the first key.
 - `GET /get_section` and `GET /get_section_bin`: fetch normalized traces for a given `key1` index (JSON or binary).
 
+## Keyboard Shortcuts
+
+- `N`: Toggle between raw and denoised display modes.
+
 ## Development
 1. Install dependencies (FastAPI, Uvicorn, NumPy, segyio, msgpack, etc.).
 2. Launch the server: `uvicorn app.main:app --reload`.

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1160,6 +1160,22 @@
     }
 
     window.addEventListener('DOMContentLoaded', loadSettings);
+
+    // Toggle between raw and denoised displays with the "n" key
+    window.addEventListener('keydown', (e) => {
+        if (
+          e.key.toLowerCase() === 'n' &&
+          !e.ctrlKey &&
+          !e.altKey &&
+          !e.metaKey &&
+          !['INPUT', 'SELECT', 'TEXTAREA'].includes(document.activeElement.tagName)
+        ) {
+          const sel = document.getElementById('displayMode');
+          sel.value = sel.value === 'denoised' ? 'raw' : 'denoised';
+          fetchAndPlot();
+        }
+      });
+
     window.addEventListener('keyup', (e) => {
         if (e.key === 'Shift') {
           linePickStart = null;


### PR DESCRIPTION
## Summary
- add `n` keyboard shortcut to swap between raw and denoised sections
- document keyboard shortcut in README

## Testing
- `ruff check .` *(fails: Found 287 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f8572180832b9992569a02e7c943