### PR TITLE
Make compare metric calculations strict and add numeric tests for diff / RMS

### DIFF
--- a/app/static/viewer/compare_metrics.js
+++ b/app/static/viewer/compare_metrics.js
@@ -1,6 +1,26 @@
 (function () {
+  function assertFiniteArray(values, name) {
+    if (!(values instanceof Float32Array)) {
+      throw new Error(`${name} must be Float32Array.`);
+    }
+    for (let i = 0; i < values.length; i += 1) {
+      if (!Number.isFinite(values[i])) {
+        throw new Error(`${name} contains non-finite value at index ${i}.`);
+      }
+    }
+  }
+
+  function assertComparableArrays(a, b) {
+    assertFiniteArray(a, 'a');
+    assertFiniteArray(b, 'b');
+    if (a.length !== b.length) {
+      throw new Error('Compare inputs must have the same length.');
+    }
+  }
+
   function computeDiff(a, b, mode) {
-    const len = Math.min(a?.length || 0, b?.length || 0);
+    assertComparableArrays(a, b);
+    const len = a.length;
     const diff = new Float32Array(len);
     const subtractBMinusA = mode !== 'a_minus_b';
     for (let i = 0; i < len; i += 1) {
@@ -10,7 +30,8 @@
   }
 
   function computeSummaryStats(diff) {
-    const len = diff?.length || 0;
+    assertFiniteArray(diff, 'diff');
+    const len = diff.length;
     if (!len) {
       return {
         mean: 0,
@@ -24,7 +45,7 @@
     let sumSq = 0;
     let maxAbs = 0;
     for (let i = 0; i < len; i += 1) {
-      const value = Number(diff[i]) || 0;
+      const value = diff[i];
       const absValue = Math.abs(value);
       sum += value;
       sumSq += value * value;
@@ -42,16 +63,22 @@
   }
 
   function computeRmsByTrace(a, b, height, width) {
-    const rows = Math.max(0, Number(height) | 0);
-    const cols = Math.max(0, Number(width) | 0);
+    assertComparableArrays(a, b);
+    const rows = Number(height);
+    const cols = Number(width);
+    if (!Number.isInteger(rows) || rows <= 0 || !Number.isInteger(cols) || cols <= 0) {
+      throw new Error('RMS shape must be positive integers.');
+    }
+    if ((rows * cols) !== a.length) {
+      throw new Error('RMS shape does not match input length.');
+    }
     const out = new Float32Array(cols);
-    if (!rows || !cols) return out;
 
     for (let ix = 0; ix < cols; ix += 1) {
       let sumSq = 0;
       for (let iy = 0; iy < rows; iy += 1) {
         const k = (iy * cols) + ix;
-        const d = (Number(b[k]) || 0) - (Number(a[k]) || 0);
+        const d = b[k] - a[k];
         sumSq += d * d;
       }
       out[ix] = Math.sqrt(sumSq / rows);
@@ -60,7 +87,8 @@
   }
 
   function percentileAbs(values, percentile) {
-    const len = values?.length || 0;
+    assertFiniteArray(values, 'values');
+    const len = values.length;
     if (!len) return 0;
 
     const pRaw = Number(percentile);
@@ -69,7 +97,7 @@
     const stride = Math.max(1, Math.ceil(len / sampleLimit));
     const sampled = [];
     for (let i = 0; i < len; i += stride) {
-      sampled.push(Math.abs(Number(values[i]) || 0));
+      sampled.push(Math.abs(values[i]));
     }
     if (!sampled.length) return 0;
     sampled.sort((a, b) => a - b);

--- a/app/tests/e2e/test_compare_metrics_playwright.py
+++ b/app/tests/e2e/test_compare_metrics_playwright.py
@@ -1,0 +1,85 @@
+import pytest
+
+
+def _compare_metric_error(page, expression: str) -> str | None:
+    return page.evaluate(
+        """
+        ({ expression }) => {
+          try {
+            Function(expression)();
+            return null;
+          } catch (error) {
+            if (error instanceof Error) return error.message;
+            return String(error);
+          }
+        }
+        """,
+        {"expression": expression},
+    )
+
+
+@pytest.mark.e2e
+def test_compare_metrics_playwright_computes_exact_diff_and_rms(
+    page, base_url, e2e_debug
+):
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    result = page.evaluate(
+        """
+        () => {
+          const metrics = window.compareMetrics;
+          const a = new Float32Array([1, 2, 3, 4]);
+          const b = new Float32Array([2, 1, 5, 0]);
+          return {
+            diffBA: Array.from(metrics.computeDiff(a, b, 'b_minus_a')),
+            diffAB: Array.from(metrics.computeDiff(a, b, 'a_minus_b')),
+            rmsByTrace: Array.from(metrics.computeRmsByTrace(a, b, 2, 2)),
+          };
+        }
+        """
+    )
+
+    assert result["diffBA"] == [1, -1, 2, -4]
+    assert result["diffAB"] == [-1, 1, -2, 4]
+    assert result["rmsByTrace"][0] == pytest.approx(((1**2 + 2**2) / 2) ** 0.5)
+    assert result["rmsByTrace"][1] == pytest.approx((((-1) ** 2 + (-4) ** 2) / 2) ** 0.5)
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_compare_metrics_playwright_rejects_invalid_inputs(page, base_url, e2e_debug):
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+
+    assert _compare_metric_error(
+        page,
+        "window.compareMetrics.computeDiff(new Float32Array([1]), new Float32Array([1, 2]), 'b_minus_a')",
+    ) == "Compare inputs must have the same length."
+    assert _compare_metric_error(
+        page,
+        "window.compareMetrics.computeDiff([1, 2], new Float32Array([1, 2]), 'b_minus_a')",
+    ) == "a must be Float32Array."
+    assert _compare_metric_error(
+        page,
+        "window.compareMetrics.computeDiff(new Float32Array([1, NaN]), new Float32Array([1, 2]), 'b_minus_a')",
+    ) == "a contains non-finite value at index 1."
+    assert _compare_metric_error(
+        page,
+        "window.compareMetrics.computeSummaryStats(new Float32Array([1, Infinity]))",
+    ) == "diff contains non-finite value at index 1."
+    assert _compare_metric_error(
+        page,
+        "window.compareMetrics.computeRmsByTrace(new Float32Array([1, 2, 3, 4]), new Float32Array([2, 3, 4, 5]), 0, 2)",
+    ) == "RMS shape must be positive integers."
+    assert _compare_metric_error(
+        page,
+        "window.compareMetrics.computeRmsByTrace(new Float32Array([1, 2, 3, 4]), new Float32Array([2, 3, 4, 5]), 1.5, 2)",
+    ) == "RMS shape must be positive integers."
+    assert _compare_metric_error(
+        page,
+        "window.compareMetrics.computeRmsByTrace(new Float32Array([1, 2, 3, 4]), new Float32Array([2, 3, 4, 5]), 3, 2)",
+    ) == "RMS shape does not match input length."
+    assert _compare_metric_error(
+        page,
+        "window.compareMetrics.percentileAbs(new Float32Array([1, NaN]), 99)",
+    ) == "values contains non-finite value at index 1."
+    e2e_debug.assert_clean()


### PR DESCRIPTION
Closes #228

## Summary
- Make compare metric calculations strict and add numeric tests for diff / RMS

## Changed files
- `app/static/viewer/compare_metrics.js`
- `app/tests/e2e/test_compare_metrics_playwright.py`

## Checks
- `.work/codex/checks.log`: 250 passed in 65.82s (0:01:05)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
