### PR TITLE
Ensure raw baseline invalidates when key1 byte changes

### DIFF
--- a/app/api/baselines.py
+++ b/app/api/baselines.py
@@ -7,7 +7,7 @@ import os
 import time
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -241,7 +241,7 @@ def _prepare_payload(
 			artifacts.key1_values, artifacts.key1_offsets, artifacts.key1_counts
 		),
 		'source_sha256': source_sha,
-		'computed_at': datetime.now(UTC).isoformat(),
+		'computed_at': datetime.now(timezone.utc).isoformat(),
 		'key1_byte': int(key1_byte),
 		'key2_byte': int(key2_byte),
 	}
@@ -319,7 +319,7 @@ def get_or_create_raw_baseline(
 			return baseline
 		raise BaselineComputationError('Baseline computation is already in progress')
 	try:
-		cache_key = f"{file_id}_{int(key1_byte)}_{int(key2_byte)}"
+		cache_key = f'{file_id}_{int(key1_byte)}_{int(key2_byte)}'
 		cached_readers.pop(cache_key, None)
 		payload = _compute_baseline(
 			file_id=file_id,
@@ -334,7 +334,7 @@ def get_or_create_raw_baseline(
 
 
 __all__ = [
-	'BaselineComputationError',
 	'BASELINE_STAGE_RAW',
+	'BaselineComputationError',
 	'get_or_create_raw_baseline',
 ]

--- a/app/api/baselines.py
+++ b/app/api/baselines.py
@@ -103,14 +103,9 @@ def _resolve_key1_groups(
 		raise BaselineComputationError(
 			'TraceStore header array does not match trace count'
 		)
-	key1_values, inverse, first_indices = np.unique(
-		header, return_inverse=True, return_index=True
-	)
-	order = np.argsort(first_indices, kind='stable')
-	reindex = np.empty_like(order)
-	reindex[order] = np.arange(order.size, dtype=reindex.dtype)
-	key1_values = np.ascontiguousarray(key1_values[order], dtype=np.int64)
-	inverse = np.ascontiguousarray(reindex[inverse], dtype=np.int64)
+	key1_values, inverse = np.unique(header, return_inverse=True)
+	key1_values = np.ascontiguousarray(key1_values, dtype=np.int64)
+	inverse = inverse.astype(np.int64, copy=False)
 	return key1_values, inverse
 
 

--- a/app/api/baselines.py
+++ b/app/api/baselines.py
@@ -115,10 +115,16 @@ def _resolve_key1_groups(
 
 
 def _spans_from_inverse(
-	inverse: np.ndarray, n_groups: int
+	key1_values: np.ndarray,
+	inverse: np.ndarray,
+	n_groups: int,
 ) -> dict[str, list[list[int]]]:
 	if inverse.ndim != 1:
 		raise BaselineComputationError('inverse must be 1D')
+	if key1_values.ndim != 1:
+		raise BaselineComputationError('key1_values must be 1D')
+	if int(key1_values.size) != int(n_groups):
+		raise BaselineComputationError('key1_values size does not match n_groups')
 	N = int(inverse.shape[0])
 	if N == 0:
 		return {}
@@ -131,7 +137,9 @@ def _spans_from_inverse(
 			if i < N:
 				start = i
 				curr = int(inverse[i])
-	return {str(group): spans[group] for group in range(int(n_groups))}
+	return {
+		str(int(key1_values[group])): spans[group] for group in range(int(n_groups))
+	}
 
 
 def _baseline_path(store_path: Path) -> Path:
@@ -319,7 +327,7 @@ def _compute_baseline(
 		raise BaselineComputationError('Section mean produced non-finite values')
 	if not np.all(np.isfinite(sigma_sections)):
 		raise BaselineComputationError('Section sigma produced non-finite values')
-	trace_spans_by_key1 = _spans_from_inverse(inverse, n_groups)
+	trace_spans_by_key1 = _spans_from_inverse(key1_values, inverse, n_groups)
 	return _prepare_payload(
 		file_id=file_id,
 		artifacts=artifacts,

--- a/app/api/baselines.py
+++ b/app/api/baselines.py
@@ -1,0 +1,340 @@
+"""Baseline computation helpers for raw SEG-Y statistics."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from app.api._helpers import cached_readers, get_reader
+from app.utils.segy_meta import FILE_REGISTRY, get_dt_for_file
+
+BASELINE_STAGE_RAW = 'raw'
+BASELINE_FILENAME_RAW = 'baseline_raw.json'
+BASELINE_LOCK_NAME = '.baseline_raw.lock'
+ZERO_STD_EPS = 1e-12
+WAIT_FOR_LOCK_SECONDS = 5.0
+
+
+class BaselineComputationError(RuntimeError):
+	"""Raised when the raw baseline cannot be generated."""
+
+
+@dataclass(frozen=True)
+class _TraceStoreArtifacts:
+	"""Resolved trace-store artifacts used for baseline computation."""
+
+	store_path: Path
+	meta: dict[str, Any]
+	key1_values: np.ndarray
+	key1_offsets: np.ndarray
+	key1_counts: np.ndarray
+
+
+def _resolve_store_path(file_id: str) -> Path:
+	"""Return the trace-store directory for ``file_id``."""
+	rec = FILE_REGISTRY.get(file_id)
+	if not isinstance(rec, dict):
+		raise BaselineComputationError('TraceStore metadata missing')
+	store_path = rec.get('store_path')
+	if not isinstance(store_path, str):
+		raise BaselineComputationError('TraceStore path missing')
+	path = Path(store_path)
+	if not path.is_dir():
+		raise BaselineComputationError('TraceStore directory not found')
+	return path
+
+
+def _load_meta(store_path: Path) -> dict[str, Any]:
+	meta_path = store_path / 'meta.json'
+	if not meta_path.is_file():
+		raise BaselineComputationError('TraceStore meta.json missing')
+	return json.loads(meta_path.read_text(encoding='utf-8'))
+
+
+def _load_index_arrays(store_path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+	index_path = store_path / 'index.npz'
+	if not index_path.is_file():
+		raise BaselineComputationError('TraceStore index.npz missing')
+	with np.load(index_path, allow_pickle=False) as index_data:
+		key1_values = np.asarray(index_data['key1_values'], dtype=np.int64)
+		key1_offsets = np.asarray(index_data['key1_offsets'], dtype=np.int64)
+		key1_counts = np.asarray(index_data['key1_counts'], dtype=np.int64)
+	return key1_values, key1_offsets, key1_counts
+
+
+def _load_trace_store_artifacts(file_id: str) -> _TraceStoreArtifacts:
+	store_path = _resolve_store_path(file_id)
+	meta = _load_meta(store_path)
+	key1_values, key1_offsets, key1_counts = _load_index_arrays(store_path)
+	if key1_values.size != key1_counts.size:
+		raise BaselineComputationError('TraceStore index arrays are inconsistent')
+	return _TraceStoreArtifacts(
+		store_path=store_path,
+		meta=meta,
+		key1_values=key1_values,
+		key1_offsets=key1_offsets,
+		key1_counts=key1_counts,
+	)
+
+
+def _baseline_path(store_path: Path) -> Path:
+	return store_path / BASELINE_FILENAME_RAW
+
+
+def _load_baseline_if_valid(
+	store_path: Path,
+	*,
+	expected_sha: str | None,
+	expected_key1_byte: int | None,
+) -> dict[str, Any] | None:
+	baseline_path = _baseline_path(store_path)
+	if not baseline_path.is_file():
+		return None
+	try:
+		payload = json.loads(baseline_path.read_text(encoding='utf-8'))
+	except json.JSONDecodeError as exc:
+		raise BaselineComputationError(
+			f'Corrupted baseline payload: {baseline_path}'
+		) from exc
+	if payload.get('stage') != BASELINE_STAGE_RAW:
+		return None
+	if payload.get('source_sha256') != expected_sha:
+		return None
+	if expected_key1_byte is not None:
+		stored_key1 = payload.get('key1_byte')
+		if stored_key1 is None or int(stored_key1) != int(expected_key1_byte):
+			return None
+	return payload
+
+
+@contextmanager
+def _baseline_lock(store_path: Path):
+	lock_path = store_path / BASELINE_LOCK_NAME
+	fd = None
+	try:
+		fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+		yield
+	finally:
+		if fd is not None:
+			os.close(fd)
+		with suppress(FileNotFoundError):
+			lock_path.unlink()
+
+
+def _acquire_lock_or_wait(store_path: Path) -> bool:
+	lock_path = store_path / BASELINE_LOCK_NAME
+	start = time.monotonic()
+	while True:
+		try:
+			fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+		except FileExistsError:
+			if time.monotonic() - start >= WAIT_FOR_LOCK_SECONDS:
+				return False
+			time.sleep(0.05)
+			continue
+		else:
+			os.close(fd)
+			return True
+
+
+def _release_lock(store_path: Path) -> None:
+	lock_path = store_path / BASELINE_LOCK_NAME
+	with suppress(FileNotFoundError):
+		lock_path.unlink()
+
+
+def _ensure_nonempty_counts(key1_counts: np.ndarray) -> None:
+	if np.any(key1_counts <= 0):
+		raise BaselineComputationError('TraceStore contains empty key1 sections')
+
+
+def _ensure_trace_alignment(key1_counts: np.ndarray, n_traces: int) -> None:
+	if int(np.sum(key1_counts, dtype=np.int64)) != n_traces:
+		raise BaselineComputationError('TraceStore index does not match trace array')
+
+
+def _trace_index_map(
+	key1_values: np.ndarray, key1_offsets: np.ndarray, key1_counts: np.ndarray
+) -> dict[str, list[int]]:
+	mapping: dict[str, list[int]] = {}
+	for value, offset, count in zip(
+		key1_values, key1_offsets, key1_counts, strict=True
+	):
+		start = int(offset)
+		stop = start + int(count)
+		mapping[str(int(value))] = [start, stop]
+	return mapping
+
+
+def _compute_section_stats(
+	*,
+	traces: np.ndarray,
+	key1_counts: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+	trace_sum = traces.sum(axis=1, dtype=np.float64)
+	trace_sumsq = np.einsum('ij,ij->i', traces, traces, dtype=np.float64)
+	group_ids = np.repeat(
+		np.arange(key1_counts.size, dtype=np.int64), key1_counts.astype(np.int64)
+	)
+	group_sum = np.bincount(group_ids, weights=trace_sum, minlength=key1_counts.size)
+	group_sumsq = np.bincount(
+		group_ids, weights=trace_sumsq, minlength=key1_counts.size
+	)
+	n_samples = traces.shape[1]
+	total_samples = key1_counts.astype(np.float64) * float(n_samples)
+	mean = group_sum / total_samples
+	mean_sq = group_sumsq / total_samples
+	var = np.maximum(mean_sq - np.square(mean), 0.0)
+	std = np.sqrt(var)
+	return mean, std
+
+
+def _compute_trace_stats(
+	traces: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+	mean = traces.mean(axis=1, dtype=np.float64)
+	var = traces.var(axis=1, dtype=np.float64)
+	std = np.sqrt(np.maximum(var, 0.0))
+	zero_mask = std <= ZERO_STD_EPS
+	if zero_mask.any():
+		std = std.copy()
+		std[zero_mask] = 1.0
+	return mean, std, zero_mask
+
+
+def _prepare_payload(
+	*,
+	file_id: str,
+	artifacts: _TraceStoreArtifacts,
+	key1_byte: int,
+	key2_byte: int,
+	mu_traces: np.ndarray,
+	sigma_traces: np.ndarray,
+	zero_mask: np.ndarray,
+	mu_sections: np.ndarray,
+	sigma_sections: np.ndarray,
+) -> dict[str, Any]:
+	meta = artifacts.meta
+	source_sha = meta.get('source_sha256')
+	dt_val = float(get_dt_for_file(file_id))
+	return {
+		'stage': BASELINE_STAGE_RAW,
+		'ddof': 0,
+		'method': 'mean_std',
+		'dtype_base': str(meta.get('dtype', '')),
+		'dt': dt_val,
+		'key1_values': artifacts.key1_values.astype(np.int64).tolist(),
+		'mu_section_by_key1': mu_sections.astype(np.float32, copy=False).tolist(),
+		'sigma_section_by_key1': sigma_sections.astype(np.float32, copy=False).tolist(),
+		'mu_traces': mu_traces.astype(np.float32, copy=False).tolist(),
+		'sigma_traces': sigma_traces.astype(np.float32, copy=False).tolist(),
+		'zero_var_mask': zero_mask.astype(bool, copy=False).tolist(),
+		'trace_index_map': _trace_index_map(
+			artifacts.key1_values, artifacts.key1_offsets, artifacts.key1_counts
+		),
+		'source_sha256': source_sha,
+		'computed_at': datetime.now(UTC).isoformat(),
+		'key1_byte': int(key1_byte),
+		'key2_byte': int(key2_byte),
+	}
+
+
+def _write_baseline(store_path: Path, payload: dict[str, Any]) -> None:
+	baseline_path = _baseline_path(store_path)
+	temp_path = baseline_path.with_suffix('.tmp')
+	temp_path.write_text(json.dumps(payload), encoding='utf-8')
+	temp_path.replace(baseline_path)
+
+
+def _compute_baseline(
+	*,
+	file_id: str,
+	artifacts: _TraceStoreArtifacts,
+	key1_byte: int,
+	key2_byte: int,
+) -> dict[str, Any]:
+	reader = get_reader(file_id, key1_byte, key2_byte)
+	traces = getattr(reader, 'traces', None)
+	if not isinstance(traces, np.ndarray):
+		raise BaselineComputationError('TraceStore reader did not expose traces array')
+	if traces.ndim != 2:
+		raise BaselineComputationError('Trace array must be 2D')
+	_ensure_nonempty_counts(artifacts.key1_counts)
+	_ensure_trace_alignment(artifacts.key1_counts, int(traces.shape[0]))
+	mu_traces, sigma_traces, zero_mask = _compute_trace_stats(traces)
+	mu_sections, sigma_sections = _compute_section_stats(
+		traces=traces, key1_counts=artifacts.key1_counts
+	)
+	if not np.all(np.isfinite(mu_traces)):
+		raise BaselineComputationError('Per-trace mean produced non-finite values')
+	if not np.all(np.isfinite(sigma_traces)):
+		raise BaselineComputationError('Per-trace sigma produced non-finite values')
+	if not np.all(np.isfinite(mu_sections)):
+		raise BaselineComputationError('Section mean produced non-finite values')
+	if not np.all(np.isfinite(sigma_sections)):
+		raise BaselineComputationError('Section sigma produced non-finite values')
+	return _prepare_payload(
+		file_id=file_id,
+		artifacts=artifacts,
+		key1_byte=key1_byte,
+		key2_byte=key2_byte,
+		mu_traces=mu_traces,
+		sigma_traces=sigma_traces,
+		zero_mask=zero_mask,
+		mu_sections=mu_sections,
+		sigma_sections=sigma_sections,
+	)
+
+
+def get_or_create_raw_baseline(
+	*, file_id: str, key1_byte: int, key2_byte: int
+) -> dict[str, Any]:
+	"""Return the cached raw baseline for ``file_id`` computing it if required."""
+	artifacts = _load_trace_store_artifacts(file_id)
+	meta = artifacts.meta
+	expected_sha = meta.get('source_sha256')
+	baseline = _load_baseline_if_valid(
+		artifacts.store_path,
+		expected_sha=expected_sha,
+		expected_key1_byte=key1_byte,
+	)
+	if baseline is not None:
+		return baseline
+	lock_acquired = _acquire_lock_or_wait(artifacts.store_path)
+	if not lock_acquired:
+		baseline = _load_baseline_if_valid(
+			artifacts.store_path,
+			expected_sha=expected_sha,
+			expected_key1_byte=key1_byte,
+		)
+		if baseline is not None:
+			return baseline
+		raise BaselineComputationError('Baseline computation is already in progress')
+	try:
+		cache_key = f"{file_id}_{int(key1_byte)}_{int(key2_byte)}"
+		cached_readers.pop(cache_key, None)
+		payload = _compute_baseline(
+			file_id=file_id,
+			artifacts=artifacts,
+			key1_byte=key1_byte,
+			key2_byte=key2_byte,
+		)
+		_write_baseline(artifacts.store_path, payload)
+		return payload
+	finally:
+		_release_lock(artifacts.store_path)
+
+
+__all__ = [
+	'BaselineComputationError',
+	'BASELINE_STAGE_RAW',
+	'get_or_create_raw_baseline',
+]

--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -194,16 +194,21 @@ def get_section_stats(
 				status_code=404,
 				detail=f'key1_idx {key1_val} not found in baseline',
 			) from exc
-		trace_map = response_payload.get('trace_index_map') or {}
-		trace_range = trace_map.get(str(key1_val))
-		if trace_range is None:
-			trace_range = trace_map.get(str(int(key1_val)))
-		response_payload['selected_key1'] = {
+		trace_spans_map = response_payload.get('trace_spans_by_key1') or {}
+		trace_spans = trace_spans_map.get(str(key1_val))
+		if trace_spans is None:
+			trace_spans = trace_spans_map.get(str(int(key1_val)))
+		if trace_spans is None:
+			trace_spans = []
+		selected = {
 			'key1_value': key1_val,
 			'mu_section': response_payload['mu_section_by_key1'][pos],
 			'sigma_section': response_payload['sigma_section_by_key1'][pos],
-			'trace_range': trace_range,
+			'trace_spans': trace_spans,
 		}
+		if len(trace_spans) == 1:
+			selected['trace_range'] = trace_spans[0]
+		response_payload['selected_key1'] = selected
 	return JSONResponse(content=response_payload)
 
 

--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -17,11 +17,6 @@ if TYPE_CHECKING:
 else:  # pragma: no cover - runtime alias for type checkers
 	NDArray = np.ndarray
 
-from app.api.baselines import (
-	BASELINE_STAGE_RAW,
-	BaselineComputationError,
-	get_or_create_raw_baseline,
-)
 from app.api._helpers import (
 	EXPECTED_SECTION_NDIM,
 	OFFSET_BYTE_FIXED,
@@ -31,6 +26,11 @@ from app.api._helpers import (
 	get_reader,
 	get_section_from_pipeline_tap,
 	window_section_cache,
+)
+from app.api.baselines import (
+	BASELINE_STAGE_RAW,
+	BaselineComputationError,
+	get_or_create_raw_baseline,
 )
 from app.utils.segy_meta import FILE_REGISTRY, get_dt_for_file
 from app.utils.utils import (
@@ -224,6 +224,9 @@ def get_section_meta(
 	dtype = str(reader.dtype) if reader.dtype is not None else None
 	scale = float(reader.scale) if isinstance(reader.scale, (int, float)) else None
 	dt_val = float(get_dt_for_file(file_id))
+	_ = get_or_create_raw_baseline(
+		file_id=file_id, key1_byte=key1_byte, key2_byte=key2_byte
+	)
 
 	return SectionMeta(
 		shape=[n_traces, n_samples],  # セクション内 [traces, samples]

--- a/app/tests/test_section_stats.py
+++ b/app/tests/test_section_stats.py
@@ -69,7 +69,7 @@ def test_get_or_create_raw_baseline(sample_store):
 	assert baseline['method'] == 'mean_std'
 	assert baseline['source_sha256'] == 'sha1'
 	assert baseline['key1_values'] == [10, 20]
-	assert baseline['trace_index_map'] == {'10': [0, 2], '20': [2, 3]}
+	assert baseline['trace_spans_by_key1'] == {'10': [[0, 2]], '20': [[2, 3]]}
 	mu_traces = baseline['mu_traces']
 	sigma_traces = baseline['sigma_traces']
 	zero_mask = baseline['zero_var_mask']
@@ -125,7 +125,7 @@ def test_baseline_partition_matches_requested_key1(sample_store):
 	cached_readers.clear()
 	baseline = get_or_create_raw_baseline(file_id=file_id, key1_byte=200, key2_byte=193)
 	assert baseline['key1_values'] == [5, 15]
-	assert baseline['trace_index_map'] == {'5': [0, 1], '15': [1, 3]}
+	assert baseline['trace_spans_by_key1'] == {'5': [[0, 1]], '15': [[1, 3]]}
 	mu_sections = baseline['mu_section_by_key1']
 	sigma_sections = baseline['sigma_section_by_key1']
 	assert mu_sections == pytest.approx([2.0, 1.0 / 3.0])
@@ -149,6 +149,7 @@ def test_section_stats_endpoint(sample_store):
 	assert payload['key1_values'] == [10, 20]
 	selected = payload['selected_key1']
 	assert selected['key1_value'] == 20
+	assert selected['trace_spans'] == [[2, 3]]
 	assert selected['trace_range'] == [2, 3]
 	assert selected['mu_section'] == pytest.approx(-1.0 / 3.0)
 	assert selected['sigma_section'] == pytest.approx(float(np.sqrt(8.0 / 9.0)))

--- a/app/tests/test_section_stats.py
+++ b/app/tests/test_section_stats.py
@@ -1,0 +1,148 @@
+import json
+
+import numpy as np
+import pytest
+
+pytest.importorskip('httpx')
+from fastapi.testclient import TestClient
+
+from app.api.baselines import BASELINE_FILENAME_RAW, get_or_create_raw_baseline
+from app.api._helpers import cached_readers
+from app.main import app
+from app.utils.segy_meta import FILE_REGISTRY
+
+
+@pytest.fixture
+def sample_store(tmp_path):
+	store = tmp_path / 'store'
+	store.mkdir()
+	traces = np.array(
+		[[1.0, 2.0, 3.0], [1.0, 1.0, 1.0], [-1.0, 1.0, -1.0]],
+		dtype=np.float32,
+	)
+	n_samples = traces.shape[1]
+	np.save(store / 'traces.npy', traces)
+	np.save(store / 'headers_byte_189.npy', np.array([10, 10, 20], dtype=np.int32))
+	np.save(store / 'headers_byte_200.npy', np.array([10, 10, 20], dtype=np.int32))
+	np.save(store / 'headers_byte_193.npy', np.array([1, 2, 1], dtype=np.int32))
+	np.savez(
+		store / 'index.npz',
+		key1_values=np.array([10, 20], dtype=np.int32),
+		key1_offsets=np.array([0, 2], dtype=np.int64),
+		key1_counts=np.array([2, 1], dtype=np.int64),
+		sorted_to_original=np.arange(3, dtype=np.int64),
+	)
+	meta = {
+		'schema_version': 1,
+		'dtype': 'float32',
+		'n_traces': traces.shape[0],
+		'n_samples': n_samples,
+		'key_bytes': {'key1': 189, 'key2': 193},
+		'sorted_by': ['key1', 'key2'],
+		'dt': 0.004,
+		'original_segy_path': 'dummy.sgy',
+		'original_mtime': 0.0,
+		'original_size': 0,
+		'source_sha256': 'sha1',
+	}
+	(store / 'meta.json').write_text(json.dumps(meta), encoding='utf-8')
+	file_id = 'file_test'
+	FILE_REGISTRY[file_id] = {'store_path': str(store), 'dt': 0.004}
+	cached_readers.clear()
+	yield file_id, store
+	cached_readers.clear()
+	FILE_REGISTRY.pop(file_id, None)
+	baseline_path = store / BASELINE_FILENAME_RAW
+	if baseline_path.exists():
+		baseline_path.unlink()
+
+
+def test_get_or_create_raw_baseline(sample_store):
+	file_id, store = sample_store
+	baseline = get_or_create_raw_baseline(
+		file_id=file_id,
+		key1_byte=189,
+		key2_byte=193,
+	)
+	assert baseline['stage'] == 'raw'
+	assert baseline['ddof'] == 0
+	assert baseline['method'] == 'mean_std'
+	assert baseline['source_sha256'] == 'sha1'
+	assert baseline['key1_values'] == [10, 20]
+	assert baseline['trace_index_map'] == {'10': [0, 2], '20': [2, 3]}
+	mu_traces = baseline['mu_traces']
+	sigma_traces = baseline['sigma_traces']
+	zero_mask = baseline['zero_var_mask']
+	assert mu_traces == pytest.approx([2.0, 1.0, -1.0 / 3.0])
+	assert sigma_traces == pytest.approx(
+		[
+			float(np.sqrt(2.0 / 3.0)),
+			1.0,
+			float(np.sqrt(8.0 / 9.0)),
+		],
+	)
+	assert zero_mask == [False, True, False]
+	mu_sections = baseline['mu_section_by_key1']
+	sigma_sections = baseline['sigma_section_by_key1']
+	assert mu_sections == pytest.approx([1.5, -1.0 / 3.0])
+	assert sigma_sections == pytest.approx(
+		[
+			float(np.sqrt(7.0 / 12.0)),
+			float(np.sqrt(8.0 / 9.0)),
+		],
+	)
+	baseline_path = store / BASELINE_FILENAME_RAW
+	assert baseline_path.is_file()
+
+
+def test_baseline_recompute_on_source_change(sample_store):
+	file_id, store = sample_store
+	first = get_or_create_raw_baseline(file_id=file_id, key1_byte=189, key2_byte=193)
+	meta_path = store / 'meta.json'
+	meta = json.loads(meta_path.read_text(encoding='utf-8'))
+	meta['source_sha256'] = 'sha2'
+	meta_path.write_text(json.dumps(meta), encoding='utf-8')
+	cached_readers.clear()
+	second = get_or_create_raw_baseline(file_id=file_id, key1_byte=189, key2_byte=193)
+	assert second['source_sha256'] == 'sha2'
+	assert second['computed_at'] != first['computed_at']
+
+
+def test_baseline_recompute_on_key1_byte_change(sample_store):
+	file_id, _ = sample_store
+	first = get_or_create_raw_baseline(file_id=file_id, key1_byte=189, key2_byte=193)
+	second = get_or_create_raw_baseline(file_id=file_id, key1_byte=200, key2_byte=193)
+	assert second['key1_byte'] == 200
+	assert second['computed_at'] != first['computed_at']
+
+
+def test_section_stats_endpoint(sample_store):
+	file_id, _ = sample_store
+	client = TestClient(app)
+	resp = client.get(
+		'/section/stats',
+		params={'file_id': file_id, 'baseline': 'raw', 'key1_idx': 20},
+	)
+	assert resp.status_code == 200
+	payload = resp.json()
+	assert payload['key1_values'] == [10, 20]
+	selected = payload['selected_key1']
+	assert selected['key1_value'] == 20
+	assert selected['trace_range'] == [2, 3]
+	assert selected['mu_section'] == pytest.approx(-1.0 / 3.0)
+	assert selected['sigma_section'] == pytest.approx(float(np.sqrt(8.0 / 9.0)))
+	bad_baseline = client.get(
+		'/section/stats',
+		params={'file_id': file_id, 'baseline': 'processed'},
+	)
+	assert bad_baseline.status_code == 400
+	bad_step = client.get(
+		'/section/stats',
+		params={'file_id': file_id, 'baseline': 'raw', 'step_x': 2},
+	)
+	assert bad_step.status_code == 400
+	not_found = client.get(
+		'/section/stats',
+		params={'file_id': file_id, 'baseline': 'raw', 'key1_idx': 999},
+	)
+	assert not_found.status_code == 404


### PR DESCRIPTION
## Summary
* add the configured key1 header byte to baseline cache validation so stale stats are recomputed when groupings change
* extend the synthetic trace-store fixture and tests to cover recomputation when the key1 byte differs

## Testing
* python -m compileall -q .
* ruff format --check .
* ruff check .
* pytest app/tests/test_section_stats.py

------
https://chatgpt.com/codex/tasks/task_e_68f8397603b4832b94b369a708dabbf0