### PR TITLE
Add first-break probability inference pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Thumbs.db
 *.segy
 *.pth
 *.gz
+*.json
 
 data/
 output/

--- a/app/static/api.js
+++ b/app/static/api.js
@@ -1,5 +1,35 @@
-async function fetchAndPlot(key1) {
-    const res = await fetch(`/get_section?key1=${key1}`);
-    const data = await res.json();
-    plotSeismicData(data);
+async function fetchFbpickSectionBin(body) {
+  const resp = await fetch('/fbpick_section_bin', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    // サーバ側のエラー内容をそのまま表示できるように
+    const text = await resp.text().catch(() => '');
+    throw new Error(`HTTP ${resp.status} ${resp.statusText} — ${text}`);
+  }
+
+  const buf = await resp.arrayBuffer();
+  let u8 = new Uint8Array(buf);
+
+  // --- gzip ヘッダをスニフ（0x1f, 0x8b） ---
+  const isGzip = u8.length >= 2 && u8[0] === 0x1f && u8[1] === 0x8b;
+  if (isGzip) {
+    // 本当に gzip のときだけ解凍
+    u8 = pako.ungzip(u8);
+  }
+  // ここまでで u8 は msgpack の生バイト
+  const payload = msgpack.decode(u8);
+
+  if (payload.dtype !== 'u8') {
+    throw new Error(`Unexpected dtype: ${payload.dtype}`);
+  }
+  const { h, w, data, meta } = payload;
+  const bytes = new Uint8Array(data);
+  const probs = new Float32Array(h * w);
+  for (let i = 0; i < bytes.length; i++) probs[i] = bytes[i] / 255.0;
+
+  return { h, w, probs, meta };
 }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -67,6 +67,7 @@
       <option value="raw">raw</option>
       <option value="denoised">denoised</option>
       <option value="filtered">表示: フィルタ</option>
+      <option value="fbprob">FB Prob</option>
     </select>
     <label for="gain">Gain:</label>
     <input type="range" id="gain" min="0.1" max="5" step="0.1" value="1" oninput="onGainChange()" />
@@ -241,6 +242,46 @@
         dt: parseFloat(document.getElementById('dt').value),
         taper: parseFloat(document.getElementById('taper').value),
       };
+    }
+
+    async function fetchFbProb(key1Val) {
+      const body = {
+        file_id: currentFileId,
+        key1_idx: key1Val,
+        key1_byte: currentKey1Byte,
+        key2_byte: currentKey2Byte,
+        tile_h: 256,
+        tile_w: 256,
+        overlap: 32,
+        amp: true,
+      };
+      const res = await fetch('/fbpick_section_bin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        throw new Error('fbpick job failed');
+      }
+      const { job_id } = await res.json();
+      while (true) {
+        const st = await fetch(`/fbpick_job_status?job_id=${job_id}`);
+        const js = await st.json();
+        if (js.status === 'done') break;
+        if (js.status === 'error') {
+          throw new Error(js.message || 'fbpick failed');
+        }
+        await new Promise(r => setTimeout(r, 1000));
+      }
+      const binRes = await fetch(`/get_fbpick_section_bin?job_id=${job_id}`);
+      if (!binRes.ok) {
+        throw new Error('fbpick result fetch failed');
+      }
+      const bin = new Uint8Array(await binRes.arrayBuffer());
+      const obj = msgpack.decode(bin);
+      const int8 = new Int8Array(obj.data.buffer);
+      const f32 = Float32Array.from(int8, v => v / obj.scale);
+      return { f32, shape: obj.shape };
     }
 
     function onGainChange() {
@@ -598,7 +639,7 @@
       }
 
       function prefetchAround(centerIdx, mode) {
-        if (mode === 'denoised') return;
+        if (mode === 'denoised' || mode === 'fbprob') return;
         for (const ctrl of inflight.values()) ctrl.abort();
         inflight.clear();
         const start = Math.max(0, centerIdx - PREFETCH_WIDTH);
@@ -758,6 +799,8 @@
       hit = getCacheF32(cacheKey(key1Val, 'den'));
     } else if (mode === 'filtered') {
       hit = getCacheF32(cacheKey(key1Val, 'filt'));
+    } else if (mode === 'fbprob') {
+      hit = getCacheF32(cacheKey(key1Val, 'fbp'));
     } else {
       hit = getCacheF32(cacheKey(key1Val, 'den')) ||
             getCacheF32(cacheKey(key1Val, 'filt')) ||
@@ -779,50 +822,53 @@
       latestSeismicData = traces;
     } else {
       console.time('Fetch binary');
-      const denoiseParams = getDenoiseParams();
-      const bpfParams = getBpfParams();
-      const urlDen = `/get_denoised_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&chunk_h=${denoiseParams.chunk_h}&overlap=${denoiseParams.overlap}&mask_ratio=${denoiseParams.mask_ratio}&noise_std=${denoiseParams.noise_std}&mask_noise_mode=${denoiseParams.mask_noise_mode}`;
-      const urlFilt = `/get_bandpassed_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&low_hz=${bpfParams.low_hz}&high_hz=${bpfParams.high_hz}&dt=${bpfParams.dt}&taper=${bpfParams.taper}`;
-      const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
-      let res;
-      let fetchedMode = 'raw';
-      if (mode === 'raw') {
-        res = await fetch(urlRaw);
-        if (!res.ok) {
+      if (mode === 'fbprob') {
+        try {
+          const { f32: f32fb, shape } = await fetchFbProb(key1Val);
           console.timeEnd('Fetch binary');
-          alert('Failed to load section');
+          f32 = f32fb;
+          putCacheF32(cacheKey(key1Val, 'fbp'), f32);
+          sectionShape = shape;
+          const [nTraces, nSamples] = sectionShape;
+          traces = new Array(nTraces);
+          for (let i = 0; i < nTraces; i++) {
+            traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
+          }
+          latestSeismicData = traces;
+        } catch (e) {
+          console.timeEnd('Fetch binary');
+          alert('Failed to load FB Prob');
           return;
         }
-      } else if (mode === 'denoised') {
-        res = await fetch(urlDen);
-        if (res.ok) {
-          fetchedMode = 'den';
-        } else {
-          alert('denoised section not available, showing raw');
-          res = await fetch(urlRaw);
-          if (!res.ok) {
-            console.timeEnd('Fetch binary');
-            alert('Failed to load section');
-            return;
-          }
-        }
-      } else if (mode === 'filtered') {
-        res = await fetch(urlFilt);
-        if (res.ok) {
-          fetchedMode = 'filt';
-        } else {
-          res = await fetch(urlRaw);
-          if (!res.ok) {
-            console.timeEnd('Fetch binary');
-            alert('Failed to load section');
-            return;
-          }
-        }
       } else {
-        res = await fetch(urlDen);
-        if (res.ok) {
-          fetchedMode = 'den';
-        } else {
+        const denoiseParams = getDenoiseParams();
+        const bpfParams = getBpfParams();
+        const urlDen = `/get_denoised_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&chunk_h=${denoiseParams.chunk_h}&overlap=${denoiseParams.overlap}&mask_ratio=${denoiseParams.mask_ratio}&noise_std=${denoiseParams.noise_std}&mask_noise_mode=${denoiseParams.mask_noise_mode}`;
+        const urlFilt = `/get_bandpassed_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&low_hz=${bpfParams.low_hz}&high_hz=${bpfParams.high_hz}&dt=${bpfParams.dt}&taper=${bpfParams.taper}`;
+        const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
+        let res;
+        let fetchedMode = 'raw';
+        if (mode === 'raw') {
+          res = await fetch(urlRaw);
+          if (!res.ok) {
+            console.timeEnd('Fetch binary');
+            alert('Failed to load section');
+            return;
+          }
+        } else if (mode === 'denoised') {
+          res = await fetch(urlDen);
+          if (res.ok) {
+            fetchedMode = 'den';
+          } else {
+            alert('denoised section not available, showing raw');
+            res = await fetch(urlRaw);
+            if (!res.ok) {
+              console.timeEnd('Fetch binary');
+              alert('Failed to load section');
+              return;
+            }
+          }
+        } else if (mode === 'filtered') {
           res = await fetch(urlFilt);
           if (res.ok) {
             fetchedMode = 'filt';
@@ -834,24 +880,41 @@
               return;
             }
           }
+        } else {
+          res = await fetch(urlDen);
+          if (res.ok) {
+            fetchedMode = 'den';
+          } else {
+            res = await fetch(urlFilt);
+            if (res.ok) {
+              fetchedMode = 'filt';
+            } else {
+              res = await fetch(urlRaw);
+              if (!res.ok) {
+                console.timeEnd('Fetch binary');
+                alert('Failed to load section');
+                return;
+              }
+            }
+          }
         }
-      }
-      const bin = new Uint8Array(await res.arrayBuffer());
-      console.timeEnd('Fetch binary');
+        const bin = new Uint8Array(await res.arrayBuffer());
+        console.timeEnd('Fetch binary');
 
-      console.time('Decode & cache');
-      const obj = msgpack.decode(bin);
-      const int8 = new Int8Array(obj.data.buffer);
-      f32 = Float32Array.from(int8, v => v / obj.scale);
-      putCacheF32(cacheKey(key1Val, fetchedMode), f32);
-      sectionShape = obj.shape;
-      const [nTraces, nSamples] = sectionShape;
-      traces = new Array(nTraces);
-      for (let i = 0; i < nTraces; i++) {
-        traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
+        console.time('Decode & cache');
+        const obj = msgpack.decode(bin);
+        const int8 = new Int8Array(obj.data.buffer);
+        f32 = Float32Array.from(int8, v => v / obj.scale);
+        putCacheF32(cacheKey(key1Val, fetchedMode), f32);
+        sectionShape = obj.shape;
+        const [nTraces, nSamples] = sectionShape;
+        traces = new Array(nTraces);
+        for (let i = 0; i < nTraces; i++) {
+          traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
+        }
+        console.timeEnd('Decode & cache');
+        latestSeismicData = traces;
       }
-      console.timeEnd('Decode & cache');
-      latestSeismicData = traces;
     }
 
     console.time('Plotting');
@@ -887,11 +950,13 @@
       const xRange = savedXRange ?? [0, totalTraces - 1];
       const visibleTraces = endTrace - startTrace + 1;
       const density = visibleTraces / widthPx;
+      const mode = document.getElementById('displayMode').value;
+      const fbMode = mode === 'fbprob';
 
       let traces = [];
       const gain = parseFloat(document.getElementById('gain').value) || 1.0;
 
-      if (density < 0.1) {
+      if (!fbMode && density < 0.1) {
         downsampleFactor = 1;
         const time = new Float32Array(nSamples);
         for (let t = 0; t < nSamples; t++) {
@@ -931,17 +996,21 @@
         }
 
         const zData = Array.from({ length: nSamplesDS }, () => new Float32Array(nTracesDS));
-        // カラースケールはゲイン前の値で固定する（自己正規化を避ける）
-        let baseMin = Infinity;
-        let baseMax = -Infinity;
+        let baseMin = fbMode ? 0 : Infinity;
+        let baseMax = fbMode ? 255 : -Infinity;
         for (let i = startTrace, col = 0; col < nTracesDS; i += factor, col++) {
           const trace = seismic[i];
           for (let j = 0, row = 0; row < nSamplesDS; j += factor, row++) {
-            const raw = trace[j];
-            const val = raw * gain;
-            zData[row][col] = val;
-            if (raw < baseMin) baseMin = raw;
-            if (raw > baseMax) baseMax = raw;
+            if (fbMode) {
+              const val = trace[j] * 255;
+              zData[row][col] = val;
+            } else {
+              const raw = trace[j];
+              const val = raw * gain;
+              zData[row][col] = val;
+              if (raw < baseMin) baseMin = raw;
+              if (raw > baseMax) baseMax = raw;
+            }
           }
         }
         const xVals = new Float32Array(nTracesDS);
@@ -959,9 +1028,9 @@
           colorscale: cm,
           reversescale: reverse,
           // ゲイン前のベース範囲を使うことで、ゲイン変更が可視的なコントラスト変化になる
-          zmin: baseMin,
-          zmax: baseMax,
-          ...(isDiv ? { zmid: 0 } : {}),
+          zmin: fbMode ? 0 : baseMin,
+          zmax: fbMode ? 255 : baseMax,
+          ...(fbMode ? {} : (isDiv ? { zmid: 0 } : {})),
           showscale: false,
           hoverinfo: 'x+y',
           hovertemplate: '',
@@ -988,7 +1057,8 @@
         paper_bgcolor: '#fff',
         plot_bgcolor: '#fff',
         margin: { t: 10, r: 10, l: 60, b: 40 },
-        dragmode: isPickMode ? false : 'zoom'
+        dragmode: isPickMode ? false : 'zoom',
+        ...(fbMode ? { title: 'First-break Probability' } : {}),
       };
         layout.shapes = picks.map(p => ({
           type: 'line',

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -103,7 +103,7 @@
       <option value="RdBu">RdBu</option>
       <option value="BWR">BWR</option>
       <option value="Cividis">Cividis</option>
-      <option value="Viridis">Viridis</option>
+      <option value="Jet">Jet</option>
     </select>
     <label><input type="checkbox" id="cmReverse" onchange="onColormapChange()">reverse</label>
   </div>
@@ -171,7 +171,7 @@
       RdBu: 'RdBu',
       BWR: [[0, 'blue'], [0.5, 'white'], [1, 'red']],
       Cividis: 'Cividis',
-      Viridis: 'Viridis',
+      Jet: 'Jet',
     };
 
     (function() {

--- a/app/utils/fbpick.py
+++ b/app/utils/fbpick.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""First-break probability model wrapper."""
+
+from functools import lru_cache
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from .model import NetAE
+
+__all__ = ["_MODEL_PATH", "infer_prob_map"]
+
+_MODEL_PATH = (
+    Path(__file__).resolve().parents[2] / "model" / "fbpick_edgenext_small.pth"
+)
+
+
+def _device() -> torch.device:
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+@lru_cache(maxsize=1)
+def _load_model() -> tuple[torch.nn.Module, torch.device]:
+    device = _device()
+    model = NetAE(
+        backbone="edgenext_small.usi_in1k",
+        pretrained=False,
+        stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+        pre_stages=2,
+        pre_stage_strides=((1, 1), (1, 2)),
+    )
+    state = torch.load(_MODEL_PATH, map_location="cpu", weights_only=False)
+    if isinstance(state, dict) and "model_ema" in state:
+        state = state["model_ema"]
+    model.load_state_dict(state, strict=True)
+    model.eval().to(device)
+    return model, device
+
+
+@torch.no_grad()
+def _run_tiled(
+    model: torch.nn.Module,
+    x: torch.Tensor,
+    *,
+    tile: tuple[int, int] = (256, 256),
+    overlap: int = 32,
+    amp: bool = True,
+) -> torch.Tensor:
+    """Run ``model`` on ``x`` using sliding-window tiling."""
+    b, c, h, w = x.shape
+    tile_h, tile_w = tile
+    stride_h = tile_h - overlap
+    stride_w = tile_w - overlap
+    out = torch.zeros((b, 1, h, w), device=x.device, dtype=torch.float32)
+    weight = torch.zeros_like(out)
+    for top in range(0, h, stride_h):
+        for left in range(0, w, stride_w):
+            bottom = min(top + tile_h, h)
+            right = min(left + tile_w, w)
+            h0 = max(0, bottom - tile_h)
+            w0 = max(0, right - tile_w)
+            patch = x[:, :, h0:bottom, w0:right]
+            with torch.cuda.amp.autocast(enabled=amp and torch.cuda.is_available()):
+                yp = model(patch)
+            out[:, :, h0:bottom, w0:right] += yp
+            weight[:, :, h0:bottom, w0:right] += 1
+    out /= weight.clamp_min(1.0)
+    return out
+
+
+@torch.no_grad()
+def infer_prob_map(
+    section: np.ndarray,
+    *,
+    amp: bool = True,
+    tile: tuple[int, int] = (256, 256),
+    overlap: int = 32,
+) -> np.ndarray:
+    """Infer first-break probability for ``section``."""
+    model, device = _load_model()
+    x = torch.from_numpy(section).float().unsqueeze(0).unsqueeze(0).to(device)
+    y = _run_tiled(model, x, tile=tile, overlap=overlap, amp=amp)
+    y = torch.sigmoid(y)
+    return y.squeeze(0).squeeze(0).clamp_(0, 1).cpu().numpy().astype(np.float32)


### PR DESCRIPTION
## Summary
- add EdgeNeXt-based first-break probability model wrapper with tiled inference
- extend backend with FB pick job queue, caching, and binary payload endpoints
- expose “FB Prob” mode on the frontend with polling and heatmap rendering

## Testing
- `python -m py_compile app/utils/fbpick.py app/api/endpoints.py`
- `ruff check app/utils/fbpick.py app/api/endpoints.py` *(fails: FAST002, E501 and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b944d114cc832b9a42db34ff190be5