### PR TITLE
Refactor viewer grid/layout utilities into modules

### DIFF
--- a/app/static/viewer/bootstrap.js
+++ b/app/static/viewer/bootstrap.js
@@ -1,5 +1,7 @@
 // /viewer/bootstrap.js
 import { createStore } from './store.js';
+import * as GridCore from './core/grid.js';
+import { buildLayout, buildPickShapes } from './core/layout.js';
 import { initPrefs, getPref } from './settings/prefs.js';
 
 // Read initial values from existing DOM / globals
@@ -24,6 +26,22 @@ const store = createStore(initial);
 
 // Expose for debugging
 window.store = store;
+
+// ---- Expose core modules to existing global code (override safely) ----
+// Grid & coordinate helpers
+window.Grid = GridCore.Grid;
+window.setGrid = GridCore.setGrid;
+window.getPlotEnv = GridCore.getPlotEnv;
+window.dataXYFromClient = GridCore.dataXYFromClient;
+window.snapTraceFromDataX = GridCore.snapTraceFromDataX;
+window.snapTimeFromDataY = GridCore.snapTimeFromDataY;
+window.traceAtPixel = GridCore.traceAtPixel;
+window.pixelForTrace = GridCore.pixelForTrace;
+window.timeAtPixel = GridCore.timeAtPixel;
+
+// Layout helpers
+window.buildLayout = buildLayout;
+window.buildPickShapes = buildPickShapes;
 
 // Initialize preferences (applies to DOM & sets listeners)
 initPrefs({

--- a/app/static/viewer/bootstrap.js
+++ b/app/static/viewer/bootstrap.js
@@ -4,16 +4,24 @@ import * as GridCore from './core/grid.js';
 import { buildLayout, buildPickShapes } from './core/layout.js';
 import { initPrefs, getPref } from './settings/prefs.js';
 
+// ---- helpers
+const toNum = (v, d) => {
+  const x = Number(v);
+  return Number.isFinite(x) ? x : d;
+};
+const toStr = (v, d) => (v == null ? d : String(v));
+const toBool = (v) => (typeof v === 'string' ? v === 'true' : !!v);
+
 // Read initial values from existing DOM / globals
-const slider   = document.getElementById('key1_idx_slider');
+const slider = document.getElementById('key1_idx_slider');
 
 const initial = {
   fileId: document.getElementById('file_id')?.value || (window.currentFileId || ''),
   pickMode: !!window.isPickMode,
-  wiggleDensity: Number(getPref('wiggle_density')),
-  gain: Number(getPref('gain')),
-  colormap: String(getPref('colormap')),
-  cmReverse: !!getPref('cmReverse'),
+  wiggleDensity: toNum(getPref('wiggle_density'), 0.20),
+  gain: toNum(getPref('gain'), toNum(document.getElementById('gain')?.value, 1)),
+  colormap: toStr(getPref('colormap'), document.getElementById('colormap')?.value || 'Greys'),
+  cmReverse: toBool(getPref('cmReverse')),
   savedXRange: window.savedXRange || null,
   savedYRange: window.savedYRange || null,
   key1Index: Number.parseInt(slider?.value || '0', 10) || 0,
@@ -27,7 +35,10 @@ const store = createStore(initial);
 // Expose for debugging
 window.store = store;
 
-// ---- Expose core modules to existing global code (override safely) ----
+// ---- Sync global wiggle-threshold at boot (wantWiggleForWindow uses this)
+window.WIGGLE_DENSITY_THRESHOLD = store.get().wiggleDensity;
+
+// ---- Expose core modules to existing global code (override safely)
 // Grid & coordinate helpers
 window.Grid = GridCore.Grid;
 window.setGrid = GridCore.setGrid;
@@ -46,12 +57,28 @@ window.buildPickShapes = buildPickShapes;
 // Initialize preferences (applies to DOM & sets listeners)
 initPrefs({
   onChange(key, value) {
-    // Patch only the fields we mirror in store (render will be triggered below)
-    if (key === 'gain')             store.patch({ gain: Number(value) || 1 });
-    if (key === 'colormap')         store.patch({ colormap: String(value) });
-    if (key === 'cmReverse')        store.patch({ cmReverse: !!value });
-    if (key === 'wiggle_density')   store.patch({ wiggleDensity: Number(value) });
-    if (typeof window.renderLatestView === 'function') window.renderLatestView();
+    // patch store (描画は必要時のみ行う)
+    if (key === 'gain') store.patch({ gain: toNum(value, 1) });
+    if (key === 'colormap') store.patch({ colormap: toStr(value, 'Greys') });
+    if (key === 'cmReverse') store.patch({ cmReverse: toBool(value) });
+
+    if (key === 'wiggle_density') {
+      const v = toNum(value, 0.20);
+      store.patch({ wiggleDensity: v });
+      // モード判定はこのグローバルを見るので同期が必須
+      window.WIGGLE_DENSITY_THRESHOLD = v;
+      if (typeof window.scheduleWindowFetch === 'function') {
+        window.scheduleWindowFetch();
+      }
+      return; // 閾値変更では即時再描画しない（fetchに任せる）
+    }
+
+    // それ以外（gain/colormap等）は pan/zoom 中でなければ軽量再描画
+    if (!window.isRelayouting && !window.suppressRelayout) {
+      if (typeof window.renderLatestView === 'function') {
+        window.renderLatestView();
+      }
+    }
   }
 });
 
@@ -89,9 +116,18 @@ if (typeof window.handleRelayout === 'function') {
   };
 }
 
-// Whenever store changes, ask existing renderer to refresh (cheap & safe)
-store.subscribe(() => {
-  if (typeof window.renderLatestView === 'function') {
-    window.renderLatestView();
-  }
-});
+// loadSettings 後に store を実データで追従（fileId/key1Values 等）
+if (typeof window.loadSettings === 'function') {
+  const _load = window.loadSettings;
+  window.loadSettings = async function () {
+    await _load();
+    window.store.patch({
+      fileId: document.getElementById('file_id')?.value || (window.currentFileId || ''),
+      key1Values: Array.isArray(window.key1Values) ? window.key1Values : [],
+      sectionShape: window.sectionShape || null,
+      pipelineKey: window.latestPipelineKey || null,
+    });
+    // dt が変わる可能性があるので、閾値更新は不要だが、必要ならここで再フェッチ可能
+  };
+}
+store.subscribe(() => { });

--- a/app/static/viewer/core/grid.js
+++ b/app/static/viewer/core/grid.js
@@ -1,0 +1,82 @@
+// /static/viewer/core/grid.js
+// Single source of truth for coordinate/grid math and DOM<->data helpers
+
+export const Grid = {
+  x0: 0,      // leftmost trace center
+  stepX: 1,   // trace stride (1 for wiggle; step for heatmap)
+  y0: 0,      // top sample index center
+  stepY: 1,   // sample stride
+  get dt() { return (window.defaultDt ?? 0.002) || 0.002; }
+};
+
+export function setGrid({ x0, stepX, y0, stepY }) {
+  Grid.x0   = Number.isFinite(x0)   ? x0   : 0;
+  Grid.stepX= Number.isFinite(stepX) ? stepX: 1;
+  Grid.y0   = Number.isFinite(y0)   ? y0   : 0;
+  Grid.stepY= Number.isFinite(stepY) ? stepY: 1;
+}
+
+export function getPlotEnv() {
+  const gd  = document.getElementById('plot');
+  const rect= gd?.getBoundingClientRect();
+  const m   = gd?._fullLayout?._size;   // {l,t,w,h}
+  const xa  = gd?._fullLayout?.xaxis;
+  const ya  = gd?._fullLayout?.yaxis;
+  if (!gd || !rect || !m || !xa || !ya) return null;
+  return { gd, rect, m, xa, ya };
+}
+
+// Convert client pixels to data coords using Plotly axes
+export function dataXYFromClient(clientX, clientY) {
+  const env = getPlotEnv(); if (!env) return null;
+  const { rect, m, xa, ya } = env;
+  let x = Number.NaN, y = Number.NaN;
+  if (Number.isFinite(clientX)) {
+    const innerX = clientX - rect.left - m.l;
+    x = xa.p2d(innerX);
+  }
+  if (Number.isFinite(clientY)) {
+    const innerY = clientY - rect.top - m.t;
+    y = ya.p2d(innerY);
+  }
+  return { x, y };
+}
+
+// Snap helpers relative to current Grid
+export function snapTraceFromDataX(x) {
+  const k = Math.round((x - Grid.x0) / Grid.stepX);
+  return Grid.x0 + k * Grid.stepX;
+}
+export function snapTimeFromDataY(y) {
+  const idx = y / Grid.dt;
+  const k = Math.round((idx - Grid.y0) / Grid.stepY);
+  const snappedIdx = Grid.y0 + k * Grid.stepY;
+  return snappedIdx * Grid.dt;
+}
+
+// Public helpers used around the codebase
+export function traceAtPixel(clientX) {
+  const env = getPlotEnv(); if (!env) return Number.NaN;
+  const { rect, m, xa } = env;
+  const innerX = clientX - rect.left - m.l;
+  const x = xa.p2d(innerX);
+  if (!Number.isFinite(x)) return Number.NaN;
+  return snapTraceFromDataX(x);
+}
+
+export function pixelForTrace(trace) {
+  const env = getPlotEnv(); if (!env) return null;
+  const { rect, m, xa } = env;
+  const snapped = snapTraceFromDataX(trace);
+  const inner = xa.d2p(snapped);
+  return rect.left + m.l + inner; // clientX
+}
+
+export function timeAtPixel(clientY) {
+  const env = getPlotEnv(); if (!env) return Number.NaN;
+  const { rect, m, ya } = env;
+  const innerY = clientY - rect.top - m.t;
+  const y = ya.p2d(innerY);
+  if (!Number.isFinite(y)) return Number.NaN;
+  return snapTimeFromDataY(y);
+}

--- a/app/static/viewer/core/layout.js
+++ b/app/static/viewer/core/layout.js
@@ -1,0 +1,102 @@
+// /static/viewer/core/layout.js
+// Build Plotly layout objects & pick overlay shapes
+
+export function buildLayout({
+  mode,
+  x0,
+  x1,
+  y0,
+  y1,
+  stepX = 1,
+  stepY = 1,
+  totalSamples,
+  dt,
+  savedXRange,
+  savedYRange,
+  clickmode,
+  dragmode,
+  uirevision,
+  fbTitle = null,
+}) {
+  const effectiveDt = typeof dt === 'number' ? dt : 0;
+  const xaxis = {
+    title: 'Trace',
+    showgrid: false,
+    tickfont: { color: '#000' },
+    titlefont: { color: '#000' },
+  };
+  const yaxis = {
+    title: 'Time (s)',
+    showgrid: false,
+    tickfont: { color: '#000' },
+    titlefont: { color: '#000' },
+  };
+
+  if (mode === 'wiggle') {
+    const defaultXRange = [x0, x1];
+    const defaultYRange = [totalSamples * effectiveDt, 0];
+    xaxis.autorange = false;
+    xaxis.range = savedXRange ?? defaultXRange;
+    yaxis.autorange = false;
+    yaxis.range = savedYRange ?? defaultYRange;
+  } else if (mode === 'heatmap') {
+    const halfX = (stepX || 1) * 0.5;
+    const halfYSec = (stepY || 1) * effectiveDt * 0.5;
+    const defaultXRange = [x0 - halfX, x1 + halfX];
+    const defaultYRange = [(y1 * effectiveDt) + halfYSec, (y0 * effectiveDt) - halfYSec];
+    xaxis.autorange = !savedXRange;
+    xaxis.range = savedXRange ?? defaultXRange;
+    yaxis.autorange = false;
+    yaxis.range = savedYRange ?? defaultYRange;
+  }
+
+  const layout = {
+    xaxis,
+    yaxis,
+    clickmode,
+    dragmode,
+    uirevision,
+    paper_bgcolor: '#fff',
+    plot_bgcolor: '#fff',
+    margin: { t: 10, r: 10, l: 60, b: 40 },
+  };
+
+  if (fbTitle !== null) layout.title = fbTitle;
+  return layout;
+}
+
+export function buildPickShapes({
+  manualPicks,
+  predicted,
+  xMin,
+  xMax,
+  showPredicted,
+}) {
+  const manualShapes = (manualPicks || [])
+    .filter((p) => p && typeof p.trace === 'number' && p.trace >= xMin && p.trace <= xMax)
+    .map((p) => ({
+      xref: 'x',
+      yref: 'y',
+      type: 'line',
+      x0: p.trace - 0.4,
+      x1: p.trace + 0.4,
+      y0: p.time,
+      y1: p.time,
+      line: { color: 'red', width: 2 },
+    }));
+
+  const predictedShapes = (predicted || [])
+    .filter((p) => p && typeof p.trace === 'number' && p.trace >= xMin && p.trace <= xMax)
+    .map((p) => ({
+      xref: 'x',
+      yref: 'y',
+      type: 'line',
+      x0: p.trace - 0.4,
+      x1: p.trace + 0.4,
+      y0: p.time,
+      y1: p.time,
+      line: { color: '#1f77b4', width: 5, dash: 'dot' },
+    }));
+
+  return [...manualShapes, ...(showPredicted ? predictedShapes : [])];
+}


### PR DESCRIPTION
## Summary
- add core/grid module as the source of coordinate helpers used by the viewer
- add core/layout module for Plotly layout and pick shape builders
- update bootstrap to import the new modules and re-expose their APIs on window for existing scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e849c3c604832bad4922ffa3df1ea0