### PR TITLE
Add API and UI export for all key1 manual picks

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -1003,8 +1003,12 @@ async def export_manual_picks_all_npy(
                 if isinstance(traces, np.ndarray) and traces.ndim >= 2:
                         n_samples = int(traces.shape[-1])
 
-        for i, _key1_val in enumerate(key1_list):
-                row_picks = picks_by_name.list_picks(file_name, key1_idx=i, key1_byte=key1_byte)
+        for i, key1_val in enumerate(key1_list):
+                row_picks = picks_by_name.list_picks(
+                        file_name,
+                        key1_idx=key1_val,
+                        key1_byte=key1_byte,
+                )
                 if not row_picks:
                         continue
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -405,6 +405,7 @@
 
         <button id="predictFbBtn" onclick="predictFromFb()">Predict from FB</button>
         <button type="button" onclick="exportPickIndexVectorNpy()">Export pick index vector (.npy)</button>
+        <button type="button" id="export-npy-all-key1" onclick="exportManualPicksAllKey1Npy()">Export manual picks (ALL key1) (.npy)</button>
         <label for="gain">Gain:</label>
         <input type="range" id="gain" min="0.1" max="5" step="0.1" value="1" oninput="onGainChange()" />
         <span id="gain_display">1×</span>
@@ -635,6 +636,21 @@
       return out;
     }
 
+    function filenameFromContentDisposition(disposition) {
+      if (!disposition) return null;
+      const utfMatch = /filename\*=UTF-8''([^;\n]+)/i.exec(disposition);
+      if (utfMatch && utfMatch[1]) {
+        try {
+          return decodeURIComponent(utfMatch[1]);
+        } catch (err) {
+          console.warn('Failed to decode UTF-8 filename from Content-Disposition:', err);
+          return utfMatch[1];
+        }
+      }
+      const match = /filename="?([^";]+)"?/i.exec(disposition);
+      return match && match[1] ? match[1] : null;
+    }
+
     // ---- Export current section's manual picks as int32 index vector (.npy) ----
     async function exportPickIndexVectorNpy() {
       if (!sectionShape || !Array.isArray(sectionShape) || sectionShape.length < 2) {
@@ -707,7 +723,67 @@
       } catch (err) {
           console.error('Save failed:', err);
           alert('Save failed: ' + (err && err.message ? err.message : err));
+      }
+    }
+
+    async function exportManualPicksAllKey1Npy() {
+      if (!currentFileId) {
+        alert('No file selected.');
+        return;
+      }
+
+      const params = new URLSearchParams({
+        file_id: currentFileId,
+        key1_byte: String(currentKey1Byte ?? 189),
+        key2_byte: String(currentKey2Byte ?? 193),
+      });
+
+      try {
+        const res = await fetch(`/export_manual_picks_all_npy?${params.toString()}`);
+        if (!res.ok) {
+          const text = await res.text();
+          let detail = text;
+          try {
+            const data = JSON.parse(text);
+            if (data && data.detail) detail = data.detail;
+          } catch (_) {
+            // plain text response
+          }
+          throw new Error(detail || `Request failed (${res.status})`);
         }
+
+        const blob = await res.blob();
+        const bytes = new Uint8Array(await blob.arrayBuffer());
+        const disposition = res.headers.get('Content-Disposition');
+        const filename = filenameFromContentDisposition(disposition) || 'pvec_idx_all.npy';
+
+        if (window.isSecureContext && 'showSaveFilePicker' in window) {
+          const handle = await window.showSaveFilePicker({
+            suggestedName: filename,
+            types: [{ description: 'NumPy array', accept: { 'application/octet-stream': ['.npy'] } }],
+          });
+          const writable = await handle.createWritable();
+          await writable.write(bytes);
+          await writable.close();
+        } else {
+          const downloadBlob = new Blob([bytes], { type: 'application/octet-stream' });
+          const href = URL.createObjectURL(downloadBlob);
+          const a = document.createElement('a');
+          a.href = href;
+          a.download = filename;
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          setTimeout(() => URL.revokeObjectURL(href), 1000);
+          if (!window.isSecureContext) {
+            console.warn('Downloading over an insecure context (HTTP). Consider HTTPS/localhost to silence warnings.');
+          }
+        }
+      } catch (err) {
+        console.error('Export failed:', err);
+        const message = err && err.message ? err.message : String(err);
+        alert('Export failed: ' + message);
+      }
     }
 
     let suppressRelayout = false;       // ignore relayouts we cause internally

--- a/app/tests/test_export_all_key1.py
+++ b/app/tests/test_export_all_key1.py
@@ -1,0 +1,139 @@
+import io
+
+import numpy as np
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+try:
+	# app.main は `from api import endpoints` を使用するため、こちらを優先
+	import api.endpoints as ep
+except Exception:
+	import app.api.endpoints as ep  # フォールバック（環境差異対策）
+
+
+def test_export_all_key1_basic(monkeypatch):
+	"""- key1 values are arbitrary (100, 200)
+	- header says: 100→3 traces, 200→2 traces ⇒ width = 3
+	- manual picks persisted by *actual key1 value* (not zero-based index)
+	- verifies:
+	    * matrix shape == (len(key1_values), max_traces)
+	    * indices = round(time / dt)
+	    * correct rows get filled (and others stay -1)
+	    * list_picks was called with key1 values [100, 200]
+	"""
+	assert any(
+		getattr(r, 'path', '') == '/export_manual_picks_all_npy'
+		for r in app.router.routes
+	), (
+		f'route not found. routes={[getattr(r, "path", None) for r in app.router.routes]}'
+	)
+
+	class FakeReader:
+		key1_byte = 189
+
+		def get_key1_values(self):
+			return [100, 200]
+
+		def _get_header(self, byte):
+			# 5 traces total: first 3 belong to key1=100, next 2 belong to key1=200
+			return np.array([100, 100, 100, 200, 200], dtype=np.int32)
+
+		@property
+		def traces(self):
+			# provide n_samples for clamping
+			return np.zeros((5, 1000), dtype=np.float32)
+
+	# ---- monkeypatch を全部先に当てる ----
+	monkeypatch.setattr(
+		ep, 'get_reader', lambda file_id, key1_byte, key2_byte: FakeReader()
+	)
+	monkeypatch.setattr(ep, '_filename_for_file_id', lambda file_id: 'lineA.sgy')
+	monkeypatch.setattr(ep, 'get_dt_for_file', lambda file_id: 0.004)  # 4 ms
+
+	calls = []
+
+	def fake_list_picks(file_name, key1_idx, key1_byte):
+		# Ensure we are called with *actual key1 value* (100, then 200)
+		calls.append(key1_idx)
+		if key1_idx == 100:
+			return [{'trace': 0, 'time': 0.012}, {'trace': 2, 'time': 0.020}]  # -> 3, 5
+		if key1_idx == 200:
+			return [{'trace': 1, 'time': 0.0}]  # -> 0
+		return []
+
+	monkeypatch.setattr(ep.picks_by_name, 'list_picks', fake_list_picks)
+
+	# ✨ ここがキモ：isinstance チェックを通すためにシンボルを差し替える
+	monkeypatch.setattr(ep, 'TraceStoreSectionReader', FakeReader)
+	# （SegySectionReader を触る必要はないが、保険で ↓ でも可）
+	# monkeypatch.setattr(ep, 'SegySectionReader', FakeReader)
+
+	# ---- その後で TestClient を生成 ----
+	client = TestClient(app, raise_server_exceptions=False)
+
+	r = client.get(
+		'/export_manual_picks_all_npy',
+		params={'file_id': 'X', 'key1_byte': 189, 'key2_byte': 193},
+	)
+	assert r.status_code == 200
+
+	arr = np.load(io.BytesIO(r.content))
+	# width=max(3,2)=3
+	assert arr.shape == (2, 3)
+	# dt=0.004 ⇒ 0.012/0.004=3, 0.020/0.004=5, 0.0/0.004=0
+	assert arr[0].tolist() == [3, -1, 5]  # key1=100 row
+	assert arr[1].tolist() == [-1, 0, -1]  # key1=200 row
+	assert calls == [100, 200]
+
+
+def test_export_all_key1_empty_is_all_minus1(monkeypatch):
+	"""- 1つの key1 値しかないが、ピックは空
+	- 幅は header により width=2
+	- 返る行列は -1 埋め
+	"""
+	assert any(
+		getattr(r, 'path', '') == '/export_manual_picks_all_npy'
+		for r in app.router.routes
+	), (
+		f'route not found. routes={[getattr(r, "path", None) for r in app.router.routes]}'
+	)
+
+	class FakeReader:
+		key1_byte = 189
+
+		def get_key1_values(self):
+			return [10]
+
+		def _get_header(self, byte):
+			return np.array([10, 10], dtype=np.int32)  # width=2
+
+		@property
+		def traces(self):
+			return np.zeros((2, 100), dtype=np.float32)
+
+	# ---- monkeypatch を全部先に当てる ----
+	monkeypatch.setattr(
+		ep, 'get_reader', lambda file_id, key1_byte, key2_byte: FakeReader()
+	)
+	monkeypatch.setattr(ep, '_filename_for_file_id', lambda file_id: 'lineB.sgy')
+	monkeypatch.setattr(ep, 'get_dt_for_file', lambda file_id: 0.002)
+	monkeypatch.setattr(
+		ep.picks_by_name, 'list_picks', lambda file_name, key1_idx, key1_byte: []
+	)
+
+	# ✨ ここも同じく isinstance を通す
+	monkeypatch.setattr(ep, 'TraceStoreSectionReader', FakeReader)
+
+	# ---- その後で TestClient を生成 ----
+	client = TestClient(app, raise_server_exceptions=False)
+
+	r = client.get(
+		'/export_manual_picks_all_npy',
+		params={'file_id': 'Y', 'key1_byte': 189, 'key2_byte': 193},
+	)
+	assert r.status_code == 200
+
+	arr = np.load(io.BytesIO(r.content))
+	assert arr.shape == (1, 2)
+	assert arr.tolist() == [[-1, -1]]


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint that gathers manual picks across every key1 and exports them as a padded NumPy array
- return the array as a downloadable `.npy` file named for the current dataset
- expose a frontend control that calls the new endpoint and saves the download via File System Access API or anchor fallback

## Testing
- python -m compileall app/api/endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68ea1e067b18832bbb4b8dfe6c64f084