### PR TITLE
Backend MVP: add staged SEG-Y header QC before ingest

### DIFF
--- a/app/api/routers/upload.py
+++ b/app/api/routers/upload.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import threading
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
 from uuid import uuid4
@@ -23,6 +24,7 @@ from app.core.paths import (
 from app.core.state import AppState
 from app.utils.ingest import SegyIngestor
 from app.utils.baseline_artifacts import has_split_baseline_artifacts
+from app.utils.header_qc import inspect_segy_header_qc
 from app.trace_store.reader import TraceStoreSectionReader
 
 router = APIRouter()
@@ -32,6 +34,23 @@ UPLOAD_DIR = get_upload_dir()
 PROCESSED_DIR = get_processed_upload_dir()
 TRACE_DIR = get_trace_store_dir()
 UPLOAD_CHUNK_SIZE = 4 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class SavedUpload:
+    original_name: str
+    safe_name: str
+    raw_path: Path
+    source_sha256: str
+    source_size: int
+
+
+def _safe_upload_name(filename: str) -> str:
+    return re.sub(r'[^A-Za-z0-9_.-]', '_', filename)
+
+
+def _staged_upload_dir() -> Path:
+    return UPLOAD_DIR / 'staged'
 
 
 def _trace_store_complete(store_dir: Path, key1_byte: int, key2_byte: int) -> bool:
@@ -209,6 +228,139 @@ def _register_trace_store(
     return reader
 
 
+async def _save_upload_file(
+    file: UploadFile,
+    safe_name: str,
+    *,
+    raw_path: Path,
+) -> SavedUpload:
+    original_name = file.filename or safe_name
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = raw_path.with_suffix(raw_path.suffix + f'.{uuid4().hex}.tmp')
+    hasher = hashlib.sha256()
+    try:
+        with tmp_path.open('wb') as temp_file:
+            while True:
+                chunk = await file.read(UPLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+                hasher.update(chunk)
+                temp_file.write(chunk)
+        tmp_path.replace(raw_path)
+        source_size = raw_path.stat().st_size
+    except OSError as exc:
+        tmp_path.unlink(missing_ok=True)
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return SavedUpload(
+        original_name=original_name,
+        safe_name=safe_name,
+        raw_path=raw_path,
+        source_sha256=hasher.hexdigest(),
+        source_size=int(source_size),
+    )
+
+
+async def _ingest_saved_segy(
+    *,
+    request: Request,
+    original_name: str,
+    safe_name: str,
+    raw_path: Path,
+    source_sha256: str,
+    source_size: int,
+    key1_byte: int,
+    key2_byte: int,
+) -> dict:
+    state = get_state(request.app)
+    store_dir = TRACE_DIR / safe_name
+    file_id = str(uuid4())
+
+    meta: dict | None = None
+    reused = False
+    if store_dir.exists():
+        meta = _trace_store_matches_source(
+            store_dir,
+            key1_byte,
+            key2_byte,
+            source_sha256=source_sha256,
+            source_size=source_size,
+        )
+        if meta is not None:
+            reused = True
+        else:
+            try:
+                _archive_trace_store(store_dir)
+            except OSError as exc:
+                msg = f'Unable to archive existing trace store: {exc}'
+                raise HTTPException(status_code=409, detail=msg) from exc
+
+    if reused and meta is not None:
+        logger.info('Reusing trace store for %s', original_name)
+        _register_trace_store(file_id, store_dir, key1_byte, key2_byte, state=state)
+        _touch_trace_store_meta(store_dir)
+        state.file_registry.update(
+            file_id,
+            store_path=str(store_dir),
+            dt=meta.get('dt'),
+        )
+        return {'file_id': file_id, 'reused_trace_store': True}
+
+    store_dir.mkdir(parents=True, exist_ok=True)
+    meta = await asyncio.to_thread(
+        SegyIngestor.from_segy,
+        str(raw_path),
+        store_dir,
+        key1_byte,
+        key2_byte,
+        source_sha256=source_sha256,
+    )
+    _register_trace_store(file_id, store_dir, key1_byte, key2_byte, state=state)
+    _touch_trace_store_meta(store_dir)
+    if isinstance(meta, dict):
+        state.file_registry.update(
+            file_id,
+            store_path=str(store_dir),
+            dt=meta.get('dt'),
+        )
+    else:
+        state.file_registry.update(file_id, store_path=str(store_dir))
+    return {'file_id': file_id, 'reused_trace_store': False}
+
+
+def _selected_header_qc_summary(
+    header_qc: object,
+    *,
+    key1_byte: int,
+    key2_byte: int,
+) -> dict | None:
+    if not isinstance(header_qc, dict):
+        return None
+
+    pairs = header_qc.get('recommended_pairs')
+    if isinstance(pairs, list):
+        for pair in pairs:
+            if not isinstance(pair, dict):
+                continue
+            if (
+                pair.get('key1_byte') == key1_byte
+                and pair.get('key2_byte') == key2_byte
+            ):
+                warnings = pair.get('warnings')
+                return {
+                    'selected_pair_score': pair.get('score'),
+                    'confidence': pair.get('confidence', 'unknown'),
+                    'warnings': warnings if isinstance(warnings, list) else [],
+                }
+
+    warnings = header_qc.get('warnings')
+    return {
+        'selected_pair_score': None,
+        'confidence': 'unknown',
+        'warnings': warnings if isinstance(warnings, list) else [],
+    }
+
+
 @router.get('/recent_datasets')
 async def recent_datasets():
     return {'datasets': _list_recent_dataset_summaries()}
@@ -274,83 +426,113 @@ async def upload_segy(
     key1_byte: Annotated[int, Form()] = 189,
     key2_byte: Annotated[int, Form()] = 193,
 ):
-    state = get_state(request.app)
     if not file.filename:
         raise HTTPException(
             status_code=400, detail='Uploaded file must have a filename'
         )
     logger.info('Uploading file: %s', file.filename)
-    safe_name = re.sub(r'[^A-Za-z0-9_.-]', '_', file.filename)
-    store_dir = TRACE_DIR / safe_name
-    file_id = str(uuid4())
-    raw_path = UPLOAD_DIR / safe_name
-    raw_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = raw_path.with_suffix(raw_path.suffix + f'.{uuid4().hex}.tmp')
-    hasher = hashlib.sha256()
-    with tmp_path.open('wb') as temp_file:
-        while True:
-            chunk = await file.read(UPLOAD_CHUNK_SIZE)
-            if not chunk:
-                break
-            hasher.update(chunk)
-            temp_file.write(chunk)
-    tmp_path.replace(raw_path)
-    source_sha256 = hasher.hexdigest()
-    try:
-        source_size = raw_path.stat().st_size
-    except OSError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-
-    meta: dict | None = None
-    reused = False
-    if store_dir.exists():
-        meta = _trace_store_matches_source(
-            store_dir,
-            key1_byte,
-            key2_byte,
-            source_sha256=source_sha256,
-            source_size=source_size,
-        )
-        if meta is not None:
-            reused = True
-        else:
-            try:
-                _archive_trace_store(store_dir)
-            except OSError as exc:
-                msg = f'Unable to archive existing trace store: {exc}'
-                raise HTTPException(status_code=409, detail=msg) from exc
-
-    if reused and meta is not None:
-        logger.info('Reusing trace store for %s', file.filename)
-        _register_trace_store(file_id, store_dir, key1_byte, key2_byte, state=state)
-        _touch_trace_store_meta(store_dir)
-        state.file_registry.update(
-            file_id,
-            store_path=str(store_dir),
-            dt=meta.get('dt'),
-        )
-        return {'file_id': file_id, 'reused_trace_store': True}
-
-    store_dir.mkdir(parents=True, exist_ok=True)
-    meta = await asyncio.to_thread(
-        SegyIngestor.from_segy,
-        str(raw_path),
-        store_dir,
-        key1_byte,
-        key2_byte,
-        source_sha256=source_sha256,
+    safe_name = _safe_upload_name(file.filename)
+    saved = await _save_upload_file(file, safe_name, raw_path=UPLOAD_DIR / safe_name)
+    return await _ingest_saved_segy(
+        request=request,
+        original_name=saved.original_name,
+        safe_name=saved.safe_name,
+        raw_path=saved.raw_path,
+        source_sha256=saved.source_sha256,
+        source_size=saved.source_size,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
     )
-    _register_trace_store(file_id, store_dir, key1_byte, key2_byte, state=state)
-    _touch_trace_store_meta(store_dir)
-    if isinstance(meta, dict):
-        state.file_registry.update(
-            file_id,
-            store_path=str(store_dir),
-            dt=meta.get('dt'),
+
+
+@router.post('/stage_segy')
+async def stage_segy(
+    request: Request,
+    file: Annotated[UploadFile, File(...)],
+):
+    state = get_state(request.app)
+    if not file.filename:
+        raise HTTPException(
+            status_code=400, detail='Uploaded file must have a filename'
         )
-    else:
-        state.file_registry.update(file_id, store_path=str(store_dir))
-    return {'file_id': file_id, 'reused_trace_store': False}
+
+    staged_id = uuid4().hex
+    safe_name = _safe_upload_name(file.filename)
+    raw_path = _staged_upload_dir() / staged_id / safe_name
+    saved = await _save_upload_file(file, safe_name, raw_path=raw_path)
+    try:
+        header_qc = await asyncio.to_thread(inspect_segy_header_qc, saved.raw_path)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=422,
+            detail=f'Unable to inspect SEG-Y headers: {exc}',
+        ) from exc
+
+    record = {
+        'original_name': saved.original_name,
+        'safe_name': saved.safe_name,
+        'raw_path': str(saved.raw_path),
+        'source_sha256': saved.source_sha256,
+        'source_size': saved.source_size,
+        'header_qc': header_qc,
+    }
+    with state.lock:
+        state.staged_uploads.set(staged_id, record)
+
+    return {
+        'staged_id': staged_id,
+        'file': {
+            'original_name': saved.original_name,
+            'safe_name': saved.safe_name,
+            'size': saved.source_size,
+            'sha256': saved.source_sha256,
+        },
+        **header_qc,
+    }
+
+
+@router.post('/ingest_staged_segy')
+async def ingest_staged_segy(
+    request: Request,
+    staged_id: Annotated[str, Form(...)],
+    key1_byte: Annotated[int, Form()] = 189,
+    key2_byte: Annotated[int, Form()] = 193,
+):
+    state = get_state(request.app)
+    with state.lock:
+        staged = state.staged_uploads.get(staged_id)
+    if staged is None:
+        raise HTTPException(status_code=404, detail='Staged SEG-Y not found')
+    if key1_byte == key2_byte:
+        raise HTTPException(
+            status_code=400,
+            detail='key1_byte and key2_byte must be different',
+        )
+    if not isinstance(staged, dict):
+        raise HTTPException(status_code=404, detail='Staged SEG-Y not found')
+
+    raw_path = Path(str(staged.get('raw_path', '')))
+    if not raw_path.is_file():
+        raise HTTPException(status_code=410, detail='Staged SEG-Y file is missing')
+
+    result = await _ingest_saved_segy(
+        request=request,
+        original_name=str(staged.get('original_name') or staged.get('safe_name')),
+        safe_name=str(staged.get('safe_name')),
+        raw_path=raw_path,
+        source_sha256=str(staged.get('source_sha256')),
+        source_size=int(staged.get('source_size')),
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+    )
+    summary = _selected_header_qc_summary(
+        staged.get('header_qc'),
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+    )
+    if summary is not None:
+        result['header_qc'] = summary
+    return result
 
 
 @router.get('/file_info')

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -200,6 +200,7 @@ class AppState:
     file_registry: FileRegistry = field(default_factory=FileRegistry)
     cached_readers: LRUCache = field(init=False)
     fbpick_cache: ExpiringLRUCache = field(init=False)
+    staged_uploads: ExpiringLRUCache = field(init=False)
     jobs: JobManager = field(default_factory=JobManager)
     pipeline_tap_cache: LRUCache = field(default_factory=lambda: LRUCache(16))
     window_section_cache: LRUCache = field(default_factory=lambda: LRUCache(32))
@@ -211,6 +212,7 @@ class AppState:
             capacity=self.settings.sv_fbpick_cache_capacity,
             ttl_sec=self.settings.sv_fbpick_cache_ttl_sec,
         )
+        self.staged_uploads = ExpiringLRUCache(capacity=16, ttl_sec=3600)
         self.trace_stats_cache = TraceStatsCache(
             max_sections=self.settings.sv_trace_stats_max_sections,
             max_windows=self.settings.sv_trace_stats_max_windows,

--- a/app/tests/test_header_qc.py
+++ b/app/tests/test_header_qc.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.utils.header_qc import inspect_segy_header_qc
+
+
+class _Attr:
+    def __init__(self, values: np.ndarray) -> None:
+        self._values = np.asarray(values)
+
+    def __getitem__(self, _key):
+        return self._values
+
+
+class _FakeBin:
+    def __init__(self, interval_us: int | None) -> None:
+        self._interval_us = interval_us
+
+    def __getitem__(self, _key):
+        if self._interval_us is None:
+            raise KeyError(_key)
+        return self._interval_us
+
+
+class _FakeSegy:
+    def __init__(
+        self,
+        *,
+        headers: dict[int, np.ndarray],
+        n_samples: int,
+        interval_us: int | None,
+    ) -> None:
+        self._headers = {int(k): np.asarray(v) for k, v in headers.items()}
+        first = next(iter(self._headers.values()))
+        self.tracecount = int(first.size)
+        self.samples = np.arange(n_samples, dtype=np.int32)
+        self.bin = _FakeBin(interval_us)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def attributes(self, byte: int):
+        values = self._headers.get(int(byte))
+        if values is None:
+            values = np.zeros(self.tracecount, dtype=np.int32)
+        return _Attr(values)
+
+
+def _patch_segyio(
+    monkeypatch,
+    *,
+    headers: dict[int, np.ndarray],
+    n_samples: int = 1500,
+    interval_us: int | None = 2000,
+) -> None:
+    import app.utils.header_qc as header_qc
+
+    def _open_stub(_path, _mode='r', ignore_geometry=True):
+        assert ignore_geometry is True
+        return _FakeSegy(
+            headers=headers,
+            n_samples=n_samples,
+            interval_us=interval_us,
+        )
+
+    monkeypatch.setattr(header_qc.segyio, 'open', _open_stub, raising=True)
+
+    class _BinField:
+        Interval = 'Interval'
+
+    monkeypatch.setattr(header_qc.segyio, 'BinField', _BinField, raising=True)
+
+
+def _find_header(result: dict, byte: int) -> dict:
+    return next(item for item in result['headers'] if item['byte'] == byte)
+
+
+def _find_pair(result: dict, key1_byte: int, key2_byte: int) -> dict:
+    return next(
+        item
+        for item in result['recommended_pairs']
+        if item['key1_byte'] == key1_byte and item['key2_byte'] == key2_byte
+    )
+
+
+def test_inline_crossline_headers_rank_highly(monkeypatch, tmp_path: Path):
+    inline = np.repeat(np.arange(10), 20)
+    crossline = np.tile(np.arange(20), 10)
+    dt = np.full(200, 2000)
+    _patch_segyio(
+        monkeypatch,
+        headers={189: inline, 193: crossline, 117: dt},
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'line.sgy')
+
+    assert result['segy'] == {
+        'n_traces': 200,
+        'n_samples': 1500,
+        'dt': pytest.approx(0.002),
+    }
+    best = result['recommended_pairs'][0]
+    assert best['key1_byte'] == 189
+    assert best['key2_byte'] == 193
+    assert best['confidence'] == 'high'
+    assert best['score'] > 0.8
+
+
+def test_constant_header_gets_low_score_and_warning(monkeypatch, tmp_path: Path):
+    inline = np.repeat(np.arange(10), 20)
+    crossline = np.tile(np.arange(20), 10)
+    constant = np.full(200, 7)
+    _patch_segyio(
+        monkeypatch,
+        headers={189: inline, 193: crossline, 21: constant},
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'line.sgy')
+    header = _find_header(result, 21)
+
+    assert header['key1_score'] < 0.2
+    assert any('constant' in warning for warning in header['warnings'])
+
+
+def test_all_unique_header_gets_low_key1_score(monkeypatch, tmp_path: Path):
+    inline = np.repeat(np.arange(10), 20)
+    crossline = np.tile(np.arange(20), 10)
+    all_unique = np.arange(200)
+    _patch_segyio(
+        monkeypatch,
+        headers={189: inline, 193: crossline, 1: all_unique},
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'line.sgy')
+    header = _find_header(result, 1)
+
+    assert header['key1_score'] < 0.2
+    assert any('unique for every trace' in warning for warning in header['warnings'])
+
+
+def test_bad_key2_duplicate_behavior_warns(monkeypatch, tmp_path: Path):
+    inline = np.repeat(np.arange(10), 20)
+    duplicated_key2 = np.tile(np.repeat(np.arange(5), 4), 10)
+    _patch_segyio(
+        monkeypatch,
+        headers={189: inline, 193: duplicated_key2},
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'line.sgy')
+    pair = _find_pair(result, 189, 193)
+
+    assert pair['confidence'] in {'low', 'medium'}
+    assert any('duplicates' in warning for warning in pair['warnings'])
+
+
+def test_recommended_pairs_are_sorted_by_descending_score(monkeypatch, tmp_path: Path):
+    inline = np.repeat(np.arange(10), 20)
+    crossline = np.tile(np.arange(20), 10)
+    _patch_segyio(
+        monkeypatch,
+        headers={189: inline, 193: crossline},
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'line.sgy')
+    scores = [item['score'] for item in result['recommended_pairs']]
+
+    assert scores == sorted(scores, reverse=True)

--- a/app/tests/test_staged_segy_upload.py
+++ b/app/tests/test_staged_segy_upload.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _qc_payload() -> dict:
+    return {
+        'segy': {'n_traces': 200, 'n_samples': 1500, 'dt': 0.002},
+        'recommended_pairs': [
+            {
+                'key1_byte': 189,
+                'key1_name': 'INLINE_3D',
+                'key2_byte': 193,
+                'key2_name': 'CROSSLINE_3D',
+                'score': 0.94,
+                'confidence': 'high',
+                'reasons': ['key1 has 10 sections with median 20 traces/section'],
+                'warnings': [],
+            }
+        ],
+        'headers': [
+            {
+                'byte': 189,
+                'name': 'INLINE_3D',
+                'available': True,
+                'min': 1,
+                'max': 10,
+                'unique_count': 10,
+                'unique_ratio': 0.05,
+                'key1_score': 0.91,
+                'group_size': {'min': 20, 'p05': 20, 'p50': 20, 'p95': 20, 'max': 20},
+                'warnings': [],
+            }
+        ],
+        'warnings': [],
+    }
+
+
+@pytest.fixture()
+def _staged_env(tmp_path: Path, monkeypatch):
+    from app.api.routers import upload as upload_mod
+
+    state = app.state.sv
+    state.file_registry.clear()
+    state.cached_readers.clear()
+    state.staged_uploads.clear()
+
+    upload_root = tmp_path / 'uploads'
+    processed = upload_root / 'processed'
+    trace_dir = processed / 'traces'
+    trace_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(upload_mod, 'UPLOAD_DIR', upload_root, raising=True)
+    monkeypatch.setattr(upload_mod, 'PROCESSED_DIR', processed, raising=True)
+    monkeypatch.setattr(upload_mod, 'TRACE_DIR', trace_dir, raising=True)
+    monkeypatch.setattr(upload_mod, '_register_trace_store', lambda *a, **k: None)
+
+    calls = {'qc': 0, 'ingest': 0}
+
+    def _fake_qc(path: str | Path) -> dict:
+        calls['qc'] += 1
+        assert Path(path).is_file()
+        return _qc_payload()
+
+    def _fake_from_segy(
+        path: str,
+        store_dir: str | Path,
+        key1_byte: int,
+        key2_byte: int,
+        *,
+        source_sha256: str | None = None,
+        **_kwargs,
+    ) -> dict:
+        calls['ingest'] += 1
+        store_path = Path(store_dir)
+        store_path.mkdir(parents=True, exist_ok=True)
+        np.save(store_path / 'traces.npy', np.zeros((2, 4), dtype=np.float32))
+        np.savez(
+            store_path / 'index.npz',
+            key1_values=np.asarray([1], dtype=np.int32),
+            key1_offsets=np.asarray([0], dtype=np.int64),
+            key1_counts=np.asarray([2], dtype=np.int64),
+        )
+        meta = {
+            'key_bytes': {'key1': int(key1_byte), 'key2': int(key2_byte)},
+            'dt': 0.002,
+            'original_segy_path': str(path),
+            'original_size': Path(path).stat().st_size,
+            'source_sha256': source_sha256,
+        }
+        (store_path / 'meta.json').write_text(json.dumps(meta), encoding='utf-8')
+        return meta
+
+    monkeypatch.setattr(upload_mod, 'inspect_segy_header_qc', _fake_qc, raising=True)
+    monkeypatch.setattr(
+        upload_mod.SegyIngestor, 'from_segy', _fake_from_segy, raising=True
+    )
+
+    try:
+        yield TestClient(app), upload_mod, calls
+    finally:
+        state.file_registry.clear()
+        state.cached_readers.clear()
+        state.staged_uploads.clear()
+
+
+def _stage(client: TestClient, *, name: str = 'line 001.sgy', data: bytes = b'segy') -> dict:
+    response = client.post(
+        '/stage_segy',
+        files={'file': (name, data, 'application/octet-stream')},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def test_stage_segy_returns_qc_and_stores_metadata(_staged_env):
+    client, _upload_mod, calls = _staged_env
+
+    body = _stage(client, data=b'abc123')
+    staged_id = body['staged_id']
+    staged = app.state.sv.staged_uploads.get(staged_id)
+
+    assert calls['qc'] == 1
+    assert body['file']['original_name'] == 'line 001.sgy'
+    assert body['file']['safe_name'] == 'line_001.sgy'
+    assert body['file']['size'] == 6
+    assert body['segy']['n_traces'] == 200
+    assert body['headers']
+    assert body['recommended_pairs']
+    assert isinstance(staged, dict)
+    assert staged['original_name'] == 'line 001.sgy'
+    assert staged['safe_name'] == 'line_001.sgy'
+    assert Path(staged['raw_path']).read_bytes() == b'abc123'
+    assert staged['header_qc']['segy']['n_samples'] == 1500
+
+
+def test_ingest_staged_segy_ingests_valid_stage(_staged_env):
+    client, upload_mod, calls = _staged_env
+    staged = _stage(client)
+
+    response = client.post(
+        '/ingest_staged_segy',
+        data={
+            'staged_id': staged['staged_id'],
+            'key1_byte': '189',
+            'key2_byte': '193',
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert calls['ingest'] == 1
+    assert body['file_id']
+    assert body['reused_trace_store'] is False
+    assert body['header_qc'] == {
+        'selected_pair_score': 0.94,
+        'confidence': 'high',
+        'warnings': [],
+    }
+    meta = json.loads(
+        (Path(upload_mod.TRACE_DIR) / 'line_001.sgy' / 'meta.json').read_text(
+            encoding='utf-8'
+        )
+    )
+    assert meta['key_bytes'] == {'key1': 189, 'key2': 193}
+
+
+def test_ingest_staged_segy_invalid_id_returns_404(_staged_env):
+    client, _upload_mod, calls = _staged_env
+
+    response = client.post(
+        '/ingest_staged_segy',
+        data={'staged_id': 'missing', 'key1_byte': '189', 'key2_byte': '193'},
+    )
+
+    assert response.status_code == 404
+    assert calls['ingest'] == 0
+
+
+def test_ingest_staged_segy_identical_key_bytes_return_400(_staged_env):
+    client, _upload_mod, calls = _staged_env
+    staged = _stage(client)
+
+    response = client.post(
+        '/ingest_staged_segy',
+        data={
+            'staged_id': staged['staged_id'],
+            'key1_byte': '189',
+            'key2_byte': '189',
+        },
+    )
+
+    assert response.status_code == 400
+    assert calls['ingest'] == 0
+
+
+def test_ingest_staged_segy_missing_file_returns_410(_staged_env):
+    client, _upload_mod, calls = _staged_env
+    staged = _stage(client)
+    record = app.state.sv.staged_uploads.get(staged['staged_id'])
+    assert isinstance(record, dict)
+    Path(record['raw_path']).unlink()
+
+    response = client.post(
+        '/ingest_staged_segy',
+        data={
+            'staged_id': staged['staged_id'],
+            'key1_byte': '189',
+            'key2_byte': '193',
+        },
+    )
+
+    assert response.status_code == 410
+    assert calls['ingest'] == 0
+
+
+def test_upload_segy_still_returns_existing_basic_shape(_staged_env):
+    client, _upload_mod, calls = _staged_env
+
+    response = client.post(
+        '/upload_segy',
+        files={'file': ('direct.sgy', b'direct', 'application/octet-stream')},
+        data={'key1_byte': '189', 'key2_byte': '193'},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(body) == {'file_id', 'reused_trace_store'}
+    assert body['file_id']
+    assert body['reused_trace_store'] is False
+    assert calls == {'qc': 0, 'ingest': 1}

--- a/app/utils/header_qc.py
+++ b/app/utils/header_qc.py
@@ -1,0 +1,472 @@
+"""Lightweight SEG-Y trace-header QC and key-byte recommendations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import segyio
+
+HEADER_CANDIDATES: list[tuple[int, str]] = [
+    (1, "TRACE_SEQUENCE_LINE"),
+    (5, "TRACE_SEQUENCE_FILE"),
+    (9, "FIELD_RECORD"),
+    (13, "TRACE_NUMBER"),
+    (21, "CDP"),
+    (25, "CDP_TRACE"),
+    (37, "OFFSET"),
+    (115, "NS"),
+    (117, "DT"),
+    (189, "INLINE_3D"),
+    (193, "CROSSLINE_3D"),
+    (197, "SHOT_POINT"),
+]
+
+_CANDIDATE_NAMES = dict(HEADER_CANDIDATES)
+_MAX_PAIR_GROUPS = 64
+
+_KEY1_PRIOR = {
+    1: 0.20,
+    5: 0.20,
+    9: 0.75,
+    13: 0.30,
+    21: 0.70,
+    25: 0.45,
+    37: 0.20,
+    115: 0.0,
+    117: 0.0,
+    189: 1.0,
+    193: 0.65,
+    197: 0.65,
+}
+
+_KEY2_PRIOR = {
+    1: 0.35,
+    5: 0.35,
+    9: 0.35,
+    13: 0.85,
+    21: 0.45,
+    25: 0.80,
+    37: 0.75,
+    115: 0.0,
+    117: 0.0,
+    189: 0.45,
+    193: 1.0,
+    197: 0.55,
+}
+
+
+def inspect_segy_header_qc(path: str | Path) -> dict:
+    """Inspect SEG-Y trace headers and recommend key-byte pairs."""
+    segy_path = Path(path)
+    header_values: dict[int, np.ndarray] = {}
+    unavailable: dict[int, str] = {}
+
+    with segyio.open(str(segy_path), 'r', ignore_geometry=True) as segy_file:
+        n_traces = int(getattr(segy_file, 'tracecount', 0))
+        n_samples = len(getattr(segy_file, 'samples', []))
+        raw_dt = _read_binary_dt(segy_file)
+
+        for byte, _name in HEADER_CANDIDATES:
+            try:
+                values = np.asarray(segy_file.attributes(byte)[:])
+            except Exception as exc:  # noqa: BLE001
+                unavailable[byte] = f'Header could not be read: {exc}'
+                continue
+
+            if values.ndim != 1 or int(values.shape[0]) != n_traces:
+                unavailable[byte] = 'Header length does not match trace count'
+                continue
+
+            try:
+                header_values[byte] = values.astype(np.int64, copy=False)
+            except (TypeError, ValueError) as exc:
+                unavailable[byte] = f'Header values are not integer-like: {exc}'
+
+    dt = _dt_seconds(raw_dt)
+    if dt is None and 117 in header_values:
+        dt = _dt_from_header_values(header_values[117])
+
+    return _build_qc_result(
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt=dt,
+        header_values=header_values,
+        unavailable=unavailable,
+    )
+
+
+def _read_binary_dt(segy_file: Any) -> Any:
+    try:
+        return segy_file.bin[segyio.BinField.Interval]
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _dt_seconds(raw_dt: Any) -> float | None:
+    if isinstance(raw_dt, (int, float, np.integer, np.floating)) and raw_dt > 0:
+        return float(raw_dt) / 1_000_000.0
+    return None
+
+
+def _dt_from_header_values(values: np.ndarray) -> float | None:
+    if values.size == 0:
+        return None
+    positive = values[values > 0]
+    if positive.size == 0:
+        return None
+    return float(np.median(positive)) / 1_000_000.0
+
+
+def _build_qc_result(
+    *,
+    n_traces: int,
+    n_samples: int,
+    dt: float | None,
+    header_values: dict[int, np.ndarray],
+    unavailable: dict[int, str],
+) -> dict:
+    headers: list[dict] = []
+    headers_by_byte: dict[int, dict] = {}
+
+    for byte, name in HEADER_CANDIDATES:
+        values = header_values.get(byte)
+        if values is None:
+            warning = unavailable.get(byte, 'Header is unavailable')
+            item = _unavailable_header(byte, name, warning)
+        else:
+            item = _score_key1_header(byte, name, values, n_traces)
+        headers.append(item)
+        headers_by_byte[byte] = item
+
+    recommended_pairs = _rank_pairs(header_values, headers_by_byte)
+    warnings: list[str] = []
+    if n_traces <= 0:
+        warnings.append('SEG-Y contains no traces')
+    if not header_values:
+        warnings.append('No candidate trace headers could be read')
+    elif not recommended_pairs or recommended_pairs[0]['score'] < 0.55:
+        warnings.append('No confident key byte pair found')
+
+    return {
+        'segy': {
+            'n_traces': int(n_traces),
+            'n_samples': int(n_samples),
+            'dt': dt,
+        },
+        'recommended_pairs': recommended_pairs,
+        'headers': headers,
+        'warnings': warnings,
+    }
+
+
+def _unavailable_header(byte: int, name: str, warning: str) -> dict:
+    return {
+        'byte': int(byte),
+        'name': name,
+        'available': False,
+        'min': None,
+        'max': None,
+        'unique_count': 0,
+        'unique_ratio': 0.0,
+        'key1_score': 0.0,
+        'group_size': None,
+        'warnings': [warning],
+    }
+
+
+def _score_key1_header(
+    byte: int,
+    name: str,
+    values: np.ndarray,
+    n_traces: int,
+) -> dict:
+    warnings: list[str] = []
+    if n_traces <= 0 or values.size == 0:
+        return {
+            'byte': int(byte),
+            'name': name,
+            'available': True,
+            'min': None,
+            'max': None,
+            'unique_count': 0,
+            'unique_ratio': 0.0,
+            'key1_score': 0.0,
+            'group_size': None,
+            'warnings': ['Header cannot be scored without traces'],
+        }
+
+    unique_values, counts = np.unique(values, return_counts=True)
+    unique_count = int(unique_values.size)
+    unique_ratio = float(unique_count / max(int(n_traces), 1))
+    group_size = _group_size_stats(counts)
+    median_group_size = float(group_size['p50'])
+
+    if unique_count <= 1:
+        warnings.append('Header is constant')
+    if unique_count == n_traces:
+        warnings.append('Header is unique for every trace')
+    if median_group_size <= 1:
+        warnings.append('Median group size is too small')
+    if _is_extremely_imbalanced(group_size):
+        warnings.append('Group sizes are extremely imbalanced')
+
+    if unique_count <= 1:
+        score = 0.05 + (0.05 * _KEY1_PRIOR.get(byte, 0.0))
+    elif unique_count == n_traces:
+        score = 0.06 + (0.04 * _KEY1_PRIOR.get(byte, 0.0))
+    else:
+        group_score = min(1.0, max(0.0, (median_group_size - 1.0) / 9.0))
+        ratio_score = 1.0 if unique_ratio <= 0.5 else max(0.0, (1.0 - unique_ratio) / 0.5)
+        contiguity_score = _contiguity_score(values, unique_count)
+        balance_score = _balance_score(group_size)
+        semantic_score = _KEY1_PRIOR.get(byte, 0.0)
+        score = (
+            0.28 * group_score
+            + 0.22 * ratio_score
+            + 0.22 * contiguity_score
+            + 0.18 * balance_score
+            + 0.10 * semantic_score
+        )
+
+    return {
+        'byte': int(byte),
+        'name': name,
+        'available': True,
+        'min': int(np.min(values)),
+        'max': int(np.max(values)),
+        'unique_count': unique_count,
+        'unique_ratio': _round_score(unique_ratio),
+        'key1_score': _round_score(score),
+        'group_size': group_size,
+        'warnings': warnings,
+    }
+
+
+def _group_size_stats(counts: np.ndarray) -> dict[str, int | float]:
+    if counts.size == 0:
+        return {'min': 0, 'p05': 0, 'p50': 0, 'p95': 0, 'max': 0}
+    percentiles = np.percentile(counts.astype(np.float64), [5, 50, 95])
+    return {
+        'min': int(np.min(counts)),
+        'p05': _number(percentiles[0]),
+        'p50': _number(percentiles[1]),
+        'p95': _number(percentiles[2]),
+        'max': int(np.max(counts)),
+    }
+
+
+def _number(value: float) -> int | float:
+    value = float(value)
+    rounded = round(value)
+    if abs(value - rounded) < 1e-9:
+        return int(rounded)
+    return round(value, 6)
+
+
+def _is_extremely_imbalanced(group_size: dict[str, int | float]) -> bool:
+    p05 = float(group_size['p05'])
+    p95 = float(group_size['p95'])
+    median = float(group_size['p50'])
+    maximum = float(group_size['max'])
+    if median <= 0:
+        return False
+    if p05 > 0 and p95 / p05 >= 10.0:
+        return True
+    return maximum / median >= 20.0
+
+
+def _balance_score(group_size: dict[str, int | float]) -> float:
+    p05 = float(group_size['p05'])
+    p95 = float(group_size['p95'])
+    if p05 <= 0 or p95 <= 0:
+        return 0.0
+    return min(1.0, p05 / p95)
+
+
+def _contiguity_score(values: np.ndarray, unique_count: int) -> float:
+    if values.size <= 1 or unique_count <= 1:
+        return 1.0
+    runs = int(np.count_nonzero(values[1:] != values[:-1])) + 1
+    if runs <= 0:
+        return 0.0
+    return min(1.0, float(unique_count) / float(runs))
+
+
+def _rank_pairs(
+    header_values: dict[int, np.ndarray],
+    headers_by_byte: dict[int, dict],
+) -> list[dict]:
+    pairs: list[dict] = []
+    for key1_byte, key1_name in HEADER_CANDIDATES:
+        key1_values = header_values.get(key1_byte)
+        key1_stats = headers_by_byte[key1_byte]
+        if key1_values is None:
+            continue
+        for key2_byte, key2_name in HEADER_CANDIDATES:
+            if key1_byte == key2_byte:
+                continue
+            key2_values = header_values.get(key2_byte)
+            if key2_values is None:
+                continue
+            pairs.append(
+                _score_pair(
+                    key1_byte=key1_byte,
+                    key1_name=key1_name,
+                    key1_values=key1_values,
+                    key1_stats=key1_stats,
+                    key2_byte=key2_byte,
+                    key2_name=key2_name,
+                    key2_values=key2_values,
+                )
+            )
+    pairs.sort(key=lambda item: item['score'], reverse=True)
+    return pairs
+
+
+def _score_pair(
+    *,
+    key1_byte: int,
+    key1_name: str,
+    key1_values: np.ndarray,
+    key1_stats: dict,
+    key2_byte: int,
+    key2_name: str,
+    key2_values: np.ndarray,
+) -> dict:
+    pair_metrics = _key2_within_group_metrics(key1_values, key2_values)
+    key1_score = float(key1_stats.get('key1_score') or 0.0)
+    key2_quality = (
+        0.55 * pair_metrics['median_unique_ratio']
+        + 0.25 * (1.0 - pair_metrics['median_duplicate_rate'])
+        + 0.20 * pair_metrics['monotonic_fraction']
+    )
+    semantic_multiplier = 0.95 + (0.05 * _KEY2_PRIOR.get(key2_byte, 0.0))
+    score = ((0.65 * key1_score) + (0.35 * key2_quality)) * semantic_multiplier
+    if pair_metrics['constant_section_fraction'] >= 0.30:
+        score *= 0.65
+    if pair_metrics['median_duplicate_rate'] > 0.25:
+        score *= 0.75
+    score = max(0.0, min(1.0, score))
+
+    group_size = key1_stats.get('group_size') or {}
+    sections = int(key1_stats.get('unique_count') or 0)
+    median_group_size = group_size.get('p50', 0)
+    reasons = [
+        f'key1 has {sections} sections with median {median_group_size} traces/section',
+        f"key2 median unique ratio within sections is {pair_metrics['median_unique_ratio']:.2f}",
+    ]
+    if pair_metrics['monotonic_fraction'] >= 0.80:
+        reasons.append('key2 is mostly monotonic within key1 sections')
+    elif pair_metrics['monotonic_fraction'] <= 0.20:
+        reasons.append('key2 is rarely monotonic within key1 sections')
+
+    warnings = _pair_warnings(key1_stats, pair_metrics)
+
+    rounded_score = _round_score(score)
+    return {
+        'key1_byte': int(key1_byte),
+        'key1_name': key1_name,
+        'key2_byte': int(key2_byte),
+        'key2_name': key2_name,
+        'score': rounded_score,
+        'confidence': _confidence(rounded_score),
+        'reasons': reasons,
+        'warnings': warnings,
+    }
+
+
+def _key2_within_group_metrics(
+    key1_values: np.ndarray,
+    key2_values: np.ndarray,
+) -> dict[str, float]:
+    if key1_values.size == 0 or key2_values.size == 0:
+        return {
+            'median_unique_ratio': 0.0,
+            'median_duplicate_rate': 1.0,
+            'monotonic_fraction': 0.0,
+            'constant_section_fraction': 1.0,
+            'evaluated_groups': 0.0,
+        }
+
+    order = np.argsort(key1_values, kind='stable')
+    sorted_key1 = key1_values[order]
+    boundaries = np.flatnonzero(sorted_key1[1:] != sorted_key1[:-1]) + 1
+    starts = np.concatenate(([0], boundaries))
+    ends = np.concatenate((boundaries, [sorted_key1.size]))
+    group_count = int(starts.size)
+    if group_count > _MAX_PAIR_GROUPS:
+        sampled = np.unique(
+            np.linspace(0, group_count - 1, _MAX_PAIR_GROUPS).astype(np.int64)
+        )
+        starts = starts[sampled]
+        ends = ends[sampled]
+
+    unique_ratios: list[float] = []
+    duplicate_rates: list[float] = []
+    monotonic: list[float] = []
+    constant: list[float] = []
+
+    for start, end in zip(starts, ends):
+        group_order = order[int(start) : int(end)]
+        if group_order.size <= 1:
+            continue
+        values = key2_values[group_order]
+        unique_count = int(np.unique(values).size)
+        unique_ratio = float(unique_count / int(values.size))
+        unique_ratios.append(unique_ratio)
+        duplicate_rates.append(1.0 - unique_ratio)
+        constant.append(1.0 if unique_count <= 1 else 0.0)
+
+        diffs = np.diff(values)
+        is_monotonic = bool(
+            np.any(diffs != 0)
+            and (np.all(diffs >= 0) or np.all(diffs <= 0))
+        )
+        monotonic.append(1.0 if is_monotonic else 0.0)
+
+    if not unique_ratios:
+        return {
+            'median_unique_ratio': 0.0,
+            'median_duplicate_rate': 1.0,
+            'monotonic_fraction': 0.0,
+            'constant_section_fraction': 1.0,
+            'evaluated_groups': 0.0,
+        }
+
+    return {
+        'median_unique_ratio': float(np.median(unique_ratios)),
+        'median_duplicate_rate': float(np.median(duplicate_rates)),
+        'monotonic_fraction': float(np.mean(monotonic)),
+        'constant_section_fraction': float(np.mean(constant)),
+        'evaluated_groups': float(len(unique_ratios)),
+    }
+
+
+def _pair_warnings(key1_stats: dict, pair_metrics: dict[str, float]) -> list[str]:
+    warnings: list[str] = []
+    for warning in key1_stats.get('warnings') or []:
+        warnings.append(f'key1 {str(warning)[0].lower()}{str(warning)[1:]}')
+    if pair_metrics['evaluated_groups'] <= 0:
+        warnings.append('key2 could not be evaluated inside key1 sections')
+    if pair_metrics['constant_section_fraction'] >= 0.30:
+        warnings.append('key2 is constant in many key1 sections')
+    if pair_metrics['median_duplicate_rate'] > 0.25:
+        warnings.append('key2 has many duplicates inside key1 sections')
+    return warnings
+
+
+def _confidence(score: float) -> str:
+    if score >= 0.80:
+        return 'high'
+    if score >= 0.55:
+        return 'medium'
+    return 'low'
+
+
+def _round_score(value: float) -> float:
+    return round(float(value), 6)
+
+
+__all__ = ['HEADER_CANDIDATES', 'inspect_segy_header_qc']


### PR DESCRIPTION
Closes #246

## Summary
- Backend MVP: add staged SEG-Y header QC before ingest

## Changed files
- `app/api/routers/upload.py`
- `app/core/state.py`
- `app/tests/test_header_qc.py`
- `app/tests/test_staged_segy_upload.py`
- `app/utils/header_qc.py`

## Checks
- `.work/codex/checks.log`: 249 passed in 39.62s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
