### PR TITLE
Use metadata dt for bandpass pipeline step

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -9,22 +9,25 @@ AnalyzerName = Literal['fbpick']
 
 
 class BandpassParams(BaseModel):
-	"""Parameters for the band-pass filter."""
+        """Parameters for the band-pass filter."""
 
-	low_hz: float = Field(..., ge=0.0)
-	high_hz: float = Field(..., ge=0.0)
-	dt: float = Field(0.002, gt=0.0)
-	taper: float = Field(0.0, ge=0.0)
+        low_hz: float = Field(..., ge=0.0)
+        high_hz: float = Field(..., ge=0.0)
+        taper: float = Field(0.0, ge=0.0)
 
-	@model_validator(mode='after')
-	def _check_bounds(self) -> 'BandpassParams':
-		# フィールド制約（ge/gt）は Field で既に検証済み。
-		if self.low_hz >= self.high_hz:
-			raise ValueError('low_hz must be less than high_hz')
-		nyq = 0.5 / self.dt
-		if self.high_hz > nyq:
-			raise ValueError('high_hz must be <= Nyquist (0.5/dt)')
-		return self
+        @model_validator(mode='before')
+        @classmethod
+        def _ensure_no_dt(cls, data: Any) -> Any:
+                if isinstance(data, dict) and 'dt' in data:
+                        raise ValueError('dt is derived from the data and can no longer be specified')
+                return data
+
+        @model_validator(mode='after')
+        def _check_bounds(self) -> 'BandpassParams':
+                # フィールド制約（ge/gt）は Field で既に検証済み。
+                if self.low_hz >= self.high_hz:
+                        raise ValueError('low_hz must be less than high_hz')
+                return self
 
 
 class PipelineOp(BaseModel):

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -496,20 +496,14 @@
     }
 
     function applyServerDt(obj) {
-      try {
-        let dtSec = null;
-        if (obj && typeof obj.dt === 'number' && isFinite(obj.dt) && obj.dt > 0) dtSec = obj.dt;
-        else if (obj && typeof obj.dt_ms === 'number' && isFinite(obj.dt_ms) && obj.dt_ms > 0) dtSec = obj.dt_ms / 1000;
-        else if (obj && typeof obj.dt_us === 'number' && isFinite(obj.dt_us) && obj.dt_us > 0) dtSec = obj.dt_us / 1e6;
-
-        if (dtSec && isFinite(dtSec) && dtSec > 0) {
-          defaultDt = dtSec;
-          window.defaultDt = dtSec;
-          try { localStorage.setItem('segy.dt', String(dtSec)); } catch (_) {}
-          savedYRange = null;
-        }
-      } catch (_) {}
-    }
+      const dt = obj?.dt;
+      if (typeof dt === 'number' && isFinite(dt) && dt > 0) {
+            defaultDt = dt;
+            window.defaultDt = dt;
+            try { localStorage.setItem('segy.dt', String(dt)); } catch (_) { }
+            savedYRange = null; // y軸スケールをdtに合わせてリセット
+          }
+      }
 
     const COLORMAPS = {
       Greys: 'Greys',

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -496,14 +496,26 @@
     }
 
     function applyServerDt(obj) {
-      const dt = obj?.dt;
-      if (typeof dt === 'number' && isFinite(dt) && dt > 0) {
-            defaultDt = dt;
-            window.defaultDt = dt;
-            try { localStorage.setItem('segy.dt', String(dt)); } catch (_) { }
-            savedYRange = null; // y軸スケールをdtに合わせてリセット
-          }
+      const dtSec =
+        obj && typeof obj.dt === 'number' && isFinite(obj.dt) && obj.dt > 0
+          ? obj.dt
+          : null;
+
+      if (dtSec === null) return;
+
+      const prev =
+        typeof window.defaultDt === 'number' && isFinite(window.defaultDt)
+          ? window.defaultDt
+          : defaultDt;
+
+      // dt が実際に変わった時だけ更新＆Yレンジ初期化
+      if (!Number.isFinite(prev) || Math.abs(prev - dtSec) > 1e-12) {
+        defaultDt = dtSec;
+        window.defaultDt = dtSec;
+        try { localStorage.setItem('segy.dt', String(dtSec)); } catch (_) { }
+        savedYRange = null;
       }
+    }
 
     const COLORMAPS = {
       Greys: 'Greys',

--- a/app/static/pipeline_ui.js
+++ b/app/static/pipeline_ui.js
@@ -31,7 +31,6 @@
     bandpass: [
       { key: 'low_hz', label: 'low_hz', type: 'number', step: '0.1' },
       { key: 'high_hz', label: 'high_hz', type: 'number', step: '0.1' },
-      { key: 'dt', label: 'dt', type: 'number', step: '0.0001' },
       { key: 'taper', label: 'taper', type: 'number', step: '0.05' },
     ],
     denoise: [
@@ -68,17 +67,9 @@
     return name.charAt(0).toUpperCase() + name.slice(1);
   }
 
-  function getDtFromUI() {
-    const input = document.getElementById('dt');
-    const candidate = input ? parseFloat(input.value) : NaN;
-    if (!Number.isNaN(candidate) && isFinite(candidate) && candidate > 0) return candidate;
-    if (typeof window.defaultDt === 'number' && isFinite(window.defaultDt)) return window.defaultDt;
-    return 0.002;
-  }
-
   function defaultParamsFor(name) {
     if (name === 'bandpass') {
-      return { low_hz: 5, high_hz: 60, dt: getDtFromUI(), taper: 0.1 };
+      return { low_hz: 5, high_hz: 60, taper: 0.1 };
     }
     if (name === 'denoise') {
       return {
@@ -95,7 +86,10 @@
 
   function applyDefaultParams(name, params) {
     const base = defaultParamsFor(name);
-    const incoming = params && typeof params === 'object' ? params : {};
+    const incoming = params && typeof params === 'object' ? { ...params } : {};
+    if (name === 'bandpass') {
+      delete incoming.dt;
+    }
     return { ...base, ...incoming };
   }
 

--- a/app/utils/bandpass.py
+++ b/app/utils/bandpass.py
@@ -12,7 +12,7 @@ def bandpass_np(  # noqa: D417
 	*,
 	low_hz: float,
 	high_hz: float,
-	dt: float = 0.002,
+	dt: float,
 	taper: float = 0.0,
 ) -> np.ndarray:
 	"""Apply a zero-phase rectangular band-pass filter to ``section``.

--- a/app/utils/ops.py
+++ b/app/utils/ops.py
@@ -47,8 +47,24 @@ def op_bandpass(
     meta: dict[str, Any],
 ) -> np.ndarray:
     """Apply bandpass transform."""
-    _ = meta
-    return bandpass_np(x, **params)
+    dt = None
+    if isinstance(meta, dict):
+        dt = meta.get("dt")
+    if not isinstance(dt, (int, float)) or dt <= 0:
+        msg = "Bandpass transform requires a positive dt value in metadata"
+        raise ValueError(msg)
+
+    kwargs = dict(params or {})
+    kwargs.pop("dt", None)
+
+    high_hz = kwargs.get("high_hz")
+    if isinstance(high_hz, (int, float)):
+        nyquist = 0.5 / float(dt)
+        if high_hz > nyquist:
+            msg = f"high_hz must be <= Nyquist (0.5/dt={nyquist:g})"
+            raise ValueError(msg)
+
+    return bandpass_np(x, dt=float(dt), **kwargs)
 
 
 def op_denoise(

--- a/app/utils/segy_meta.py
+++ b/app/utils/segy_meta.py
@@ -9,65 +9,64 @@ from typing import Any
 HEADER_SAMPLE_INTERVAL_OFFSET = 3200 + 16
 SAMPLE_INTERVAL_BYTES = 2
 MICROSECONDS_PER_SECOND = 1_000_000.0
-FALLBACK_DT_SECONDS = 0.002
 
 # ファイル毎のメタ情報を保持
 FILE_REGISTRY: dict[str, dict[str, Any]] = {}
 
 
 def read_segy_dt_seconds(path: str) -> float | None:
-    """Return the SEG-Y sampling interval in seconds, if available."""
-    sample_path = Path(path)
-    try:
-        with sample_path.open("rb") as f:
-            f.seek(HEADER_SAMPLE_INTERVAL_OFFSET)
-            raw = f.read(SAMPLE_INTERVAL_BYTES)
-        if len(raw) != SAMPLE_INTERVAL_BYTES:
-            return None
-        us = int.from_bytes(raw, byteorder="big", signed=False)
-        if us <= 0:
-            return None
-        return us / MICROSECONDS_PER_SECOND
-    except Exception:  # noqa: BLE001
-        return None
+	"""Return the SEG-Y sampling interval in seconds, if available."""
+	sample_path = Path(path)
+	try:
+		with sample_path.open('rb') as f:
+			f.seek(HEADER_SAMPLE_INTERVAL_OFFSET)
+			raw = f.read(SAMPLE_INTERVAL_BYTES)
+		if len(raw) != SAMPLE_INTERVAL_BYTES:
+			return None
+		us = int.from_bytes(raw, byteorder='big', signed=False)
+		if us <= 0:
+			return None
+		return us / MICROSECONDS_PER_SECOND
+	except Exception:  # noqa: BLE001
+		return None
 
 
 def get_dt_for_file(file_id: str) -> float:
-    """Resolve the sampling interval in seconds for ``file_id``."""
-    rec = FILE_REGISTRY.get(file_id)
-    if not isinstance(rec, dict):
-        rec = {}
+	"""Resolve the sampling interval in seconds for ``file_id``."""
+	rec = FILE_REGISTRY.get(file_id)
+	if not isinstance(rec, dict):
+		rec = {}
 
-    dt_val = rec.get("dt")
-    if isinstance(dt_val, (int, float)) and dt_val > 0:
-        return float(dt_val)
+	dt_val = rec.get('dt')
+	if isinstance(dt_val, (int, float)) and dt_val > 0:
+		return float(dt_val)
 
-    # 1) 直接パスが分かっていればヘッダから読む
-    path = rec.get("path")
+	# 1) 直接パスが分かっていればヘッダから読む
+	path = rec.get('path')
 
-    # 2) trace store から meta.json を参照して復元
-    if not path:
-        store_path = rec.get("store_path")
-        if isinstance(store_path, str):
-            meta_path = Path(store_path) / "meta.json"
-            try:
-                meta = json.loads(meta_path.read_text())
-            except Exception:  # noqa: BLE001
-                meta = None
-            if isinstance(meta, dict):
-                meta_dt = meta.get("dt")
-                if isinstance(meta_dt, (int, float)) and meta_dt > 0:
-                    rec["dt"] = float(meta_dt)
-                    FILE_REGISTRY[file_id] = rec
-                    return float(meta_dt)
-                original = meta.get("original_segy_path")
-                if isinstance(original, str):
-                    path = original
-                    rec["path"] = path
+	# 2) trace store から meta.json を参照して復元
+	if not path:
+		store_path = rec.get('store_path')
+		if isinstance(store_path, str):
+			meta_path = Path(store_path) / 'meta.json'
+			try:
+				meta = json.loads(meta_path.read_text())
+			except Exception:  # noqa: BLE001
+				meta = None
+			if isinstance(meta, dict):
+				meta_dt = meta.get('dt')
+				if isinstance(meta_dt, (int, float)) and meta_dt > 0:
+					rec['dt'] = float(meta_dt)
+					FILE_REGISTRY[file_id] = rec
+					return float(meta_dt)
+				original = meta.get('original_segy_path')
+				if isinstance(original, str):
+					path = original
+					rec['path'] = path
 
-    dt = read_segy_dt_seconds(path) if path else None
-    if not dt:
-        dt = FALLBACK_DT_SECONDS
-    rec["dt"] = dt
-    FILE_REGISTRY[file_id] = rec
-    return dt
+	dt = read_segy_dt_seconds(path) if path else None
+	if not dt:
+		raise RuntimeError('dt not found')
+	rec['dt'] = dt
+	FILE_REGISTRY[file_id] = rec
+	return dt


### PR DESCRIPTION
## Summary
- derive the bandpass sampling interval from reader metadata and reject user-provided dt values
- enforce Nyquist validation inside the bandpass transform using the metadata-derived dt
- remove the dt control from the pipeline UI and sanitize stored parameters so users can no longer submit dt

## Testing
- ❌ `ruff check app` (fails due to pre-existing lint errors in `app/utils/model.py` and `app/utils/predict.py`)


------
https://chatgpt.com/codex/tasks/task_e_68e34811f46c832bb519b8429ebae70e