### PR TITLE
Implement raw baseline stats and inference normalization

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -30,6 +30,7 @@ from app.api._helpers import (
 from app.api.routers import (
 	fbpick_predict_router,
 	fbpick_router,
+	inference_router,
 	picks_router,
 	pipeline_router,
 	section_router,
@@ -52,6 +53,7 @@ router.include_router(upload_router)
 router.include_router(section_router)
 router.include_router(fbpick_router)
 router.include_router(fbpick_predict_router)
+router.include_router(inference_router)
 router.include_router(pipeline_router)
 router.include_router(picks_router)
 
@@ -68,6 +70,7 @@ __all__ = [
 	'cached_readers',
 	'fbpick_cache',
 	'fbpick_predict_router',
+	'inference_router',
 	'get_raw_section',
 	'get_reader',
 	'get_section_from_pipeline_tap',

--- a/app/api/routers/__init__.py
+++ b/app/api/routers/__init__.py
@@ -2,6 +2,7 @@
 
 from app.api.routers.fbpick import router as fbpick_router
 from app.api.routers.fbpick_predict import router as fbpick_predict_router
+from app.api.routers.inference import router as inference_router
 from app.api.routers.picks import router as picks_router
 from app.api.routers.pipeline import router as pipeline_router
 from app.api.routers.section import router as section_router
@@ -10,6 +11,7 @@ from app.api.routers.upload import router as upload_router
 __all__ = [
 	'fbpick_router',
 	'fbpick_predict_router',
+	'inference_router',
 	'picks_router',
 	'pipeline_router',
 	'section_router',

--- a/app/api/routers/inference.py
+++ b/app/api/routers/inference.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Annotated
+
+import numpy as np
+from fastapi import APIRouter, Body, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from app.api._helpers import (
+	coerce_section_f32,
+	get_reader,
+	get_section_from_pipeline_tap,
+)
+from app.api.schemas import PipelineSpec
+from app.utils.ops import TRANSFORMS
+from app.utils.raw_stats import per_trace_normalization
+from app.utils.segy_meta import get_dt_for_file
+from app.utils.utils import to_builtin
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+INFERENCE_DDOF = 0
+
+
+class InferencePredictRequest(BaseModel):
+	file_id: str
+	key1_val: int
+	key1_byte: int = 189
+	key2_byte: int = 193
+	pipeline: PipelineSpec | None = None
+	pipeline_key: str | None = None
+	tap_label: str | None = None
+	model: str = 'passthrough'
+	step_x: int = 1
+	step_y: int = 1
+
+
+def _run_transforms(
+	x: np.ndarray, *, spec: PipelineSpec | None, meta: dict[str, object]
+) -> np.ndarray:
+	if spec is None:
+		return x
+
+	y = x
+	for step in spec.steps:
+		if step.kind != 'transform':
+			msg = 'Inference preprocessing only supports transform steps'
+			raise HTTPException(status_code=422, detail=msg)
+		op = TRANSFORMS.get(step.name)
+		if op is None:
+			msg = f'Unknown transform: {step.name}'
+			raise HTTPException(status_code=422, detail=msg)
+		y = op(y, params=step.params, meta=meta)
+
+	y = np.ascontiguousarray(y, dtype=np.float32)
+	if y.ndim != 2:
+		msg = 'Transform output must remain 2D'
+		raise HTTPException(status_code=500, detail=msg)
+	return y
+
+
+def _load_denoise_modules() -> tuple[object, object]:
+	torch_spec = importlib.util.find_spec('torch')
+	if torch_spec is None:
+		raise HTTPException(status_code=503, detail='denoise model unavailable')
+
+	torch = importlib.import_module('torch')
+	denoise_mod_spec = importlib.util.find_spec('app.utils.denoise')
+	if denoise_mod_spec is None:
+		raise HTTPException(status_code=503, detail='denoise model unavailable')
+
+	denoise_mod = importlib.import_module('app.utils.denoise')
+	return torch, denoise_mod.denoise_tensor
+
+
+def _run_model(name: str, data: np.ndarray) -> np.ndarray:
+	if name == 'passthrough':
+		return data
+	if name == 'denoise':
+		torch, denoise_tensor = _load_denoise_modules()
+		tensor = torch.from_numpy(data.astype(np.float32)).unsqueeze(0).unsqueeze(0)
+		out = denoise_tensor(tensor)
+		return out.squeeze(0).squeeze(0).cpu().numpy()
+
+	msg = f'Unsupported model: {name}'
+	raise HTTPException(status_code=422, detail=msg)
+
+
+def _resolve_section(
+	*,
+	req: InferencePredictRequest,
+	reader,
+) -> np.ndarray:
+	if req.pipeline_key and req.tap_label:
+		section = get_section_from_pipeline_tap(
+			file_id=req.file_id,
+			key1_val=req.key1_val,
+			key1_byte=req.key1_byte,
+			pipeline_key=req.pipeline_key,
+			tap_label=req.tap_label,
+		)
+		return np.ascontiguousarray(section, dtype=np.float32)
+
+	if (req.pipeline_key is None) ^ (req.tap_label is None):
+		raise HTTPException(
+			status_code=422,
+			detail='pipeline_key and tap_label must be provided together',
+		)
+
+	view = reader.get_section(req.key1_val)
+	return coerce_section_f32(view.arr, view.scale)
+
+
+@router.post('/inference/predict')
+def inference_predict(
+	*,
+	req: Annotated[InferencePredictRequest, Body(...)],
+) -> JSONResponse:
+	if req.step_x != 1 or req.step_y != 1:
+		msg = 'step_x and step_y must be 1'
+		raise HTTPException(status_code=400, detail=msg)
+
+	reader = get_reader(req.file_id, req.key1_byte, req.key2_byte)
+	dt_val = float(get_dt_for_file(req.file_id))
+	meta = {'dt': dt_val}
+
+	section = _resolve_section(req=req, reader=reader)
+	section = np.ascontiguousarray(section, dtype=np.float32)
+	if section.ndim != 2:
+		msg = 'Inference section must be 2D'
+		raise HTTPException(status_code=500, detail=msg)
+
+	preprocessed = _run_transforms(section, spec=req.pipeline, meta=meta)
+
+	normed, mu, sigma, zero_mask = per_trace_normalization(
+		preprocessed,
+		ddof=INFERENCE_DDOF,
+	)
+
+	pred_norm = _run_model(req.model, normed)
+	if pred_norm.shape != normed.shape:
+		msg = 'Model output shape mismatch'
+		raise HTTPException(status_code=500, detail=msg)
+
+	restored = mu[:, None] + sigma[:, None] * pred_norm.astype(np.float32)
+
+	logger.info(
+		'inference.predict model=%s key1=%s ddof=%s',
+		req.model,
+		req.key1_val,
+		INFERENCE_DDOF,
+	)
+
+	payload = {
+		'model': req.model,
+		'dt': dt_val,
+		'normalization': {'method': 'mean_std', 'ddof': INFERENCE_DDOF},
+		'mu_traces': to_builtin(mu),
+		'sigma_traces': to_builtin(sigma),
+		'zero_var_mask': to_builtin(zero_mask.astype(np.bool_)),
+		'prediction': to_builtin(restored.astype(np.float32)),
+	}
+	return JSONResponse(content=payload)
+
+
+__all__ = ['router', 'InferencePredictRequest']

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from app.api.routers import (
 	fbpick_predict_router,
 	fbpick_router,
+	inference_router,
 	picks_router,
 	pipeline_router,
 	section_router,
@@ -32,6 +33,7 @@ app.include_router(upload_router)
 app.include_router(section_router)
 app.include_router(fbpick_router)
 app.include_router(fbpick_predict_router)
+app.include_router(inference_router)
 app.include_router(pipeline_router)
 app.include_router(picks_router)
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -405,6 +405,12 @@
 
         <button id="predictFbBtn" onclick="predictFromFb()">Predict from FB</button>
         <button type="button" id="export-npy-all-key1" onclick="exportAllPickIndexMatrixNpy()">Export manual picks (.npy)</button>
+        <label style="margin-left:8px">Normalize:
+          <select id="vizNormalize" onchange="onNormalizeModeChange()">
+            <option value="amax" selected>AMAX (section)</option>
+            <option value="tracewise">Tracewise</option>
+          </select>
+        </label>
         <label for="gain">Gain:</label>
         <input type="range" id="gain" min="0.1" max="5" step="0.1" value="1" oninput="onGainChange()" />
         <span id="gain_display">1×</span>
@@ -523,6 +529,11 @@
     var savedYRange = null;
     var latestSeismicData = null;
     var rawSeismicData = null;
+    var rawSeismicDataRaw = null;
+    var rawBaselineStats = null;
+    var rawBaselineCache = new Map();
+    var normalizationMode = 'amax';
+    var normalizationCaches = { key: null, amax: null, tracewise: null };
     var latestTapData = {};
     var latestPipelineKey = null;
     var latestWindowRender = null;
@@ -1696,7 +1707,7 @@
       const sel = document.getElementById('layerSelect');
       const layer = sel?.value || 'raw';
       // ★ 加工レイヤは window API 経由のみ。配列は raw のみ保持。
-      return (layer === 'raw' && Array.isArray(rawSeismicData)) ? rawSeismicData : null;
+      return (layer === 'raw' && Array.isArray(rawSeismicDataRaw)) ? rawSeismicDataRaw : null;
     }
 
     // 3-point parabolic interpolation around index i (for peak/trough). Returns a float index.
@@ -2225,6 +2236,118 @@
       }
     }
 
+    function normalizationDatasetKey(fileId, key1Val, stats) {
+      const sha = stats && typeof stats.source_sha256 === 'string'
+        ? stats.source_sha256
+        : 'none';
+      return `${fileId}:${key1Val}:${sha}`;
+    }
+
+    function resetNormalizationCaches(datasetKey) {
+      if (normalizationCaches.key !== datasetKey) {
+        normalizationCaches.key = datasetKey;
+        normalizationCaches.amax = null;
+        normalizationCaches.tracewise = null;
+      }
+    }
+
+    function buildNormalizedTraces(mode, stats) {
+      if (!Array.isArray(rawSeismicDataRaw) || !rawSeismicDataRaw.length) return null;
+      if (!stats) return { traces: rawSeismicDataRaw, backing: null };
+      const nTraces = rawSeismicDataRaw.length;
+      const nSamples = rawSeismicDataRaw[0]?.length ?? 0;
+      if (!nSamples) return null;
+      const backing = new Float32Array(nTraces * nSamples);
+      const traces = new Array(nTraces);
+      const useTracewise = mode === 'tracewise'
+        && stats.mu_traces instanceof Float32Array
+        && stats.sigma_traces instanceof Float32Array
+        && stats.mu_traces.length >= nTraces;
+      const sectionMu = Number(stats.mu_section ?? 0);
+      const sectionSigma = Number(stats.sigma_section ?? 1) || 1;
+
+      for (let tr = 0; tr < nTraces; tr++) {
+        const dst = backing.subarray(tr * nSamples, (tr + 1) * nSamples);
+        const src = rawSeismicDataRaw[tr];
+        const mean = useTracewise ? stats.mu_traces[tr] ?? sectionMu : sectionMu;
+        const sigma = useTracewise ? (stats.sigma_traces[tr] || 1) : sectionSigma;
+        const safeSigma = (sigma && Number.isFinite(sigma)) ? sigma : 1;
+        for (let s = 0; s < nSamples; s++) {
+          dst[s] = (src[s] - mean) / safeSigma;
+        }
+        traces[tr] = dst;
+      }
+      return { traces, backing };
+    }
+
+    async function ensureRawBaselineStatsFor(fileId, key1Val) {
+      if (!fileId || key1Val == null) return null;
+      const cacheKey = `${fileId}:${key1Val}`;
+      if (rawBaselineCache.has(cacheKey)) {
+        return rawBaselineCache.get(cacheKey);
+      }
+      if (typeof fetchRawBaselineStats !== 'function') {
+        console.warn('fetchRawBaselineStats API is unavailable');
+        return null;
+      }
+      const stats = await fetchRawBaselineStats({
+        fileId,
+        key1Val,
+        key1Byte: currentKey1Byte,
+        key2Byte: currentKey2Byte,
+      });
+      rawBaselineCache.set(cacheKey, stats);
+      return stats;
+    }
+
+    function applyVisualizationNormalizationFor(key1Val) {
+      if (!Array.isArray(rawSeismicDataRaw)) {
+        rawSeismicData = null;
+        return;
+      }
+      if (!rawBaselineStats) {
+        rawSeismicData = rawSeismicDataRaw;
+        return;
+      }
+      const datasetKey = normalizationDatasetKey(currentFileId, key1Val, rawBaselineStats);
+      resetNormalizationCaches(datasetKey);
+      const mode = normalizationMode === 'tracewise' ? 'tracewise' : 'amax';
+      let cacheEntry = normalizationCaches[mode];
+      if (!cacheEntry) {
+        cacheEntry = buildNormalizedTraces(mode, rawBaselineStats);
+        normalizationCaches[mode] = cacheEntry;
+      }
+      rawSeismicData = cacheEntry && cacheEntry.traces ? cacheEntry.traces : rawSeismicDataRaw;
+    }
+
+    function getTraceNormalizationParams(traceIndex) {
+      if (!rawBaselineStats) return null;
+      if (normalizationMode === 'tracewise'
+        && rawBaselineStats.mu_traces instanceof Float32Array
+        && rawBaselineStats.sigma_traces instanceof Float32Array
+        && traceIndex >= 0
+        && traceIndex < rawBaselineStats.mu_traces.length) {
+        const mu = rawBaselineStats.mu_traces[traceIndex];
+        const sigma = rawBaselineStats.sigma_traces[traceIndex] || 1;
+        return { mu, sigma: sigma || 1 };
+      }
+      return {
+        mu: Number(rawBaselineStats.mu_section ?? 0),
+        sigma: Number(rawBaselineStats.sigma_section ?? 1) || 1,
+      };
+    }
+
+    function onNormalizeModeChange() {
+      const sel = document.getElementById('vizNormalize');
+      const next = sel ? sel.value : 'amax';
+      normalizationMode = next === 'tracewise' ? 'tracewise' : 'amax';
+      const slider = document.getElementById('key1_idx_slider');
+      const idx = slider ? parseInt(slider.value || '0', 10) : 0;
+      const key1Val = key1Values?.[idx];
+      applyVisualizationNormalizationFor(key1Val);
+      drawSelectedLayer(renderedStart, renderedEnd);
+    }
+
     async function fetchAndPlot() {
       snapshotAxesRangesFromDOM();
       console.log('--- fetchAndPlot start ---');
@@ -2247,6 +2370,13 @@
 
       await fetchPicks();
 
+      try {
+        rawBaselineStats = await ensureRawBaselineStatsFor(currentFileId, key1Val);
+      } catch (err) {
+        console.warn('Failed to load baseline stats', err);
+        rawBaselineStats = null;
+      }
+
       // 🪄 Window-first ならフルraw構築をスキップして即ウィンドウ描画へ
       if (shouldPreferWindowFirst()) {
           latestWindowRender = null;
@@ -2264,6 +2394,8 @@
                   sel.value = 'raw';
                 }
             }
+          rawSeismicDataRaw = null;
+          rawSeismicData = null;
           latestSeismicData = null;
           renderLatestView();
           fetchWindowAndPlot();
@@ -2287,7 +2419,8 @@
           traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
         }
         console.timeEnd('Decode from cache');
-        rawSeismicData = traces;
+        rawSeismicDataRaw = traces;
+        applyVisualizationNormalizationFor(key1Val);
       } else {
         console.time('Fetch binary');
         const meta = sectionShape || await fetchSectionMeta();
@@ -2336,7 +2469,8 @@
           traces[i] = f32.subarray(i * nSamples, (i + 1) * nSamples);
         }
         console.timeEnd('Decode & cache');
-        rawSeismicData = traces;
+        rawSeismicDataRaw = traces;
+        applyVisualizationNormalizationFor(key1Val);
       }
 
       latestWindowRender = null;
@@ -2472,10 +2606,16 @@
         const shiftedFullX = new Float32Array(rows);
         const shiftedPosX = new Float32Array(rows);
         const traceIndex = x0 + c * stepX;
+        const normParams = getTraceNormalizationParams(traceIndex);
+        const mean = normParams ? normParams.mu : 0;
+        const sigma = normParams ? normParams.sigma : 1;
         for (let r = 0; r < rows; r++) {
           const idxVal = r * cols + c;
-          let val = (useI8 ? (windowData.valuesI8[idxVal] / scale)
-            : windowData.values[idxVal]) * gain;
+          const rawVal = useI8
+            ? (windowData.valuesI8[idxVal] / scale)
+            : windowData.values[idxVal];
+          const normVal = normParams ? ((rawVal - mean) / (sigma || 1)) : rawVal;
+          let val = normVal * gain;
           if (val > AMP_LIMIT) val = AMP_LIMIT;
           if (val < -AMP_LIMIT) val = -AMP_LIMIT;
 
@@ -2573,6 +2713,8 @@
 
       const { shape, x0, x1, y0, y1, effectiveLayer } = windowData;
       let { stepX, stepY } = windowData;
+      stepX = stepX || 1;
+      stepY = stepY || 1;
       const rows = Number(shape?.[0] ?? 0);
       const cols = Number(shape?.[1] ?? 0);
       if (!rows || !cols) return;
@@ -2597,6 +2739,9 @@
           : (windowData.scale != null ? { scale: windowData.scale } : null)
       );
       const fallbackScale = Number(windowData.scale) || 1;
+      const normCache = (!fbMode && rawBaselineStats)
+        ? Array.from({ length: cols }, (_, c) => getTraceNormalizationParams(x0 + c * stepX))
+        : null;
 
       let zData;
       const poolingCandidate = (
@@ -2616,7 +2761,16 @@
         const total = rows * cols;
         if (fbMode) {
             for (let p = 0; p < total; p++) backing[p] = backing[p] * 255;
-          } else {
+          } else if (normCache) {
+            for (let c = 0; c < cols; c++) {
+              const params = normCache[c];
+              const mean = params ? params.mu : 0;
+              const sigma = params ? params.sigma || 1 : 1;
+              for (let r = 0; r < rows; r++) {
+                const idx = r * cols + c;
+                backing[idx] = (backing[idx] - mean) / (sigma || 1);
+              }
+            }
           }
       }
       else {
@@ -2637,6 +2791,7 @@
           const row = new Float32Array(cols);
           const offset = r * cols;
           for (let c = 0; c < cols; c++) {
+            const params = normCache ? normCache[c] : null;
             let rawValue;
             if (useI8) {
               const q = windowData.valuesI8[offset + c];
@@ -2650,7 +2805,13 @@
             if (fbMode) {
               row[c] = rawValue * 255;
             } else {
-              row[c] = rawValue
+              if (params) {
+                const mean = params.mu;
+                const sigma = params.sigma || 1;
+                row[c] = (rawValue - mean) / (sigma || 1);
+              } else {
+                row[c] = rawValue;
+              }
             }
           }
           zRows[r] = row;
@@ -2790,6 +2951,12 @@
       const idx = parseInt(slider.value, 10);
       const key1Val = key1Values[idx];
       if (key1Val === undefined) return;
+
+      try {
+        rawBaselineStats = await ensureRawBaselineStatsFor(currentFileId, key1Val);
+      } catch (err) {
+        console.warn('Baseline stats fetch failed for window', err);
+      }
 
       const windowInfo = currentVisibleWindow();
       if (!windowInfo) return;
@@ -3466,6 +3633,11 @@
           latestWindowRender = null;
           windowFetchToken += 1;
           rawSeismicData = null;
+          rawSeismicDataRaw = null;
+          rawBaselineStats = null;
+          normalizationCaches.key = null;
+          normalizationCaches.amax = null;
+          normalizationCaches.tracewise = null;
           latestSeismicData = null;
           latestTapData = {};
           fbPredReqId += 1;

--- a/app/tests/test_raw_stats.py
+++ b/app/tests/test_raw_stats.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.utils.raw_stats import compute_raw_baseline, ensure_raw_baseline
+from app.utils.utils import SectionView
+
+
+class _StubReader:
+	def __init__(self, store_dir: Path, arr: np.ndarray) -> None:
+		self.store_dir = Path(store_dir)
+		self.store_dir.mkdir(parents=True, exist_ok=True)
+		self._arr = np.asarray(arr, dtype=np.float32)
+		self.traces = type('T', (), {'filename': str(self.store_dir / 'traces.npy')})()
+		np.save(self.store_dir / 'traces.npy', self._arr.astype(np.float32))
+
+	def get_section(self, key1_val: int) -> SectionView:
+		return SectionView(arr=self._arr, dtype=self._arr.dtype, scale=None)
+
+	def update_array(self, arr: np.ndarray) -> None:
+		self._arr = np.asarray(arr, dtype=np.float32)
+		np.save(self.store_dir / 'traces.npy', self._arr.astype(np.float32))
+
+
+def test_compute_raw_baseline_stats() -> None:
+	arr = np.array([[1, 3, 5, 7], [2, 4, 6, 8]], dtype=np.float32)
+	stats = compute_raw_baseline(
+		arr,
+		dtype_base='int8',
+		dt=0.004,
+		source_sha256='abc123',
+		ddof=0,
+	)
+	assert pytest.approx(float(stats.mu_section), rel=1e-6) == 4.5
+	assert pytest.approx(float(stats.sigma_section), rel=1e-6) == 2.291288
+	assert stats.mu_traces.shape == (2,)
+	assert stats.sigma_traces.shape == (2,)
+	assert pytest.approx(stats.mu_traces[0], rel=1e-6) == 4.0
+	assert pytest.approx(stats.mu_traces[1], rel=1e-6) == 5.0
+	assert pytest.approx(stats.sigma_traces[0], rel=1e-6) == np.sqrt(5.0)
+	assert pytest.approx(stats.sigma_traces[1], rel=1e-6) == np.sqrt(5.0)
+	assert not np.any(stats.zero_var_mask)
+
+
+def test_compute_raw_baseline_zero_variance() -> None:
+	arr = np.array([[4, 4, 4, 4], [1, 2, 3, 4]], dtype=np.float32)
+	stats = compute_raw_baseline(
+		arr,
+		dtype_base='float32',
+		dt=0.002,
+		source_sha256='hash',
+		ddof=0,
+	)
+	assert stats.zero_var_mask.shape == (2,)
+	assert bool(stats.zero_var_mask[0])
+	assert pytest.approx(stats.sigma_traces[0], rel=1e-6) == 1.0
+	assert not bool(stats.zero_var_mask[1])
+
+
+def test_ensure_raw_baseline_cache_and_recompute(tmp_path: Path) -> None:
+	store_dir = tmp_path / 'store'
+	reader = _StubReader(store_dir, np.array([[0, 1], [2, 3]], dtype=np.float32))
+	section = reader.get_section(1).arr
+	stats1 = ensure_raw_baseline(
+		reader=reader,
+		key1_val=1,
+		section=section,
+		dtype_base=str(section.dtype),
+		dt=0.004,
+		ddof=0,
+	)
+	baseline_path = store_dir / 'baseline_stats' / 'raw' / 'key1_1.json'
+	assert baseline_path.exists()
+	stats2 = ensure_raw_baseline(
+		reader=reader,
+		key1_val=1,
+		section=reader.get_section(1).arr,
+		dtype_base=str(section.dtype),
+		dt=0.004,
+		ddof=0,
+	)
+	assert stats1.source_sha256 == stats2.source_sha256
+	assert stats1.computed_at == stats2.computed_at
+	payload = json.loads(baseline_path.read_text())
+	assert payload['source_sha256'] == stats1.source_sha256
+
+	reader.update_array(np.array([[10, 10], [20, 20]], dtype=np.float32))
+	stats3 = ensure_raw_baseline(
+		reader=reader,
+		key1_val=1,
+		section=reader.get_section(1).arr,
+		dtype_base=str(section.dtype),
+		dt=0.004,
+		ddof=0,
+	)
+	assert stats3.source_sha256 != stats1.source_sha256
+	assert stats3.mu_section != pytest.approx(float(stats1.mu_section))
+
+
+def test_section_stats_endpoint_uses_cache(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	client = TestClient(app)
+	store_dir = tmp_path / 'store'
+	initial = np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32)
+	reader = _StubReader(store_dir, initial)
+
+	def _get_reader(*_args, **_kwargs):
+		return reader
+
+	monkeypatch.setattr('app.api.routers.section.get_reader', _get_reader)
+	monkeypatch.setattr(
+		'app.api.routers.section.get_dt_for_file', lambda _file_id: 0.002
+	)
+
+	params = {'file_id': 'demo', 'key1_val': 1, 'baseline': 'raw'}
+	resp1 = client.get('/section/stats', params=params)
+	assert resp1.status_code == 200
+	data1 = resp1.json()
+	path = store_dir / 'baseline_stats' / 'raw' / 'key1_1.json'
+	assert path.exists()
+	resp2 = client.get('/section/stats', params=params)
+	assert resp2.status_code == 200
+	assert resp2.json() == data1
+
+	reader.update_array(np.array([[5.0, 5.0], [5.0, 5.0]], dtype=np.float32))
+	resp3 = client.get('/section/stats', params=params)
+	assert resp3.status_code == 200
+	data3 = resp3.json()
+	assert data3['source_sha256'] != data1['source_sha256']
+	assert data3['mu_section'] != pytest.approx(data1['mu_section'])

--- a/app/utils/raw_stats.py
+++ b/app/utils/raw_stats.py
@@ -1,0 +1,295 @@
+"""Raw baseline statistics and inference normalization utilities."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+
+import numpy as np
+
+from app.utils.utils import to_builtin
+
+logger = logging.getLogger(__name__)
+
+
+_EPS = 1e-12
+
+
+@dataclass(slots=True)
+class RawBaselineStats:
+	"""Container for persisted raw baseline statistics."""
+
+	stage: str
+	ddof: int
+	method: str
+	dtype_base: str | None
+	dt: float
+	mu_section: np.float32
+	sigma_section: np.float32
+	mu_traces: np.ndarray
+	sigma_traces: np.ndarray
+	zero_var_mask: np.ndarray
+	source_sha256: str
+	computed_at: str
+
+	def to_payload(self) -> dict[str, object]:
+		"""Return a JSON-serialisable payload."""
+
+		return {
+			'stage': self.stage,
+			'ddof': int(self.ddof),
+			'method': self.method,
+			'dtype_base': self.dtype_base,
+			'dt': float(self.dt),
+			'mu_section': float(self.mu_section),
+			'sigma_section': float(self.sigma_section),
+			'mu_traces': to_builtin(self.mu_traces.astype(np.float32)),
+			'sigma_traces': to_builtin(self.sigma_traces.astype(np.float32)),
+			'zero_var_mask': to_builtin(self.zero_var_mask.astype(np.bool_)),
+			'source_sha256': self.source_sha256,
+			'computed_at': self.computed_at,
+		}
+
+
+def _welford_per_trace(arr: np.ndarray, *, ddof: int) -> tuple[np.ndarray, np.ndarray]:
+	"""Return per-trace mean and M2 using Welford's algorithm."""
+
+	if arr.ndim != 2:
+		msg = f'Expected 2D array for per-trace stats, got {arr.ndim}D'
+		raise ValueError(msg)
+
+	traces, samples = arr.shape
+	if samples == 0:
+		raise ValueError('Cannot compute statistics on empty traces')
+
+	means = np.zeros(traces, dtype=np.float64)
+	m2 = np.zeros(traces, dtype=np.float64)
+	for idx in range(samples):
+		column = np.asarray(arr[:, idx], dtype=np.float64)
+		delta = column - means
+		means += delta / float(idx + 1)
+		delta2 = column - means
+		m2 += delta * delta2
+	return means, m2
+
+
+def _finalize_sigma(m2: np.ndarray, count: int, *, ddof: int) -> np.ndarray:
+	"""Convert accumulated M2 into standard deviations."""
+
+	den = count - ddof
+	if den <= 0:
+		raise ValueError('Degrees of freedom lead to non-positive denominator')
+
+	var = m2 / float(den)
+	var[var < 0] = 0.0
+	sigma = np.sqrt(var, dtype=np.float64)
+	return sigma
+
+
+def _resolve_sha256_from_file(path: Path) -> str:
+	"""Return the SHA-256 hash of ``path``."""
+
+	hash_obj = sha256()
+	with path.open('rb') as fh:
+		for chunk in iter(lambda: fh.read(1024 * 1024), b''):
+			hash_obj.update(chunk)
+	return hash_obj.hexdigest()
+
+
+def _resolve_sha256_from_array(arr: np.ndarray) -> str:
+	"""Return SHA-256 for ``arr`` without persisting to disk."""
+
+	hash_obj = sha256()
+	view = np.ascontiguousarray(arr).view(np.uint8)
+	hash_obj.update(view.tobytes())
+	return hash_obj.hexdigest()
+
+
+def resolve_source_sha256(*, reader: object | None, section: np.ndarray | None) -> str:
+	"""Resolve the source checksum from TraceStore artifacts or fallback."""
+
+	if reader is not None:
+		traces = getattr(reader, 'traces', None)
+		filename = getattr(traces, 'filename', None)
+		if filename:
+			path = Path(filename)
+			if path.exists():
+				return _resolve_sha256_from_file(path)
+
+		sha_attr = getattr(reader, 'source_sha256', None)
+		if isinstance(sha_attr, str) and len(sha_attr) == 64:
+			return sha_attr
+
+	if section is None:
+		raise ValueError('Unable to resolve source checksum without section data')
+
+	return _resolve_sha256_from_array(section)
+
+
+def compute_raw_baseline(
+	arr: np.ndarray,
+	*,
+	dtype_base: str | None,
+	dt: float,
+	source_sha256: str,
+	ddof: int,
+) -> RawBaselineStats:
+	"""Compute baseline stats for ``arr`` (traces x samples)."""
+
+	arr = np.ascontiguousarray(arr, dtype=np.float32)
+	mu_traces64, m2_traces = _welford_per_trace(arr, ddof=ddof)
+	samples = arr.shape[1]
+	sigma_traces64 = _finalize_sigma(m2_traces, samples, ddof=ddof)
+	mu_traces32 = mu_traces64.astype(np.float32)
+	sigma_traces32 = sigma_traces64.astype(np.float32)
+	zero_mask = np.less_equal(np.abs(sigma_traces32), _EPS)
+	sigma_traces32[zero_mask] = 1.0
+	total_samples = arr.shape[0] * samples
+	weighted_sum = float(mu_traces64.sum(dtype=np.float64) * samples)
+	mu_section = weighted_sum / float(total_samples)
+	delta = mu_traces64 - mu_section
+	total_m2 = float(m2_traces.sum()) + float(samples) * float(np.dot(delta, delta))
+	sigma_section = np.sqrt(max(total_m2, 0.0) / float(total_samples))
+	if sigma_section <= _EPS:
+		sigma_section = 1.0
+
+	computed_at = datetime.now(timezone.utc).isoformat()
+	stats = RawBaselineStats(
+		stage='raw',
+		ddof=ddof,
+		method='mean_std',
+		dtype_base=dtype_base,
+		dt=float(dt),
+		mu_section=np.float32(mu_section),
+		sigma_section=np.float32(sigma_section),
+		mu_traces=mu_traces32,
+		sigma_traces=sigma_traces32,
+		zero_var_mask=zero_mask.astype(np.bool_),
+		source_sha256=source_sha256,
+		computed_at=computed_at,
+	)
+	return stats
+
+
+def _baseline_path(base_dir: Path, stage: str, key1_val: int) -> Path:
+	return base_dir / stage / f'key1_{key1_val}.json'
+
+
+def load_raw_baseline(*, store_dir: Path, key1_val: int) -> RawBaselineStats | None:
+	"""Load baseline stats from disk if present."""
+
+	path = _baseline_path(Path(store_dir), 'raw', key1_val)
+	if not path.exists():
+		return None
+
+	data = json.loads(path.read_text())
+	mu_traces = np.asarray(data['mu_traces'], dtype=np.float32)
+	sigma_traces = np.asarray(data['sigma_traces'], dtype=np.float32)
+	zero_mask = np.asarray(data['zero_var_mask'], dtype=np.bool_)
+	return RawBaselineStats(
+		stage=data.get('stage', 'raw'),
+		ddof=int(data.get('ddof', 0)),
+		method=data.get('method', 'mean_std'),
+		dtype_base=data.get('dtype_base'),
+		dt=float(data.get('dt', 0.0)),
+		mu_section=np.float32(data['mu_section']),
+		sigma_section=np.float32(data['sigma_section']),
+		mu_traces=mu_traces,
+		sigma_traces=sigma_traces,
+		zero_var_mask=zero_mask,
+		source_sha256=str(data.get('source_sha256', '')),
+		computed_at=str(data.get('computed_at', '')),
+	)
+
+
+def save_raw_baseline(
+	*, store_dir: Path, key1_val: int, stats: RawBaselineStats
+) -> None:
+	"""Persist baseline stats to disk."""
+
+	base_dir = Path(store_dir)
+	stage_dir = base_dir / stats.stage
+	stage_dir.mkdir(parents=True, exist_ok=True)
+	path = _baseline_path(base_dir, stats.stage, key1_val)
+	tmp_path = path.with_suffix('.json.tmp')
+	tmp_path.write_text(json.dumps(stats.to_payload()))
+	tmp_path.replace(path)
+	logger.info(
+		'Persisted baseline stats stage=%s key1=%s path=%s',
+		stats.stage,
+		key1_val,
+		path,
+	)
+
+
+def ensure_raw_baseline(
+	*,
+	reader: object,
+	key1_val: int,
+	section: np.ndarray,
+	dtype_base: str | None,
+	dt: float,
+	ddof: int,
+) -> RawBaselineStats:
+	"""Return cached baseline or compute a new one when source changes."""
+
+	store_dir = Path(getattr(reader, 'store_dir', '.')) / 'baseline_stats'
+	store_dir.mkdir(parents=True, exist_ok=True)
+	current_sha = resolve_source_sha256(reader=reader, section=section)
+	cached = load_raw_baseline(store_dir=store_dir, key1_val=key1_val)
+	if cached and cached.source_sha256 == current_sha:
+		logger.info(
+			'Loaded cached baseline stage=%s key1=%s ddof=%s',
+			cached.stage,
+			key1_val,
+			cached.ddof,
+		)
+		return cached
+
+	logger.info('Computing baseline stage=raw key1=%s ddof=%s', key1_val, ddof)
+	stats = compute_raw_baseline(
+		section,
+		dtype_base=dtype_base,
+		dt=dt,
+		source_sha256=current_sha,
+		ddof=ddof,
+	)
+	save_raw_baseline(store_dir=store_dir, key1_val=key1_val, stats=stats)
+	return stats
+
+
+def per_trace_normalization(
+	arr: np.ndarray,
+	*,
+	ddof: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+	"""Return z-scored array along with mean/std per trace."""
+
+	arr = np.ascontiguousarray(arr, dtype=np.float32)
+	mu_traces64, m2_traces = _welford_per_trace(arr, ddof=ddof)
+	samples = arr.shape[1]
+	sigma64 = _finalize_sigma(m2_traces, samples, ddof=ddof)
+	mu = mu_traces64.astype(np.float32)
+	sigma = sigma64.astype(np.float32)
+	zero_mask = np.less_equal(np.abs(sigma), _EPS)
+	sigma_safe = sigma.copy()
+	sigma_safe[zero_mask] = 1.0
+	mu_broadcast = mu[:, None]
+	sigma_broadcast = sigma_safe[:, None]
+	z = (arr - mu_broadcast) / sigma_broadcast
+	return z.astype(np.float32), mu, sigma_safe, zero_mask
+
+
+__all__ = [
+	'RawBaselineStats',
+	'compute_raw_baseline',
+	'ensure_raw_baseline',
+	'load_raw_baseline',
+	'per_trace_normalization',
+	'resolve_source_sha256',
+	'save_raw_baseline',
+]


### PR DESCRIPTION
## Summary
- add raw baseline statistics utilities and persistence helpers used by visualization and inference
- expose /section/stats and /inference/predict endpoints for baseline access and per-request normalization
- update the frontend to fetch baseline stats, cache normalization modes, and render AMAX/Tracewise views
- cover baseline computations and caching with unit tests

## Testing
- python -m compileall -q .
- ruff format --check .
- ruff check .
- PYTHONPATH=. pytest app/tests/test_raw_stats.py *(fails: ModuleNotFoundError: No module named 'msgpack')*

------
https://chatgpt.com/codex/tasks/task_e_68f82509b58c832bb6da620906400364