### PR TITLE
Use reader API for FB picks

### DIFF
--- a/app/static/api.js
+++ b/app/static/api.js
@@ -1,8 +1,9 @@
-export async function fbInfer({ path, axis, index, dt_us = null }) {
+export async function fbInfer({ file_id, key1_idx, key1_byte = 189, key2_byte = 193, dt_us = null }) {
     const form = new FormData();
-    form.append('path', path);
-    form.append('axis', axis);
-    form.append('index', index);
+    form.append('file_id', file_id);
+    form.append('key1_idx', key1_idx);
+    form.append('key1_byte', key1_byte);
+    form.append('key2_byte', key2_byte);
     if (dt_us !== null && dt_us !== undefined) {
         form.append('dt_us', dt_us);
     }
@@ -16,9 +17,10 @@ export async function fbInfer({ path, axis, index, dt_us = null }) {
 
 export async function fbPicks({
     cache_id,
-    path,
-    axis,
-    index,
+    file_id,
+    key1_idx,
+    key1_byte = 189,
+    key2_byte = 193,
     dt_us,
     t0_us,
     method = 'argmax',
@@ -33,9 +35,10 @@ export async function fbPicks({
 }) {
     const form = new FormData();
     form.append('cache_id', cache_id);
-    form.append('path', path);
-    form.append('axis', axis);
-    form.append('index', index);
+    form.append('file_id', file_id);
+    form.append('key1_idx', key1_idx);
+    form.append('key1_byte', key1_byte);
+    form.append('key2_byte', key2_byte);
     form.append('dt_us', dt_us);
     form.append('t0_us', t0_us);
     form.append('method', method);

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1214,15 +1214,13 @@
 
     async function runAndDraw() {
       if (!fbCacheId || !fbMeta) return;
-      const path = window.currentSegyPath;
-      const axis = window.currentAxis;
-      const index = window.currentIndex;
       const dt_us = window.currentDtUs ?? fbMeta.dt_us;
       const params = {
         cache_id: fbCacheId,
-        path,
-        axis,
-        index,
+        file_id: window.currentFileId,
+        key1_idx: window.key1Values[parseInt(document.getElementById('key1_idx_slider').value)],
+        key1_byte: window.currentKey1Byte || 189,
+        key2_byte: window.currentKey2Byte || 193,
         dt_us,
         t0_us: fbMeta.t0_us,
         median_kernel: (() => {
@@ -1279,31 +1277,22 @@
     });
 
     document.getElementById('btn-fb-infer')?.addEventListener('click', async () => {
-        console.log({ path: window.currentSegyPath, axis: window.currentAxis, index: window.currentIndex, dt_us: window.currentDtUs });
-        // --- 追加: 足りてないグローバルを補完 ---
-        window.currentAxis ??= 'iline'; // 仮に inline とする
         const idx = parseInt(document.getElementById('key1_idx_slider').value);
-        window.currentIndex = idx;
+        const key1Val = window.key1Values[idx];
         const dt = parseFloat(document.getElementById('dt').value);
-        window.currentDtUs = Math.round((Number.isFinite(dt) ? dt : 0.002) * 1e6);
-
-        // ⚠ ここは本来 "path" が必要。今のバックエンドが file_id 非対応なら失敗する。
-        // 一時的に file_id を突っ込んでもサーバ側が受け取れない可能性が高い。
-        window.currentSegyPath ??= currentFileId;
-
         try {
           const { cache_id, meta } = await fbInfer({
-            path: window.currentSegyPath,
-            axis: window.currentAxis,
-            index: window.currentIndex,
-            dt_us: window.currentDtUs,
+            file_id: window.currentFileId,
+            key1_idx: key1Val,
+            key1_byte: window.currentKey1Byte || 189,
+            key2_byte: window.currentKey2Byte || 193,
+            dt_us: Number.isFinite(dt) ? Math.round(dt * 1e6) : undefined,
           });
           fbCacheId = cache_id;
           fbMeta = meta;
           await runAndDraw();
         } catch (err) {
           console.error('fbInfer failed', err);
-          alert('fbInfer failed: ' + (err?.message || err));
         }
       });
   </script>


### PR DESCRIPTION
## Summary
- remove dependency on utils.get_section for FB inference and read sections via get_reader
- send file_id/key1 information from frontend when invoking FB inference and picks
- persist inferred picks using existing add_pick API

## Testing
- `ruff check .` *(fails: Found 186 errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9170251f4832b90c493179882f945