### PR TITLE
Add Z key zoom override while in pick mode

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -651,13 +651,15 @@
 
     let dragBase = localStorage.getItem('drag_base') || 'zoom'; // 'zoom' or 'pan'
     let dragOverride = null; // 一時上書き（'pan' を入れる）
+    let isZHeld = false;
 
     function effectiveDragMode() {
-      if (isPickMode) {
-        // ピック中でも Alt 押してる間だけ pan を許可
-        return (dragOverride === 'pan') ? 'pan' : false;
+      if (!isPickMode) {
+        return dragOverride || dragBase; // 通常時はベース or 一時上書き
       }
-      return dragOverride || dragBase; // 通常時はベース or 一時上書き
+      if (isZHeld) return 'zoom';
+      if (dragOverride === 'pan') return 'pan';
+      return false;
     }
     function applyDragMode() {
       const plotDiv = document.getElementById('plot');
@@ -666,6 +668,10 @@
       if (applyDragMode._last === dm) return; // 余計な relayout 防止
       applyDragMode._last = dm;
       Plotly.relayout(plotDiv, { dragmode: dm });
+    }
+
+    function refreshDragMode() {
+      applyDragMode();
     }
 
     // 統一キー関数（FB予測キャッシュ用）
@@ -732,6 +738,42 @@
       if (!(insideX && insideY)) scheduleWindowFetch();
     }
 
+    function isTypingTarget(el) {
+      return el && (
+        el.tagName === 'INPUT' ||
+        el.tagName === 'TEXTAREA' ||
+        el.isContentEditable
+      );
+    }
+
+    function ensureKeyHandlersOnce() {
+      if (window.__zZoomHotkeyInstalled) return;
+      window.__zZoomHotkeyInstalled = true;
+
+      window.addEventListener('keydown', (e) => {
+        if (e.repeat) return;
+        if (isTypingTarget(e.target)) return;
+        if (e.key === 'z' || e.key === 'Z') {
+          if (!isZHeld) {
+            isZHeld = true;
+            refreshDragMode();
+          }
+        }
+      }, { capture: true });
+
+      window.addEventListener('keyup', (e) => {
+        if (isTypingTarget(e.target)) return;
+        if (e.key === 'z' || e.key === 'Z') {
+          if (isZHeld) {
+            isZHeld = false;
+            refreshDragMode();
+          }
+        }
+      }, { capture: true });
+    }
+
+    ensureKeyHandlersOnce();
+
     // 入力系にフォーカスがある時は無効
     function canUseGlobalHotkey() {
       const el = document.activeElement;
@@ -749,7 +791,13 @@
     });
 
     // 取りこぼし対策
-    window.addEventListener('blur', () => setAltPan(false));
+    window.addEventListener('blur', () => {
+      setAltPan(false);
+      if (isZHeld) {
+        isZHeld = false;
+        refreshDragMode();
+      }
+    });
     document.addEventListener('visibilitychange', () => { if (document.hidden) setAltPan(false); });
     window.addEventListener('pointerup', (e) => { if (!e.altKey) setAltPan(false); });
 


### PR DESCRIPTION
## Summary
- add a temporary Z hotkey that enables Plotly zoom while picking
- ensure zoom override is ignored while typing and falls back to Alt-pan when released
- refresh the drag mode when focus changes to avoid getting stuck in zoom

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e72f6d1f7c832b87ebe8468cc5c51f