### PR TITLE
Fix staged SEG-Y lifecycle and upload filename safety in PR

### DIFF
--- a/app/api/routers/upload.py
+++ b/app/api/routers/upload.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import re
+import shutil
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,11 +47,65 @@ class SavedUpload:
 
 
 def _safe_upload_name(filename: str) -> str:
-    return re.sub(r'[^A-Za-z0-9_.-]', '_', filename)
+    safe_name = re.sub(r'[^A-Za-z0-9_.-]', '_', filename)
+    if safe_name in {'', '.', '..'}:
+        raise HTTPException(
+            status_code=400,
+            detail='Uploaded file must have a safe filename',
+        )
+    return safe_name
 
 
 def _staged_upload_dir() -> Path:
     return UPLOAD_DIR / 'staged'
+
+
+def _cleanup_staged_upload(raw_path: Path) -> None:
+    try:
+        raw_path.unlink(missing_ok=True)
+    except OSError:
+        logger.warning('Unable to delete staged SEG-Y file: %s', raw_path)
+
+    staged_dir = raw_path.parent
+    if staged_dir.parent != _staged_upload_dir():
+        return
+    shutil.rmtree(staged_dir, ignore_errors=True)
+
+
+def _sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open('rb') as fh:
+        for chunk in iter(lambda: fh.read(UPLOAD_CHUNK_SIZE), b''):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _promote_staged_segy_to_raw(
+    *,
+    staged_path: Path,
+    safe_name: str,
+    source_sha256: str,
+) -> Path:
+    raw_dir = UPLOAD_DIR / 'raw' / source_sha256
+    raw_path = raw_dir / safe_name
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    if raw_path.exists():
+        if raw_path.is_file() and _sha256_file(raw_path) == source_sha256:
+            return raw_path
+        raw_path = raw_dir / f'{raw_path.stem}.{uuid4().hex}{raw_path.suffix}'
+
+    tmp_path = raw_path.with_suffix(raw_path.suffix + f'.{uuid4().hex}.tmp')
+    try:
+        shutil.copy2(staged_path, tmp_path)
+        tmp_path.replace(raw_path)
+    except OSError as exc:
+        tmp_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=422,
+            detail=f'Unable to promote staged SEG-Y: {exc}',
+        ) from exc
+    return raw_path
 
 
 def _trace_store_complete(store_dir: Path, key1_byte: int, key2_byte: int) -> bool:
@@ -93,6 +148,53 @@ def _load_trace_store_meta(meta_path: Path) -> dict | None:
     if not isinstance(meta, dict):
         return None
     return meta
+
+
+def _ensure_trace_store_meta_raw_path(
+    store_dir: Path,
+    meta: dict,
+    *,
+    raw_path: Path,
+    source_sha256: str,
+    source_size: int,
+) -> dict:
+    updated = dict(meta)
+    changed = False
+    raw_path_text = str(raw_path)
+
+    if updated.get('original_segy_path') != raw_path_text:
+        updated['original_segy_path'] = raw_path_text
+        changed = True
+    if updated.get('original_size') != source_size:
+        updated['original_size'] = source_size
+        changed = True
+    if updated.get('source_sha256') != source_sha256:
+        updated['source_sha256'] = source_sha256
+        changed = True
+
+    try:
+        original_mtime = raw_path.stat().st_mtime
+    except OSError:
+        original_mtime = None
+    if original_mtime is not None and updated.get('original_mtime') != original_mtime:
+        updated['original_mtime'] = original_mtime
+        changed = True
+
+    if not changed:
+        return meta
+
+    meta_path = store_dir / 'meta.json'
+    tmp_path = meta_path.with_suffix(meta_path.suffix + f'.{uuid4().hex}.tmp')
+    try:
+        tmp_path.write_text(json.dumps(updated), encoding='utf-8')
+        tmp_path.replace(meta_path)
+    except OSError as exc:
+        tmp_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=409,
+            detail=f'Unable to update trace store metadata: {exc}',
+        ) from exc
+    return updated
 
 
 def _trace_store_matches_source(
@@ -296,6 +398,13 @@ async def _ingest_saved_segy(
                 raise HTTPException(status_code=409, detail=msg) from exc
 
     if reused and meta is not None:
+        meta = _ensure_trace_store_meta_raw_path(
+            store_dir,
+            meta,
+            raw_path=raw_path,
+            source_sha256=source_sha256,
+            source_size=source_size,
+        )
         logger.info('Reusing trace store for %s', original_name)
         _register_trace_store(file_id, store_dir, key1_byte, key2_byte, state=state)
         _touch_trace_store_meta(store_dir)
@@ -463,6 +572,7 @@ async def stage_segy(
     try:
         header_qc = await asyncio.to_thread(inspect_segy_header_qc, saved.raw_path)
     except Exception as exc:  # noqa: BLE001
+        _cleanup_staged_upload(saved.raw_path)
         raise HTTPException(
             status_code=422,
             detail=f'Unable to inspect SEG-Y headers: {exc}',
@@ -515,16 +625,27 @@ async def ingest_staged_segy(
     if not raw_path.is_file():
         raise HTTPException(status_code=410, detail='Staged SEG-Y file is missing')
 
+    safe_name = str(staged.get('safe_name'))
+    source_sha256 = str(staged.get('source_sha256'))
+    source_size = int(staged.get('source_size'))
+    durable_raw_path = _promote_staged_segy_to_raw(
+        staged_path=raw_path,
+        safe_name=safe_name,
+        source_sha256=source_sha256,
+    )
     result = await _ingest_saved_segy(
         request=request,
         original_name=str(staged.get('original_name') or staged.get('safe_name')),
-        safe_name=str(staged.get('safe_name')),
-        raw_path=raw_path,
-        source_sha256=str(staged.get('source_sha256')),
-        source_size=int(staged.get('source_size')),
+        safe_name=safe_name,
+        raw_path=durable_raw_path,
+        source_sha256=source_sha256,
+        source_size=source_size,
         key1_byte=key1_byte,
         key2_byte=key2_byte,
     )
+    with state.lock:
+        state.staged_uploads.pop(staged_id, None)
+    _cleanup_staged_upload(raw_path)
     summary = _selected_header_qc_summary(
         staged.get('header_qc'),
         key1_byte=key1_byte,

--- a/app/tests/test_staged_segy_upload.py
+++ b/app/tests/test_staged_segy_upload.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -8,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.tests._stubs import write_baseline_raw
 
 
 def _qc_payload() -> dict:
@@ -144,11 +146,16 @@ def test_stage_segy_returns_qc_and_stores_metadata(_staged_env):
 def test_ingest_staged_segy_ingests_valid_stage(_staged_env):
     client, upload_mod, calls = _staged_env
     staged = _stage(client)
+    staged_id = staged['staged_id']
+    record = app.state.sv.staged_uploads.get(staged_id)
+    assert isinstance(record, dict)
+    staged_path = Path(record['raw_path'])
+    staged_dir = staged_path.parent
 
     response = client.post(
         '/ingest_staged_segy',
         data={
-            'staged_id': staged['staged_id'],
+            'staged_id': staged_id,
             'key1_byte': '189',
             'key2_byte': '193',
         },
@@ -169,7 +176,97 @@ def test_ingest_staged_segy_ingests_valid_stage(_staged_env):
             encoding='utf-8'
         )
     )
+    durable_raw_path = (
+        Path(upload_mod.UPLOAD_DIR)
+        / 'raw'
+        / staged['file']['sha256']
+        / 'line_001.sgy'
+    )
     assert meta['key_bytes'] == {'key1': 189, 'key2': 193}
+    assert meta['original_segy_path'] == str(durable_raw_path)
+    assert durable_raw_path.read_bytes() == b'segy'
+    assert not staged_path.exists()
+    assert not staged_dir.exists()
+    assert app.state.sv.staged_uploads.get(staged_id) is None
+
+
+def test_stage_segy_qc_failure_removes_staged_file(_staged_env, monkeypatch):
+    client, upload_mod, calls = _staged_env
+
+    def _raise_qc(_path: str | Path) -> dict:
+        calls['qc'] += 1
+        raise RuntimeError('bad headers')
+
+    monkeypatch.setattr(upload_mod, 'inspect_segy_header_qc', _raise_qc, raising=True)
+
+    response = client.post(
+        '/stage_segy',
+        files={'file': ('bad.sgy', b'bad-data', 'application/octet-stream')},
+    )
+
+    assert response.status_code == 422
+    assert calls == {'qc': 1, 'ingest': 0}
+    assert len(app.state.sv.staged_uploads) == 0
+    staged_root = Path(upload_mod.UPLOAD_DIR) / 'staged'
+    assert not staged_root.exists() or list(staged_root.iterdir()) == []
+
+
+def test_ingest_staged_segy_reused_store_metadata_points_to_durable_raw(
+    _staged_env,
+):
+    client, upload_mod, calls = _staged_env
+    data = b'reuse-me'
+    source_sha256 = hashlib.sha256(data).hexdigest()
+    store_dir = Path(upload_mod.TRACE_DIR) / 'line_001.sgy'
+    old_staged_path = Path(upload_mod.UPLOAD_DIR) / 'staged' / 'old' / 'line_001.sgy'
+    store_dir.mkdir(parents=True, exist_ok=True)
+    np.save(store_dir / 'traces.npy', np.zeros((2, 4), dtype=np.float32))
+    np.savez(
+        store_dir / 'index.npz',
+        key1_values=np.asarray([1], dtype=np.int32),
+        key1_offsets=np.asarray([0], dtype=np.int64),
+        key1_counts=np.asarray([2], dtype=np.int64),
+    )
+    (store_dir / 'meta.json').write_text(
+        json.dumps(
+            {
+                'key_bytes': {'key1': 189, 'key2': 193},
+                'dt': 0.002,
+                'original_segy_path': str(old_staged_path),
+                'original_size': len(data),
+                'source_sha256': source_sha256,
+            }
+        ),
+        encoding='utf-8',
+    )
+    write_baseline_raw(
+        store_dir,
+        key1=1,
+        n_traces=2,
+        key1_byte=189,
+        key2_byte=193,
+        source_sha256=source_sha256,
+    )
+    staged = _stage(client, data=data)
+
+    response = client.post(
+        '/ingest_staged_segy',
+        data={
+            'staged_id': staged['staged_id'],
+            'key1_byte': '189',
+            'key2_byte': '193',
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()['reused_trace_store'] is True
+    assert calls == {'qc': 1, 'ingest': 0}
+    durable_raw_path = (
+        Path(upload_mod.UPLOAD_DIR) / 'raw' / source_sha256 / 'line_001.sgy'
+    )
+    meta = json.loads((store_dir / 'meta.json').read_text(encoding='utf-8'))
+    assert meta['original_segy_path'] == str(durable_raw_path)
+    assert durable_raw_path.read_bytes() == data
 
 
 def test_ingest_staged_segy_invalid_id_returns_404(_staged_env):
@@ -219,6 +316,23 @@ def test_ingest_staged_segy_missing_file_returns_410(_staged_env):
 
     assert response.status_code == 410
     assert calls['ingest'] == 0
+
+
+@pytest.mark.parametrize('endpoint', ['/upload_segy', '/stage_segy'])
+@pytest.mark.parametrize('filename', ['.', '..'])
+def test_segy_upload_rejects_dot_filenames(_staged_env, endpoint: str, filename: str):
+    client, _upload_mod, calls = _staged_env
+    kwargs = {
+        'files': {'file': (filename, b'data', 'application/octet-stream')},
+    }
+    if endpoint == '/upload_segy':
+        kwargs['data'] = {'key1_byte': '189', 'key2_byte': '193'}
+
+    response = client.post(endpoint, **kwargs)
+
+    assert response.status_code == 400
+    assert response.json()['detail'] == 'Uploaded file must have a safe filename'
+    assert calls == {'qc': 0, 'ingest': 0}
 
 
 def test_upload_segy_still_returns_existing_basic_shape(_staged_env):


### PR DESCRIPTION
Closes #248

## Summary
- Fix staged SEG-Y lifecycle and upload filename safety in PR

## Changed files
- `app/api/routers/upload.py`
- `app/tests/test_staged_segy_upload.py`

## Checks
- `.work/codex/checks.log`: 255 passed in 39.52s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
