### PR TITLE
Add abort handling for window fetches

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -466,6 +466,7 @@
     var latestPipelineKey = null;
     var latestWindowRender = null;
     var windowFetchToken = 0;
+    var windowFetchAbort = null;
     const defaultDt = 0.002;
     const PREFETCH_WIDTH = 3;
     const FALLBACK_MAX = 8;
@@ -1892,15 +1893,21 @@
         params.set('tap_label', tapLabel);
       }
 
+      if (windowFetchAbort) {
+        try { windowFetchAbort.abort(); } catch (_) {}
+      }
+      const ac = new AbortController();
+      windowFetchAbort = ac;
       const requestId = ++windowFetchToken;
       try {
-        const res = await fetch(`/get_section_window_bin?${params.toString()}`);
+        const res = await fetch(`/get_section_window_bin?${params.toString()}`, { signal: ac.signal });
         if (!res.ok) {
           console.warn('Window fetch failed', res.status);
           return;
         }
         const bin = new Uint8Array(await res.arrayBuffer());
         if (requestId !== windowFetchToken) return;
+        if (windowFetchAbort !== ac) return;
         const obj = msgpack.decode(bin);
         const int8 = new Int8Array(obj.data.buffer);
         const values = Float32Array.from(int8, (v) => v / obj.scale);
@@ -1934,7 +1941,11 @@
           renderWindowHeatmap(windowPayload);
         }
       } catch (err) {
-        if (requestId === windowFetchToken) console.warn('Window fetch error', err);
+        if (!(err && err.name === 'AbortError')) {
+          if (requestId === windowFetchToken) console.warn('Window fetch error', err);
+        }
+      } finally {
+        if (windowFetchAbort === ac) windowFetchAbort = null;
       }
     }
 


### PR DESCRIPTION
## Summary
- add an AbortController for window fetch requests and cancel any in-flight call before a new one
- gate window updates on both the numeric token and controller instance to ignore stale responses
- suppress AbortError logging while preserving existing error handling and cleanup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca3af853c4832b97e93838329d76ee