### PR TITLE
Frontend MVP: add side-by-side and difference compare view for raw / processed windows

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -375,6 +375,126 @@
       align-items: stretch;
     }
 
+    #compareSurface {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding: 0.75rem;
+      min-width: 0;
+      min-height: 0;
+      background: #fff;
+    }
+
+    #compareSurface[hidden] {
+      display: none;
+    }
+
+    .compare-status {
+      padding: 0.55rem 0.7rem;
+      border: 1px solid #cbd5e1;
+      border-radius: 10px;
+      background: #f8fafc;
+      color: #334155;
+      font-size: 0.9rem;
+    }
+
+    .compare-status[hidden] {
+      display: none;
+    }
+
+    .compare-status.is-error {
+      border-color: #fca5a5;
+      background: #fef2f2;
+      color: #991b1b;
+    }
+
+    .compare-grid {
+      flex: 1;
+      min-height: 0;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .compare-grid-side {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .compare-grid-diff {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: minmax(0, 1fr) auto auto;
+    }
+
+    .compare-panel {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      min-height: 0;
+      border: 1px solid #dbe3ef;
+      border-radius: 12px;
+      background: #fff;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+      overflow: hidden;
+    }
+
+    .compare-panel-header {
+      padding: 0.65rem 0.8rem;
+      border-bottom: 1px solid #e2e8f0;
+      background: #f8fafc;
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #334155;
+    }
+
+    .compare-plot {
+      flex: 1;
+      min-height: 260px;
+    }
+
+    .compare-note {
+      padding: 0.8rem 0.8rem 0;
+      font-size: 0.88rem;
+      line-height: 1.4;
+      color: #475569;
+    }
+
+    .compare-metrics {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 0.65rem;
+      padding: 0.8rem;
+    }
+
+    #compareRmsPlot {
+      min-height: 180px;
+    }
+
+    .compare-metric {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+      padding: 0.55rem 0.65rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      background: #f8fafc;
+    }
+
+    .compare-metric-label {
+      font-size: 0.78rem;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .compare-metric-value {
+      font-size: 1rem;
+      font-weight: 700;
+      color: #0f172a;
+    }
+
     #viewerEmptyState {
       position: absolute;
       inset: 0;
@@ -790,6 +910,14 @@
       .viewer-shortcuts-item {
         grid-template-columns: 1fr;
         gap: 0.2rem;
+      }
+
+      .compare-grid-side {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .compare-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
     }
 
@@ -1299,6 +1427,38 @@
                     oninput="onWiggleDensityChange()">
                 </label>
               </div>
+              <div class="control-subgroup" aria-labelledby="controls-compare-title">
+                <div id="controls-compare-title" class="control-subgroup-title">Compare</div>
+                <div class="control-row">
+                  <label class="control-field">Compare mode:
+                    <select id="compareModeSelect" data-testid="compare-mode-select">
+                      <option value="single" selected>Single</option>
+                      <option value="side_by_side">Side-by-side</option>
+                      <option value="difference">Difference</option>
+                    </select>
+                  </label>
+                  <label class="control-field">Diff:
+                    <select id="compareDiffModeSelect">
+                      <option value="b_minus_a" selected>B - A</option>
+                      <option value="a_minus_b">A - B</option>
+                    </select>
+                  </label>
+                  <label class="control-field"><input type="checkbox" id="compareShowRms" checked>RMS(B - A) by trace</label>
+                </div>
+                <div class="control-row">
+                  <label class="control-field">A:
+                    <select id="compareSourceASelect">
+                      <option value="raw" selected>raw</option>
+                    </select>
+                  </label>
+                  <label class="control-field">B:
+                    <select id="compareSourceBSelect">
+                      <option value="raw" selected>raw</option>
+                    </select>
+                  </label>
+                </div>
+                <div id="compareStatus" class="compare-status" hidden aria-live="polite"></div>
+              </div>
             </section>
 
             <section class="control-section control-section-status" aria-labelledby="controls-status-title">
@@ -1325,6 +1485,51 @@
       </div>
       <div id="plotViewport">
         <div id="plot"></div>
+        <div id="compareSurface" hidden>
+          <div id="compareStatusViewport" class="compare-status" hidden aria-live="polite"></div>
+          <div id="compareSideBySide" class="compare-grid compare-grid-side" hidden>
+            <section class="compare-panel">
+              <div id="compareSourceALabel" class="compare-panel-header">A: raw</div>
+              <div id="comparePlotA" class="compare-plot"></div>
+            </section>
+            <section class="compare-panel">
+              <div id="compareSourceBLabel" class="compare-panel-header">B: raw</div>
+              <div id="comparePlotB" class="compare-plot"></div>
+            </section>
+          </div>
+          <div id="compareDiffView" class="compare-grid compare-grid-diff" hidden>
+            <section class="compare-panel">
+              <div id="compareDiffExpression" class="compare-panel-header">B - A</div>
+              <div id="comparePlotDiff" class="compare-plot"></div>
+            </section>
+            <section class="compare-panel">
+              <div class="compare-panel-header">Metrics</div>
+              <div id="compareNotice" class="compare-note" hidden></div>
+              <div class="compare-metrics">
+                <div class="compare-metric">
+                  <span class="compare-metric-label">mean(B - A)</span>
+                  <span id="compareStatMean" class="compare-metric-value">-</span>
+                </div>
+                <div class="compare-metric">
+                  <span class="compare-metric-label">std(B - A)</span>
+                  <span id="compareStatStd" class="compare-metric-value">-</span>
+                </div>
+                <div class="compare-metric">
+                  <span class="compare-metric-label">rms(B - A)</span>
+                  <span id="compareStatRms" class="compare-metric-value">-</span>
+                </div>
+                <div class="compare-metric">
+                  <span class="compare-metric-label">max_abs(B - A)</span>
+                  <span id="compareStatMaxAbs" class="compare-metric-value">-</span>
+                </div>
+              </div>
+            </section>
+            <section id="compareRmsSection" class="compare-panel" hidden>
+              <div class="compare-panel-header">RMS(B - A) by trace</div>
+              <div id="compareRmsPlot" class="compare-plot"></div>
+            </section>
+          </div>
+        </div>
         <section id="viewerEmptyState" hidden aria-live="polite" aria-atomic="true">
           <div class="viewer-empty-state-card" aria-labelledby="viewerEmptyStateTitle"
             aria-describedby="viewerEmptyStateDescription viewerEmptyStateHelper">
@@ -1511,6 +1716,8 @@
   <script src="/static/viewer/window_render.js"></script>
   <script src="/static/viewer/window_fetch.js"></script>
   <script src="/static/viewer/viewer_legacy.js"></script>
+  <script src="/static/viewer/compare_metrics.js"></script>
+  <script src="/static/viewer/compare_view.js"></script>
   <script>
     (function initControlsPanel() {
       const STORAGE_OPEN = 'sv.controls_panel.open';

--- a/app/static/viewer/compare_metrics.js
+++ b/app/static/viewer/compare_metrics.js
@@ -1,0 +1,86 @@
+(function () {
+  function computeDiff(a, b, mode) {
+    const len = Math.min(a?.length || 0, b?.length || 0);
+    const diff = new Float32Array(len);
+    const subtractBMinusA = mode !== 'a_minus_b';
+    for (let i = 0; i < len; i += 1) {
+      diff[i] = subtractBMinusA ? (b[i] - a[i]) : (a[i] - b[i]);
+    }
+    return diff;
+  }
+
+  function computeSummaryStats(diff) {
+    const len = diff?.length || 0;
+    if (!len) {
+      return {
+        mean: 0,
+        std: 0,
+        rms: 0,
+        maxAbs: 0,
+      };
+    }
+
+    let sum = 0;
+    let sumSq = 0;
+    let maxAbs = 0;
+    for (let i = 0; i < len; i += 1) {
+      const value = Number(diff[i]) || 0;
+      const absValue = Math.abs(value);
+      sum += value;
+      sumSq += value * value;
+      if (absValue > maxAbs) maxAbs = absValue;
+    }
+
+    const mean = sum / len;
+    const variance = Math.max(0, (sumSq / len) - (mean * mean));
+    return {
+      mean,
+      std: Math.sqrt(variance),
+      rms: Math.sqrt(sumSq / len),
+      maxAbs,
+    };
+  }
+
+  function computeRmsByTrace(a, b, height, width) {
+    const rows = Math.max(0, Number(height) | 0);
+    const cols = Math.max(0, Number(width) | 0);
+    const out = new Float32Array(cols);
+    if (!rows || !cols) return out;
+
+    for (let ix = 0; ix < cols; ix += 1) {
+      let sumSq = 0;
+      for (let iy = 0; iy < rows; iy += 1) {
+        const k = (iy * cols) + ix;
+        const d = (Number(b[k]) || 0) - (Number(a[k]) || 0);
+        sumSq += d * d;
+      }
+      out[ix] = Math.sqrt(sumSq / rows);
+    }
+    return out;
+  }
+
+  function percentileAbs(values, percentile) {
+    const len = values?.length || 0;
+    if (!len) return 0;
+
+    const pRaw = Number(percentile);
+    const p = Number.isFinite(pRaw) ? Math.max(0, Math.min(100, pRaw)) : 99;
+    const sampleLimit = 16384;
+    const stride = Math.max(1, Math.ceil(len / sampleLimit));
+    const sampled = [];
+    for (let i = 0; i < len; i += stride) {
+      sampled.push(Math.abs(Number(values[i]) || 0));
+    }
+    if (!sampled.length) return 0;
+    sampled.sort((a, b) => a - b);
+    const rank = Math.min(sampled.length - 1, Math.floor((sampled.length - 1) * (p / 100)));
+    return sampled[rank];
+  }
+
+  window.compareMetrics = {
+    computeDiff,
+    computeSummaryStats,
+    computeRmsByTrace,
+    percentileAbs,
+  };
+})();

--- a/app/static/viewer/compare_view.js
+++ b/app/static/viewer/compare_view.js
@@ -1,0 +1,972 @@
+(function () {
+  const AMP_LIMIT = 3.0;
+  const DIFF_NOTE = 'Diff is computed from decoded displayed window values.';
+  const EPSILON_DIFF_LIMIT = 1e-6;
+  const DOMAIN_MISMATCH_MESSAGE = 'Cannot compare sources: source domains differ.';
+
+  const state = {
+    mode: 'single',
+    sourceA: { type: 'raw' },
+    sourceB: { type: 'raw' },
+    diffMode: 'b_minus_a',
+    showRmsByTrace: true,
+    sourceBAuto: true,
+    lastResult: null,
+    fetchToken: 0,
+    fetchCtrl: null,
+    decodeJobs: [],
+    suppressRelayout: false,
+  };
+
+  function getUi() {
+    return {
+      mainPlot: document.getElementById('plot'),
+      compareModeSelect: document.getElementById('compareModeSelect'),
+      compareSourceASelect: document.getElementById('compareSourceASelect'),
+      compareSourceBSelect: document.getElementById('compareSourceBSelect'),
+      compareDiffModeSelect: document.getElementById('compareDiffModeSelect'),
+      compareShowRms: document.getElementById('compareShowRms'),
+      compareStatus: document.getElementById('compareStatus'),
+      compareStatusViewport: document.getElementById('compareStatusViewport'),
+      compareSurface: document.getElementById('compareSurface'),
+      compareSideBySide: document.getElementById('compareSideBySide'),
+      compareDiffView: document.getElementById('compareDiffView'),
+      compareSourceALabel: document.getElementById('compareSourceALabel'),
+      compareSourceBLabel: document.getElementById('compareSourceBLabel'),
+      compareDiffExpression: document.getElementById('compareDiffExpression'),
+      compareNotice: document.getElementById('compareNotice'),
+      compareStatMean: document.getElementById('compareStatMean'),
+      compareStatStd: document.getElementById('compareStatStd'),
+      compareStatRms: document.getElementById('compareStatRms'),
+      compareStatMaxAbs: document.getElementById('compareStatMaxAbs'),
+      compareRmsSection: document.getElementById('compareRmsSection'),
+      comparePlotA: document.getElementById('comparePlotA'),
+      comparePlotB: document.getElementById('comparePlotB'),
+      comparePlotDiff: document.getElementById('comparePlotDiff'),
+      compareRmsPlot: document.getElementById('compareRmsPlot'),
+      layerSelect: document.getElementById('layerSelect'),
+    };
+  }
+
+  function cloneSource(source) {
+    if (!source || source.type !== 'pipeline_tap') {
+      return { type: 'raw' };
+    }
+    return {
+      type: 'pipeline_tap',
+      pipelineKey: source.pipelineKey || null,
+      tapLabel: String(source.tapLabel || ''),
+    };
+  }
+
+  function sameSource(a, b) {
+    const sourceA = cloneSource(a);
+    const sourceB = cloneSource(b);
+    return (
+      sourceA.type === sourceB.type &&
+      (sourceA.pipelineKey || null) === (sourceB.pipelineKey || null) &&
+      String(sourceA.tapLabel || '') === String(sourceB.tapLabel || '')
+    );
+  }
+
+  function sourceLabel(source) {
+    const next = cloneSource(source);
+    if (next.type === 'pipeline_tap') return next.tapLabel || 'pipeline tap';
+    return 'raw';
+  }
+
+  function sourceOptionValue(source) {
+    const next = cloneSource(source);
+    if (next.type !== 'pipeline_tap') return 'raw';
+    return `pipeline_tap:${encodeURIComponent(next.pipelineKey || '')}:${encodeURIComponent(next.tapLabel || '')}`;
+  }
+
+  function parseSourceOptionValue(value) {
+    if (!value || value === 'raw') return { type: 'raw' };
+    if (!String(value).startsWith('pipeline_tap:')) return { type: 'raw' };
+    const raw = String(value).slice('pipeline_tap:'.length);
+    const splitIndex = raw.indexOf(':');
+    if (splitIndex < 0) return { type: 'raw' };
+    return {
+      type: 'pipeline_tap',
+      pipelineKey: decodeURIComponent(raw.slice(0, splitIndex)) || null,
+      tapLabel: decodeURIComponent(raw.slice(splitIndex + 1)) || '',
+    };
+  }
+
+  function inferSourceDomain(source) {
+    const next = cloneSource(source);
+    if (next.type !== 'pipeline_tap') return 'amplitude';
+    const label = String(next.tapLabel || '').toLowerCase();
+    if (label.includes('fbpick') || label.includes('fbprob') || label.includes('prob')) {
+      return 'probability';
+    }
+    return 'amplitude';
+  }
+
+  function listAvailableSources() {
+    const ui = getUi();
+    const sources = [{ type: 'raw' }];
+    const seen = new Set(['raw']);
+    const pipelineKey = window.latestPipelineKey || null;
+    const options = Array.from(ui.layerSelect?.options || []);
+    for (const option of options) {
+      const value = String(option?.value || '');
+      if (!value || value === 'raw') continue;
+      const source = {
+        type: 'pipeline_tap',
+        pipelineKey,
+        tapLabel: value,
+      };
+      const key = sourceOptionValue(source);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      sources.push(source);
+    }
+    return sources;
+  }
+
+  function firstProcessedSource(sources) {
+    return (Array.isArray(sources) ? sources : []).find((source) => cloneSource(source).type === 'pipeline_tap') || null;
+  }
+
+  function normalizeSource(source, sources, fallbackSource) {
+    const next = cloneSource(source);
+    const available = Array.isArray(sources) ? sources : [];
+    const exact = available.find((candidate) => sameSource(candidate, next));
+    if (exact) return cloneSource(exact);
+    if (next.type === 'pipeline_tap') {
+      const labelMatch = available.find((candidate) => (
+        cloneSource(candidate).type === 'pipeline_tap' &&
+        String(candidate.tapLabel || '') === String(next.tapLabel || '')
+      ));
+      if (labelMatch) return cloneSource(labelMatch);
+    }
+    return cloneSource(fallbackSource || { type: 'raw' });
+  }
+
+  function formatMetric(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return '-';
+    const absValue = Math.abs(num);
+    if ((absValue >= 1000) || (absValue > 0 && absValue < 0.001)) {
+      return num.toExponential(3);
+    }
+    return num.toFixed(4);
+  }
+
+  function rowsFromBacking(backing, rows, cols) {
+    const zRows = new Array(rows);
+    for (let r = 0; r < rows; r += 1) {
+      zRows[r] = backing.subarray(r * cols, (r + 1) * cols);
+    }
+    return zRows;
+  }
+
+  function getPlotSizeForCompareMode() {
+    const ui = getUi();
+    const fallbackHost = ui.compareSurface || ui.mainPlot;
+    const host = state.mode === 'side_by_side'
+      ? (ui.comparePlotA || fallbackHost)
+      : (ui.comparePlotDiff || fallbackHost);
+    const widthPx = host?.clientWidth || host?.offsetWidth || fallbackHost?.clientWidth || 1;
+    const heightPx = host?.clientHeight || host?.offsetHeight || fallbackHost?.clientHeight || 1;
+    return { widthPx, heightPx };
+  }
+
+  function getCompareDragMode() {
+    const dragMode = (typeof window.effectiveDragMode === 'function')
+      ? window.effectiveDragMode()
+      : null;
+    return dragMode === 'pan' ? 'pan' : 'zoom';
+  }
+
+  function getAxisRangeFromDiv(plotDiv, axisName) {
+    const axis = plotDiv?._fullLayout?.[axisName];
+    if (!axis || !Array.isArray(axis.range) || axis.range.length !== 2) return null;
+    const a = Number(axis.range[0]);
+    const b = Number(axis.range[1]);
+    if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+    return [a, b];
+  }
+
+  function readRelayoutRange(plotDiv, event, axisName) {
+    if (typeof window.readAxisRange === 'function') {
+      const range = window.readAxisRange(event, axisName);
+      if (range) return range;
+    }
+    return getAxisRangeFromDiv(plotDiv, axisName);
+  }
+
+  function setCompareStatus(message, isError) {
+    const ui = getUi();
+    const text = typeof message === 'string' ? message.trim() : '';
+    const nodes = [ui.compareStatus, ui.compareStatusViewport].filter(Boolean);
+    for (const node of nodes) {
+      node.textContent = text;
+      node.hidden = text.length === 0;
+      node.classList.toggle('is-error', !!text && isError === true);
+    }
+  }
+
+  function clearCompareStatus() {
+    setCompareStatus('', false);
+  }
+
+  function clearSummaryMetrics() {
+    const ui = getUi();
+    if (ui.compareStatMean) ui.compareStatMean.textContent = '-';
+    if (ui.compareStatStd) ui.compareStatStd.textContent = '-';
+    if (ui.compareStatRms) ui.compareStatRms.textContent = '-';
+    if (ui.compareStatMaxAbs) ui.compareStatMaxAbs.textContent = '-';
+  }
+
+  function cancelActiveCompareFetch() {
+    if (state.fetchCtrl) {
+      state.fetchCtrl.abort();
+      state.fetchCtrl = null;
+    }
+    while (state.decodeJobs.length > 0) {
+      const jobId = state.decodeJobs.pop();
+      if (typeof window.cancelDecodeJob === 'function' && Number.isInteger(jobId)) {
+        try {
+          window.cancelDecodeJob('main', jobId, { resolveDropped: true });
+        } catch (_) {
+          // Best effort only.
+        }
+      }
+    }
+  }
+
+  function updateSurfaceVisibility() {
+    const ui = getUi();
+    const active = state.mode !== 'single';
+    if (ui.mainPlot) ui.mainPlot.hidden = active;
+    if (ui.compareSurface) ui.compareSurface.hidden = !active;
+    if (ui.compareSideBySide) ui.compareSideBySide.hidden = state.mode !== 'side_by_side';
+    if (ui.compareDiffView) ui.compareDiffView.hidden = state.mode !== 'difference';
+    if (ui.compareRmsSection) ui.compareRmsSection.hidden = !(state.mode === 'difference' && state.showRmsByTrace);
+    if (ui.compareNotice) {
+      ui.compareNotice.hidden = state.mode !== 'difference';
+      ui.compareNotice.textContent = state.mode === 'difference' ? DIFF_NOTE : '';
+    }
+  }
+
+  function updateControlState() {
+    const ui = getUi();
+    const active = state.mode !== 'single';
+    const diffActive = state.mode === 'difference';
+    if (ui.compareModeSelect) ui.compareModeSelect.value = state.mode;
+    if (ui.compareDiffModeSelect) {
+      ui.compareDiffModeSelect.value = state.diffMode;
+      ui.compareDiffModeSelect.disabled = !diffActive;
+    }
+    if (ui.compareShowRms) {
+      ui.compareShowRms.checked = !!state.showRmsByTrace;
+      ui.compareShowRms.disabled = !diffActive;
+    }
+    if (ui.compareSourceASelect) ui.compareSourceASelect.disabled = !active;
+    if (ui.compareSourceBSelect) ui.compareSourceBSelect.disabled = !active;
+    updateSurfaceVisibility();
+  }
+
+  function syncSourceSelect(selectEl, sources, currentSource) {
+    if (!selectEl) return;
+    const nextSources = Array.isArray(sources) ? sources : [];
+    const currentValue = sourceOptionValue(currentSource);
+    selectEl.innerHTML = '';
+    for (const source of nextSources) {
+      selectEl.appendChild(new Option(sourceLabel(source), sourceOptionValue(source)));
+    }
+    selectEl.value = currentValue;
+  }
+
+  function syncCompareControls() {
+    const ui = getUi();
+    const prevSourceA = cloneSource(state.sourceA);
+    const prevSourceB = cloneSource(state.sourceB);
+    const sources = listAvailableSources();
+    const rawSource = { type: 'raw' };
+    const defaultB = firstProcessedSource(sources) || rawSource;
+    state.sourceA = normalizeSource(state.sourceA, sources, rawSource);
+    if (state.sourceBAuto) {
+      state.sourceB = cloneSource(defaultB);
+    } else {
+      state.sourceB = normalizeSource(state.sourceB, sources, defaultB);
+    }
+    syncSourceSelect(ui.compareSourceASelect, sources, state.sourceA);
+    syncSourceSelect(ui.compareSourceBSelect, sources, state.sourceB);
+    updateControlState();
+    return {
+      sourceAChanged: !sameSource(prevSourceA, state.sourceA),
+      sourceBChanged: !sameSource(prevSourceB, state.sourceB),
+    };
+  }
+
+  function buildRequestContextForSource(source, requestBase) {
+    const next = cloneSource(source);
+    const requestedLayer = sourceLabel(next);
+    if (next.type !== 'pipeline_tap') {
+      return {
+        ...requestBase,
+        requestedLayer,
+        effectiveLayer: 'raw',
+        pipelineKey: null,
+        tapLabel: null,
+      };
+    }
+    if (!next.pipelineKey || !next.tapLabel) {
+      throw new Error('Selected compare source is unavailable.');
+    }
+    return {
+      ...requestBase,
+      requestedLayer,
+      effectiveLayer: next.tapLabel,
+      pipelineKey: next.pipelineKey,
+      tapLabel: next.tapLabel,
+    };
+  }
+
+  async function readCompareErrorDetail(response) {
+    if (!response) return '';
+    try {
+      const contentType = response.headers?.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const payload = await response.json();
+        if (payload && payload.detail != null) return String(payload.detail);
+      }
+      const text = await response.text();
+      return text || '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function resolvePayloadDt(payload) {
+    const payloadDt = Number(payload?.dt);
+    if (Number.isFinite(payloadDt) && payloadDt > 0) return payloadDt;
+    const defaultDt = Number(window.defaultDt);
+    if (Number.isFinite(defaultDt) && defaultDt > 0) return defaultDt;
+    return 0;
+  }
+
+  function ensureCompareHeatmapPayload(payload) {
+    if (!payload) return null;
+    if (typeof window.materializeHeatmapPayload === 'function') {
+      return window.materializeHeatmapPayload(payload) ? payload : null;
+    }
+    return payload.zBacking instanceof Float32Array ? payload : null;
+  }
+
+  async function decodeComparePayload(buffer, payloadMeta, token) {
+    const workerEnabled = typeof window.readWindowDecodeUseWorker === 'function'
+      ? window.readWindowDecodeUseWorker()
+      : true;
+    if (workerEnabled && typeof window.enqueueDecodeJob === 'function') {
+      const decodeJob = window.enqueueDecodeJob('main', {
+        bin: buffer,
+        mode: 'heatmap',
+        fbMode: payloadMeta.effectiveLayer === 'fbprob',
+        wantZ: true,
+      });
+      const jobId = Number(decodeJob?.jobId);
+      if (Number.isInteger(jobId)) state.decodeJobs.push(jobId);
+      try {
+        const decoded = await decodeJob.promise;
+        const jobIndex = state.decodeJobs.indexOf(jobId);
+        if (jobIndex >= 0) state.decodeJobs.splice(jobIndex, 1);
+        if (token !== state.fetchToken || !decoded) return null;
+        const payload = window.buildWindowPayloadFromWorkerDecoded(
+          decoded,
+          payloadMeta,
+          null,
+          (shape) => console.warn('Unexpected compare window shape', shape)
+        );
+        return ensureCompareHeatmapPayload(payload);
+      } catch (err) {
+        const jobIndex = state.decodeJobs.indexOf(jobId);
+        if (jobIndex >= 0) state.decodeJobs.splice(jobIndex, 1);
+        throw err;
+      }
+    }
+
+    const payload = window.decodeWindowPayload(
+      new Uint8Array(buffer),
+      payloadMeta,
+      null,
+      (shape) => console.warn('Unexpected compare window shape', shape),
+      { applyDt: false }
+    );
+    return ensureCompareHeatmapPayload(payload);
+  }
+
+  async function fetchComparePayload(source, requestBase, fetchToken, cachePromises) {
+    const requestContext = buildRequestContextForSource(source, requestBase);
+    const artifacts = window.buildWindowRequestArtifacts(requestContext);
+    const cacheKey = artifacts.cacheKey;
+    if (cachePromises.has(cacheKey)) return cachePromises.get(cacheKey);
+
+    const promise = (async () => {
+      const cachedPayload = window.windowCacheGet(cacheKey);
+      if (cachedPayload) return ensureCompareHeatmapPayload(cachedPayload);
+
+      const response = await fetch(`/get_section_window_bin?${artifacts.params.toString()}`, {
+        signal: state.fetchCtrl?.signal,
+      });
+      if (!response.ok) {
+        const detail = await readCompareErrorDetail(response);
+        const suffix = detail ? `: ${detail}` : '';
+        throw new Error(`Compare fetch failed (${response.status})${suffix}`);
+      }
+      const buffer = await response.arrayBuffer();
+      if (fetchToken !== state.fetchToken) return null;
+      const payload = await decodeComparePayload(buffer, artifacts.payloadMeta, fetchToken);
+      if (!payload) return null;
+      const cachePayload = payload.__perf ? { ...payload, __perf: null } : payload;
+      window.windowCacheSet(cacheKey, cachePayload);
+      return cachePayload;
+    })();
+
+    cachePromises.set(cacheKey, promise);
+    return promise;
+  }
+
+  function isMixedDomainDifference() {
+    if (state.mode === 'single') return false;
+    const domainA = inferSourceDomain(state.sourceA);
+    const domainB = inferSourceDomain(state.sourceB);
+    return domainA !== domainB;
+  }
+
+  function buildHeatmapTrace(payload, zRows, colors) {
+    const rows = Number(payload.shape?.[0] ?? 0);
+    const cols = Number(payload.shape?.[1] ?? 0);
+    const xVals = new Float32Array(cols);
+    for (let c = 0; c < cols; c += 1) xVals[c] = payload.x0 + (c * (payload.stepX || 1));
+    const dt = resolvePayloadDt(payload);
+    const yVals = new Float32Array(rows);
+    for (let r = 0; r < rows; r += 1) yVals[r] = (payload.y0 + (r * (payload.stepY || 1))) * dt;
+    return {
+      trace: {
+        type: 'heatmap',
+        x: xVals,
+        y: yVals,
+        z: zRows,
+        colorscale: colors.colorscale,
+        reversescale: colors.reversescale,
+        zmin: colors.zmin,
+        zmax: colors.zmax,
+        zmid: colors.zmid,
+        showscale: false,
+        hovertemplate: '',
+      },
+      dt,
+    };
+  }
+
+  function buildHeatmapLayout(payload, title) {
+    const dt = resolvePayloadDt(payload);
+    return window.buildLayout({
+      mode: 'heatmap',
+      x0: payload.x0,
+      x1: payload.x1,
+      y0: payload.y0,
+      y1: payload.y1,
+      stepX: payload.stepX || 1,
+      stepY: payload.stepY || 1,
+      totalSamples: Array.isArray(window.sectionShape) ? window.sectionShape[1] : (payload.y1 - payload.y0 + 1),
+      dt,
+      savedXRange: window.savedXRange,
+      savedYRange: window.savedYRange,
+      clickmode: 'event',
+      dragmode: getCompareDragMode(),
+      uirevision: `compare:${state.mode}:${sourceOptionValue(state.sourceA)}:${sourceOptionValue(state.sourceB)}:${state.diffMode}`,
+      fbTitle: title,
+    });
+  }
+
+  function resolveStandardColors(payload) {
+    const colormap = document.getElementById('colormap')?.value || 'Greys';
+    const reverse = !!document.getElementById('cmReverse')?.checked;
+    const gain = parseFloat(document.getElementById('gain')?.value || '1') || 1;
+    const fbMode = payload?.effectiveLayer === 'fbprob';
+    return {
+      colorscale: (window.COLORMAPS && window.COLORMAPS[colormap]) || 'Greys',
+      reversescale: reverse,
+      zmin: fbMode ? 0 : (-AMP_LIMIT / Math.max(gain, 1e-9)),
+      zmax: fbMode ? 255 : (AMP_LIMIT / Math.max(gain, 1e-9)),
+      zmid: (!fbMode && (colormap === 'RdBu' || colormap === 'BWR')) ? 0 : undefined,
+    };
+  }
+
+  function resolveDiffColors(limit) {
+    const selected = document.getElementById('colormap')?.value || 'Greys';
+    const diffMap = (selected === 'RdBu' || selected === 'BWR') ? selected : 'RdBu';
+    return {
+      colorscale: (window.COLORMAPS && window.COLORMAPS[diffMap]) || 'RdBu',
+      reversescale: !!document.getElementById('cmReverse')?.checked,
+      zmin: -limit,
+      zmax: limit,
+      zmid: 0,
+    };
+  }
+
+  function ensureCompareHandlers(plotDiv, role) {
+    if (!plotDiv || plotDiv.__svCompareRole === role) return;
+    plotDiv.__svCompareRole = role;
+    plotDiv.on('plotly_relayout', (event) => {
+      if (state.mode === 'single' || state.suppressRelayout) return;
+      const xRange = readRelayoutRange(plotDiv, event, 'xaxis');
+      const yRange = role === 'rms' ? null : readRelayoutRange(plotDiv, event, 'yaxis');
+
+      if (xRange) {
+        window.savedXRange = [xRange[0], xRange[1]];
+      }
+      if (yRange) {
+        const y0 = Number(yRange[0]);
+        const y1 = Number(yRange[1]);
+        if (Number.isFinite(y0) && Number.isFinite(y1)) {
+          window.savedYRange = y0 > y1 ? [y0, y1] : [y1, y0];
+        }
+      }
+
+      const ui = getUi();
+      const updates = {};
+      if (xRange) updates['xaxis.range'] = xRange;
+      if (yRange) updates['yaxis.range'] = yRange;
+      const syncTargets = [];
+      const rmsReady = !!ui.compareRmsPlot?.data?.length;
+
+      if (state.mode === 'side_by_side') {
+        if (role === 'a' && ui.comparePlotB) syncTargets.push(ui.comparePlotB);
+        if (role === 'b' && ui.comparePlotA) syncTargets.push(ui.comparePlotA);
+      } else if (state.mode === 'difference') {
+        if (role === 'diff' && xRange && state.showRmsByTrace && rmsReady) {
+          syncTargets.push({ div: ui.compareRmsPlot, updates: { 'xaxis.range': xRange } });
+        }
+        if (role === 'rms' && xRange && ui.comparePlotDiff) {
+          syncTargets.push({ div: ui.comparePlotDiff, updates: { 'xaxis.range': xRange } });
+        }
+      }
+
+      if (syncTargets.length) {
+        state.suppressRelayout = true;
+        const relayouts = syncTargets.map((target) => {
+          const div = target.div || target;
+          const nextUpdates = target.updates || updates;
+          return window.Plotly.relayout(div, nextUpdates);
+        });
+        Promise.allSettled(relayouts).finally(() => {
+          state.suppressRelayout = false;
+        });
+      }
+
+      if (typeof window.scheduleWindowFetch === 'function') {
+        window.scheduleWindowFetch();
+      }
+    });
+  }
+
+  async function renderHeatmapInto(plotDiv, payload, title, colors, zBacking) {
+    if (!plotDiv || !payload || !(zBacking instanceof Float32Array)) return;
+    const rows = Number(payload.shape?.[0] ?? 0);
+    const cols = Number(payload.shape?.[1] ?? 0);
+    const zRows = rowsFromBacking(zBacking, rows, cols);
+    const { trace } = buildHeatmapTrace(payload, zRows, colors);
+    const layout = buildHeatmapLayout(payload, title);
+    await window.Plotly.react(plotDiv, [trace], layout, { responsive: true });
+  }
+
+  async function renderRmsPlot(plotDiv, payload, rmsByTrace) {
+    if (!plotDiv || !payload) return;
+    const width = Number(payload.shape?.[1] ?? 0);
+    const xVals = new Float32Array(width);
+    for (let i = 0; i < width; i += 1) xVals[i] = payload.x0 + (i * (payload.stepX || 1));
+    const layout = {
+      xaxis: {
+        title: 'Trace',
+        showgrid: false,
+        range: window.savedXRange || undefined,
+      },
+      yaxis: {
+        title: 'RMS(B - A)',
+        showgrid: false,
+      },
+      margin: { t: 10, r: 10, l: 60, b: 40 },
+      paper_bgcolor: '#fff',
+      plot_bgcolor: '#fff',
+      dragmode: getCompareDragMode(),
+      uirevision: `compare:rms:${sourceOptionValue(state.sourceA)}:${sourceOptionValue(state.sourceB)}`,
+    };
+    const trace = {
+      type: 'scattergl',
+      mode: 'lines',
+      x: xVals,
+      y: rmsByTrace,
+      line: {
+        color: '#0f172a',
+        width: 1.5,
+      },
+      hovertemplate: 'Trace %{x}<br>RMS %{y:.4g}<extra></extra>',
+    };
+    await window.Plotly.react(plotDiv, [trace], layout, { responsive: true });
+  }
+
+  async function renderSideBySide(result) {
+    const ui = getUi();
+    const labelA = `A: ${sourceLabel(state.sourceA)}`;
+    const labelB = `B: ${sourceLabel(state.sourceB)}`;
+    if (ui.compareSourceALabel) ui.compareSourceALabel.textContent = labelA;
+    if (ui.compareSourceBLabel) ui.compareSourceBLabel.textContent = labelB;
+    clearSummaryMetrics();
+    if (ui.compareNotice) ui.compareNotice.textContent = '';
+    state.suppressRelayout = true;
+    try {
+      await Promise.all([
+        renderHeatmapInto(ui.comparePlotA, result.payloadA, labelA, resolveStandardColors(result.payloadA), result.payloadA.zBacking),
+        renderHeatmapInto(ui.comparePlotB, result.payloadB, labelB, resolveStandardColors(result.payloadB), result.payloadB.zBacking),
+      ]);
+    } finally {
+      state.suppressRelayout = false;
+    }
+    ensureCompareHandlers(ui.comparePlotA, 'a');
+    ensureCompareHandlers(ui.comparePlotB, 'b');
+  }
+
+  async function renderDifference(result) {
+    const ui = getUi();
+    const metricsApi = window.compareMetrics;
+    if (!metricsApi) throw new Error('compareMetrics is unavailable');
+    const payloadA = result.payloadA;
+    const payloadB = result.payloadB;
+    const a = payloadA.zBacking;
+    const b = payloadB.zBacking;
+    const diffBA = metricsApi.computeDiff(a, b, 'b_minus_a');
+    const displayDiff = state.diffMode === 'b_minus_a'
+      ? diffBA
+      : metricsApi.computeDiff(a, b, 'a_minus_b');
+    const stats = metricsApi.computeSummaryStats(diffBA);
+    const rows = Number(payloadA.shape?.[0] ?? 0);
+    const cols = Number(payloadA.shape?.[1] ?? 0);
+    const rmsByTrace = metricsApi.computeRmsByTrace(a, b, rows, cols);
+    const rawLimit = metricsApi.percentileAbs(displayDiff, 99);
+    const noDifference = !Number.isFinite(rawLimit) || rawLimit <= 0;
+    const diffLimit = noDifference ? EPSILON_DIFF_LIMIT : rawLimit;
+    const expression = state.diffMode === 'a_minus_b' ? 'A - B' : 'B - A';
+
+    if (ui.compareDiffExpression) ui.compareDiffExpression.textContent = expression;
+    if (ui.compareNotice) {
+      ui.compareNotice.textContent = noDifference
+        ? `${DIFF_NOTE} No visible difference in the current window.`
+        : DIFF_NOTE;
+    }
+    if (ui.compareStatMean) ui.compareStatMean.textContent = formatMetric(stats.mean);
+    if (ui.compareStatStd) ui.compareStatStd.textContent = formatMetric(stats.std);
+    if (ui.compareStatRms) ui.compareStatRms.textContent = formatMetric(stats.rms);
+    if (ui.compareStatMaxAbs) ui.compareStatMaxAbs.textContent = formatMetric(stats.maxAbs);
+
+    state.suppressRelayout = true;
+    try {
+      await renderHeatmapInto(
+        ui.comparePlotDiff,
+        payloadA,
+        expression,
+        resolveDiffColors(diffLimit),
+        displayDiff
+      );
+      if (state.showRmsByTrace) {
+        await renderRmsPlot(ui.compareRmsPlot, payloadA, rmsByTrace);
+      } else if (ui.compareRmsPlot && typeof window.Plotly?.purge === 'function') {
+        window.Plotly.purge(ui.compareRmsPlot);
+      }
+    } finally {
+      state.suppressRelayout = false;
+    }
+    ensureCompareHandlers(ui.comparePlotDiff, 'diff');
+    if (state.showRmsByTrace) ensureCompareHandlers(ui.compareRmsPlot, 'rms');
+  }
+
+  async function renderFromCache() {
+    if (state.mode === 'single') {
+      updateSurfaceVisibility();
+      return;
+    }
+    if (!state.lastResult) return;
+    updateSurfaceVisibility();
+    clearCompareStatus();
+    if (state.mode === 'side_by_side') {
+      if (isMixedDomainDifference()) {
+        purgeComparePlots();
+        updateSurfaceVisibility();
+        clearSummaryMetrics();
+        setCompareStatus(DOMAIN_MISMATCH_MESSAGE, true);
+        return;
+      }
+      await renderSideBySide(state.lastResult);
+      return;
+    }
+    if (isMixedDomainDifference()) {
+      purgeComparePlots();
+      updateSurfaceVisibility();
+      clearSummaryMetrics();
+      setCompareStatus(DOMAIN_MISMATCH_MESSAGE, true);
+      return;
+    }
+    await renderDifference(state.lastResult);
+  }
+
+  async function fetchWindowAndRender() {
+    if (state.mode === 'single') return null;
+    const metricsApi = window.compareMetrics;
+    if (!metricsApi) return null;
+    const ui = getUi();
+    updateSurfaceVisibility();
+    clearCompareStatus();
+    if (isMixedDomainDifference()) {
+      state.lastResult = null;
+      purgeComparePlots();
+      clearSummaryMetrics();
+      setCompareStatus(DOMAIN_MISMATCH_MESSAGE, true);
+      return null;
+    }
+
+    if (!window.currentFileId) {
+      state.lastResult = null;
+      return null;
+    }
+    if (!Array.isArray(window.sectionShape) || window.sectionShape.length < 2) {
+      if (typeof window.fetchSectionMeta === 'function') {
+        await window.fetchSectionMeta();
+      }
+      if (!Array.isArray(window.sectionShape) || window.sectionShape.length < 2) return null;
+    }
+
+    const slider = document.getElementById('key1_slider');
+    const key1Index = slider ? parseInt(slider.value || '0', 10) : 0;
+    const key1Val = Array.isArray(window.key1Values) ? window.key1Values[key1Index] : undefined;
+    if (key1Val === undefined) return null;
+
+    const windowInfo = typeof window.currentVisibleWindow === 'function'
+      ? window.currentVisibleWindow()
+      : null;
+    if (!windowInfo) return null;
+
+    const { widthPx, heightPx } = getPlotSizeForCompareMode();
+    const { step_x, step_y } = window.computeStepsForWindow({
+      tracesVisible: windowInfo.nTraces,
+      samplesVisible: windowInfo.nSamples,
+      widthPx,
+      heightPx,
+    });
+
+    cancelActiveCompareFetch();
+    state.fetchToken += 1;
+    const token = state.fetchToken;
+    state.fetchCtrl = new AbortController();
+
+    if (typeof window.showLoading === 'function') {
+      window.showLoading(`Loading compare view... stepX=${step_x}, stepY=${step_y}`);
+    }
+
+    const requestBase = {
+      fileId: window.currentFileId,
+      key1Val,
+      key1Byte: window.currentKey1Byte,
+      key2Byte: window.currentKey2Byte,
+      windowInfo,
+      stepX: step_x,
+      stepY: step_y,
+      scaling: window.currentScaling || 'amax',
+      transpose: '1',
+      mode: 'heatmap',
+    };
+
+    const cachePromises = new Map();
+    try {
+      const [payloadA, payloadB] = await Promise.all([
+        fetchComparePayload(state.sourceA, requestBase, token, cachePromises),
+        fetchComparePayload(state.sourceB, requestBase, token, cachePromises),
+      ]);
+      if (token !== state.fetchToken || !payloadA || !payloadB) return null;
+
+      const shapeA = Array.isArray(payloadA.shape) ? payloadA.shape.join('x') : '';
+      const shapeB = Array.isArray(payloadB.shape) ? payloadB.shape.join('x') : '';
+      if (shapeA !== shapeB) {
+        state.lastResult = null;
+        purgeComparePlots();
+        clearSummaryMetrics();
+        setCompareStatus('Cannot compare sources: decoded window shapes differ.', true);
+        return null;
+      }
+
+      const dtA = resolvePayloadDt(payloadA);
+      const dtB = resolvePayloadDt(payloadB);
+      if (Number.isFinite(dtA) && Number.isFinite(dtB) && Math.abs(dtA - dtB) > 1e-12) {
+        state.lastResult = null;
+        purgeComparePlots();
+        clearSummaryMetrics();
+        setCompareStatus('Cannot compare sources: decoded window sample intervals differ.', true);
+        return null;
+      }
+
+      state.lastResult = { payloadA, payloadB };
+      await renderFromCache();
+      return state.lastResult;
+    } catch (err) {
+      if (err && err.name === 'AbortError') return null;
+      state.lastResult = null;
+      purgeComparePlots();
+      clearSummaryMetrics();
+      setCompareStatus(err instanceof Error ? err.message : String(err), true);
+      return null;
+    } finally {
+      cancelActiveCompareFetch();
+      if (typeof window.hideLoading === 'function') window.hideLoading();
+    }
+  }
+
+  function purgeComparePlots() {
+    const ui = getUi();
+    const plots = [ui.comparePlotA, ui.comparePlotB, ui.comparePlotDiff, ui.compareRmsPlot];
+    for (const plotDiv of plots) {
+      if (!plotDiv || typeof window.Plotly?.purge !== 'function') continue;
+      try {
+        window.Plotly.purge(plotDiv);
+      } catch (_) {
+        // Ignore purge errors for empty divs.
+      }
+      plotDiv.innerHTML = '';
+    }
+  }
+
+  function reset(options = {}) {
+    cancelActiveCompareFetch();
+    if (options.clearCache !== false) state.lastResult = null;
+    if (options.keepStatus !== true) {
+      clearCompareStatus();
+      clearSummaryMetrics();
+    }
+    purgeComparePlots();
+    if (options.forceHide === true) {
+      const ui = getUi();
+      if (ui.compareSurface) ui.compareSurface.hidden = true;
+      if (ui.mainPlot) ui.mainPlot.hidden = false;
+      return;
+    }
+    updateSurfaceVisibility();
+  }
+
+  function restylePlots() {
+    if (state.mode === 'single') return;
+    void renderFromCache().catch((err) => {
+      setCompareStatus(err instanceof Error ? err.message : String(err), true);
+    });
+  }
+
+  function handleModeChange() {
+    const ui = getUi();
+    state.mode = ui.compareModeSelect?.value || 'single';
+    updateControlState();
+    if (state.mode === 'single') {
+      reset({ clearCache: false });
+      if (typeof window.drawSelectedLayer === 'function') window.drawSelectedLayer();
+      return;
+    }
+    void fetchWindowAndRender();
+  }
+
+  function handleSourceChange(which) {
+    const ui = getUi();
+    if (which === 'a') {
+      state.sourceA = parseSourceOptionValue(ui.compareSourceASelect?.value || 'raw');
+      syncCompareControls();
+    } else {
+      state.sourceBAuto = false;
+      state.sourceB = parseSourceOptionValue(ui.compareSourceBSelect?.value || 'raw');
+      syncCompareControls();
+    }
+    if (state.mode !== 'single') {
+      void fetchWindowAndRender();
+    }
+  }
+
+  function handleDiffModeChange() {
+    const ui = getUi();
+    state.diffMode = ui.compareDiffModeSelect?.value === 'a_minus_b' ? 'a_minus_b' : 'b_minus_a';
+    if (state.mode === 'difference') {
+      void renderFromCache();
+    }
+  }
+
+  function handleShowRmsChange() {
+    const ui = getUi();
+    state.showRmsByTrace = !!ui.compareShowRms?.checked;
+    updateControlState();
+    if (state.mode === 'difference') {
+      void renderFromCache();
+    }
+  }
+
+  function bindControls() {
+    const ui = getUi();
+    if (ui.compareModeSelect) ui.compareModeSelect.addEventListener('change', handleModeChange);
+    if (ui.compareSourceASelect) ui.compareSourceASelect.addEventListener('change', () => handleSourceChange('a'));
+    if (ui.compareSourceBSelect) ui.compareSourceBSelect.addEventListener('change', () => handleSourceChange('b'));
+    if (ui.compareDiffModeSelect) ui.compareDiffModeSelect.addEventListener('change', handleDiffModeChange);
+    if (ui.compareShowRms) ui.compareShowRms.addEventListener('change', handleShowRmsChange);
+
+    if (ui.layerSelect && typeof MutationObserver === 'function') {
+      const observer = new MutationObserver(() => {
+        const { sourceAChanged, sourceBChanged } = syncCompareControls();
+        if (state.mode !== 'single' && (sourceAChanged || sourceBChanged)) {
+          void fetchWindowAndRender();
+        }
+      });
+      observer.observe(ui.layerSelect, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+      });
+    }
+
+    const resizeTargets = [
+      ui.compareSurface,
+      ui.comparePlotA,
+      ui.comparePlotB,
+      ui.comparePlotDiff,
+      ui.compareRmsPlot,
+    ].filter(Boolean);
+    if (typeof ResizeObserver === 'function' && resizeTargets.length) {
+      const resizeObserver = new ResizeObserver(() => {
+        if (state.mode === 'single') return;
+        const plots = [ui.comparePlotA, ui.comparePlotB, ui.comparePlotDiff, ui.compareRmsPlot];
+        for (const plotDiv of plots) {
+          if (!plotDiv || typeof window.Plotly?.Plots?.resize !== 'function') continue;
+          try {
+            window.Plotly.Plots.resize(plotDiv);
+          } catch (_) {
+            // Ignore empty plot resize failures.
+          }
+        }
+      });
+      for (const target of resizeTargets) resizeObserver.observe(target);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    bindControls();
+    syncCompareControls();
+    updateSurfaceVisibility();
+  });
+
+  window.compareView = {
+    isActive() {
+      return state.mode !== 'single';
+    },
+    fetchWindowAndRender,
+    renderFromCache,
+    reset,
+    restylePlots,
+    syncControls: syncCompareControls,
+  };
+})();

--- a/app/static/viewer/restyle_only.js
+++ b/app/static/viewer/restyle_only.js
@@ -12,6 +12,10 @@
       window.heatmapTraceIndex = heatmapTraceIndex;
 
       window.restyleColorAndGain = function () {
+        if (window.compareView && typeof window.compareView.isActive === 'function' && window.compareView.isActive()) {
+          window.compareView.restylePlots();
+          return;
+        }
         const plotDiv = document.getElementById('plot');
         if (!plotDiv) throw new Error('plot div not found');
         const idx = heatmapTraceIndex(plotDiv);

--- a/app/static/viewer/viewer_legacy.js
+++ b/app/static/viewer/viewer_legacy.js
@@ -256,6 +256,9 @@
     function showViewerEmptyState(kind = 'no-dataset') {
       const copy = VIEWER_EMPTY_STATE_COPY[kind] || VIEWER_EMPTY_STATE_COPY['no-dataset'];
       const { root, title, description, helper } = getViewerEmptyStateNodes();
+      if (window.compareView && typeof window.compareView.reset === 'function') {
+        window.compareView.reset({ forceHide: true });
+      }
       if (title) title.textContent = copy.title;
       if (description) description.textContent = copy.description;
       if (helper) helper.textContent = copy.helper;
@@ -648,6 +651,7 @@
 
       return null;
     }
+    window.readAxisRange = readAxisRange;
 
     function filenameFromContentDisposition(disposition) {
       if (!disposition) return null;
@@ -1895,6 +1899,7 @@
         savedYRange = null;
       }
     }
+    window.applyServerDt = applyServerDt;
 
     const COLORMAPS = {
       Greys: 'Greys',
@@ -2594,6 +2599,7 @@
         nSamples: y1 - y0 + 1,
       };
     }
+    window.currentVisibleWindow = currentVisibleWindow;
 
     function updateKey1Display() {
       updateSectionNavigation({ syncDisplay: true });
@@ -2731,6 +2737,7 @@
       }
       return null;
     }
+    window.fetchSectionMeta = fetchSectionMeta;
 
     async function fetchCurrentFileName() {
       if (!currentFileId) {
@@ -2858,6 +2865,12 @@
 
 
     function renderLatestView(startOverride = null, endOverride = null) {
+      if (window.compareView && typeof window.compareView.isActive === 'function' && window.compareView.isActive()) {
+        window.compareView.renderFromCache().catch((err) => {
+          console.warn('compare render failed', err);
+        });
+        return;
+      }
       const sel = document.getElementById('layerSelect');
       const layer = sel ? sel.value : 'raw';
       const slider = document.getElementById('key1_slider');

--- a/app/static/viewer/window_fetch.js
+++ b/app/static/viewer/window_fetch.js
@@ -66,6 +66,7 @@
 
       return { step_x: stepX, step_y: stepY };
     }
+    window.computeStepsForWindow = computeStepsForWindow;
 
     function buildWindowLoadingMessage({ mode, stepX, stepY }) {
       return `Loading window... Mode: ${mode}, stepX=${stepX}, stepY=${stepY}`;
@@ -81,12 +82,14 @@
       overlay.style.pointerEvents = window.windowLoadingBlocksInput === true ? 'auto' : 'none';
       overlay.classList.add('show');
     }
+    window.showLoading = showLoading;
 
     function hideLoading() {
       const overlay = document.getElementById('windowLoadingOverlay');
       if (!overlay) return;
       overlay.classList.remove('show');
     }
+    window.hideLoading = hideLoading;
 
     function bumpWindowFetchId() {
       activeWindowFetchId += 1;
@@ -209,6 +212,7 @@
       }
       return WINDOW_DECODE_USE_WORKER_DEFAULT;
     }
+    window.readWindowDecodeUseWorker = readWindowDecodeUseWorker;
 
     function readWindowDecodeWorkerPath() {
       const configured = (typeof cfg === 'object' && cfg !== null)
@@ -259,6 +263,7 @@
       syncWindowCacheStats();
       return entry.payload;
     }
+    window.windowCacheGet = windowCacheGet;
 
     function windowCacheSet(key, payload) {
       const bytes = estimateWindowPayloadBytes(payload);
@@ -277,6 +282,7 @@
       syncWindowCacheStats();
       return payload;
     }
+    window.windowCacheSet = windowCacheSet;
 
     function windowCachePeek(key) {
       const entry = windowPayloadCache.get(key);
@@ -402,6 +408,7 @@
         },
       };
     }
+    window.buildWindowRequestArtifacts = buildWindowRequestArtifacts;
 
     function resolveWindowShape(shapeRaw) {
       const shape = Array.isArray(shapeRaw) ? shapeRaw : Array.from(shapeRaw ?? []);
@@ -507,6 +514,7 @@
       });
       return { jobId, promise };
     }
+    window.enqueueDecodeJob = enqueueDecodeJob;
 
     function cancelDecodeJob(kind, jobId, { resolveDropped = false } = {}) {
       if (!Number.isInteger(jobId)) return;
@@ -528,6 +536,7 @@
         pending.reject(new Error('decode_job_canceled'));
       }
     }
+    window.cancelDecodeJob = cancelDecodeJob;
 
     function cancelActiveMainDecodeJob() {
       if (!Number.isInteger(activeMainDecodeJobId)) return;
@@ -568,10 +577,12 @@
         shape: [rows, cols],
         valuesI8,
         scale,
+        dt: Number.isFinite(Number(obj?.dt)) ? Number(obj.dt) : null,
         quant: resolveWindowQuantMeta(obj),
         __perf: perfMeta || null,
       };
     }
+    window.decodeWindowPayload = decodeWindowPayload;
 
     function buildWindowPayloadFromWorkerDecoded(decoded, payloadMeta, perfMeta, onInvalidShape) {
       if (!decoded || decoded.ok !== true) return null;
@@ -589,6 +600,7 @@
         ...payloadMeta,
         shape: [rows, cols],
         scale: Number.isFinite(scaleRaw) ? scaleRaw : null,
+        dt: Number.isFinite(Number(decoded.dt)) ? Number(decoded.dt) : null,
         quant: decoded.quant ?? null,
         __perf: perfMeta || null,
       };
@@ -627,6 +639,7 @@
       payload.valuesI8 = valuesI8;
       return payload;
     }
+    window.buildWindowPayloadFromWorkerDecoded = buildWindowPayloadFromWorkerDecoded;
 
     function renderWindowPayload(windowPayload) {
       if (!windowPayload) return;
@@ -922,6 +935,9 @@
     };
 
     async function fetchWindowAndPlot() {
+      if (window.compareView && typeof window.compareView.isActive === 'function' && window.compareView.isActive()) {
+        return window.compareView.fetchWindowAndRender();
+      }
       D('WINDOW@req', { key1: key1Values?.[parseInt(document.getElementById('key1_slider')?.value || '0', 10)] });
       if (!currentFileId) return;
       if (!sectionShape) {
@@ -1143,3 +1159,4 @@
         if (requestId === activeWindowFetchId) hideLoading();
       }
     }
+    window.fetchWindowAndPlot = fetchWindowAndPlot;

--- a/app/static/viewer/window_render.js
+++ b/app/static/viewer/window_render.js
@@ -512,6 +512,148 @@
       plotDiv.__svWiggleSig = wiggleSig;
     }
 
+    function buildHeatmapRowsFromBacking(zBacking, rows, cols) {
+      const zRows = new Array(rows);
+      for (let r = 0; r < rows; r++) {
+        zRows[r] = zBacking.subarray(r * cols, (r + 1) * cols);
+      }
+      return zRows;
+    }
+
+    function flattenHeatmapRows(zRows, rows, cols) {
+      const backing = new Float32Array(rows * cols);
+      for (let r = 0; r < rows; r++) {
+        const row = zRows?.[r];
+        if (!row) continue;
+        const start = r * cols;
+        if (ArrayBuffer.isView(row) && typeof row.subarray === 'function' && row.length >= cols) {
+          backing.set(row.subarray(0, cols), start);
+          continue;
+        }
+        for (let c = 0; c < cols; c++) {
+          backing[start + c] = Number(row[c]) || 0;
+        }
+      }
+      return backing;
+    }
+
+    function resolveHeatmapQuantMeta(windowData) {
+      return windowData.quant || (
+        (windowData.lo !== undefined && windowData.hi !== undefined)
+          ? { mode: windowData.method || 'linear', lo: windowData.lo, hi: windowData.hi, mu: windowData.mu ?? 255 }
+          : (windowData.scale != null ? { scale: windowData.scale } : null)
+      );
+    }
+
+    function materializeHeatmapPayload(windowData) {
+      if (!windowData) return null;
+      const rows = Number(windowData.shape?.[0] ?? 0);
+      const cols = Number(windowData.shape?.[1] ?? 0);
+      const total = rows * cols;
+      if (!rows || !cols) return null;
+
+      const hasWorkerBacking = windowData.zBacking instanceof Float32Array && windowData.zBacking.length >= total;
+      if (hasWorkerBacking) {
+        if (!(Array.isArray(windowData.zRows) && windowData.zRows.length === rows)) {
+          windowData.zRows = buildHeatmapRowsFromBacking(windowData.zBacking, rows, cols);
+        }
+        return {
+          zBacking: windowData.zBacking,
+          zRows: windowData.zRows,
+          poolingCandidate: false,
+        };
+      }
+
+      if (Array.isArray(windowData.zRows) && windowData.zRows.length === rows) {
+        windowData.zBacking = flattenHeatmapRows(windowData.zRows, rows, cols);
+        return {
+          zBacking: windowData.zBacking,
+          zRows: windowData.zRows,
+          poolingCandidate: false,
+        };
+      }
+
+      const useI8 = windowData.valuesI8 instanceof Int8Array;
+      const useF32 = !useI8 && windowData.values && windowData.values.length != null;
+      if (!useI8 && !useF32) return null;
+      if (useI8 && windowData.valuesI8.length < total) return null;
+      if (useF32 && windowData.values.length < total) return null;
+
+      const fbMode = windowData.effectiveLayer === 'fbprob';
+      const quantMeta = resolveHeatmapQuantMeta(windowData);
+      const fallbackScale = Number(windowData.scale) || 1;
+      const poolingCandidate = (
+        USE_HEATMAP_POOLING &&
+        useI8 &&
+        window.SeisHeatmap &&
+        typeof window.SeisHeatmap.toPlotlyHeatmapZ === 'function'
+      );
+
+      if (poolingCandidate) {
+        const zRows = window.SeisHeatmap.toPlotlyHeatmapZ({
+          i8: windowData.valuesI8,
+          rows,
+          cols,
+          quant: quantMeta,
+        });
+        let backing = zRows?.backing instanceof Float32Array && zRows.backing.length >= total
+          ? zRows.backing
+          : null;
+        if (!backing) backing = flattenHeatmapRows(zRows, rows, cols);
+        if (fbMode) {
+          for (let i = 0; i < total; i++) backing[i] = backing[i] * 255;
+        }
+        windowData.zBacking = backing;
+        windowData.zRows = Array.isArray(zRows) && zRows.length === rows
+          ? zRows
+          : buildHeatmapRowsFromBacking(backing, rows, cols);
+        return {
+          zBacking: windowData.zBacking,
+          zRows: windowData.zRows,
+          poolingCandidate,
+        };
+      }
+
+      let invScale = 1 / (fallbackScale || 1);
+      if (quantMeta && 'scale' in (quantMeta || {})) {
+        const scaleVal = Number(quantMeta.scale);
+        if (Number.isFinite(scaleVal) && scaleVal !== 0) {
+          invScale = 1 / scaleVal;
+        }
+      }
+      const hasLut = !!(quantMeta && 'lo' in quantMeta && 'hi' in quantMeta);
+      const lut = hasLut && window.SeisHeatmap && typeof window.SeisHeatmap.getQuantLUT === 'function'
+        ? window.SeisHeatmap.getQuantLUT(quantMeta)
+        : null;
+      const srcF32 = useF32 ? windowData.values : null;
+      const backing = new Float32Array(total);
+      const zRows = buildHeatmapRowsFromBacking(backing, rows, cols);
+      for (let r = 0; r < rows; r++) {
+        const offset = r * cols;
+        for (let c = 0; c < cols; c++) {
+          let rawValue;
+          if (useI8) {
+            const q = windowData.valuesI8[offset + c];
+            if (lut) rawValue = lut[(q + 128) & 0xff];
+            else rawValue = q * invScale;
+          } else if (srcF32) {
+            rawValue = srcF32[offset + c];
+          } else {
+            rawValue = 0;
+          }
+          backing[offset + c] = fbMode ? (rawValue * 255) : rawValue;
+        }
+      }
+      windowData.zBacking = backing;
+      windowData.zRows = zRows;
+      return {
+        zBacking: windowData.zBacking,
+        zRows: windowData.zRows,
+        poolingCandidate: false,
+      };
+    }
+    window.materializeHeatmapPayload = materializeHeatmapPayload;
+
     function renderWindowHeatmap(windowData) {
       D('RENDER@heatmap', { key1: windowData.key1, x: [windowData.x0, windowData.x1],
         y: [windowData.y0, windowData.y1], step: [windowData.stepX, windowData.stepY],
@@ -573,100 +715,20 @@
       let tPlot0 = null;
       let plotPromise = null;
 
-      const N = rows * cols;
-      const hasWorkerRows = Array.isArray(windowData.zRows) && windowData.zRows.length === rows;
-      const hasWorkerBacking = windowData.zBacking instanceof Float32Array && windowData.zBacking.length >= N;
-      const useI8 = !hasWorkerRows && !hasWorkerBacking && windowData.valuesI8 instanceof Int8Array;
-      const useF32 = !hasWorkerRows && !hasWorkerBacking && !useI8 && windowData.values && windowData.values.length != null;
-      if (!hasWorkerRows && !hasWorkerBacking && !useI8 && !useF32) {
+      const materialized = materializeHeatmapPayload(windowData);
+      if (!materialized) {
         console.warn('renderWindowHeatmap: missing values');
         return;
       }
-      if (useI8 && windowData.valuesI8.length < N) return;
-      if (useF32 && windowData.values.length < N) return;
 
       setGrid({ x0, stepX, y0, stepY });
       const gain = parseFloat(document.getElementById('gain').value) || 1.0;
       const AMP_LIMIT = 3.0;
       const fbMode = effectiveLayer === 'fbprob';
-      const quantMeta = windowData.quant || (
-        (windowData.lo !== undefined && windowData.hi !== undefined)
-          ? { mode: windowData.method || 'linear', lo: windowData.lo, hi: windowData.hi, mu: windowData.mu ?? 255 }
-          : (windowData.scale != null ? { scale: windowData.scale } : null)
-      );
-      const fallbackScale = Number(windowData.scale) || 1;
 
       if (perfEnabled) tLut0 = performance.now();
-      let zData;
-      let poolingCandidate = false;
-      if (hasWorkerRows) {
-        zData = windowData.zRows;
-      } else if (hasWorkerBacking) {
-        const zRows = new Array(rows);
-        const backing = windowData.zBacking;
-        for (let r = 0; r < rows; r++) {
-          zRows[r] = backing.subarray(r * cols, (r + 1) * cols);
-        }
-        windowData.zRows = zRows;
-        zData = zRows;
-      } else {
-        poolingCandidate = (
-          USE_HEATMAP_POOLING &&
-          useI8 &&
-          window.SeisHeatmap &&
-          typeof window.SeisHeatmap.toPlotlyHeatmapZ === 'function'
-        );
-        if (poolingCandidate) {
-          zData = window.SeisHeatmap.toPlotlyHeatmapZ({
-            i8: windowData.valuesI8,
-            rows,
-            cols,
-            quant: quantMeta,
-          });
-          const backing = zData.backing;
-          const total = rows * cols;
-          if (fbMode) {
-            for (let p = 0; p < total; p++) backing[p] = backing[p] * 255;
-          }
-        } else {
-          const zRows = new Array(rows);
-          const hasLut = !!(quantMeta && 'lo' in quantMeta && 'hi' in quantMeta);
-          const lut = hasLut && window.SeisHeatmap && typeof window.SeisHeatmap.getQuantLUT === 'function'
-            ? window.SeisHeatmap.getQuantLUT(quantMeta)
-            : null;
-          let invScale = 1 / (fallbackScale || 1);
-          if (quantMeta && 'scale' in (quantMeta || {})) {
-            const scaleVal = Number(quantMeta.scale);
-            if (Number.isFinite(scaleVal) && scaleVal !== 0) {
-              invScale = 1 / scaleVal;
-            }
-          }
-          const srcF32 = useF32 ? windowData.values : null;
-          for (let r = 0; r < rows; r++) {
-            const row = new Float32Array(cols);
-            const offset = r * cols;
-            for (let c = 0; c < cols; c++) {
-              let rawValue;
-              if (useI8) {
-                const q = windowData.valuesI8[offset + c];
-                if (lut) rawValue = lut[(q + 128) & 0xff];
-                else rawValue = q * invScale;
-              } else if (srcF32) {
-                rawValue = srcF32[offset + c];
-              } else {
-                rawValue = 0;
-              }
-              if (fbMode) {
-                row[c] = rawValue * 255;
-              } else {
-                row[c] = rawValue;
-              }
-            }
-            zRows[r] = row;
-          }
-          zData = zRows;
-        }
-      }
+      const zData = materialized.zRows;
+      const poolingCandidate = materialized.poolingCandidate === true;
       if (perfEnabled) tLut1 = performance.now();
 
       const xVals = new Float32Array(cols);

--- a/app/tests/e2e/test_compare_view_playwright.py
+++ b/app/tests/e2e/test_compare_view_playwright.py
@@ -1,0 +1,388 @@
+import time
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+
+def _wait_for(condition, message: str, timeout_s: float = 5.0) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if condition():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"Timed out waiting for {message}.")
+
+
+def _install_compare_window_stubs(page, *, tap_dt: float = 0.002) -> None:
+    page.evaluate(
+        """
+        ({ tapDt }) => {
+          const slider = document.getElementById('key1_slider');
+          if (slider) {
+            slider.value = '0';
+            slider.max = '0';
+          }
+
+          const attachPlotHooks = (div) => {
+            if (!div) return;
+            div.on = () => div;
+            div.data = [];
+            div._fullLayout = {
+              xaxis: { range: [0, 1] },
+              yaxis: { range: [1, 0] },
+            };
+          };
+
+          ['comparePlotA', 'comparePlotB', 'comparePlotDiff', 'compareRmsPlot'].forEach((id) => {
+            attachPlotHooks(document.getElementById(id));
+          });
+
+          window.currentFileId = 'compare-test-file';
+          window.sectionShape = [4, 4];
+          window.key1Values = [100];
+          window.currentKey1Byte = 189;
+          window.currentKey2Byte = 193;
+          window.currentScaling = 'amax';
+          window.defaultDt = 0.002;
+          window.savedXRange = null;
+          window.savedYRange = null;
+
+          window.currentVisibleWindow = () => ({
+            x0: 0,
+            x1: 1,
+            y0: 0,
+            y1: 1,
+            nTraces: 2,
+            nSamples: 2,
+          });
+          window.computeStepsForWindow = () => ({ step_x: 1, step_y: 1 });
+          window.readWindowDecodeUseWorker = () => false;
+          window.__compareApplyDt = null;
+          window.decodeWindowPayload = (_bin, payloadMeta, _perfMeta, _onInvalidShape, options = {}) => {
+            window.__compareApplyDt = options?.applyDt ?? null;
+            return {
+              ...payloadMeta,
+              shape: [2, 2],
+              dt: payloadMeta.effectiveLayer && payloadMeta.effectiveLayer !== 'raw' ? tapDt : 0.002,
+              zBacking: new Float32Array([1, 2, 3, 4]),
+            };
+          };
+          window.windowCacheGet = () => null;
+          window.windowCacheSet = (_key, payload) => payload;
+          window.showLoading = () => {};
+          window.hideLoading = () => {};
+          window.Plotly = {
+            react: async (div, data) => {
+              attachPlotHooks(div);
+              div.data = Array.isArray(data) ? data : [];
+              return div;
+            },
+            purge: (div) => {
+              if (!div) return;
+              attachPlotHooks(div);
+              div.data = [];
+            },
+            relayout: async (div) => div,
+            Plots: {
+              resize: () => {},
+            },
+          };
+        }
+        """,
+        {"tapDt": tap_dt},
+    )
+
+
+def _install_compare_worker_window_stubs(page, *, tap_dt: float = 0.002) -> None:
+    _install_compare_window_stubs(page, tap_dt=tap_dt)
+    page.evaluate(
+        """
+        ({ tapDt }) => {
+          window.readWindowDecodeUseWorker = () => true;
+          window.__compareWorkerJobs = 0;
+          window.enqueueDecodeJob = () => {
+            window.__compareWorkerJobs += 1;
+            return {
+              jobId: window.__compareWorkerJobs,
+              promise: Promise.resolve({
+                ok: true,
+                rows: 2,
+                cols: 2,
+                dt: tapDt,
+                zBuf: new Float32Array([1, 2, 3, 4]).buffer,
+              }),
+            };
+          };
+          window.cancelDecodeJob = () => {};
+          window.buildWindowPayloadFromWorkerDecoded = (decoded, payloadMeta) => ({
+            ...payloadMeta,
+            shape: [2, 2],
+            dt: payloadMeta.effectiveLayer && payloadMeta.effectiveLayer !== 'raw' ? tapDt : 0.002,
+            zBacking: new Float32Array([1, 2, 3, 4]),
+            zRows: [
+              new Float32Array([1, 2]),
+              new Float32Array([3, 4]),
+            ],
+          });
+        }
+        """,
+        {"tapDt": tap_dt},
+    )
+
+
+def _append_pipeline_layer_option(page, label: str = "denoise") -> None:
+    page.evaluate(
+        """
+        ({ label }) => {
+          window.latestPipelineKey = 'pipe-1';
+          const select = document.getElementById('layerSelect');
+          if (!select) return;
+          const hasOption = Array.from(select.options).some((option) => option.value === label);
+          if (!hasOption) {
+            select.appendChild(new Option(label, label));
+          }
+        }
+        """,
+        {"label": label},
+    )
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_refetches_when_auto_source_b_changes(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    requests: list[str] = []
+
+    def handle_window(route, request):
+        requests.append(request.url)
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_window_stubs(page)
+
+    page.select_option("#compareModeSelect", "side_by_side")
+    _wait_for(lambda: len(requests) >= 1, "the initial compare fetch")
+    initial_request_count = len(requests)
+
+    _append_pipeline_layer_option(page)
+    page.wait_for_function(
+        "() => document.getElementById('compareSourceBSelect')?.value === 'pipeline_tap:pipe-1:denoise'"
+    )
+    _wait_for(
+        lambda: len(requests) >= initial_request_count + 2,
+        "the compare refetch after source B auto-switches",
+    )
+
+    queries = [parse_qs(urlparse(url).query) for url in requests]
+    assert any(
+        query.get("pipeline_key") == ["pipe-1"]
+        and query.get("tap_label") == ["denoise"]
+        for query in queries
+    )
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_preserves_server_dt_in_non_worker_decode(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    def handle_window(route, _request):
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_window_stubs(page, tap_dt=0.004)
+    _append_pipeline_layer_option(page)
+    page.evaluate("() => { window.savedYRange = [5, 1]; }")
+
+    page.wait_for_function(
+        "() => document.getElementById('compareSourceBSelect')?.value === 'pipeline_tap:pipe-1:denoise'"
+    )
+    page.select_option("#compareModeSelect", "difference")
+    page.wait_for_function(
+        "() => (document.getElementById('compareStatus')?.textContent || '').includes('sample intervals differ')"
+    )
+
+    assert (
+        page.locator("#compareStatus").text_content()
+        == "Cannot compare sources: decoded window sample intervals differ."
+    )
+    assert page.evaluate("() => window.__compareApplyDt") is False
+    assert page.evaluate("() => window.defaultDt") == pytest.approx(0.002)
+    assert page.evaluate("() => window.savedYRange") == [5, 1]
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_preserves_server_dt_in_worker_decode(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    def handle_window(route, _request):
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_worker_window_stubs(page, tap_dt=0.004)
+    _append_pipeline_layer_option(page)
+    page.evaluate("() => { window.savedYRange = [7, 2]; }")
+
+    page.wait_for_function(
+        "() => document.getElementById('compareSourceBSelect')?.value === 'pipeline_tap:pipe-1:denoise'"
+    )
+    page.select_option("#compareModeSelect", "difference")
+    page.wait_for_function(
+        "() => (document.getElementById('compareStatus')?.textContent || '').includes('sample intervals differ')"
+    )
+
+    assert (
+        page.locator("#compareStatus").text_content()
+        == "Cannot compare sources: decoded window sample intervals differ."
+    )
+    assert page.evaluate("() => window.defaultDt") == pytest.approx(0.002)
+    assert page.evaluate("() => window.savedYRange") == [7, 2]
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_uses_main_heatmap_decode_values(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    def handle_window(route, _request):
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_window_stubs(page)
+    page.evaluate(
+        """
+        () => {
+          window.SeisHeatmap = {
+            getQuantLUT: () => {
+              const lut = new Float32Array(256);
+              lut[128] = 10;
+              lut[129] = 20;
+              lut[130] = 30;
+              lut[131] = 40;
+              return lut;
+            },
+          };
+          window.decodeWindowPayload = (_bin, payloadMeta, _perfMeta, _onInvalidShape, options = {}) => {
+            window.__compareApplyDt = options?.applyDt ?? null;
+            return {
+              ...payloadMeta,
+              shape: [2, 2],
+              dt: 0.002,
+              scale: 2,
+              quant: { mode: 'linear', lo: -1, hi: 1, mu: 255 },
+              valuesI8: new Int8Array([0, 1, 2, 3]),
+            };
+          };
+        }
+        """
+    )
+
+    page.select_option("#compareModeSelect", "side_by_side")
+    page.wait_for_function(
+        "() => Array.isArray(document.getElementById('comparePlotA')?.data?.[0]?.z)"
+    )
+
+    z_values = page.evaluate(
+        """
+        () => Array.from(
+          document.getElementById('comparePlotA').data[0].z,
+          (row) => Array.from(row),
+        )
+        """
+    )
+    assert z_values == [[10.0, 20.0], [30.0, 40.0]]
+    assert page.evaluate("() => window.__compareApplyDt") is False
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_scales_probability_layers_to_display_range(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    def handle_window(route, _request):
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_window_stubs(page)
+    _append_pipeline_layer_option(page, label="fbprob")
+    page.wait_for_function(
+        "() => document.getElementById('compareSourceBSelect')?.value === 'pipeline_tap:pipe-1:fbprob'"
+    )
+    page.evaluate(
+        """
+        () => {
+          window.SeisHeatmap = {};
+          window.decodeWindowPayload = (_bin, payloadMeta, _perfMeta, _onInvalidShape, options = {}) => {
+            window.__compareApplyDt = options?.applyDt ?? null;
+            return {
+              ...payloadMeta,
+              shape: [2, 2],
+              dt: 0.002,
+              scale: 4,
+              quant: { scale: 4 },
+              valuesI8: new Int8Array([0, 1, 4, 2]),
+            };
+          };
+        }
+        """
+    )
+
+    page.select_option("#compareModeSelect", "side_by_side")
+    page.select_option("#compareSourceASelect", "pipeline_tap:pipe-1:fbprob")
+    page.wait_for_function(
+        "() => Array.isArray(document.getElementById('comparePlotB')?.data?.[0]?.z)"
+    )
+
+    rendered = page.evaluate(
+        """
+        () => {
+          const trace = document.getElementById('comparePlotB').data[0];
+          return {
+            z: Array.from(trace.z, (row) => Array.from(row)),
+            zmin: trace.zmin,
+            zmax: trace.zmax,
+          };
+        }
+        """
+    )
+    assert rendered["z"][0] == pytest.approx([0.0, 63.75])
+    assert rendered["z"][1] == pytest.approx([255.0, 127.5])
+    assert rendered["zmin"] == pytest.approx(0)
+    assert rendered["zmax"] == pytest.approx(255)
+    e2e_debug.assert_clean()

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -8,4 +8,5 @@ test('upload page loads', async ({ page }) => {
 test('main viewer page loads', async ({ page }) => {
 	await page.goto('/');
 	await expect(page.locator('body')).toBeVisible();
+	await expect(page.getByTestId('compare-mode-select')).toHaveValue('single');
 });


### PR DESCRIPTION
Closes #221

## Summary
- Frontend MVP: add side-by-side and difference compare view for raw / processed windows

## Changed files
- `app/static/index.html`
- `app/static/viewer/compare_metrics.js`
- `app/static/viewer/compare_view.js`
- `app/static/viewer/restyle_only.js`
- `app/static/viewer/viewer_legacy.js`
- `app/static/viewer/window_fetch.js`
- `app/static/viewer/window_render.js`
- `app/tests/e2e/test_compare_view_playwright.py`
- `tests/e2e/smoke.spec.ts`

## Checks
- `.work/codex/checks.log`: 241 passed in 66.22s (0:01:06)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
