### PR TITLE
P0: Allow intentional section-window aborts in E2E request failure collector

### DIFF
--- a/app/tests/e2e/conftest.py
+++ b/app/tests/e2e/conftest.py
@@ -214,16 +214,25 @@ class E2EDebug:
         self,
         allow_open_segy_aborted: bool = True,
         allow_favicon_aborted: bool = True,
+        allow_window_fetch_aborted: bool = True,
     ) -> list[str]:
         out: list[str] = []
         for x in self.request_failed:
+            is_aborted = "ERR_ABORTED" in x
             if (
                 allow_open_segy_aborted
                 and "/open_segy" in x
-                and "net::ERR_ABORTED" in x
+                and is_aborted
             ):
                 continue
-            if allow_favicon_aborted and "favicon.ico" in x and "ERR_ABORTED" in x:
+            if allow_favicon_aborted and "favicon.ico" in x and is_aborted:
+                continue
+            if (
+                allow_window_fetch_aborted
+                and x.startswith("REQ_FAILED GET ")
+                and "/get_section_window_bin" in x
+                and is_aborted
+            ):
                 continue
             out.append(x)
         return out

--- a/app/tests/e2e/test_debug_collector.py
+++ b/app/tests/e2e/test_debug_collector.py
@@ -1,0 +1,26 @@
+from app.tests.e2e.conftest import E2EDebug
+
+
+def test_unexpected_request_failed_allows_only_aborted_get_section_window_fetches(
+    tmp_path,
+):
+    dbg = E2EDebug(
+        artifact_dir=tmp_path,
+        request_failed=[
+            "REQ_FAILED GET http://127.0.0.1:8000/get_section_window_bin?file_id=x (net::ERR_ABORTED)",
+            "REQ_FAILED GET http://127.0.0.1:8000/get_section_window_bin?file_id=x (net::ERR_FAILED)",
+            "REQ_FAILED POST http://127.0.0.1:8000/get_section_window_bin?file_id=x (net::ERR_ABORTED)",
+            "REQ_FAILED POST http://127.0.0.1:8000/open_segy (net::ERR_ABORTED)",
+            "REQ_FAILED GET http://127.0.0.1:8000/favicon.ico (net::ERR_ABORTED)",
+        ],
+    )
+
+    assert dbg.unexpected_request_failed() == [
+        "REQ_FAILED GET http://127.0.0.1:8000/get_section_window_bin?file_id=x (net::ERR_FAILED)",
+        "REQ_FAILED POST http://127.0.0.1:8000/get_section_window_bin?file_id=x (net::ERR_ABORTED)",
+    ]
+    assert dbg.unexpected_request_failed(allow_window_fetch_aborted=False) == [
+        "REQ_FAILED GET http://127.0.0.1:8000/get_section_window_bin?file_id=x (net::ERR_ABORTED)",
+        "REQ_FAILED GET http://127.0.0.1:8000/get_section_window_bin?file_id=x (net::ERR_FAILED)",
+        "REQ_FAILED POST http://127.0.0.1:8000/get_section_window_bin?file_id=x (net::ERR_ABORTED)",
+    ]


### PR DESCRIPTION
Closes #234

## Summary
- P0: Allow intentional section-window aborts in E2E request failure collector

## Changed files
- `app/tests/e2e/conftest.py`
- `app/tests/e2e/test_debug_collector.py`

## Checks
- `.work/codex/checks.log`: 251 passed in 65.79s (0:01:05)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
