### PR TITLE
Handle window-first rendering without known section shape

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -489,7 +489,6 @@
     const WIGGLE_MAX_POINTS = 1_000_000;
 
     const cache = new Map(); // key -> { f32: Float32Array }
-    const inflight = new Map();
     const CACHE_LIMIT = 12;
 
     const __pickOps = new Map();
@@ -1246,6 +1245,19 @@
       }
     }
 
+    async function fetchSectionMeta() {
+      const slider = document.getElementById('key1_idx_slider');
+      if (!slider) return;
+      const idx = parseInt(slider.value, 10) | 0;
+      const key1Val = key1Values[idx];
+      if (key1Val === undefined) return;
+      const r = await fetch(`/get_section_meta?file_id=${currentFileId}&key1_val=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`);
+      if (!r.ok) return;
+      const j = await r.json();
+      if (Array.isArray(j.shape) && j.shape.length === 2) sectionShape = j.shape;
+      if (typeof j.dt === 'number') applyServerDt({ dt: j.dt });
+    }
+
     const COLORMAPS = {
       Greys: 'Greys',
       RdBu: 'RdBu',
@@ -1699,6 +1711,70 @@
       return layer === 'raw' ? rawSeismicData : (latestTapData[layer] || rawSeismicData);
     }
 
+    async function fetchFineWindowFloat32({ x0, x1, y0, y1, layer = 'raw' }) {
+      const slider = document.getElementById('key1_idx_slider');
+      if (!slider) throw new Error('missing key1 slider');
+      const idx = parseInt(slider.value, 10) | 0;
+      const key1Val = key1Values[idx];
+      if (key1Val === undefined) throw new Error('invalid key1 index');
+      const q = new URLSearchParams({
+        file_id: currentFileId,
+        key1_val: String(key1Val),
+        key1_byte: String(currentKey1Byte),
+        key2_byte: String(currentKey2Byte),
+        x0: String(x0),
+        x1: String(x1),
+        y0: String(y0),
+        y1: String(y1),
+        step_x: '1',
+        step_y: '1',
+      });
+      if (layer !== 'raw' && window.latestPipelineKey) {
+        q.set('pipeline_key', window.latestPipelineKey);
+        q.set('tap_label', layer);
+      }
+      const r = await fetch(`/get_section_window_bin?${q}`);
+      if (!r.ok) throw new Error('fine window fetch failed');
+      const bin = new Uint8Array(await r.arrayBuffer());
+      const obj = msgpack.decode(bin);
+      applyServerDt(obj);
+
+      const i8 = new Int8Array(obj.data.buffer);
+      const f32 = new Float32Array(i8.length);
+      const sc = obj.scale || 1;
+      for (let i = 0; i < i8.length; i++) f32[i] = i8[i] / sc;
+
+      const shape = Array.isArray(obj.shape) ? obj.shape : Array.from(obj.shape ?? []);
+      const rows = Math.max(0, Math.floor(Number(shape[0]) || 0));
+      const cols = Math.max(0, Math.floor(Number(shape[1]) || 0));
+      return { f32, rows, cols, x0, y0, dt: (window.defaultDt ?? defaultDt) };
+    }
+
+    async function getTraceSliceFine(trace, timeSec, halfWinSec = 0.30) {
+      const dt = window.defaultDt ?? defaultDt;
+      if (!Number.isFinite(dt) || dt <= 0) {
+        return { arr: new Float32Array(0), baseY0: 0, dt: dt }; // fallback
+      }
+      const iCenter = Math.round(timeSec / dt);
+      const rad = Math.max(1, Math.round(halfWinSec / dt));
+      let y0 = Math.max(0, iCenter - rad);
+      let y1 = iCenter + rad;
+      const totalSamples = sectionShape?.[1];
+      if (Number.isFinite(totalSamples)) {
+        y1 = Math.min(y1, totalSamples - 1);
+      }
+      if (y1 < y0) y1 = y0;
+      const layer = document.getElementById('layerSelect')?.value || 'raw';
+      const { f32, rows, cols, x0 } = await fetchFineWindowFloat32({ x0: trace, x1: trace, y0, y1, layer });
+      if (rows <= 0 || cols <= 0 || f32.length === 0) {
+        return { arr: new Float32Array(0), baseY0: y0, dt };
+      }
+      const col = Math.max(0, Math.min(cols - 1, Math.round(trace - x0)));
+      const out = new Float32Array(rows);
+      for (let r = 0; r < rows; r++) out[r] = f32[r * cols + col];
+      return { arr: out, baseY0: y0, dt };
+    }
+
     // 3-point parabolic interpolation around index i (for peak/trough). Returns a float index.
     function parabolicRefine(arr, i) {
       const n = arr.length;
@@ -1736,28 +1812,47 @@
 
     // Adjust a pick's time (seconds) on a given trace to the nearest feature in ±window.
     // Uses the *original* data of the currently selected layer (raw or pipeline layer).
-    function adjustPickToFeature(trace, timeSec) {
+    async function adjustPickToFeature(trace, timeSec) {
       const mode = (document.getElementById('snap_mode')?.value) || 'none';
       if (mode === 'none') return timeSec;
 
       const refineMode = (document.getElementById('snap_refine')?.value) || 'none';
 
       const seismic = getSeismicForProcessing(); // raw or current TAP layer
-      if (!seismic || !seismic[trace]) return timeSec;
+      let arr;
+      let dt;
+      let baseY0 = 0;
+      if (seismic && seismic[trace]) {
+        dt = (window.defaultDt ?? defaultDt);
+        arr = seismic[trace];
+      } else {
+        try {
+          const fine = await getTraceSliceFine(trace, timeSec, 0.30);
+          arr = fine.arr;
+          dt = fine.dt;
+          baseY0 = Math.max(0, Math.floor(fine.baseY0 || 0));
+        } catch (err) {
+          console.warn('fine slice fetch failed', err);
+          return timeSec;
+        }
+      }
 
-      const dt = (window.defaultDt ?? defaultDt);
-      const arr = seismic[trace]; // Float32Array (one trace)
-      if (!arr || !arr.length) return timeSec;
+      if (!arr || arr.length < 3) return timeSec;
+      if (!Number.isFinite(dt) || dt <= 0) return timeSec;
 
-      const i0 = Math.round(timeSec / dt);
+      const rawIdx = Math.round(timeSec / dt) - baseY0;
+      if (!Number.isFinite(rawIdx)) return timeSec;
+      const arrLen = arr.length;
+      let i0 = Math.max(1, Math.min(arrLen - 2, rawIdx));
 
       // ±window in samples
       const ms = parseFloat(document.getElementById('snap_ms')?.value) || 4;
       const rad = Math.max(1, Math.round((ms / 1000) / dt));
 
       // keep one-sample margin for central differences
-      const lo = Math.max(1, i0 - rad);
-      const hi = Math.min(arr.length - 2, i0 + rad);
+      let lo = Math.max(1, i0 - rad);
+      let hi = Math.min(arrLen - 2, i0 + rad);
+      if (hi < lo) hi = lo;
 
       let idx = i0;
 
@@ -1818,7 +1913,7 @@
         if (refineMode === 'zc') idxFloat = zeroCrossRefine(arr, idx);
       }
 
-      return idxFloat * dt;
+      return (idxFloat + baseY0) * dt;
     }
 
     function putCacheF32(key, f32) {
@@ -2037,43 +2132,6 @@
       }
     }
 
-    function prefetchAround(centerIdx, mode) {
-      if (mode === 'fbprob') return;
-      const effectiveMode = mode === 'auto' ? 'raw' : mode;
-      if (effectiveMode !== 'raw') return;
-      for (const ctrl of inflight.values()) ctrl.abort();
-      inflight.clear();
-      const start = Math.max(0, centerIdx - cfg.PREFETCH_WIDTH);
-      const end = Math.min(key1Values.length - 1, centerIdx + cfg.PREFETCH_WIDTH);
-      const scheduler = cb => { ('requestIdleCallback' in window) ? requestIdleCallback(cb) : setTimeout(cb, 0); };
-      for (let i = start; i <= end; i++) {
-        if (i === centerIdx) continue;
-        const key1Val = key1Values[i];
-        const rawKey = cacheKey(key1Val, 'raw');
-        if (cache.has(rawKey) || inflight.has(rawKey)) continue;
-        const controller = new AbortController();
-        inflight.set(rawKey, controller);
-        scheduler(async () => {
-          try {
-            const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_val=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
-            const res = await fetch(urlRaw, { signal: controller.signal });
-            if (!res.ok) return;
-            const bin = new Uint8Array(await res.arrayBuffer());
-            const obj = msgpack.decode(bin);
-            applyServerDt(obj);
-            const int8 = new Int8Array(obj.data.buffer);
-            const f32 = Float32Array.from(int8, v => v / obj.scale);
-            putCacheF32(rawKey, f32);
-            if (!sectionShape) sectionShape = obj.shape;
-          } catch (err) {
-            if (err.name !== 'AbortError') console.warn('Prefetch failed', key1Val, err);
-          } finally {
-            inflight.delete(rawKey);
-          }
-        });
-      }
-    }
-
     async function loadSettings() {
       const params = new URLSearchParams(window.location.search);
       currentFileId = params.get('file_id') || localStorage.getItem('file_id') || '';
@@ -2192,54 +2250,15 @@
 
       await fetchPicks();
 
-      console.time('Cache lookup');
-      const hit = getCacheF32(cacheKey(key1Val, 'raw'));
-      console.timeEnd('Cache lookup');
+      if (!sectionShape) { try { await fetchSectionMeta(); } catch (_) {} }
 
-      let traces;
-      let f32 = hit ? hit.f32 : null;
-
-      if (f32) {
-        console.time('Decode from cache');
-        const [nTraces, nSamples] = sectionShape;
-        traces = new Array(nTraces);
-        for (let i = 0; i < nTraces; i++) {
-          traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
-        }
-        console.timeEnd('Decode from cache');
-        rawSeismicData = traces;
-      } else {
-        console.time('Fetch binary');
-        const urlRaw = `/get_section_bin?file_id=${currentFileId}&key1_val=${key1Val}&key1_byte=${currentKey1Byte}&key2_byte=${currentKey2Byte}`;
-        const res = await fetch(urlRaw);
-        if (!res.ok) {
-          console.timeEnd('Fetch binary');
-          alert('Failed to load section');
-          return;
-        }
-        const bin = new Uint8Array(await res.arrayBuffer());
-        console.timeEnd('Fetch binary');
-
-        console.time('Decode & cache');
-        const obj = msgpack.decode(bin);
-        applyServerDt(obj);
-        const int8 = new Int8Array(obj.data.buffer);
-        f32 = Float32Array.from(int8, (v) => v / obj.scale);
-        putCacheF32(cacheKey(key1Val, 'raw'), f32);
-        sectionShape = obj.shape;
-        const [nTraces, nSamples] = sectionShape;
-        traces = new Array(nTraces);
-        for (let i = 0; i < nTraces; i++) {
-          traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
-        }
-        console.timeEnd('Decode & cache');
-        rawSeismicData = traces;
-      }
-
+      rawSeismicData = null;
+      latestSeismicData = null;
       latestWindowRender = null;
+      forceFullExtentOnce = true;
       windowFetchToken += 1;
       uiResetNonce++;
-      if (window.pipelineUI && typeof window.pipelineUI.prepareForNewSection === 'function') {
+      if (window.pipelineUI?.prepareForNewSection) {
         window.pipelineUI.prepareForNewSection();
       } else {
         latestTapData = {};
@@ -2252,26 +2271,19 @@
         }
       }
 
-      const totalTraces = rawSeismicData ? rawSeismicData.length : (sectionShape ? sectionShape[0] : 0);
-      const [s, e] = totalTraces > 0
-        ? (savedXRange ? visibleTraceIndices(savedXRange, totalTraces) : [0, totalTraces - 1])
-        : [0, 0];
-      drawSelectedLayer(s, e);
-
-      // Pipeline execution: manual via ▶ Run button
-
-      console.time('Prefetch');
-      prefetchAround(index, 'raw');
-      console.timeEnd('Prefetch');
+      renderLatestView();
+      scheduleWindowFetch();
 
       console.timeEnd('Total fetchAndPlot');
       console.log('--- fetchAndPlot end ---');
     }
 
     function shouldPreferWindowFirst() {
-      const win = currentVisibleWindow();
       const plotDiv = document.getElementById('plot');
-      if (!win || !plotDiv) return false;
+      if (!plotDiv) return true; // 画面サイズ不明でも安全側に
+
+      // sectionShape 未確定の初回でもウィンドウ先行に倒す
+      const win = currentVisibleWindow() || { nTraces: 4096, nSamples: 2048 };
       const { step_x, step_y } = computeStepsForWindow({
         tracesVisible: win.nTraces,
         samplesVisible: win.nSamples,
@@ -2630,14 +2642,17 @@
 
     async function fetchWindowAndPlot() {
       D('WINDOW@req', { key1: key1Values?.[parseInt(document.getElementById('key1_idx_slider')?.value || '0', 10)] });
-      if (!currentFileId || !sectionShape) return;
+      if (!currentFileId) return;
       const slider = document.getElementById('key1_idx_slider');
       if (!slider) return;
       const idx = parseInt(slider.value, 10);
       const key1Val = key1Values[idx];
       if (key1Val === undefined) return;
 
-      const windowInfo = currentVisibleWindow();
+      // sectionShape が無い場合は、控えめなプローブ窓で発車して total_shape を拾う
+      const windowInfo = sectionShape
+        ? currentVisibleWindow()
+        : { x0: 0, x1: 4095, y0: 0, y1: 2047, nTraces: 4096, nSamples: 2048 };
       if (!windowInfo) return;
 
       const plotDiv = document.getElementById('plot');
@@ -2728,6 +2743,9 @@
 
         const obj = msgpack.decode(bin);
         applyServerDt(obj);
+        if (!sectionShape && obj.total_shape && obj.total_shape.length === 2) {
+          sectionShape = obj.total_shape;
+        }
 
         // Int8 のまま保持（Float32生成しない）
         const valuesI8 = new Int8Array(obj.data.buffer);
@@ -3020,7 +3038,7 @@
           for (let x = xStart; x <= xEnd; x++) {
             const y = x1 === x0 ? y1 : y0 + slope * (x - x0);
             const snapped = snapTimeFromDataY(y);
-            const tAdj = adjustPickToFeature(x, snapped);
+            const tAdj = await adjustPickToFeature(x, snapped);
 
             const idx = pickOnTrace(x);
             if (idx >= 0) {
@@ -3045,7 +3063,7 @@
           promises.push(deletePick(trInt));
           picks.splice(idx, 1);
         }
-        const tAdj = adjustPickToFeature(trInt, time);
+        const tAdj = await adjustPickToFeature(trInt, time);
         picks.push({ trace: trInt, time: tAdj });
         promises.push(postPick(trInt, tAdj));
         await Promise.all(promises);


### PR DESCRIPTION
## Summary
- allow windowed fetching to start even when the section shape has not been learned yet by falling back to a probe window
- prefer window-first rendering while section metadata is missing so the probe kicks in automatically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1ddd8a778832ba738049a9c49b0fa