### PR TITLE
Prevent Compare mode from reusing display-scaled probability cache values

### DIFF
--- a/app/static/viewer/compare.js
+++ b/app/static/viewer/compare.js
@@ -1,6 +1,7 @@
 (function () {
   const AXIS_MARGIN = 0.035;
   const AMP_LIMIT = 3.0;
+  const COMPARE_CACHE_PURPOSE = 'compare';
   let latestCompareRender = null;
   let compareSyncing = false;
 
@@ -199,6 +200,7 @@
       scaling: currentScaling,
       transpose: '1',
       mode: decision.mode,
+      purpose: COMPARE_CACHE_PURPOSE,
     };
     const artifacts = buildWindowRequestArtifacts(requestContext);
     return { source, requestContext, ...artifacts };
@@ -206,7 +208,7 @@
 
   async function fetchComparePayload(request, ctrl, requestId) {
     const cached = windowCacheGet(request.cacheKey);
-    if (cached) return cached;
+    if (cached && canUseCachedComparePayload(cached, request.source)) return cached;
 
     const res = await fetch(`/get_section_window_bin?${request.params.toString()}`, { signal: ctrl.signal });
     if (!res.ok) {
@@ -244,14 +246,56 @@
     return Number.isFinite(fallback) && fallback > 0 ? fallback : null;
   }
 
-  function payloadToF32(payload) {
+  function payloadShapeInfo(payload) {
     if (!payload || !Array.isArray(payload.shape) || payload.shape.length !== 2) return null;
     const rows = Number(payload.shape[0]);
     const cols = Number(payload.shape[1]);
     if (!Number.isInteger(rows) || !Number.isInteger(cols) || rows <= 0 || cols <= 0) return null;
-    const total = rows * cols;
+    return { rows, cols, total: rows * cols };
+  }
+
+  function payloadInvScale(payload) {
+    const payloadScale = Number(payload?.scale);
+    const quantScale = Number(payload?.quant?.scale);
+    const scale = Number.isFinite(payloadScale) && payloadScale !== 0
+      ? payloadScale
+      : quantScale;
+    return Number.isFinite(scale) && scale !== 0 ? 1 / scale : 1;
+  }
+
+  function payloadHasComputeValues(payload) {
+    const shape = payloadShapeInfo(payload);
+    if (!shape) return false;
+    return (
+      (payload.valuesI8 instanceof Int8Array && payload.valuesI8.length >= shape.total) ||
+      (payload.values instanceof Float32Array && payload.values.length >= shape.total)
+    );
+  }
+
+  function canUseCachedComparePayload(payload, source) {
+    if (source?.domain !== 'probability') return true;
+    return payloadHasComputeValues(payload);
+  }
+
+  function sourceDomain(options) {
+    if (typeof options === 'string') return options;
+    return options?.domain || '';
+  }
+
+  function payloadToF32(payload, options = {}) {
+    const shape = payloadShapeInfo(payload);
+    if (!shape) return null;
+    const { rows, cols, total } = shape;
     let out = null;
-    if (payload.zBacking instanceof Float32Array && payload.zBacking.length >= total) {
+    if (payload.valuesI8 instanceof Int8Array && payload.valuesI8.length >= total) {
+      const invScale = payloadInvScale(payload);
+      out = new Float32Array(total);
+      for (let i = 0; i < total; i++) out[i] = payload.valuesI8[i] * invScale;
+    } else if (payload.values instanceof Float32Array && payload.values.length >= total) {
+      out = new Float32Array(payload.values.subarray(0, total));
+    } else if (sourceDomain(options) === 'probability') {
+      return null;
+    } else if (payload.zBacking instanceof Float32Array && payload.zBacking.length >= total) {
       out = new Float32Array(payload.zBacking.subarray(0, total));
     } else if (Array.isArray(payload.zRows) && payload.zRows.length === rows) {
       out = new Float32Array(total);
@@ -260,13 +304,6 @@
         if (!row || row.length < cols) return null;
         out.set(row.subarray ? row.subarray(0, cols) : Array.from(row).slice(0, cols), r * cols);
       }
-    } else if (payload.values instanceof Float32Array && payload.values.length >= total) {
-      out = new Float32Array(payload.values.subarray(0, total));
-    } else if (payload.valuesI8 instanceof Int8Array && payload.valuesI8.length >= total) {
-      const scale = Number(payload.scale) || Number(payload.quant?.scale) || 1;
-      const invScale = scale === 0 ? 1 : 1 / scale;
-      out = new Float32Array(total);
-      for (let i = 0; i < total; i++) out[i] = payload.valuesI8[i] * invScale;
     }
     return out;
   }
@@ -607,8 +644,8 @@
   }
 
   function buildCompareRender(aPayload, bPayload, sources, decision, validation, windowInfo) {
-    const aValues = payloadToF32(aPayload);
-    const bValues = payloadToF32(bPayload);
+    const aValues = payloadToF32(aPayload, sources.a);
+    const bValues = payloadToF32(bPayload, sources.b);
     if (!aValues || !bValues) {
       return null;
     }

--- a/app/static/viewer/window_fetch.js
+++ b/app/static/viewer/window_fetch.js
@@ -312,10 +312,12 @@
       scaling,
       transpose,
       mode,
+      purpose,
     }) {
       const enc = (value) => encodeURIComponent(value == null ? '' : String(value));
-      return [
-        'svwin',
+      const parts = ['svwin'];
+      if (purpose) parts.push(`purpose=${enc(purpose)}`);
+      parts.push(
         `file=${enc(fileId)}`,
         `k1=${enc(key1)}`,
         `b1=${enc(key1Byte)}`,
@@ -333,7 +335,8 @@
         `sc=${enc(scaling)}`,
         `tr=${enc(transpose)}`,
         `mode=${enc(mode)}`,
-      ].join('|');
+      );
+      return parts.join('|');
     }
 
     function buildWindowRequestArtifacts({
@@ -353,6 +356,7 @@
       scaling,
       transpose,
       mode,
+      purpose,
     }) {
       const resolvedPipelineKey = (tapLabel && pipelineKey) ? pipelineKey : null;
       const resolvedTapLabel = (tapLabel && resolvedPipelineKey) ? tapLabel : null;
@@ -407,6 +411,7 @@
           scaling,
           transpose,
           mode,
+          purpose,
         }),
         payloadMeta: {
           key1: key1Val,
@@ -421,6 +426,7 @@
           stepX,
           stepY,
           mode,
+          purpose,
         },
       };
     }

--- a/app/tests/ui/compare.test.js
+++ b/app/tests/ui/compare.test.js
@@ -17,6 +17,14 @@ function scale(panel) {
   return window.__svCompare.compareHeatmapScale(panel, 2);
 }
 
+function expectF32Values(actual, expected) {
+  expect(actual).toBeInstanceOf(Float32Array);
+  expect(actual).toHaveLength(expected.length);
+  expected.forEach((value, index) => {
+    expect(actual[index]).toBeCloseTo(value, 6);
+  });
+}
+
 test('compare heatmap scales mixed-domain source panels independently', () => {
   expect(scale({ kind: 'source', domain: 'amplitude' })).toMatchObject({
     zmin: -1.5,
@@ -59,4 +67,59 @@ test('compare heatmap uses signed amplitude scale for amplitude diff values', ()
     zmax: 1.5,
     signed: true,
   });
+});
+
+test('compare payload decode prefers quantized compute values over display backing', () => {
+  const payload = {
+    shape: [1, 2],
+    valuesI8: new Int8Array([32, 64]),
+    scale: 128,
+    zBacking: new Float32Array([64, 128]),
+  };
+
+  const values = window.__svCompare.payloadToF32(payload, { domain: 'probability' });
+
+  expectF32Values(values, [0.25, 0.5]);
+});
+
+test('compare payload decode rejects display backing for probability sources', () => {
+  expect(window.__svCompare.payloadToF32({
+    shape: [1, 2],
+    zBacking: new Float32Array([64, 128]),
+  }, { domain: 'probability' })).toBeNull();
+
+  expect(window.__svCompare.payloadToF32({
+    shape: [1, 2],
+    zRows: [new Float32Array([64, 128])],
+  }, { domain: 'probability' })).toBeNull();
+});
+
+test('compare payload decode keeps amplitude display backing fallback', () => {
+  const values = window.__svCompare.payloadToF32({
+    shape: [1, 2],
+    zBacking: new Float32Array([1.5, -2.25]),
+  }, { domain: 'amplitude' });
+
+  expectF32Values(values, [1.5, -2.25]);
+});
+
+test('probability diff uses decoded probability values, not display-scaled backing', () => {
+  const sourceA = window.__svCompare.payloadToF32({
+    shape: [1, 1],
+    valuesI8: new Int8Array([80]),
+    scale: 100,
+    zBacking: new Float32Array([204]),
+  }, { domain: 'probability' });
+  const sourceB = window.__svCompare.payloadToF32({
+    shape: [1, 1],
+    valuesI8: new Int8Array([20]),
+    scale: 100,
+    zBacking: new Float32Array([51]),
+  }, { domain: 'probability' });
+
+  const diff = window.__svCompare.subtractF32(sourceA, sourceB);
+
+  expectF32Values(sourceA, [0.8]);
+  expectF32Values(sourceB, [0.2]);
+  expectF32Values(diff, [0.6]);
 });


### PR DESCRIPTION
Closes #243

## Summary
- Prevent Compare mode from reusing display-scaled probability cache values

## Changed files
- `app/static/viewer/compare.js`
- `app/static/viewer/window_fetch.js`
- `app/tests/ui/compare.test.js`

## Checks
- `.work/codex/checks.log`: 238 passed in 39.22s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
