### PR TITLE
Inline section trace sequence helper usage

### DIFF
--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -92,11 +92,6 @@ def get_ntraces_for(
 	raise AttributeError('Unable to determine number of traces for file')
 
 
-def get_trace_seq_for(file_id: str, key1_val: int, key1_byte: int) -> NDArray[np.int64]:
-	"""Return display-aligned trace ordering for ``key1_val`` of ``file_id``."""
-	return get_trace_seq_for_value(file_id, key1_val, key1_byte)
-
-
 def get_trace_seq_for_value(
 	file_id: str, key1_val: int, key1_byte: int
 ) -> NDArray[np.int64]:

--- a/app/tests/test_section_router_changes.py
+++ b/app/tests/test_section_router_changes.py
@@ -193,7 +193,7 @@ def test_get_trace_seq_for_with_stub_reader_matches_legacy(monkeypatch):
 
 	vals = r.get_key1_values()
 	for v in vals:
-		seq = sec.get_trace_seq_for('lineA', key1_val=int(v), key1_byte=189)
+		seq = sec.get_trace_seq_for_value('lineA', key1_val=int(v), key1_byte=189)
 		indices = np.where(r.key1s == v)[0]
 		expected = indices[np.argsort(r.key2s[indices], kind='stable')]
 		assert np.array_equal(seq, expected)
@@ -209,14 +209,14 @@ def test_get_trace_seq_for_with_tracestore_uses_public_get_header(monkeypatch):
 	monkeypatch.setattr(sec, 'get_reader', lambda fid, kb1, kb2: t, raising=True)
 
 	# unique_key1 = [7,8,9] → value=9
-	seq = sec.get_trace_seq_for('lineB', key1_val=9, key1_byte=189)
+	seq = sec.get_trace_seq_for_value('lineB', key1_val=9, key1_byte=189)
 	idx = np.where(key1s == 9)[0]
 	expected = idx[np.argsort(key2s[idx], kind='stable')]
 	assert np.array_equal(seq, expected)
 
 	# also verify missing value raises ValueError
 	with pytest.raises(ValueError):
-		sec.get_trace_seq_for('lineB', key1_val=999, key1_byte=189)
+		sec.get_trace_seq_for_value('lineB', key1_val=999, key1_byte=189)
 
 
 def test_get_section_returns_json_for_value(monkeypatch):


### PR DESCRIPTION
## Summary
- remove the redundant `get_trace_seq_for` wrapper from the section router so internal callers use `get_trace_seq_for_value`
- update section router tests to reference `get_trace_seq_for_value` directly

## Testing
- pytest app/tests *(fails: missing optional dependencies such as httpx and msgpack in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f631e44074832b850a9cbe0b42028e