### PR TITLE
Add server-side FB pick endpoint and remove probability map transfer

### DIFF
--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -5,6 +5,7 @@ tqdm
 segyio
 numba
 fastapi
+httpx
 uvicorn[standard]
 python-multipart
 omegaconf==2.3.0

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -28,6 +28,7 @@ from app.api._helpers import (
 	window_section_cache,
 )
 from app.api.routers import (
+	fbpick_predict_router,
 	fbpick_router,
 	picks_router,
 	pipeline_router,
@@ -50,6 +51,7 @@ router = APIRouter()
 router.include_router(upload_router)
 router.include_router(section_router)
 router.include_router(fbpick_router)
+router.include_router(fbpick_predict_router)
 router.include_router(pipeline_router)
 router.include_router(picks_router)
 
@@ -65,6 +67,7 @@ __all__ = [
 	'_update_file_registry',
 	'cached_readers',
 	'fbpick_cache',
+	'fbpick_predict_router',
 	'get_raw_section',
 	'get_reader',
 	'get_section_from_pipeline_tap',

--- a/app/api/routers/__init__.py
+++ b/app/api/routers/__init__.py
@@ -1,6 +1,7 @@
 """Router exports for FastAPI endpoints."""
 
 from app.api.routers.fbpick import router as fbpick_router
+from app.api.routers.fbpick_predict import router as fbpick_predict_router
 from app.api.routers.picks import router as picks_router
 from app.api.routers.pipeline import router as pipeline_router
 from app.api.routers.section import router as section_router
@@ -8,6 +9,7 @@ from app.api.routers.upload import router as upload_router
 
 __all__ = [
 	'fbpick_router',
+	'fbpick_predict_router',
 	'picks_router',
 	'pipeline_router',
 	'section_router',

--- a/app/api/routers/fbpick_predict.py
+++ b/app/api/routers/fbpick_predict.py
@@ -1,0 +1,288 @@
+"""Server-side FB picking endpoint returning pick positions."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.api._helpers import (
+	OFFSET_BYTE_FIXED,
+	USE_FBPICK_OFFSET,
+	PipelineTapNotFoundError,
+	_maybe_attach_fbpick_offsets,
+	coerce_section_f32,
+	get_reader,
+	get_section_and_meta_from_pipeline_tap,
+)
+from app.api.schemas import PipelineSpec
+from app.utils.fbpick import _MODEL_PATH as FBPICK_MODEL_PATH
+from app.utils.pipeline import apply_pipeline
+from app.utils.segy_meta import get_dt_for_file
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_CHUNK_SIZE = 4096
+_DEFAULT_TILE = (128, 6016)
+_DEFAULT_OVERLAP = 32
+_DEFAULT_AMP = True
+
+
+@dataclass
+class _LastProbabilityState:
+	key: tuple | None = None
+	value: np.ndarray | None = None
+	dt: float | None = None
+	source: str | None = None
+
+
+_last_prob_state = _LastProbabilityState()
+
+
+class FbpickPredictRequest(BaseModel):
+	file_id: str
+	key1_val: int
+	key1_byte: int = 189
+	key2_byte: int = 193
+	pipeline_key: str | None = None
+	tap_label: str | None = None
+	method: Literal['argmax', 'expectation'] = 'argmax'
+	sigma_ms_max: float = Field(
+		gt=0, description='Standard deviation gate in milliseconds'
+	)
+
+
+def _model_version() -> str:
+	path = Path(FBPICK_MODEL_PATH)
+	if not path.exists():
+		return 'missing'
+	try:
+		stat = path.stat()
+	except OSError:
+		return path.name
+	return f'{path.name}:{stat.st_mtime_ns}'
+
+
+@dataclass
+class _ProbabilityPayload:
+	prob: np.ndarray
+	dt: float
+	source: str
+
+
+def _resolve_dt(file_id: str, meta: dict[str, Any] | None) -> float:
+	dt_file = float(get_dt_for_file(file_id))
+	dt = dt_file
+	if isinstance(meta, dict) and 'dt' in meta:
+		dt_meta = meta.get('dt')
+		if not isinstance(dt_meta, (int, float)):
+			raise HTTPException(status_code=422, detail='Invalid dt metadata')
+		if dt_meta <= 0:
+			raise HTTPException(status_code=422, detail='Non-positive dt metadata')
+		dt_meta_f = float(dt_meta)
+		if abs(dt_meta_f - dt_file) > 1e-9:
+			raise HTTPException(
+				status_code=409, detail='dt mismatch between tap and source'
+			)
+		dt = dt_meta_f
+	if dt <= 0:
+		raise HTTPException(status_code=422, detail='Non-positive dt value')
+	return float(dt)
+
+
+def _compute_probability_map(req: FbpickPredictRequest) -> _ProbabilityPayload:
+	if not Path(FBPICK_MODEL_PATH).exists():
+		raise HTTPException(status_code=409, detail='FB pick model weights not found')
+
+	pipeline_key = req.pipeline_key
+	tap_label = req.tap_label
+	if (pipeline_key is None) ^ (tap_label is None):
+		raise HTTPException(
+			status_code=422,
+			detail='pipeline_key and tap_label must be provided together',
+		)
+
+	forced_offset_byte = OFFSET_BYTE_FIXED if USE_FBPICK_OFFSET else None
+	reader = get_reader(req.file_id, req.key1_byte, req.key2_byte)
+
+	meta_source = getattr(reader, 'meta', None)
+	dt = _resolve_dt(
+		req.file_id, meta_source if isinstance(meta_source, dict) else None
+	)
+
+	if pipeline_key and tap_label:
+		try:
+			section, tap_meta = get_section_and_meta_from_pipeline_tap(
+				file_id=req.file_id,
+				key1_val=req.key1_val,
+				key1_byte=req.key1_byte,
+				pipeline_key=pipeline_key,
+				tap_label=tap_label,
+				offset_byte=forced_offset_byte if USE_FBPICK_OFFSET else None,
+			)
+		except PipelineTapNotFoundError as exc:
+			raise HTTPException(status_code=404, detail=str(exc)) from exc
+		meta_for_dt = tap_meta if isinstance(tap_meta, dict) else None
+		dt = _resolve_dt(req.file_id, meta_for_dt)
+		source = f'pipeline:{tap_label}'
+	else:
+		view = reader.get_section(req.key1_val)
+		section = coerce_section_f32(view.arr, view.scale)
+		source = 'raw'
+
+	section = np.ascontiguousarray(section, dtype=np.float32)
+	if section.ndim != 2:
+		raise HTTPException(status_code=422, detail='Section must be 2D')
+
+	spec = PipelineSpec(
+		steps=[
+			{
+				'kind': 'analyzer',
+				'name': 'fbpick',
+				'params': {
+					'tile': _DEFAULT_TILE,
+					'overlap': _DEFAULT_OVERLAP,
+					'amp': _DEFAULT_AMP,
+				},
+			}
+		]
+	)
+
+	meta: dict[str, Any] = {}
+	if reader is not None:
+		meta = _maybe_attach_fbpick_offsets(
+			meta,
+			spec=spec,
+			reader=reader,
+			key1_val=req.key1_val,
+			offset_byte=forced_offset_byte if USE_FBPICK_OFFSET else None,
+		)
+
+	out = apply_pipeline(section, spec=spec, meta=meta, taps=None)
+	fbpick_out = out.get('fbpick') or out.get('final')
+	if not isinstance(fbpick_out, dict):
+		raise HTTPException(status_code=500, detail='fbpick analyzer output missing')
+	prob = np.asarray(fbpick_out.get('prob'), dtype=np.float32)
+	if prob.ndim != 2:
+		raise HTTPException(status_code=422, detail='Probability map must be 2D')
+
+	return _ProbabilityPayload(prob=prob, dt=dt, source=source)
+
+
+def _load_probability_map(req: FbpickPredictRequest) -> _ProbabilityPayload:
+	key = (req.file_id, req.key1_val, req.pipeline_key, req.tap_label, _model_version())
+	if _last_prob_state.key == key and _last_prob_state.value is not None:
+		return _ProbabilityPayload(
+			prob=_last_prob_state.value,
+			dt=float(_last_prob_state.dt),
+			source=_last_prob_state.source or 'unknown',
+		)
+	payload = _compute_probability_map(req)
+	_last_prob_state.key = key
+	_last_prob_state.value = payload.prob
+	_last_prob_state.dt = payload.dt
+	_last_prob_state.source = payload.source
+	return payload
+
+
+def _chunked_expectations(
+	prob: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+	n_traces, n_samples = prob.shape
+	indices = np.arange(n_samples, dtype=np.float64)
+	indices_sq = indices * indices
+	sums = np.empty(n_traces, dtype=np.float64)
+	sum_i = np.empty(n_traces, dtype=np.float64)
+	sum_i2 = np.empty(n_traces, dtype=np.float64)
+	for start in range(0, n_traces, _CHUNK_SIZE):
+		end = min(start + _CHUNK_SIZE, n_traces)
+		chunk = prob[start:end]
+		if not np.all(np.isfinite(chunk)):
+			raise HTTPException(
+				status_code=422, detail='Probability map contains NaN or Inf'
+			)
+		sums[start:end] = np.sum(chunk, axis=1, dtype=np.float64)
+		sum_i[start:end] = np.einsum(
+			'ij,j->i', chunk, indices, dtype=np.float64, optimize=True
+		)
+		sum_i2[start:end] = np.einsum(
+			'ij,j->i', chunk, indices_sq, dtype=np.float64, optimize=True
+		)
+	return sums, sum_i, sum_i2
+
+
+def _compute_picks(
+	prob: np.ndarray,
+	dt: float,
+	method: str,
+	sigma_ms_max: float,
+) -> tuple[list[dict[str, float]], float]:
+	if prob.ndim != 2:
+		raise HTTPException(status_code=422, detail='Probability map must be 2D')
+	n_traces, n_samples = prob.shape
+	if n_traces == 0 or n_samples == 0:
+		return [], 0.0
+	method_norm = method.lower()
+	if method_norm not in {'argmax', 'expectation'}:
+		raise HTTPException(status_code=422, detail='Unsupported method')
+	sums, sum_i, sum_i2 = _chunked_expectations(prob)
+	if not np.all(np.isfinite(sums)):
+		raise HTTPException(status_code=422, detail='Probability sum invalid')
+	if np.any(sums <= 0):
+		raise HTTPException(
+			status_code=422, detail='Probability mass is zero for a trace'
+		)
+	mu = sum_i / sums
+	second_moment = sum_i2 / sums
+	var = np.maximum(second_moment - mu * mu, 0.0)
+	if not np.all(np.isfinite(mu)) or not np.all(np.isfinite(var)):
+		raise HTTPException(status_code=422, detail='Expectation calculation failed')
+	sigma = np.sqrt(var)
+	dt_ms = dt * 1000.0
+	sigma_ms = sigma * dt_ms
+	mask = sigma_ms <= sigma_ms_max
+	accepted = int(np.count_nonzero(mask))
+	if method_norm == 'expectation':
+		idx = mu
+	else:
+		idx = np.empty(n_traces, dtype=np.float64)
+		for start in range(0, n_traces, _CHUNK_SIZE):
+			end = min(start + _CHUNK_SIZE, n_traces)
+			chunk = prob[start:end]
+			idx[start:end] = np.argmax(chunk, axis=1, keepdims=False)
+	times = idx * dt
+	picks: list[dict[str, float]] = []
+	for trace_idx, keep in enumerate(mask):
+		if keep:
+			picks.append({'trace': int(trace_idx), 'time': float(times[trace_idx])})
+	accepted_ratio = accepted / n_traces if n_traces else 0.0
+	return picks, accepted_ratio
+
+
+@router.post('/fbpick_predict')
+def fbpick_predict(req: FbpickPredictRequest) -> dict[str, Any]:
+	payload = _load_probability_map(req)
+	picks, accepted_ratio = _compute_picks(
+		payload.prob,
+		payload.dt,
+		req.method,
+		req.sigma_ms_max,
+	)
+	logger.info(
+		'fbpick_predict file_id=%s key1=%d method=%s sigma_ms_max=%.2f dt=%.6f accepted_ratio=%.3f source=%s',
+		req.file_id,
+		req.key1_val,
+		req.method,
+		req.sigma_ms_max,
+		payload.dt,
+		accepted_ratio,
+		payload.source,
+	)
+	return {'dt': payload.dt, 'picks': picks}

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.api.routers import (
+	fbpick_predict_router,
 	fbpick_router,
 	picks_router,
 	pipeline_router,
@@ -30,6 +31,7 @@ app.mount(
 app.include_router(upload_router)
 app.include_router(section_router)
 app.include_router(fbpick_router)
+app.include_router(fbpick_predict_router)
 app.include_router(pipeline_router)
 app.include_router(picks_router)
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -818,7 +818,6 @@
     var picks = [];
     var predictedPicks = [];
     const fbPredCache = new Map(); // key: "key1|layer|pipelineKey"
-    var latestFbProbTraces = null;
     var currentFbKey = null;
     var fbPredReqId = 0;
     var downsampleFactor = 1;
@@ -1333,106 +1332,12 @@
     })();
 
     // ★★★ FB確率取得：レイヤ/パイプライン対応（既存のジョブAPIを使用）
-    async function fetchFbProb(key1Val, { layer = 'raw', pipelineKey = null } = {}) {
-      const body = {
-        file_id: currentFileId,
-        key1_val: key1Val,
-        key1_byte: currentKey1Byte,
-        key2_byte: currentKey2Byte,
-        tile_h: 128,
-        tile_w: 6016,
-        overlap: 32,
-        amp: true,
-      };
-      // パイプラインの特定レイヤで推論したい場合
-      if (layer && layer !== 'raw' && pipelineKey) {
-        body.pipeline_key = pipelineKey;
-        body.tap_label = layer;
-      }
-      const res = await fetch('/fbpick_section_bin', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        let message = `fbpick job failed (${res.status})`;
-        try {
-          const text = await res.text();
-          if (text) {
-            try {
-              const parsed = JSON.parse(text);
-              if (parsed && typeof parsed.detail === 'string') {
-                message = parsed.detail;
-              } else {
-                message = text;
-              }
-            } catch (parseErr) {
-              message = text;
-            }
-          }
-        } catch (readErr) {
-          // ignore body read errors
-        }
-        throw new Error(message);
-      }
-      const { job_id } = await res.json();
-
-      // ポーリング
-      while (true) {
-        const st = await fetch(`/fbpick_job_status?job_id=${job_id}`);
-        const js = await st.json();
-        if (js.status === 'done') break;
-        if (js.status === 'error') throw new Error(js.message || 'fbpick failed');
-        await new Promise(r => setTimeout(r, 1000));
-      }
-
-      // 取得 & 復号
-      const binRes = await fetch(`/get_fbpick_section_bin?job_id=${job_id}`);
-      if (!binRes.ok) throw new Error('fbpick result fetch failed');
-      const bin = new Uint8Array(await binRes.arrayBuffer());
-      const obj = msgpack.decode(bin);
-      const int8 = new Int8Array(obj.data.buffer);
-      const f32 = Float32Array.from(int8, v => v / obj.scale);
-      return { f32, shape: obj.shape };
-    }
-
-    // prob2d: Array(H) of Float32Array(W); each row sums to ~1
-    function picksFromProb(prob2d, dt, sigmaMaxMs = 20, method = 'argmax') {
-      const H = prob2d.length;
-      const W = prob2d[0].length;
-      const picks = new Array(H).fill(-1);
-      const dt_ms = dt * 1000;
-      const eps = 1e-12;
-
-      const t = new Float32Array(W);
-      for (let i = 0; i < W; i++) t[i] = i;
-
-      for (let h = 0; h < H; h++) {
-        const p = prob2d[h];
-        let s = 0.0;
-        for (let i = 0; i < W; i++) s += p[i];
-        if (!(s > eps) || !isFinite(s)) continue;
-        const invs = 1.0 / s;
-        let mu = 0.0;
-        for (let i = 0; i < W; i++) mu += p[i] * t[i];
-        mu *= invs;
-        let v = 0.0;
-        for (let i = 0; i < W; i++) {
-          const d = t[i] - mu;
-          v += p[i] * d * d;
-        }
-        v *= invs;
-        const sigma_ms = Math.sqrt(Math.max(v, 0)) * dt_ms;
-        if (sigma_ms > sigmaMaxMs) continue;
-        if (method === 'expectation') {
-          picks[h] = Math.round(mu);
-        } else {
-          let imax = 0, vmax = -Infinity;
-          for (let i = 0; i < W; i++) if (p[i] > vmax) { vmax = p[i]; imax = i; }
-          picks[h] = imax;
-        }
-      }
-      return picks;
+    function getCachedFbEntry(cacheKey, method, sigmaMsMax) {
+      const entry = fbPredCache.get(cacheKey);
+      if (!entry) return null;
+      if (entry.method !== method) return null;
+      if (Math.abs(entry.sigma_ms_max - sigmaMsMax) > 1e-9) return null;
+      return entry;
     }
 
     function installUnifiedClickRouter(plotDiv) {
@@ -1526,42 +1431,26 @@
       installUnifiedClickRouter(plotDiv);
     }
 
-    function computePicks(prob2d) {
-      const sigmaMax = Number(document.getElementById('sigma_ms_max').value) || 20;
-      const method = document.getElementById('pick_method').value;
-      const dt = (window.defaultDt ?? defaultDt);
-      const idxs = picksFromProb(prob2d, dt, sigmaMax, method);
-      const out = [];
-      for (let h = 0; h < idxs.length; h++) {
-        const idx = idxs[h];
-        if (idx >= 0) out.push({ trace: h, time: idx * dt });
-      }
-      return out;
-    }
-
     function recomputeFbPicks() {
-      if (!latestFbProbTraces) return;
-
-      const idx0 = parseInt(document.getElementById('key1_idx_slider').value, 10);
+      const slider = document.getElementById('key1_idx_slider');
+      if (!slider) return;
+      const idx0 = parseInt(slider.value, 10);
       const keyAtNow = key1Values[idx0];
       const layerNow = (document.getElementById('layerSelect')?.value) || 'raw';
       const pKeyNow = window.latestPipelineKey || null;
-
-      // 現在のセクション＆レイヤ＆パイプラインキーに紐づく確率以外は再計算しない
-      if (currentFbKey !== keyAtNow ||
-        currentFbLayer !== layerNow ||
-        currentFbPipelineKey !== pKeyNow) {
+      const method = document.getElementById('pick_method').value;
+      const sigma = Number(document.getElementById('sigma_ms_max').value) || 20;
+      const cacheKeyStr = fbCacheKey(currentFileId, keyAtNow, layerNow, pKeyNow);
+      const cached = getCachedFbEntry(cacheKeyStr, method, sigma);
+      if (cached) {
+        predictedPicks = (cached.picks || []).slice();
+        currentFbKey = keyAtNow;
+        currentFbLayer = layerNow;
+        currentFbPipelineKey = pKeyNow;
+        renderLatestView();
         return;
       }
-
-      const picksNow = computePicks(latestFbProbTraces);
-      predictedPicks = picksNow;
-      fbPredCache.set(
-        fbCacheKey(currentFileId, currentFbKey, currentFbLayer, currentFbPipelineKey),
-        picksNow,
-      );
-
-      renderLatestView();
+      predictFromFb();
     }
 
     function onSigmaChange() {
@@ -1574,39 +1463,74 @@
     }
 
     async function predictFromFb() {
-      // Snapshot
       const idx0 = parseInt(document.getElementById('key1_idx_slider').value, 10);
       const keyAtStart = key1Values[idx0];
       const layerAtStart = (document.getElementById('layerSelect')?.value) || 'raw';
       const pipelineKeyAtStart = window.latestPipelineKey || null;
+      const method = document.getElementById('pick_method').value;
+      const sigmaMax = Number(document.getElementById('sigma_ms_max').value) || 20;
+      const cacheKeyStr = fbCacheKey(currentFileId, keyAtStart, layerAtStart, pipelineKeyAtStart);
 
-      // Request token
+      const cached = getCachedFbEntry(cacheKeyStr, method, sigmaMax);
       const reqToken = ++fbPredReqId;
-
       const btn = document.getElementById('predictFbBtn');
       if (btn) btn.disabled = true;
 
       try {
-        // Ensure probs
-        let tracesLocal = latestFbProbTraces;
-        if (!tracesLocal ||
-          currentFbKey !== keyAtStart ||
-          currentFbLayer !== layerAtStart ||
-          currentFbPipelineKey !== pipelineKeyAtStart) {
-
-          const { f32, shape } = await fetchFbProb(keyAtStart, { layer: layerAtStart, pipelineKey: pipelineKeyAtStart });
-          const [nTraces, nSamples] = shape;
-          const traces = new Array(nTraces);
-          for (let i = 0; i < nTraces; i++) {
-            traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
-          }
-          tracesLocal = traces;
+        if (cached) {
+          predictedPicks = (cached.picks || []).slice();
+          currentFbKey = keyAtStart;
+          currentFbLayer = layerAtStart;
+          currentFbPipelineKey = pipelineKeyAtStart;
+          renderLatestView();
+          return;
         }
 
-        // Compute picks locally
-        const picks = computePicks(tracesLocal);
+        const body = {
+          file_id: currentFileId,
+          key1_val: keyAtStart,
+          key1_byte: currentKey1Byte,
+          key2_byte: currentKey2Byte,
+          method,
+          sigma_ms_max: sigmaMax,
+        };
+        if (layerAtStart && layerAtStart !== 'raw' && pipelineKeyAtStart) {
+          body.pipeline_key = pipelineKeyAtStart;
+          body.tap_label = layerAtStart;
+        }
 
-        // Guard against stale
+        const res = await fetch('/fbpick_predict', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          let message = `fbpick_predict failed (${res.status})`;
+          try {
+            const text = await res.text();
+            if (text) {
+              try {
+                const parsed = JSON.parse(text);
+                if (parsed && typeof parsed.detail === 'string') {
+                  message = parsed.detail;
+                } else {
+                  message = text;
+                }
+              } catch (parseErr) {
+                message = text;
+              }
+            }
+          } catch (readErr) {
+            // ignore body read errors
+          }
+          throw new Error(message);
+        }
+
+        const data = await res.json();
+        const picks = Array.isArray(data?.picks)
+          ? data.picks.map(p => ({ trace: p.trace, time: p.time }))
+          : [];
+
         const idxNow = parseInt(document.getElementById('key1_idx_slider').value, 10);
         const keyNow = key1Values[idxNow];
         const layerNow = (document.getElementById('layerSelect')?.value) || 'raw';
@@ -1618,18 +1542,16 @@
           return;
         }
 
-        // Commit
-        predictedPicks = picks;
-        latestFbProbTraces = tracesLocal;
+        predictedPicks = picks.slice();
         currentFbKey = keyAtStart;
         currentFbLayer = layerAtStart;
         currentFbPipelineKey = pipelineKeyAtStart;
-        fbPredCache.set(
-          fbCacheKey(currentFileId, keyAtStart, layerAtStart, pipelineKeyAtStart),
-          picks,
-        );
+        fbPredCache.set(cacheKeyStr, {
+          picks: picks.slice(),
+          method,
+          sigma_ms_max: sigmaMax,
+        });
 
-        // Replot
         renderLatestView();
       } finally {
         if (btn) btn.disabled = false;
@@ -2262,9 +2184,14 @@
       // ★ FB予測キャッシュ取得：レイヤ＆パイプラインキーでキー統一
       const layerCur = (document.getElementById('layerSelect')?.value) || 'raw';
       const pKeyCur = window.latestPipelineKey || null;
-      predictedPicks = fbPredCache.get(
+      const methodCur = document.getElementById('pick_method').value;
+      const sigmaCur = Number(document.getElementById('sigma_ms_max').value) || 20;
+      const cachedEntry = getCachedFbEntry(
         fbCacheKey(currentFileId, key1Val, layerCur, pKeyCur),
-      ) || [];
+        methodCur,
+        sigmaCur,
+      );
+      predictedPicks = cachedEntry && cachedEntry.picks ? cachedEntry.picks.slice() : [];
 
       await fetchPicks();
 
@@ -3499,7 +3426,6 @@
           rawSeismicData = null;
           latestSeismicData = null;
           latestTapData = {};
-          latestFbProbTraces = null;
           fbPredReqId += 1;
 
           picks = [];

--- a/app/tests/test_fbpick_predict.py
+++ b/app/tests/test_fbpick_predict.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.routers import fbpick_predict as fbpick_predict_mod
+from app.main import app
+
+
+@pytest.fixture()
+def client(monkeypatch):
+	monkeypatch.setattr(
+		fbpick_predict_mod,
+		'_last_prob_state',
+		fbpick_predict_mod._LastProbabilityState(),
+	)
+	return TestClient(app)
+
+
+def _set_prob(monkeypatch, prob, dt=0.004, source='raw'):
+	payload = fbpick_predict_mod._ProbabilityPayload(
+		prob=np.asarray(prob, dtype=np.float32), dt=dt, source=source
+	)
+
+	def _fake_loader(_req):
+		return payload
+
+	monkeypatch.setattr(fbpick_predict_mod, '_load_probability_map', _fake_loader)
+
+
+def test_expectation_method_returns_times(client, monkeypatch):
+	prob = np.array([[0.0, 0.5, 0.5], [0.1, 0.0, 0.9]], dtype=np.float32)
+	_set_prob(monkeypatch, prob)
+
+	res = client.post(
+		'/fbpick_predict',
+		json={
+			'file_id': 'abc',
+			'key1_val': 1,
+			'key1_byte': 189,
+			'key2_byte': 193,
+			'method': 'expectation',
+			'sigma_ms_max': 5.0,
+		},
+	)
+	assert res.status_code == 200
+	data = res.json()
+	assert pytest.approx(data['dt'], rel=0, abs=1e-12) == 0.004
+	assert data['picks'] == [
+		{'trace': 0, 'time': pytest.approx(0.006)},
+		{'trace': 1, 'time': pytest.approx(0.0072)},
+	]
+
+
+def test_argmax_with_sigma_gate_filters_rows(client, monkeypatch):
+	prob = np.array([[0.5, 0.5, 0.0], [0.5, 0.5, 0.0]], dtype=np.float32)
+	_set_prob(monkeypatch, prob)
+
+	res = client.post(
+		'/fbpick_predict',
+		json={
+			'file_id': 'abc',
+			'key1_val': 2,
+			'method': 'argmax',
+			'sigma_ms_max': 1.0,
+		},
+	)
+	assert res.status_code == 200
+	assert res.json()['picks'] == []
+
+
+@pytest.mark.parametrize(
+	'prob',
+	[
+		np.zeros((2, 3), dtype=np.float32),
+		np.array([[np.nan, 1.0, 0.0]], dtype=np.float32),
+	],
+)
+def test_invalid_probability_map_rejected(client, monkeypatch, prob):
+	_set_prob(monkeypatch, prob)
+	res = client.post(
+		'/fbpick_predict',
+		json={
+			'file_id': 'bad',
+			'key1_val': 0,
+			'method': 'expectation',
+			'sigma_ms_max': 10.0,
+		},
+	)
+	assert res.status_code == 422

--- a/app/tests/test_ingest.py
+++ b/app/tests/test_ingest.py
@@ -123,7 +123,7 @@ def test_ingest_builds_artifacts_float32(tmp_path: Path, monkeypatch):
 	segy_path.write_bytes(b'stub')
 
 	store_dir = tmp_path / 'store'
-	meta = SegyIngestor.from_segy(
+	SegyIngestor.from_segy(
 		path=segy_path,
 		store_dir=store_dir,
 		key1_byte=189,
@@ -209,7 +209,7 @@ def test_ingest_quantize_int8_with_auto_scale(tmp_path: Path, monkeypatch):
 	segy_path.write_bytes(b'stub')
 
 	store_dir = tmp_path / 'store_q'
-	meta = SegyIngestor.from_segy(
+	SegyIngestor.from_segy(
 		path=segy_path,
 		store_dir=store_dir,
 		key1_byte=189,


### PR DESCRIPTION
## Summary
- add a dedicated `/fbpick_predict` FastAPI router that caches the most recent probability map, validates dt/tap metadata, and emits picks via argmax/expectation with σ gating
- extend shared helpers so pipeline taps return both arrays and metadata for dt checks, and wire the new router through the app along with chunked probability reductions
- update the legacy frontend to request picks directly, caching pick lists client-side, and add focused endpoint tests plus the missing httpx dependency and lint cleanup

## Testing
- `python -m compileall -q .`
- `ruff format --check .`
- `ruff check .`
- `pytest app/tests/test_fbpick_predict.py` *(fails without httpx; dependency added to requirements but not installable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f728faa5a0832b9cc6859643a15289