### PR TITLE
Fix Compare heatmap z-scale to be panel-specific for probability, amplitude, and A-B panels

### DIFF
--- a/app/static/viewer/compare.js
+++ b/app/static/viewer/compare.js
@@ -493,11 +493,8 @@
     const cmName = document.getElementById('colormap')?.value || 'Greys';
     const reverse = !!document.getElementById('cmReverse')?.checked;
     const cm = (window.COLORMAPS && window.COLORMAPS[cmName]) || 'Greys';
-    const g = Math.max(gain, 1e-9);
-    const isProbability = render.sources.a.domain === 'probability' || render.sources.b.domain === 'probability';
-    const zMin = isProbability ? 0 : -AMP_LIMIT / g;
-    const zMax = isProbability ? 1 / g : AMP_LIMIT / g;
-    const isDiv = !isProbability && (cmName === 'RdBu' || cmName === 'BWR');
+    const scale = compareHeatmapScale(panel, gain);
+    const isDiv = scale.signed && (cmName === 'RdBu' || cmName === 'BWR');
     return {
       type: 'heatmap',
       x: xVals,
@@ -507,8 +504,8 @@
       yaxis: axisRef('y', axisIndex),
       colorscale: cm,
       reversescale: reverse,
-      zmin: zMin,
-      zmax: zMax,
+      zmin: scale.zmin,
+      zmax: scale.zmax,
       zmid: isDiv ? 0 : null,
       showscale: false,
       hoverinfo: 'x+y',
@@ -516,15 +513,39 @@
     };
   }
 
+  function compareHeatmapScale(panel, gain) {
+    const g = Math.max(Number(gain) || 1.0, 1e-9);
+    if (panel?.kind === 'source' && panel.domain === 'probability') {
+      return { zmin: 0, zmax: 1 / g, signed: false };
+    }
+    if (panel?.kind === 'diff' && panel.domain === 'probability') {
+      return { zmin: -1 / g, zmax: 1 / g, signed: true };
+    }
+    return { zmin: -AMP_LIMIT / g, zmax: AMP_LIMIT / g, signed: true };
+  }
+
   function buildComparePanels(render) {
     const panels = [
-      { kind: 'source', role: 'A', label: render.sources.a.label, values: render.a.values },
-      { kind: 'source', role: 'B', label: render.sources.b.label, values: render.b.values },
+      {
+        kind: 'source',
+        role: 'A',
+        domain: render.sources.a.domain,
+        label: render.sources.a.label,
+        values: render.a.values,
+      },
+      {
+        kind: 'source',
+        role: 'B',
+        domain: render.sources.b.domain,
+        label: render.sources.b.label,
+        values: render.b.values,
+      },
     ];
     if (compareShowDiffEnabled() && render.diffAvailable && render.diffValues) {
       panels.push({
         kind: 'diff',
         role: 'A-B',
+        domain: render.sources.a.domain,
         label: `${render.sources.a.label} - ${render.sources.b.label}`,
         left: render.sources.a.label,
         right: render.sources.b.label,
@@ -869,6 +890,8 @@
     subtractF32,
     payloadToF32,
     resolveSourceDomain,
+    compareHeatmapScale,
+    buildComparePanels,
   };
 
   if (document.readyState === 'loading') {

--- a/app/tests/ui/compare.test.js
+++ b/app/tests/ui/compare.test.js
@@ -1,0 +1,62 @@
+import { beforeAll, beforeEach, expect, test } from 'vitest';
+
+beforeAll(async () => {
+  await import('../../static/viewer/compare.js');
+});
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <input id="compareShowDiff" type="checkbox" checked>
+    <input id="gain" value="2">
+    <select id="colormap"><option value="Greys" selected>Greys</option></select>
+    <input id="cmReverse" type="checkbox">
+  `;
+});
+
+function scale(panel) {
+  return window.__svCompare.compareHeatmapScale(panel, 2);
+}
+
+test('compare heatmap scales mixed-domain source panels independently', () => {
+  expect(scale({ kind: 'source', domain: 'amplitude' })).toMatchObject({
+    zmin: -1.5,
+    zmax: 1.5,
+    signed: true,
+  });
+  expect(scale({ kind: 'source', domain: 'probability' })).toMatchObject({
+    zmin: 0,
+    zmax: 0.5,
+    signed: false,
+  });
+});
+
+test('compare heatmap allows signed probability diff values', () => {
+  const render = {
+    sources: {
+      a: { domain: 'probability', label: 'prob-a' },
+      b: { domain: 'probability', label: 'prob-b' },
+    },
+    a: { values: new Float32Array([0.1]) },
+    b: { values: new Float32Array([0.8]) },
+    diffAvailable: true,
+    diffValues: new Float32Array([-0.7]),
+  };
+
+  const panels = window.__svCompare.buildComparePanels(render);
+  const diffPanel = panels.find((panel) => panel.kind === 'diff');
+
+  expect(diffPanel).toMatchObject({ role: 'A-B', domain: 'probability' });
+  expect(scale(diffPanel)).toMatchObject({
+    zmin: -0.5,
+    zmax: 0.5,
+    signed: true,
+  });
+});
+
+test('compare heatmap uses signed amplitude scale for amplitude diff values', () => {
+  expect(scale({ kind: 'diff', domain: 'amplitude' })).toMatchObject({
+    zmin: -1.5,
+    zmax: 1.5,
+    signed: true,
+  });
+});


### PR DESCRIPTION
Closes #241

## Summary
- Fix Compare heatmap z-scale to be panel-specific for probability, amplitude, and A-B panels

## Changed files
- `app/static/viewer/compare.js`
- `app/tests/ui/compare.test.js`

## Checks
- `.work/codex/checks.log`: 238 passed in 39.42s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
