### PR TITLE
Add baseline normalization support for section windows

### DIFF
--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -356,6 +356,9 @@ def get_section_window_bin(
 		file_id,
 		key1_val,
 		store_dir,
+		x0=x0,
+		x1=x1,
+		step_x=step_x,
 	)
 	view = prepared.T if transpose else prepared
 	window_view = np.ascontiguousarray(view, dtype=np.float32)

--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import contextlib
 import gzip
-from typing import TYPE_CHECKING, Annotated, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import msgpack
 import numpy as np
@@ -22,6 +23,7 @@ from app.api._helpers import (
 	OFFSET_BYTE_FIXED,
 	USE_FBPICK_OFFSET,
 	PipelineTapNotFoundError,
+	apply_scaling_from_baseline,
 	coerce_section_f32,
 	get_reader,
 	get_section_from_pipeline_tap,
@@ -257,8 +259,15 @@ def get_section_window_bin(
 	transpose: Annotated[bool, Query()] = True,
 	pipeline_key: Annotated[str | None, Query()] = None,
 	tap_label: Annotated[str | None, Query()] = None,
+	scaling: Annotated[
+		Literal['amax', 'tracewise'] | None, Query(description='Normalization mode')
+	] = None,
 ) -> Response:
 	"""Return a quantized window of a section, optionally via a pipeline tap."""
+	mode = 'amax' if scaling is None else scaling
+	mode = mode.lower()
+	if mode not in {'amax', 'tracewise'}:
+		raise HTTPException(status_code=400, detail='Unsupported scaling mode')
 	forced_offset_byte = OFFSET_BYTE_FIXED if USE_FBPICK_OFFSET else offset_byte
 	cache_key = (
 		file_id,
@@ -275,6 +284,7 @@ def get_section_window_bin(
 		transpose,
 		pipeline_key,
 		tap_label,
+		mode,
 	)
 
 	cached_payload = window_section_cache.get(cache_key)
@@ -285,6 +295,7 @@ def get_section_window_bin(
 			headers={'Content-Encoding': 'gzip'},
 		)
 
+	reader = None
 	try:
 		if pipeline_key and tap_label:
 			section_arr = get_section_from_pipeline_tap(
@@ -323,6 +334,29 @@ def get_section_window_bin(
 		raise HTTPException(status_code=400, detail='Requested window is empty')
 
 	prepared = coerce_section_f32(sub, section_view.scale)
+	registry_entry = FILE_REGISTRY.get(file_id)
+	store_dir: str | None = None
+	if isinstance(registry_entry, dict):
+		maybe_store = registry_entry.get('store_path')
+		if isinstance(maybe_store, str):
+			store_dir = maybe_store
+	else:
+		maybe_store = getattr(registry_entry, 'store_path', None)
+		if isinstance(maybe_store, (str, Path)):
+			store_dir = str(maybe_store)
+	if store_dir is None and reader is not None:
+		maybe_store = getattr(reader, 'store_dir', None)
+		if isinstance(maybe_store, (str, Path)):
+			store_dir = str(maybe_store)
+	if store_dir is None:
+		raise HTTPException(status_code=500, detail='Trace store path unavailable')
+	prepared = apply_scaling_from_baseline(
+		prepared,
+		mode,
+		file_id,
+		key1_val,
+		store_dir,
+	)
 	view = prepared.T if transpose else prepared
 	window_view = np.ascontiguousarray(view, dtype=np.float32)
 	scale_val, q = quantize_float32(window_view)

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -369,6 +369,12 @@
         <select id="layerSelect" onchange="drawSelectedLayer()">
           <option value="raw" selected>raw</option>
         </select>
+        <label style="margin-left:8px">Normalization:
+          <select id="scalingMode" onchange="onScalingChange()">
+            <option value="amax" selected>AMAX</option>
+            <option value="tracewise">Tracewise</option>
+          </select>
+        </label>
         <label style="margin-left:8px">σmax (ms):
           <input id="sigma_ms_max" type="number" value="20" step="1" min="1" style="width:5em"
             oninput="onSigmaChange()">
@@ -807,7 +813,12 @@
       predicted: samplePicks(predictedPicks, 10)
   });
 
-    function cacheKey(val, mode) { return `${val}|${mode}`; }
+    var currentScaling = 'amax';
+
+    function cacheKey(val, mode) {
+      const scaleKey = mode === 'raw' ? currentScaling : mode;
+      return `${val}|${mode}|${scaleKey}`;
+    }
     function syncWiggleInit() {
       const el = document.getElementById('wiggle_density');
       if (!el) return;
@@ -1609,6 +1620,19 @@
       }
     }
 
+    function onScalingChange() {
+      const sel = document.getElementById('scalingMode');
+      const rawValue = (sel && typeof sel.value === 'string') ? sel.value.toLowerCase() : 'amax';
+      currentScaling = rawValue === 'tracewise' ? 'tracewise' : 'amax';
+      if (sel) sel.value = currentScaling;
+      try { localStorage.setItem('scaling_mode', currentScaling); } catch (_) {}
+      if (windowFetchCtrl) {
+        try { windowFetchCtrl.abort(); } catch (_) {}
+        windowFetchCtrl = null;
+      }
+      scheduleWindowFetch();
+    }
+
     function onWiggleDensityChange() {
       const el = document.getElementById('wiggle_density');
       const v = parseFloat(el?.value);
@@ -2070,6 +2094,7 @@
               step_x: '1', step_y: '1',
               transpose: '0',
             });
+            q.set('scaling', currentScaling);
             const res = await fetch(`/get_section_window_bin?${q.toString()}`, { signal: controller.signal });
             if (!res.ok) return;
             const bin = new Uint8Array(await res.arrayBuffer());
@@ -2100,6 +2125,11 @@
       currentFileId = params.get('file_id') || localStorage.getItem('file_id') || '';
       currentKey1Byte = parseInt(params.get('key1_byte') || localStorage.getItem('key1_byte') || '189');
       currentKey2Byte = parseInt(params.get('key2_byte') || localStorage.getItem('key2_byte') || '193');
+      const scalingParam = (params.get('scaling') || localStorage.getItem('scaling_mode') || 'amax').toLowerCase();
+      currentScaling = scalingParam === 'tracewise' ? 'tracewise' : 'amax';
+      try { localStorage.setItem('scaling_mode', currentScaling); } catch (_) {}
+      const scalingSel = document.getElementById('scalingMode');
+      if (scalingSel) scalingSel.value = currentScaling;
       document.getElementById('file_id').value = currentFileId;
       if (!currentFileId) {
         currentFileName = '';
@@ -2307,6 +2337,7 @@
           step_x: '1', step_y: '1',
           transpose: '0',
         });
+        qFull.set('scaling', currentScaling);
         const res = await fetch(`/get_section_window_bin?${qFull.toString()}`);
         if (!res.ok) {
           console.timeEnd('Fetch binary');
@@ -2853,6 +2884,7 @@
         params.set('tap_label', tapLabel);
       }
       params.set('transpose', '1');
+      params.set('scaling', currentScaling);
 
       const requestId = ++windowFetchToken;
 

--- a/app/utils/segy_meta.py
+++ b/app/utils/segy_meta.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 from pathlib import Path
 from typing import Any
+
+import numpy as np
 
 HEADER_SAMPLE_INTERVAL_OFFSET = 3200 + 16
 SAMPLE_INTERVAL_BYTES = 2
@@ -12,6 +16,14 @@ MICROSECONDS_PER_SECOND = 1_000_000.0
 
 # ファイル毎のメタ情報を保持
 FILE_REGISTRY: dict[str, dict[str, Any]] = {}
+
+BASELINE_FILENAME_RAW = 'baseline_raw.json'
+
+logger = logging.getLogger(__name__)
+
+NORM_EPS = np.float32(float(os.getenv('NORM_EPS', '1e-6')))
+
+_BASELINE_CACHE: dict[str, dict[str, Any]] = {}
 
 
 def read_segy_dt_seconds(path: str) -> float | None:
@@ -70,3 +82,93 @@ def get_dt_for_file(file_id: str) -> float:
 	rec['dt'] = dt
 	FILE_REGISTRY[file_id] = rec
 	return dt
+
+
+def load_baseline(store_dir: str | Path) -> dict[str, Any]:
+	"""Return cached baseline statistics for ``store_dir``."""
+	store_path = Path(store_dir)
+	baseline_path = store_path / BASELINE_FILENAME_RAW
+	cache_key = str(baseline_path.resolve())
+	entry = _BASELINE_CACHE.get(cache_key)
+	if entry is not None:
+		return entry
+	if not baseline_path.is_file():
+		raise FileNotFoundError(f'baseline payload not found: {baseline_path}')
+	payload = json.loads(baseline_path.read_text(encoding='utf-8'))
+	key1_values = np.ascontiguousarray(
+		np.asarray(payload.get('key1_values'), dtype=np.int64)
+	)
+	mu_section = np.ascontiguousarray(
+		np.asarray(payload.get('mu_section_by_key1'), dtype=np.float32)
+	)
+	sigma_section = np.ascontiguousarray(
+		np.asarray(payload.get('sigma_section_by_key1'), dtype=np.float32)
+	)
+	if (
+		key1_values.shape[0] != mu_section.shape[0]
+		or mu_section.shape != sigma_section.shape
+	):
+		raise ValueError('Baseline section statistics are inconsistent')
+	if not np.all(np.isfinite(mu_section)):
+		raise ValueError('Baseline section mean contains non-finite values')
+	if not np.all(np.isfinite(sigma_section)):
+		raise ValueError('Baseline section std contains non-finite values')
+	section_clamp_mask = np.ascontiguousarray(sigma_section <= NORM_EPS, dtype=bool)
+	if section_clamp_mask.any():
+		logger.info(
+			'Clamped %d section std values to eps (%s)',
+			int(section_clamp_mask.sum()),
+			baseline_path,
+		)
+	safe_sigma_section = sigma_section.copy()
+	np.maximum(safe_sigma_section, NORM_EPS, out=safe_sigma_section)
+	inv_sigma_section = np.reciprocal(safe_sigma_section, dtype=np.float32)
+	mu_traces = np.ascontiguousarray(
+		np.asarray(payload.get('mu_traces'), dtype=np.float32)
+	)
+	sigma_traces = np.ascontiguousarray(
+		np.asarray(payload.get('sigma_traces'), dtype=np.float32)
+	)
+	if mu_traces.shape != sigma_traces.shape:
+		raise ValueError('Baseline trace statistics are inconsistent')
+	if not np.all(np.isfinite(mu_traces)):
+		raise ValueError('Baseline trace mean contains non-finite values')
+	if not np.all(np.isfinite(sigma_traces)):
+		raise ValueError('Baseline trace std contains non-finite values')
+	trace_clamp_mask = np.ascontiguousarray(sigma_traces <= NORM_EPS, dtype=bool)
+	if trace_clamp_mask.any():
+		logger.info(
+			'Clamped %d trace std values to eps (%s)',
+			int(trace_clamp_mask.sum()),
+			baseline_path,
+		)
+	safe_sigma_traces = sigma_traces.copy()
+	np.maximum(safe_sigma_traces, NORM_EPS, out=safe_sigma_traces)
+	inv_sigma_traces = np.reciprocal(safe_sigma_traces, dtype=np.float32)
+	raw_spans = payload.get('trace_spans_by_key1') or {}
+	trace_spans: dict[int, list[tuple[int, int]]] = {}
+	for key_str, ranges in raw_spans.items():
+		key_int = int(key_str)
+		span_list: list[tuple[int, int]] = []
+		for span in ranges:
+			if not isinstance(span, list) or len(span) != 2:
+				raise ValueError('Baseline trace span entry malformed')
+			start, end = int(span[0]), int(span[1])
+			if start < 0 or end < start or end > mu_traces.shape[0]:
+				raise ValueError('Baseline trace span is out of bounds')
+			span_list.append((start, end))
+		trace_spans[key_int] = span_list
+	entry = {
+		'store_key': str(store_path.resolve()),
+		'key1_values': key1_values,
+		'key1_index': {int(val): idx for idx, val in enumerate(key1_values.tolist())},
+		'section_mean': mu_section,
+		'section_inv_std': inv_sigma_section,
+		'section_clamp_mask': section_clamp_mask,
+		'trace_mean': mu_traces,
+		'trace_inv_std': inv_sigma_traces,
+		'trace_clamp_mask': trace_clamp_mask,
+		'trace_spans': trace_spans,
+	}
+	_BASELINE_CACHE[cache_key] = entry
+	return entry


### PR DESCRIPTION
## Summary
- add server-side normalization helper using baseline statistics and cache reciprocals for performance
- parse and cache baseline payloads from the trace store directory
- wire the scaling mode through the section window endpoint and viewer UI to always request normalization

## Testing
- python -m compileall -q .
- ruff format --check .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68f973bd4f14832b907b985a8a91f7ad