### PR TITLE
Add wiggle rendering for windowed seismic views

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -472,6 +472,8 @@
     const HARD_LIMIT_BYTES = 512 * 1024 * 1024;
     const WINDOW_FETCH_DEBOUNCE_MS = 120;
     const WINDOW_MAX_POINTS = 1_200_000;
+    const WIGGLE_DENSITY_THRESHOLD = 0.10;
+    const WIGGLE_MAX_POINTS = 2_500_000;
 
     const cache = new Map(); // key -> { f32: Float32Array }
     const inflight = new Map();
@@ -1125,6 +1127,13 @@
       return { step_x: stepX, step_y: stepY };
     }
 
+    function wantWiggleForWindow({ tracesVisible, samplesVisible, widthPx }) {
+      const density = tracesVisible / Math.max(1, widthPx);
+      if (density >= WIGGLE_DENSITY_THRESHOLD) return false;
+      if ((tracesVisible * samplesVisible) > WIGGLE_MAX_POINTS) return false;
+      return true;
+    }
+
     function currentVisibleWindow() {
       if (!sectionShape) return null;
       const [totalTraces, totalSamples] = sectionShape;
@@ -1468,8 +1477,134 @@
       scheduleWindowFetch();
     }
 
+    function renderWindowWiggle(windowData) {
+      if (!windowData || (windowData.mode && windowData.mode !== 'wiggle')) return;
+
+      const sel = document.getElementById('layerSelect');
+      const currentLayer = sel ? sel.value : 'raw';
+      if (windowData.requestedLayer !== currentLayer) return;
+
+      const slider = document.getElementById('key1_idx_slider');
+      const idx = slider ? parseInt(slider.value, 10) : 0;
+      const key1Val = key1Values[idx];
+      if (windowData.key1 !== key1Val) return;
+
+      if (windowData.pipelineKey && (window.latestPipelineKey || null) !== (windowData.pipelineKey || null)) {
+        return;
+      }
+
+      if (windowData.effectiveLayer === 'fbprob') return;
+
+      const plotDiv = document.getElementById('plot');
+      if (!plotDiv) return;
+
+      const { values, shape, x0, x1, y0, y1, stepX = 1, stepY = 1 } = windowData;
+      const rows = Number(shape?.[0] ?? 0);
+      const cols = Number(shape?.[1] ?? 0);
+      if (!rows || !cols) return;
+      if (values.length !== rows * cols) return;
+
+      const dt = window.defaultDt ?? defaultDt;
+      const time = new Float32Array(rows);
+      for (let r = 0; r < rows; r++) time[r] = (y0 + r * stepY) * dt;
+
+      const traces = [];
+      const gain = parseFloat(document.getElementById('gain').value) || 1.0;
+      const AMP_LIMIT = 3.0;
+
+      for (let c = 0; c < cols; c++) {
+        const baseX = new Float32Array(rows);
+        const shiftedFullX = new Float32Array(rows);
+        const shiftedPosX = new Float32Array(rows);
+        const traceIndex = x0 + c * stepX;
+        for (let r = 0; r < rows; r++) {
+          const idxVal = r * cols + c;
+          let val = values[idxVal] * gain;
+          if (val > AMP_LIMIT) val = AMP_LIMIT;
+          if (val < -AMP_LIMIT) val = -AMP_LIMIT;
+
+          baseX[r] = traceIndex;
+          shiftedFullX[r] = traceIndex + val;
+          shiftedPosX[r] = traceIndex + (val < 0 ? 0 : val);
+        }
+
+        traces.push({ type: 'scatter', mode: 'lines', x: baseX, y: time, line: { width: 0 }, hoverinfo: 'x+y', showlegend: false });
+        traces.push({ type: 'scatter', mode: 'lines', x: shiftedPosX, y: time, fill: 'tonextx', fillcolor: 'black', line: { width: 0 }, opacity: 0.6, hoverinfo: 'skip', showlegend: false });
+        traces.push({ type: 'scatter', mode: 'lines', x: shiftedFullX, y: time, line: { color: 'black', width: 0.5 }, hoverinfo: 'skip', showlegend: false });
+      }
+
+      downsampleFactor = 1;
+      const endTrace = typeof x1 === 'number' ? x1 : x0 + cols - 1;
+      renderedStart = x0;
+      renderedEnd = endTrace;
+
+      const totalTraces = sectionShape ? sectionShape[0] : endTrace - x0 + 1;
+      const totalSamples = sectionShape ? sectionShape[1] : (typeof y1 === 'number' ? y1 - y0 + 1 : rows);
+      const baseDt = dt;
+      const layout = {
+        xaxis: {
+          title: 'Trace',
+          showgrid: false,
+          tickfont: { color: '#000' },
+          titlefont: { color: '#000' },
+          autorange: !savedXRange,
+          range: savedXRange ?? [x0, endTrace],
+        },
+        yaxis: {
+          title: 'Time (s)',
+          showgrid: false,
+          tickfont: { color: '#000' },
+          titlefont: { color: '#000' },
+          autorange: false,
+          range: savedYRange ?? [totalSamples * baseDt, 0],
+        },
+        paper_bgcolor: '#fff',
+        plot_bgcolor: '#fff',
+        margin: { t: 10, r: 10, l: 60, b: 40 },
+        dragmode: isPickMode ? false : 'zoom',
+      };
+
+      const manualShapes = picks.map((p) => ({
+        type: 'line',
+        x0: p.trace - 0.4,
+        x1: p.trace + 0.4,
+        y0: p.time,
+        y1: p.time,
+        line: { color: 'red', width: 2 },
+      }));
+
+      const showPred = document.getElementById('showFbPred')?.checked;
+      const predShapes = (showPred ? predictedPicks : [])
+        .filter((p) => p.trace >= x0 && p.trace <= endTrace)
+        .map((p) => ({
+          type: 'line',
+          x0: p.trace - 0.4,
+          x1: p.trace + 0.4,
+          y0: p.time,
+          y1: p.time,
+          line: { color: '#1f77b4', width: 5, dash: 'dot' },
+        }));
+
+      layout.shapes = [...manualShapes, ...predShapes];
+
+      Plotly.react(plotDiv, traces, layout, {
+        responsive: true,
+        editable: true,
+        modeBarButtonsToAdd: ['eraseshape'],
+        edits: { shapePosition: false },
+      });
+      setTimeout(() => Plotly.Plots.resize(plotDiv), 50);
+
+      plotDiv.removeAllListeners('plotly_relayout');
+      plotDiv.removeAllListeners('plotly_click');
+      plotDiv.on('plotly_relayout', handleRelayout);
+      if (isPickMode) {
+        plotDiv.on('plotly_click', handlePlotClick);
+      }
+    }
+
     function renderWindowHeatmap(windowData) {
-      if (!windowData) return;
+      if (!windowData || (windowData.mode && windowData.mode !== 'heatmap')) return;
       const sel = document.getElementById('layerSelect');
       const currentLayer = sel ? sel.value : 'raw';
       if (windowData.requestedLayer !== currentLayer) return;
@@ -1642,7 +1777,11 @@
             return;
           }
         }
-        renderWindowHeatmap(latestWindowRender);
+        if (latestWindowRender.mode === 'wiggle') {
+          renderWindowWiggle(latestWindowRender);
+        } else {
+          renderWindowHeatmap(latestWindowRender);
+        }
       }
     }
 
@@ -1662,16 +1801,31 @@
 
       const widthPx = plotDiv.clientWidth || plotDiv.offsetWidth || 1;
       const heightPx = plotDiv.clientHeight || plotDiv.offsetHeight || 1;
-      const { step_x, step_y } = computeStepsForWindow({
+      const sel = document.getElementById('layerSelect');
+      const requestedLayer = sel ? sel.value : 'raw';
+      const isFbLayer = requestedLayer === 'fbprob';
+      const wantWiggle = !isFbLayer && wantWiggleForWindow({
         tracesVisible: windowInfo.nTraces,
         samplesVisible: windowInfo.nSamples,
         widthPx,
-        heightPx,
       });
 
-      const sel = document.getElementById('layerSelect');
-      const requestedLayer = sel ? sel.value : 'raw';
+      let step_x;
+      let step_y;
+      if (wantWiggle) {
+        step_x = 1;
+        step_y = 1;
+      } else {
+        ({ step_x, step_y } = computeStepsForWindow({
+          tracesVisible: windowInfo.nTraces,
+          samplesVisible: windowInfo.nSamples,
+          widthPx,
+          heightPx,
+        }));
+      }
+
       const pipelineKeyNow = window.latestPipelineKey || null;
+      const mode = wantWiggle ? 'wiggle' : 'heatmap';
 
       let effectiveLayer = requestedLayer;
       let tapLabel = null;
@@ -1685,10 +1839,10 @@
         effectiveLayer = 'raw';
       }
 
-      if (effectiveLayer === 'raw' && latestSeismicData && step_x === 1 && step_y === 1) {
+      if (!wantWiggle && effectiveLayer === 'raw' && latestSeismicData && step_x === 1 && step_y === 1) {
         return;
       }
-      if (tapLabel && latestTapData[requestedLayer] && step_x === 1 && step_y === 1) {
+      if (!wantWiggle && tapLabel && latestTapData[requestedLayer] && step_x === 1 && step_y === 1) {
         latestSeismicData = latestTapData[requestedLayer];
         renderLatestView(windowInfo.x0, windowInfo.x1);
         return;
@@ -1730,7 +1884,7 @@
         }
         const rows = Number(shapeRaw[0]);
         const cols = Number(shapeRaw[1]);
-        latestWindowRender = {
+        const windowPayload = {
           key1: key1Val,
           requestedLayer,
           effectiveLayer,
@@ -1743,9 +1897,15 @@
           stepY: step_y,
           shape: [rows, cols],
           values,
+          mode,
         };
         latestSeismicData = null;
-        renderWindowHeatmap(latestWindowRender);
+        latestWindowRender = windowPayload;
+        if (mode === 'wiggle') {
+          renderWindowWiggle(windowPayload);
+        } else {
+          renderWindowHeatmap(windowPayload);
+        }
       } catch (err) {
         if (requestId === windowFetchToken) console.warn('Window fetch error', err);
       }


### PR DESCRIPTION
## Summary
- add configurable thresholds and helper to decide when a window should render as wiggle traces
- implement a wiggle renderer for windowed sections with manual/predicted pick overlays
- update window fetching to pick wiggle mode, force full-resolution requests, and reuse the new renderer

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68ca143565ec832bbca6e926fd76f3e2