### PR TITLE
Refine key1 gather migration handling

### DIFF
--- a/app/api/routers/fbpick.py
+++ b/app/api/routers/fbpick.py
@@ -11,7 +11,6 @@ import msgpack
 import numpy as np
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import Response
-from pydantic import BaseModel
 
 from app.api._helpers import (
         OFFSET_BYTE_FIXED,
@@ -23,7 +22,7 @@ from app.api._helpers import (
         get_section_from_pipeline_tap,
         jobs,
 )
-from app.api.schemas import PipelineSpec
+from app.api.schemas import FbpickRequest, PipelineSpec
 from app.utils.fbpick import _MODEL_PATH as FBPICK_MODEL_PATH
 from app.utils.pipeline import apply_pipeline
 from app.utils.utils import (
@@ -33,20 +32,6 @@ from app.utils.utils import (
 )
 
 router = APIRouter()
-
-
-class FbpickRequest(BaseModel):
-        file_id: str
-        key1_idx: int
-        key1_byte: int = 189
-        key2_byte: int = 193
-        offset_byte: int | None = None
-        tile_h: int = 128
-        tile_w: int = 6016
-        overlap: int = 32
-        amp: bool = True
-        pipeline_key: str | None = None
-        tap_label: str | None = None
 
 
 def _run_fbpick_job(job_id: str, req: FbpickRequest) -> None:

--- a/app/api/routers/picks.py
+++ b/app/api/routers/picks.py
@@ -11,11 +11,11 @@ from pathlib import Path
 import numpy as np
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import FileResponse
-from pydantic import BaseModel
 from starlette.background import BackgroundTask
 
 from app.api._helpers import _filename_for_file_id, get_reader
 from app.api.routers.section import get_ntraces_for, get_trace_seq_for
+from app.api.schemas import PickPostModel
 from app.utils.pick_cache_file1d_mem import (
     clear_by_traceseq,
     clear_section,
@@ -26,14 +26,6 @@ from app.utils.segy_meta import get_dt_for_file
 from app.utils.utils import TraceStoreSectionReader
 
 router = APIRouter()
-
-
-class PickPostModel(BaseModel):
-    file_id: str
-    trace: int
-    time: float
-    key1_idx: int
-    key1_byte: int
 
 
 @router.get("/picks")


### PR DESCRIPTION
## Summary
- store the deprecated key1_idx usage flag on _Key1GatherRequest as a hidden Field
- fail fast when key1_idx migration cannot resolve key1_values from the registry and keep legacy keys out of model_extra
- reuse the gather helpers to normalize cached key lists without fallback behaviour

## Testing
- ruff check . *(fails: repository has pre-existing lint violations outside this change)*
- python - <<'PY' (PickPostModel instantiation) *(fails: missing dependency `pydantic` due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0e02b858c832badb44626d9a1fc73