### PR TITLE
Make pipeline execution manual with run button

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -94,6 +94,11 @@
       background: #f7f7f7;
       font-weight: 600;
     }
+    .pipeline-header .pipeline-actions {
+      display: inline-flex;
+      gap: 0.5em;
+      align-items: center;
+    }
     .pipeline-add {
       position: relative;
       display: inline-flex;
@@ -330,11 +335,14 @@
     <aside id="pipelinePanel">
       <div class="pipeline-header">
         <span>Pipeline</span>
-        <div class="pipeline-add">
-          <button type="button" id="pipelineAddButton">+ Add Step ▾</button>
-          <div class="pipeline-add-menu" id="pipelineAddMenu">
-            <button type="button" data-step="bandpass">Bandpass</button>
-            <button type="button" data-step="denoise">Denoise</button>
+        <div class="pipeline-actions">
+          <button type="button" id="pipelineRunButton">▶ Run</button>
+          <div class="pipeline-add">
+            <button type="button" id="pipelineAddButton">+ Add Step ▾</button>
+            <div class="pipeline-add-menu" id="pipelineAddMenu">
+              <button type="button" data-step="bandpass">Bandpass</button>
+              <button type="button" data-step="denoise">Denoise</button>
+            </div>
           </div>
         </div>
       </div>
@@ -1244,13 +1252,7 @@
     const [s, e] = savedXRange ? visibleTraceIndices(savedXRange, rawSeismicData.length) : [0, rawSeismicData.length - 1];
     drawSelectedLayer(s, e);
 
-    // ---- ここで必ず runPipeline を呼ぶ（ログ付き）----
-    if (window.pipelineUI?.runPipeline) {
-        console.info('[pipeline] fetchAndPlot → runPipeline()');
-        window.pipelineUI.runPipeline();
-      } else {
-      console.warn('[pipeline] runPipeline NOT available', window.pipelineUI);
-    }
+    // Pipeline execution is now manual via the ▶ Run button.
 
     console.time('Prefetch');
     prefetchAround(index, 'raw');

--- a/app/static/pipeline_ui.js
+++ b/app/static/pipeline_ui.js
@@ -628,7 +628,6 @@
   function notifyGraphChanged(options = {}) {
     savePipelineToLocalStorage(pipelineState.graph);
     renderPipelineCards(pipelineState.graph);
-    if (options.schedule !== false) schedulePipelineRun();
   }
 
   function initPipelineUI() {
@@ -646,6 +645,11 @@
 
     renderPipelineCards(pipelineState.graph);
     savePipelineToLocalStorage(pipelineState.graph);
+
+    const runButton = document.getElementById('pipelineRunButton');
+    if (runButton) {
+      runButton.addEventListener('click', () => runPipeline());
+    }
 
     if (pipelineState.cardsContainer) {
       pipelineState.cardsContainer.addEventListener('dragover', handleDragOver);
@@ -687,8 +691,6 @@
       });
     }
 
-    // 初期表示でも 1 回は走らせる（fetchAndPlot 側で呼ばれなくても安全）
-    try { schedulePipelineRun(); } catch (_) { }
   }
 
   const schedulePipelineRun = debounce(() => runPipeline(), 300);


### PR DESCRIPTION
## Summary
- add a pipeline actions group with a manual ▶ Run button next to the existing add-step menu
- stop automatic pipeline execution on load/fetch and wire the new button to trigger runs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8cb64e000832ba261508e0fc9e6da