### PR TITLE
Refactor float32 scaling logic in routers

### DIFF
--- a/app/api/routers/pipeline.py
+++ b/app/api/routers/pipeline.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Body, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from app.api._helpers import (
+	coerce_section_f32,
 	OFFSET_BYTE_FIXED,
 	USE_FBPICK_OFFSET,
 	_maybe_attach_fbpick_offsets,
@@ -52,17 +53,7 @@ def _run_pipeline_all_job(job_id: str, req: PipelineAllRequest, pipe_key: str) -
 		taps = req.taps
 		for idx, key1_val in enumerate(key1_vals):
 			view = reader.get_section(int(key1_val))
-			section = (
-				view.arr.astype(np.float32, copy=False)
-				if view.arr.dtype != np.float32
-				else view.arr
-			)
-			if view.scale is not None:
-				if not section.flags.writeable:
-					section = section.copy()
-				section = section.astype(np.float32, copy=False)
-				section *= float(view.scale)
-			section = np.ascontiguousarray(section, dtype=np.float32)
+			section = coerce_section_f32(view.arr, view.scale)
 
 			dt = 0.002
 			if hasattr(reader, 'meta'):
@@ -117,17 +108,7 @@ def pipeline_section(
 ):
 	reader = get_reader(file_id, key1_byte, key2_byte)
 	view = reader.get_section(key1_val)
-	section = (
-		view.arr.astype(np.float32, copy=False)
-		if view.arr.dtype != np.float32
-		else view.arr
-	)
-	if view.scale is not None:
-		if not section.flags.writeable:
-			section = section.copy()
-		section = section.astype(np.float32, copy=False)
-		section *= float(view.scale)
-	section = np.ascontiguousarray(section, dtype=np.float32)
+	section = coerce_section_f32(view.arr, view.scale)
 
 	trace_slice: slice | None = None
 	window_hash = None

--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -18,6 +18,7 @@ else:  # pragma: no cover - runtime alias for type checkers
 	NDArray = np.ndarray
 
 from app.api._helpers import (
+	coerce_section_f32,
 	EXPECTED_SECTION_NDIM,
 	OFFSET_BYTE_FIXED,
 	USE_FBPICK_OFFSET,
@@ -40,18 +41,6 @@ class SectionMeta(BaseModel):
 	dt: float
 	dtype: str | None = None
 	scale: float | None = None
-
-
-def _ensure_float32(sub: np.ndarray, *, scale: float | None) -> np.ndarray:
-	"""Return ``sub`` as float32, applying ``scale`` when provided."""
-	arr = sub.astype(np.float32, copy=False) if sub.dtype != np.float32 else sub
-	if scale is not None:
-		if arr.dtype != np.float32:
-			arr = arr.astype(np.float32, copy=False)
-		if not arr.flags.writeable:
-			arr = arr.copy()
-		arr *= float(scale)
-	return arr
 
 
 def get_ntraces_for(
@@ -248,7 +237,7 @@ def get_section_bin(
 		base = view.arr
 		if base.ndim != EXPECTED_SECTION_NDIM:
 			raise HTTPException(status_code=500, detail='Section data must be 2D')
-		prepared = _ensure_float32(base, scale=view.scale)
+		prepared = coerce_section_f32(base, view.scale)
 		scale_val, q = quantize_float32(prepared)
 		obj = {
 			'scale': scale_val,
@@ -347,7 +336,7 @@ def get_section_window_bin(
 	if sub.size == 0:
 		raise HTTPException(status_code=400, detail='Requested window is empty')
 
-	prepared = _ensure_float32(sub, scale=section_view.scale)
+	prepared = coerce_section_f32(sub, section_view.scale)
 	window_view = np.ascontiguousarray(prepared.T, dtype=np.float32)
 	scale_val, q = quantize_float32(window_view)
 	obj: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- add a shared helper to coerce section arrays to contiguous float32 with optional scaling
- replace duplicated float32 conversion logic in section, pipeline, and fbpick routers
- remove obsolete router-specific helpers now covered by the shared implementation

## Testing
- python -m compileall -q app
- ruff format --check app/api/_helpers.py app/api/routers/section.py app/api/routers/fbpick.py app/api/routers/pipeline.py
- ruff check app/api/_helpers.py app/api/routers/section.py app/api/routers/fbpick.py app/api/routers/pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68f6cea73e24832ba3e4ceab374accc9