### PR TITLE
Restrict mixed-domain rejection to Difference mode and strengthen probability-domain detection

### DIFF
--- a/app/static/api.js
+++ b/app/static/api.js
@@ -44,18 +44,25 @@ function cacheGet(key) {
   return _pipelineSectionCache.get(key);
 }
 
-function normalizeTapValue(value) {
-  let mat = value;
-  if (value && typeof value === 'object') {
-    if (value.data) {
-      mat = value.data;
-    } else if (value.prob) {
-      mat = value.prob;
-    }
-  }
+function normalizeTapMatrix(mat) {
   return Array.isArray(mat)
     ? mat.map((row) => Float32Array.from(row))
     : mat;
+}
+
+function normalizeTapValue(value) {
+  if (value && typeof value === 'object') {
+    if (Object.prototype.hasOwnProperty.call(value, 'data')) {
+      return { ...value, data: normalizeTapMatrix(value.data) };
+    }
+    if (Object.prototype.hasOwnProperty.call(value, 'prob')) {
+      return { ...value, prob: normalizeTapMatrix(value.prob) };
+    }
+    if (Object.prototype.hasOwnProperty.call(value, 'values')) {
+      return { ...value, values: normalizeTapMatrix(value.values) };
+    }
+  }
+  return normalizeTapMatrix(value);
 }
 
 async function fetchSectionWithPipeline(

--- a/app/static/viewer/compare_view.js
+++ b/app/static/viewer/compare_view.js
@@ -2,7 +2,7 @@
   const AMP_LIMIT = 3.0;
   const DIFF_NOTE = 'Diff is computed from decoded displayed window values.';
   const EPSILON_DIFF_LIMIT = 1e-6;
-  const DOMAIN_MISMATCH_MESSAGE = 'Cannot compare sources: source domains differ.';
+  const DOMAIN_MISMATCH_MESSAGE = 'Difference is disabled for amplitude-vs-probability sources.';
 
   const state = {
     mode: 'single',
@@ -97,6 +97,18 @@
   function inferSourceDomain(source) {
     const next = cloneSource(source);
     if (next.type !== 'pipeline_tap') return 'amplitude';
+    const tapData = window.latestTapData?.[next.tapLabel];
+    if (tapData && typeof tapData === 'object') {
+      const domain = String(tapData.domain || '').toLowerCase();
+      if (domain === 'amplitude' || domain === 'probability') return domain;
+      if (Object.prototype.hasOwnProperty.call(tapData, 'prob')) return 'probability';
+      if (
+        Object.prototype.hasOwnProperty.call(tapData, 'data') ||
+        Object.prototype.hasOwnProperty.call(tapData, 'values')
+      ) {
+        return 'amplitude';
+      }
+    }
     const label = String(next.tapLabel || '').toLowerCase();
     if (label.includes('fbpick') || label.includes('fbprob') || label.includes('prob')) {
       return 'probability';
@@ -445,7 +457,7 @@
   }
 
   function isMixedDomainDifference() {
-    if (state.mode === 'single') return false;
+    if (state.mode !== 'difference') return false;
     const domainA = inferSourceDomain(state.sourceA);
     const domainB = inferSourceDomain(state.sourceB);
     return domainA !== domainB;
@@ -708,13 +720,6 @@
     updateSurfaceVisibility();
     clearCompareStatus();
     if (state.mode === 'side_by_side') {
-      if (isMixedDomainDifference()) {
-        purgeComparePlots();
-        updateSurfaceVisibility();
-        clearSummaryMetrics();
-        setCompareStatus(DOMAIN_MISMATCH_MESSAGE, true);
-        return;
-      }
       await renderSideBySide(state.lastResult);
       return;
     }

--- a/app/tests/e2e/test_compare_view_playwright.py
+++ b/app/tests/e2e/test_compare_view_playwright.py
@@ -147,6 +147,17 @@ def _append_pipeline_layer_option(page, label: str = "denoise") -> None:
     )
 
 
+def _set_latest_tap_data(page, tap_map: dict[str, object]) -> None:
+    page.evaluate(
+        """
+        ({ tapMap }) => {
+          window.latestTapData = tapMap;
+        }
+        """,
+        {"tapMap": tap_map},
+    )
+
+
 def _install_compare_controlled_fetch_stubs(page) -> None:
     _install_compare_window_stubs(page)
     page.evaluate(
@@ -621,4 +632,164 @@ def test_compare_view_playwright_scales_probability_layers_to_display_range(
     assert rendered["z"][1] == pytest.approx([255.0, 127.5])
     assert rendered["zmin"] == pytest.approx(0)
     assert rendered["zmax"] == pytest.approx(255)
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_allows_mixed_domain_side_by_side(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    def handle_window(route, _request):
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_window_stubs(page)
+    _append_pipeline_layer_option(page, label="fbprob")
+    _set_latest_tap_data(page, {"fbprob": {"prob": [[0.1, 0.9], [0.2, 0.8]]}})
+    page.wait_for_function(
+        "() => document.getElementById('compareSourceBSelect')?.value === 'pipeline_tap:pipe-1:fbprob'"
+    )
+
+    page.select_option("#compareModeSelect", "side_by_side")
+    page.wait_for_function(
+        "() => Array.isArray(document.getElementById('comparePlotB')?.data?.[0]?.z)"
+    )
+
+    assert page.evaluate(
+        "() => (document.getElementById('compareStatus')?.textContent || '').trim()"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('comparePlotA')?.data?.length || 0"
+    ) == 1
+    assert page.evaluate(
+        "() => document.getElementById('comparePlotB')?.data?.length || 0"
+    ) == 1
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_rejects_mixed_domain_difference(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    def handle_window(route, _request):
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_window_stubs(page)
+    _append_pipeline_layer_option(page, label="fbprob")
+    _set_latest_tap_data(page, {"fbprob": {"prob": [[0.1, 0.9], [0.2, 0.8]]}})
+    page.wait_for_function(
+        "() => document.getElementById('compareSourceBSelect')?.value === 'pipeline_tap:pipe-1:fbprob'"
+    )
+
+    page.select_option("#compareModeSelect", "difference")
+    page.wait_for_function(
+        """
+        () => (
+          document.getElementById('compareStatus')?.textContent || ''
+        ).includes('Difference is disabled for amplitude-vs-probability sources.')
+        """
+    )
+
+    assert (
+        page.locator("#compareStatus").text_content()
+        == "Difference is disabled for amplitude-vs-probability sources."
+    )
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_rejects_probability_final_tap_in_difference(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    def handle_window(route, _request):
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_window_stubs(page)
+    _append_pipeline_layer_option(page, label="final")
+    _set_latest_tap_data(page, {"final": {"prob": [[0.1, 0.9], [0.2, 0.8]]}})
+    page.wait_for_function(
+        "() => document.getElementById('compareSourceBSelect')?.value === 'pipeline_tap:pipe-1:final'"
+    )
+
+    page.select_option("#compareModeSelect", "difference")
+    page.wait_for_function(
+        """
+        () => (
+          document.getElementById('compareStatus')?.textContent || ''
+        ).includes('Difference is disabled for amplitude-vs-probability sources.')
+        """
+    )
+
+    assert (
+        page.locator("#compareStatus").text_content()
+        == "Difference is disabled for amplitude-vs-probability sources."
+    )
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_view_playwright_allows_probability_difference(
+    page, base_url, e2e_debug
+):
+    page.set_default_timeout(60_000)
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    def handle_window(route, _request):
+        route.fulfill(
+            status=200,
+            headers={"content-type": "application/octet-stream"},
+            body=b"x",
+        )
+
+    page.route("**/get_section_window_bin?*", handle_window)
+    _install_compare_window_stubs(page)
+    _append_pipeline_layer_option(page, label="fbprob")
+    _append_pipeline_layer_option(page, label="final")
+    _set_latest_tap_data(
+        page,
+        {
+            "fbprob": {"prob": [[0.1, 0.9], [0.2, 0.8]]},
+            "final": {"prob": [[0.4, 0.6], [0.3, 0.7]]},
+        },
+    )
+    page.wait_for_function(
+        "() => document.getElementById('compareSourceBSelect')?.value === 'pipeline_tap:pipe-1:fbprob'"
+    )
+
+    page.select_option("#compareModeSelect", "side_by_side")
+    page.select_option("#compareSourceASelect", "pipeline_tap:pipe-1:final")
+    page.select_option("#compareModeSelect", "difference")
+    page.wait_for_function(
+        "() => Array.isArray(document.getElementById('comparePlotDiff')?.data?.[0]?.z)"
+    )
+
+    assert page.evaluate(
+        "() => (document.getElementById('compareStatus')?.textContent || '').trim()"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('comparePlotDiff')?.data?.length || 0"
+    ) == 1
     e2e_debug.assert_clean()


### PR DESCRIPTION
Closes #226

## Summary
- Restrict mixed-domain rejection to Difference mode and strengthen probability-domain detection

## Changed files
- `app/static/api.js`
- `app/static/viewer/compare_view.js`
- `app/tests/e2e/test_compare_view_playwright.py`

## Checks
- `.work/codex/checks.log`: 247 passed in 70.89s (0:01:10)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
