### PR TITLE
Switch smoke routes and UI display to key1 values

### DIFF
--- a/app/api/routers/fbpick.py
+++ b/app/api/routers/fbpick.py
@@ -37,7 +37,7 @@ router = APIRouter()
 
 class FbpickRequest(BaseModel):
         file_id: str
-        key1_idx: int
+        key1_val: int
         key1_byte: int = 189
         key2_byte: int = 193
         offset_byte: int | None = None
@@ -54,7 +54,7 @@ def _run_fbpick_job(job_id: str, req: FbpickRequest) -> None:
         job['status'] = 'running'
         try:
                 forced_offset_byte = OFFSET_BYTE_FIXED if USE_FBPICK_OFFSET else None
-                key1_val = req.key1_idx
+                key1_val = req.key1_val
 
                 cache_key = job['cache_key']
                 section_override = job.pop('section_override', None)
@@ -126,7 +126,7 @@ def fbpick_section_bin(req: FbpickRequest):
 
         pipeline_key = req.pipeline_key
         tap_label = req.tap_label
-        key1_val = req.key1_idx
+        key1_val = req.key1_val
         cache_key = (
                 req.file_id,
                 key1_val,

--- a/app/api/routers/pipeline.py
+++ b/app/api/routers/pipeline.py
@@ -87,7 +87,7 @@ def _run_pipeline_all_job(job_id: str, req: PipelineAllRequest, pipe_key: str) -
 @router.post('/pipeline/section', response_model=PipelineSectionResponse)
 def pipeline_section(
         file_id: str = Query(...),
-        key1_idx: int = Query(...),
+        key1_val: int = Query(...),
         key1_byte: int = Query(189),
         key2_byte: int = Query(193),
         offset_byte: int | None = Query(None),
@@ -96,7 +96,6 @@ def pipeline_section(
         window: dict[str, int | float] | None = Body(default=None),
 ):
         reader = get_reader(file_id, key1_byte, key2_byte)
-        key1_val = key1_idx
         section = np.array(reader.get_section(key1_val), dtype=np.float32)
         trace_slice: slice | None = None
         window_hash = None
@@ -216,13 +215,12 @@ def pipeline_job_status(job_id: str) -> PipelineJobStatusResponse:
 @router.get('/pipeline/job/{job_id}/artifact', response_model=Any)
 def pipeline_job_artifact(
         job_id: str,
-        key1_idx: int = Query(...),
+        key1_val: int = Query(...),
         tap: str = Query(...),
 ):
         job = jobs.get(job_id)
         if job is None:
                 raise HTTPException(status_code=404, detail='Job ID not found')
-        key1_val = key1_idx
         base_key = (
                 job.get('file_id'),
                 key1_val,

--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -60,16 +60,6 @@ def _key1_values_array(
 	return np.asarray(vals, dtype=np.int64)
 
 
-def _key1_value_for_index(
-	reader: SegySectionReader | TraceStoreSectionReader, key1_idx: int
-) -> int:
-	vals = _key1_values_array(reader)
-	if key1_idx < 0 or key1_idx >= vals.size:
-		msg = 'key1_idx out of range'
-		raise IndexError(msg)
-	return int(vals[key1_idx])
-
-
 def get_ntraces_for(
 	file_id: str, key1_byte: int | None = None, key2_byte: int | None = None
 ) -> int:
@@ -108,46 +98,13 @@ def get_ntraces_for(
 	raise AttributeError('Unable to determine number of traces for file')
 
 
-def get_trace_seq_for(file_id: str, key1_idx: int, key1_byte: int) -> NDArray[np.int64]:
-	"""Return display-aligned trace ordering for ``key1_idx`` of ``file_id``.
-	Avoids touching FILE_REGISTRY.reader directly; always goes through get_reader (lazy-safe).
-	"""
-	# Try to pick a sensible key2_byte: use configured one if available, else default 193.
-	key2_byte = 193
-	ent = FILE_REGISTRY.get(file_id)
-	if ent is None:
-		raise KeyError(f'file_id not found: {file_id}')
-	maybe_reader = getattr(ent, 'reader', None)
-	if maybe_reader is None and isinstance(ent, dict):
-		maybe_reader = ent.get('reader')
-	if maybe_reader is not None:
-		key2_byte = int(getattr(maybe_reader, 'key2_byte', 193))
-
-	reader = get_reader(file_id, int(key1_byte), key2_byte)
-
-	key1_val = _key1_value_for_index(reader, key1_idx)
-
-	get_trace_seq = getattr(reader, 'get_trace_seq_for_section', None)
-	if callable(get_trace_seq):
-		seq = get_trace_seq(key1_val, align_to='display')
-		return np.asarray(seq, dtype=np.int64)
-
-	if isinstance(reader, TraceStoreSectionReader):
-		key1s = np.asarray(reader.get_header(reader.key1_byte), dtype=np.int64)
-		indices = np.flatnonzero(key1s == key1_val)
-		if indices.size == 0:
-			msg = f'Key1 value {key1_val} not found'
-			raise ValueError(msg)
-		key2s = np.asarray(reader.get_header(reader.key2_byte)[indices])
-		order = np.argsort(key2s, kind='stable')
-		return np.asarray(indices[order], dtype=np.int64)
-
-	msg = 'Reader cannot provide trace sequence information'
-	raise AttributeError(msg)
+def get_trace_seq_for(file_id: str, key1_val: int, key1_byte: int) -> NDArray[np.int64]:
+	"""Return display-aligned trace ordering for ``key1_val`` of ``file_id``."""
+	return get_trace_seq_for_value(file_id, key1_val, key1_byte)
 
 
 def get_trace_seq_for_value(
-        file_id: str, key1_val: int, key1_byte: int
+	file_id: str, key1_val: int, key1_byte: int
 ) -> NDArray[np.int64]:
 	"""Return display-aligned trace ordering for ``key1_val`` of ``file_id``."""
 	key2_byte = 193
@@ -202,16 +159,15 @@ def get_section(
 	file_id: str = Query(...),
 	key1_byte: int = Query(189),
 	key2_byte: int = Query(193),
-	key1_idx: int = Query(...),
+	key1_val: int = Query(...),
 ) -> JSONResponse:
-	"""Return the section for the ``key1_idx`` trace grouping."""
+	"""Return the section for the ``key1_val`` trace grouping."""
 	try:
 		reader = get_reader(file_id, key1_byte, key2_byte)
-		key1_val = _key1_value_for_index(reader, key1_idx)
 		section = reader.get_section(key1_val)
 		payload = section.tolist() if isinstance(section, np.ndarray) else section
 		return JSONResponse(content={'section': payload})
-	except IndexError as exc:
+	except ValueError as exc:
 		raise HTTPException(status_code=400, detail=str(exc)) from exc
 	except Exception as exc:
 		raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -220,15 +176,13 @@ def get_section(
 @router.get('/get_section_bin')
 def get_section_bin(
 	file_id: str = Query(...),
-	key1_idx: int = Query(...),
+	key1_val: int = Query(...),
 	key1_byte: int = Query(189),
 	key2_byte: int = Query(193),
 ) -> Response:
 	"""Return a quantized, binary section payload."""
 	try:
 		reader = get_reader(file_id, key1_byte, key2_byte)
-		key1_val = key1_idx
-		# key1_val = _key1_value_for_index(reader, key1_idx)
 		section = np.array(reader.get_section(key1_val), dtype=np.float32)
 		scale, q = quantize_float32(section)
 		obj = {
@@ -243,7 +197,7 @@ def get_section_bin(
 			media_type='application/octet-stream',
 			headers={'Content-Encoding': 'gzip'},
 		)
-	except IndexError as exc:
+	except ValueError as exc:
 		raise HTTPException(status_code=400, detail=str(exc)) from exc
 	except Exception as exc:
 		raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -252,7 +206,7 @@ def get_section_bin(
 @router.get('/get_section_window_bin')
 def get_section_window_bin(
 	file_id: str = Query(...),
-	key1_idx: int = Query(...),
+	key1_val: int = Query(...),
 	key1_byte: int = Query(189),
 	key2_byte: int = Query(193),
 	offset_byte: int | None = Query(None),
@@ -267,8 +221,6 @@ def get_section_window_bin(
 ) -> Response:
 	"""Return a quantized window of a section, optionally via a pipeline tap."""
 	forced_offset_byte = OFFSET_BYTE_FIXED if USE_FBPICK_OFFSET else offset_byte
-	key1_val = key1_idx
-
 	cache_key = (
 		file_id,
 		key1_val,
@@ -305,12 +257,11 @@ def get_section_window_bin(
 			)
 		else:
 			reader = get_reader(file_id, key1_byte, key2_byte)
-			# key1_val = _key1_value_for_index(reader, key1_idx)
 			section = np.array(reader.get_section(key1_val), dtype=np.float32)
-	except IndexError as exc:
-		raise HTTPException(status_code=400, detail=str(exc)) from exc
 	except PipelineTapNotFoundError as exc:
 		raise HTTPException(status_code=409, detail=str(exc)) from exc
+	except ValueError as exc:
+		raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 	section = np.ascontiguousarray(section, dtype=np.float32)
 	if section.ndim != EXPECTED_SECTION_NDIM:

--- a/app/static/api.js
+++ b/app/static/api.js
@@ -60,12 +60,12 @@ function normalizeTapValue(value) {
 
 async function fetchSectionWithPipeline(
   fileId,
-  key1Idx,
+  key1Val,
   spec,
   taps,
   { key1Byte = 189, key2Byte = 193 } = {}
 ) {
-  const url = `/pipeline/section?file_id=${encodeURIComponent(fileId)}&key1_idx=${key1Idx}&key1_byte=${key1Byte}&key2_byte=${key2Byte}`;
+  const url = `/pipeline/section?file_id=${encodeURIComponent(fileId)}&key1_val=${key1Val}&key1_byte=${key1Byte}&key2_byte=${key2Byte}`;
   const r = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -81,6 +81,6 @@ async function fetchSectionWithPipeline(
       console.warn('normalizeTapValue failed', name, e);
     }
   }
-  cacheSet(`${fileId}:${key1Idx}:${json.pipeline_key}`, out);
+  cacheSet(`${fileId}:${key1Val}:${json.pipeline_key}`, out);
   return { taps: out, pipelineKey: json.pipeline_key };
 }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -359,10 +359,10 @@
   <div id="mainContent">
     <div id="viewerColumn">
       <div id="controls">
-        <label for="key1_idx_slider">key1 index:</label>
+        <label for="key1_idx_slider">key1 value:</label>
         <input type="range" id="key1_idx_slider" min="0" max="10000" value="0" step="1" oninput="onKey1Input()"
           onchange="onKey1Change()" />
-        <input type="number" id="key1_idx_display" value="0" min="0" max="10000" step="1" style="width: 60px;"
+        <input type="number" id="key1_val_display" value="0" min="0" max="10000" step="1" style="width: 60px;"
           onchange="syncSliderWithInput(); fetchAndPlot()" />
         <button onclick="fetchAndPlot()">Plot</button>
         <button id="pickModeBtn" onclick="togglePickMode()">Pick Mode: OFF</button>
@@ -1317,7 +1317,7 @@
     async function fetchFbProb(key1Val, { layer = 'raw', pipelineKey = null } = {}) {
       const body = {
         file_id: currentFileId,
-        key1_idx: key1Val,
+        key1_val: key1Val,
         key1_byte: currentKey1Byte,
         key2_byte: currentKey2Byte,
         tile_h: 128,
@@ -1998,14 +1998,14 @@
 
     function updateKey1Display() {
       const slider = document.getElementById('key1_idx_slider');
-      const display = document.getElementById('key1_idx_display');
+      const display = document.getElementById('key1_val_display');
       const idx = parseInt(slider.value);
       display.value = key1Values[idx] ?? '';
     }
 
     function syncSliderWithInput() {
       const slider = document.getElementById('key1_idx_slider');
-      const display = document.getElementById('key1_idx_display');
+      const display = document.getElementById('key1_val_display');
       const val = parseInt(display.value);
       const idx = key1Values.indexOf(val);
       slider.value = idx >= 0 ? idx : 0;
@@ -2030,8 +2030,8 @@
         const data = await res.json();
         key1Values = data.values;
         setKey1SliderMax(key1Values.length - 1);
-        document.getElementById('key1_idx_display').min = key1Values[0];
-        document.getElementById('key1_idx_display').max = key1Values[key1Values.length - 1];
+        document.getElementById('key1_val_display').min = key1Values[0];
+        document.getElementById('key1_val_display').max = key1Values[key1Values.length - 1];
         document.getElementById('key1_idx_slider').value = 0;
         updateKey1Display();
       }
@@ -2055,7 +2055,7 @@
         inflight.set(rawKey, controller);
         scheduler(async () => {
           try {
-            const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
+            const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_val=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
             const res = await fetch(urlRaw, { signal: controller.signal });
             if (!res.ok) return;
             const bin = new Uint8Array(await res.arrayBuffer());
@@ -2210,7 +2210,7 @@
         rawSeismicData = traces;
       } else {
         console.time('Fetch binary');
-        const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_idx=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
+        const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_val=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
         const res = await fetch(urlRaw);
         if (!res.ok) {
           console.timeEnd('Fetch binary');
@@ -2693,7 +2693,7 @@
 
       const params = new URLSearchParams({
         file_id: currentFileId,
-        key1_idx: String(key1Val),
+        key1_val: String(key1Val),
         key1_byte: String(currentKey1Byte),
         key2_byte: String(currentKey2Byte),
         x0: String(windowInfo.x0),

--- a/app/tests/test_export_all_key1.py
+++ b/app/tests/test_export_all_key1.py
@@ -36,14 +36,14 @@ def test_export_all_key1_basic(monkeypatch):
     monkeypatch.setattr(ep, "get_dt_for_file", lambda file_id: 0.004)  # 4 ms
     monkeypatch.setattr(ep, "get_ntraces_for", lambda file_id: 5)
 
-    def fake_get_trace_seq(file_id, key1_idx, key1_byte):
-        if key1_idx == 0:
+    def fake_get_trace_seq(file_id, key1_val, key1_byte):
+        if key1_val == 100:
             return np.array([0, 1, 2], dtype=np.int64)
-        if key1_idx == 1:
+        if key1_val == 200:
             return np.array([3, 4], dtype=np.int64)
-        raise AssertionError(f"unexpected key1_idx {key1_idx}")
+        raise AssertionError(f"unexpected key1_val {key1_val}")
 
-    monkeypatch.setattr(ep, "get_trace_seq_for", fake_get_trace_seq)
+    monkeypatch.setattr(ep, "get_trace_seq_for_value", fake_get_trace_seq)
 
     calls = []
 
@@ -113,8 +113,8 @@ def test_export_all_key1_empty_is_all_minus1(monkeypatch):
     monkeypatch.setattr(ep, "get_ntraces_for", lambda file_id: 2)
     monkeypatch.setattr(
         ep,
-        "get_trace_seq_for",
-        lambda file_id, key1_idx, key1_byte: np.array([0, 1], dtype=np.int64),
+        "get_trace_seq_for_value",
+        lambda file_id, key1_val, key1_byte: np.array([0, 1], dtype=np.int64),
     )
     monkeypatch.setattr(ep, "to_pairs_for_section", lambda *args, **kwargs: [])
 

--- a/app/tests/test_picks_by_filename.py
+++ b/app/tests/test_picks_by_filename.py
@@ -12,8 +12,8 @@ def test_picks_memmap_roundtrip(monkeypatch):
     monkeypatch.setattr(picks, "get_ntraces_for", lambda fid: 20)
     monkeypatch.setattr(
         picks,
-        "get_trace_seq_for",
-        lambda fid, key1_idx, key1_byte: np.arange(0, 12, dtype=np.int64),
+        "get_trace_seq_for_value",
+        lambda fid, key1_val, key1_byte: np.arange(0, 12, dtype=np.int64),
     )
 
     store: dict[int, float] = {}
@@ -51,7 +51,7 @@ def test_picks_memmap_roundtrip(monkeypatch):
                 "file_id": file_id,
                 "trace": 10,
                 "time": 0.12,
-                "key1_idx": 0,
+                "key1_val": 0,
                 "key1_byte": 189,
             },
         )
@@ -59,7 +59,7 @@ def test_picks_memmap_roundtrip(monkeypatch):
 
         response = client.get(
             "/picks",
-            params={"file_id": file_id, "key1_idx": 0, "key1_byte": 189},
+            params={"file_id": file_id, "key1_val": 0, "key1_byte": 189},
         )
         assert response.status_code == 200
         assert response.json() == {
@@ -76,7 +76,7 @@ def test_picks_memmap_roundtrip(monkeypatch):
             params={
                 "file_id": file_id,
                 "trace": 10,
-                "key1_idx": 0,
+                "key1_val": 0,
                 "key1_byte": 189,
             },
         )
@@ -84,7 +84,7 @@ def test_picks_memmap_roundtrip(monkeypatch):
 
         response = client.get(
             "/picks",
-            params={"file_id": file_id, "key1_idx": 0, "key1_byte": 189},
+            params={"file_id": file_id, "key1_val": 0, "key1_byte": 189},
         )
         assert response.status_code == 200
         assert response.json() == {"picks": []}

--- a/app/tests/test_picks_memmap_crud.py
+++ b/app/tests/test_picks_memmap_crud.py
@@ -5,7 +5,7 @@ from app.api.routers import picks as ep
 from app.main import app
 
 
-def test_picks_are_isolated_per_key1_idx(tmp_path, monkeypatch):
+def test_picks_are_isolated_per_key1_val(tmp_path, monkeypatch):
 	# memmapの保存先を一時ディレクトリへ
 	monkeypatch.setenv('PICKS_NPY_DIR', str(tmp_path / 'picks_npy'))
 
@@ -13,62 +13,62 @@ def test_picks_are_isolated_per_key1_idx(tmp_path, monkeypatch):
 	monkeypatch.setattr(ep, '_filename_for_file_id', lambda fid: 'LineX.sgy')
 	monkeypatch.setattr(ep, 'get_ntraces_for', lambda fid: 5)
 
-	# key1_idx=0 -> sec_map=[0,1,2], key1_idx=1 -> sec_map=[3,4]
-	def fake_get_trace_seq(file_id, key1_idx, key1_byte):
-		if key1_idx == 0:
+	# key1_val=0 -> sec_map=[0,1,2], key1_val=1 -> sec_map=[3,4]
+	def fake_get_trace_seq(file_id, key1_val, key1_byte):
+		if key1_val == 0:
 			return np.array([0, 1, 2], dtype=np.int64)
-		if key1_idx == 1:
+		if key1_val == 1:
 			return np.array([3, 4], dtype=np.int64)
-		raise AssertionError(f'unexpected key1_idx {key1_idx}')
+		raise AssertionError(f'unexpected key1_val {key1_val}')
 
-	monkeypatch.setattr(ep, 'get_trace_seq_for', fake_get_trace_seq)
+	monkeypatch.setattr(ep, 'get_trace_seq_for_value', fake_get_trace_seq)
 
 	client = TestClient(app, raise_server_exceptions=False)
 
-	# key1_idx=0 のセクションにピックを1本
+	# key1_val=0 のセクションにピックを1本
 	r = client.post(
 		'/picks',
 		json={
 			'file_id': 'F',
 			'trace': 1,  # sec-local index (=> global 1)
 			'time': 1.23,
-			'key1_idx': 0,
+			'key1_val': 0,
 			'key1_byte': 189,
 		},
 	)
 	assert r.status_code == 200
 
 	# そのセクションをGET → 1本だけ
-	r = client.get('/picks', params={'file_id': 'F', 'key1_idx': 0, 'key1_byte': 189})
+	r = client.get('/picks', params={'file_id': 'F', 'key1_val': 0, 'key1_byte': 189})
 	assert r.status_code == 200
 	picks0 = r.json()['picks']
 	assert len(picks0) == 1
 	assert picks0[0]['trace'] == 1 and abs(picks0[0]['time'] - 1.23) < 1e-6
 
-	# 別セクション(key1_idx=1)は空のはず（独立性の確認）
-	r = client.get('/picks', params={'file_id': 'F', 'key1_idx': 1, 'key1_byte': 189})
+	# 別セクション(key1_val=1)は空のはず（独立性の確認）
+	r = client.get('/picks', params={'file_id': 'F', 'key1_val': 1, 'key1_byte': 189})
 	assert r.status_code == 200
 	picks1 = r.json()['picks']
 	assert picks1 == []
 
-	# key1_idx=1 にも1本追加
+	# key1_val=1 にも1本追加
 	r = client.post(
 		'/picks',
 		json={
 			'file_id': 'F',
 			'trace': 0,  # sec-local index (=> global 3)
 			'time': 2.5,
-			'key1_idx': 1,
+			'key1_val': 1,
 			'key1_byte': 189,
 		},
 	)
 	assert r.status_code == 200
 
 	# それぞれのセクションで期待通りに見えるか
-	r = client.get('/picks', params={'file_id': 'F', 'key1_idx': 1, 'key1_byte': 189})
+	r = client.get('/picks', params={'file_id': 'F', 'key1_val': 1, 'key1_byte': 189})
 	assert [p['trace'] for p in r.json()['picks']] == [0]
 
-	r = client.get('/picks', params={'file_id': 'F', 'key1_idx': 0, 'key1_byte': 189})
+	r = client.get('/picks', params={'file_id': 'F', 'key1_val': 0, 'key1_byte': 189})
 	assert [p['trace'] for p in r.json()['picks']] == [1]
 
 
@@ -77,37 +77,37 @@ def test_delete_whole_section_only_affects_that_section(tmp_path, monkeypatch):
 	monkeypatch.setattr(ep, '_filename_for_file_id', lambda fid: 'LineY.sgy')
 	monkeypatch.setattr(ep, 'get_ntraces_for', lambda fid: 5)
 
-	def fake_get_trace_seq(file_id, key1_idx, key1_byte):
+	def fake_get_trace_seq(file_id, key1_val, key1_byte):
 		return (
 			np.array([0, 1, 2], dtype=np.int64)
-			if key1_idx == 0
+			if key1_val == 0
 			else np.array([3, 4], dtype=np.int64)
 		)
 
-	monkeypatch.setattr(ep, 'get_trace_seq_for', fake_get_trace_seq)
+	monkeypatch.setattr(ep, 'get_trace_seq_for_value', fake_get_trace_seq)
 
 	client = TestClient(app, raise_server_exceptions=False)
 
 	# 両セクションにピックを投入
 	client.post(
 		'/picks',
-		json={'file_id': 'F', 'trace': 0, 'time': 1.0, 'key1_idx': 0, 'key1_byte': 189},
+		json={'file_id': 'F', 'trace': 0, 'time': 1.0, 'key1_val': 0, 'key1_byte': 189},
 	)
 	client.post(
 		'/picks',
-		json={'file_id': 'F', 'trace': 1, 'time': 2.0, 'key1_idx': 1, 'key1_byte': 189},
+		json={'file_id': 'F', 'trace': 1, 'time': 2.0, 'key1_val': 1, 'key1_byte': 189},
 	)
 
-	# key1_idx=0 を丸ごと消す（trace=None）
+	# key1_val=0 を丸ごと消す（trace=None）
 	r = client.delete(
 		'/picks',
-		params={'file_id': 'F', 'key1_idx': 0, 'key1_byte': 189},
+		params={'file_id': 'F', 'key1_val': 0, 'key1_byte': 189},
 	)
 	assert r.status_code == 200
 
 	# 0側は空に、1側は残る
-	r0 = client.get('/picks', params={'file_id': 'F', 'key1_idx': 0, 'key1_byte': 189})
-	r1 = client.get('/picks', params={'file_id': 'F', 'key1_idx': 1, 'key1_byte': 189})
+	r0 = client.get('/picks', params={'file_id': 'F', 'key1_val': 0, 'key1_byte': 189})
+	r1 = client.get('/picks', params={'file_id': 'F', 'key1_val': 1, 'key1_byte': 189})
 	assert r0.json()['picks'] == []
 	assert [p['trace'] for p in r1.json()['picks']] == [1]
 
@@ -117,13 +117,13 @@ def test_post_trace_out_of_range_returns_400(tmp_path, monkeypatch):
 	monkeypatch.setattr(ep, '_filename_for_file_id', lambda fid: 'LineZ.sgy')
 	monkeypatch.setattr(ep, 'get_ntraces_for', lambda fid: 5)
 	monkeypatch.setattr(
-		ep, 'get_trace_seq_for', lambda fid, idx, b: np.array([10, 11], dtype=np.int64)
+		ep, 'get_trace_seq_for_value', lambda fid, val, b: np.array([10, 11], dtype=np.int64)
 	)  # セクション幅2
 
 	client = TestClient(app, raise_server_exceptions=False)
 	# trace=2 はセクション幅(2)に対して範囲外 → 400
 	r = client.post(
 		'/picks',
-		json={'file_id': 'F', 'trace': 2, 'time': 0.5, 'key1_idx': 0, 'key1_byte': 189},
+		json={'file_id': 'F', 'trace': 2, 'time': 0.5, 'key1_val': 0, 'key1_byte': 189},
 	)
 	assert r.status_code == 400

--- a/scripts/smoke_routes.py
+++ b/scripts/smoke_routes.py
@@ -42,7 +42,7 @@ ROUTES: list[dict[str, object]] = [
                 'path': '/get_section',
                 'params': {
                         'file_id': 'missing',
-                        'key1_idx': 0,
+                        'key1_val': 0,
                         'key1_byte': 189,
                         'key2_byte': 193,
                 },
@@ -53,7 +53,7 @@ ROUTES: list[dict[str, object]] = [
                 'path': '/get_section_bin',
                 'params': {
                         'file_id': 'missing',
-                        'key1_idx': 0,
+                        'key1_val': 0,
                         'key1_byte': 189,
                         'key2_byte': 193,
                 },
@@ -64,7 +64,7 @@ ROUTES: list[dict[str, object]] = [
                 'path': '/get_section_window_bin',
                 'params': {
                         'file_id': 'missing',
-                        'key1_idx': 0,
+                        'key1_val': 0,
                         'key1_byte': 189,
                         'key2_byte': 193,
                         'x0': 0,
@@ -81,7 +81,7 @@ ROUTES: list[dict[str, object]] = [
                 'path': '/fbpick_section_bin',
                 'json': {
                         'file_id': 'missing',
-                        'key1_idx': 0,
+                        'key1_val': 0,
                         'key1_byte': 189,
                         'key2_byte': 193,
                         'tile_h': 128,
@@ -108,7 +108,7 @@ ROUTES: list[dict[str, object]] = [
                 'path': '/pipeline/section',
                 'params': {
                         'file_id': 'missing',
-                        'key1_idx': 0,
+                        'key1_val': 0,
                         'key1_byte': 189,
                         'key2_byte': 193,
                 },
@@ -130,7 +130,7 @@ ROUTES: list[dict[str, object]] = [
         {
                 'method': 'GET',
                 'path': '/pipeline/job/missing/artifact',
-                'params': {'key1_idx': 0, 'tap': 'fbpick'},
+                'params': {'key1_val': 0, 'tap': 'fbpick'},
                 'expected': {404},
         },
         {
@@ -140,7 +140,7 @@ ROUTES: list[dict[str, object]] = [
                         'file_id': 'missing',
                         'trace': 0,
                         'time': 0.0,
-                        'key1_idx': 0,
+                        'key1_val': 0,
                         'key1_byte': 189,
                 },
                 'expected': {200},
@@ -148,7 +148,7 @@ ROUTES: list[dict[str, object]] = [
         {
                 'method': 'GET',
                 'path': '/picks',
-                'params': {'file_id': 'missing', 'key1_idx': 0, 'key1_byte': 189},
+                'params': {'file_id': 'missing', 'key1_val': 0, 'key1_byte': 189},
                 'expected': {200},
         },
         {
@@ -163,7 +163,7 @@ ROUTES: list[dict[str, object]] = [
                 'params': {
                         'file_id': 'missing',
                         'trace': 0,
-                        'key1_idx': 0,
+                        'key1_val': 0,
                         'key1_byte': 189,
                 },
                 'expected': {200},


### PR DESCRIPTION
## Summary
- rename the viewer key1 control to use the actual header value field
- update smoke route fixtures to exercise key1_val parameters instead of key1_idx

## Testing
- python -m compileall -q app

------
https://chatgpt.com/codex/tasks/task_e_68f1ac370114832b991853bda596562b