### PR TITLE
Frontend MVP: add Analyze headers workflow to upload page

### DIFF
--- a/app/static/upload.html
+++ b/app/static/upload.html
@@ -668,7 +668,7 @@
         handleSuccess(payload.file_id, originalName, key1Byte, key2Byte);
       } catch (err) {
         setUploadState('failed', 'Failed to open staged SEG-Y.', mapUploadError(err && err.message));
-        progressText.innerText = 'Ready';
+        progressText.innerText = 'Failed to open staged SEG-Y.';
       } finally {
         isOpening = false;
         updateActionButtons();

--- a/app/static/upload.html
+++ b/app/static/upload.html
@@ -55,6 +55,7 @@
     }
     #status_panel.stage-uploading #stage_badge,
     #status_panel.stage-uploaded #stage_badge,
+    #status_panel.stage-analyzing #stage_badge,
     #status_panel.stage-ingesting #stage_badge,
     #status_panel.stage-opening #stage_badge {
       border-color: #93c5fd;
@@ -128,6 +129,70 @@
       color: #475569;
       font-size: 0.9em;
     }
+    #headerQcPanel {
+      margin: 0 1em 1em;
+      padding: 0.85em 1em;
+      border: 1px solid #d1d5db;
+      border-radius: 10px;
+      background: #fff;
+      max-width: 780px;
+    }
+    #headerQcPanel h2,
+    #headerQcPanel h3 {
+      margin: 0 0 0.7em;
+    }
+    #headerQcSummary {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 0.35em 0.8em;
+      margin-bottom: 1em;
+    }
+    #headerQcSummary dt {
+      color: #475569;
+      font-weight: 600;
+    }
+    #headerQcSummary dd {
+      margin: 0;
+    }
+    #recommendedPairs {
+      display: flex;
+      flex-direction: column;
+      gap: 0.6em;
+      margin-bottom: 1em;
+    }
+    .header-qc-pair {
+      border: 1px solid #d1d5db;
+      border-radius: 8px;
+      padding: 0.75em;
+      background: #f8fafc;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5em;
+    }
+    .header-qc-pair-title {
+      font-weight: 700;
+    }
+    .header-qc-pair-meta,
+    .header-qc-empty {
+      color: #475569;
+      font-size: 0.92em;
+    }
+    .header-qc-list {
+      margin: 0;
+      padding-left: 1.25em;
+    }
+    #headerStatsTable {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 0.65em;
+    }
+    #headerStatsTable th,
+    #headerStatsTable td {
+      border-top: 1px solid #e5e7eb;
+      padding: 0.45em;
+      text-align: left;
+      vertical-align: top;
+    }
   </style>
 </head>
 <body>
@@ -187,6 +252,7 @@
         <option value="197">SHOT_POINT (byte 197)</option>
       </select>
     </label>
+    <button id="analyzeHeadersBtn" disabled>Analyze headers</button>
     <button id="upload_btn">Open</button>
     <progress id="upload_progress" value="0" max="100" style="width: 200px;"></progress>
     <span id="progress_text">0%</span>
@@ -196,24 +262,60 @@
     <div id="status_summary">Choose a SEG-Y file to begin.</div>
     <div id="status_detail"></div>
   </div>
+  <section id="headerQcPanel" aria-labelledby="headerQcHeading" hidden>
+    <h2 id="headerQcHeading">SEG-Y header QC</h2>
+    <dl id="headerQcSummary"></dl>
+    <h3>Recommended key pairs</h3>
+    <div id="recommendedPairs"></div>
+    <details>
+      <summary>Header statistics</summary>
+      <table id="headerStatsTable">
+        <thead>
+          <tr>
+            <th>Byte</th>
+            <th>Name</th>
+            <th>Unique count</th>
+            <th>Unique ratio</th>
+            <th>Group p50</th>
+            <th>Key1 score</th>
+            <th>Warnings</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </details>
+  </section>
   <section id="recent_panel" aria-labelledby="recent_heading">
     <h2 id="recent_heading">Recent datasets</h2>
     <div id="recent_state">Loading recent datasets...</div>
     <div id="recent_list"></div>
   </section>
   <script>
+    const uploadInput = document.getElementById('upload_segy');
     const progressBar = document.getElementById('upload_progress');
     const progressText = document.getElementById('progress_text');
     const uploadBtn = document.getElementById('upload_btn');
+    const analyzeHeadersBtn = document.getElementById('analyzeHeadersBtn');
     const key1Select = document.getElementById('key1_byte');
     const key2Select = document.getElementById('key2_byte');
     const statusPanel = document.getElementById('status_panel');
     const stageBadge = document.getElementById('stage_badge');
     const statusSummary = document.getElementById('status_summary');
     const statusDetail = document.getElementById('status_detail');
+    const headerQcPanel = document.getElementById('headerQcPanel');
+    const headerQcSummary = document.getElementById('headerQcSummary');
+    const recommendedPairs = document.getElementById('recommendedPairs');
+    const headerStatsTableBody = document.querySelector('#headerStatsTable tbody');
     const recentState = document.getElementById('recent_state');
     const recentList = document.getElementById('recent_list');
     const RECENT_DATASET_LIMIT = 10;
+    let selectedFile = null;
+    let stagedId = null;
+    let headerQc = null;
+    let isAnalyzing = false;
+    let isOpening = false;
+    let selectedFileRevision = 0;
+    let activeAnalysisRevision = null;
 
     const savedKey1 = localStorage.getItem('last_key1_byte');
     if (savedKey1) key1Select.value = savedKey1;
@@ -225,6 +327,21 @@
       stageBadge.textContent = stage;
       statusSummary.textContent = summary;
       statusDetail.textContent = detail;
+    }
+
+    function updateActionButtons() {
+      analyzeHeadersBtn.disabled = !selectedFile || isAnalyzing || isOpening;
+      if (selectedFile) {
+        uploadBtn.disabled = !stagedId || isAnalyzing || isOpening;
+      } else {
+        uploadBtn.disabled = isAnalyzing || isOpening;
+      }
+    }
+
+    function isCurrentAnalysis(file, revision) {
+      return selectedFile === file
+        && selectedFileRevision === revision
+        && activeAnalysisRevision === revision;
     }
 
     async function readResponseDetail(response) {
@@ -277,6 +394,287 @@
       key2Select.value = String(key2Byte);
     }
 
+    function formatValue(value) {
+      if (value === null || value === undefined || value === '') {
+        return 'n/a';
+      }
+      if (typeof value === 'number') {
+        return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)));
+      }
+      return String(value);
+    }
+
+    function formatFileSize(size) {
+      if (typeof size !== 'number' || !Number.isFinite(size)) {
+        return 'n/a';
+      }
+      if (size < 1024) {
+        return `${size} B`;
+      }
+      const units = ['KB', 'MB', 'GB'];
+      let value = size / 1024;
+      for (const unit of units) {
+        if (value < 1024 || unit === units[units.length - 1]) {
+          return `${value.toFixed(value < 10 ? 1 : 0)} ${unit}`;
+        }
+        value /= 1024;
+      }
+      return `${size} B`;
+    }
+
+    function formatWarnings(warnings) {
+      return Array.isArray(warnings) && warnings.length > 0 ? warnings.join('; ') : 'none';
+    }
+
+    function appendSummaryRow(label, value) {
+      const dt = document.createElement('dt');
+      dt.textContent = label;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      headerQcSummary.appendChild(dt);
+      headerQcSummary.appendChild(dd);
+    }
+
+    function appendList(parent, items) {
+      if (!Array.isArray(items) || items.length === 0) {
+        return;
+      }
+      const list = document.createElement('ul');
+      list.className = 'header-qc-list';
+      for (const item of items) {
+        const li = document.createElement('li');
+        li.textContent = String(item);
+        list.appendChild(li);
+      }
+      parent.appendChild(list);
+    }
+
+    function applyRecommendedPair(pair) {
+      key1Select.value = String(pair.key1_byte);
+      key2Select.value = String(pair.key2_byte);
+    }
+
+    function hideHeaderQcPanel() {
+      headerQcPanel.hidden = true;
+      headerQcSummary.innerHTML = '';
+      recommendedPairs.innerHTML = '';
+      headerStatsTableBody.innerHTML = '';
+    }
+
+    function renderRecommendedPairs(pairs) {
+      recommendedPairs.innerHTML = '';
+      if (!Array.isArray(pairs) || pairs.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'header-qc-empty';
+        empty.textContent = 'No confident key pair found. Please choose key bytes manually.';
+        recommendedPairs.appendChild(empty);
+        return;
+      }
+      for (const pair of pairs) {
+        const card = document.createElement('div');
+        card.className = 'header-qc-pair';
+        card.dataset.testid = 'recommended-pair';
+
+        const title = document.createElement('div');
+        title.className = 'header-qc-pair-title';
+        title.textContent = `${formatValue(pair.key1_name)} byte ${formatValue(pair.key1_byte)} / ${formatValue(pair.key2_name)} byte ${formatValue(pair.key2_byte)}`;
+
+        const meta = document.createElement('div');
+        meta.className = 'header-qc-pair-meta';
+        meta.textContent = `score: ${formatValue(pair.score)} / confidence: ${formatValue(pair.confidence)}`;
+
+        const reasonsLabel = document.createElement('div');
+        reasonsLabel.textContent = 'Reasons:';
+        const warnings = document.createElement('div');
+        warnings.className = 'header-qc-pair-meta';
+        warnings.textContent = `Warnings: ${formatWarnings(pair.warnings)}`;
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = 'Use this';
+        button.dataset.testid = 'use-recommended-pair';
+        button.addEventListener('click', () => applyRecommendedPair(pair));
+
+        card.appendChild(title);
+        card.appendChild(meta);
+        card.appendChild(reasonsLabel);
+        appendList(card, pair.reasons);
+        card.appendChild(warnings);
+        card.appendChild(button);
+        recommendedPairs.appendChild(card);
+      }
+    }
+
+    function renderHeaderStats(headers) {
+      headerStatsTableBody.innerHTML = '';
+      if (!Array.isArray(headers)) {
+        return;
+      }
+      for (const header of headers) {
+        const row = document.createElement('tr');
+        const values = [
+          header.byte,
+          header.name,
+          header.unique_count,
+          header.unique_ratio,
+          header.group_size && header.group_size.p50,
+          header.key1_score,
+          formatWarnings(header.warnings),
+        ];
+        for (const value of values) {
+          const cell = document.createElement('td');
+          cell.textContent = formatValue(value);
+          row.appendChild(cell);
+        }
+        headerStatsTableBody.appendChild(row);
+      }
+    }
+
+    function renderHeaderQc(payload) {
+      const file = payload && payload.file ? payload.file : {};
+      const segy = payload && payload.segy ? payload.segy : {};
+      headerQcSummary.innerHTML = '';
+      appendSummaryRow('File', formatValue(file.original_name));
+      appendSummaryRow('File size', formatFileSize(file.size));
+      appendSummaryRow('Traces', formatValue(segy.n_traces));
+      appendSummaryRow('Samples', formatValue(segy.n_samples));
+      appendSummaryRow('Sample interval', `${formatValue(segy.dt)} s`);
+      appendSummaryRow('Warnings', formatWarnings(payload && payload.warnings));
+      renderRecommendedPairs(payload && payload.recommended_pairs);
+      renderHeaderStats(payload && payload.headers);
+      headerQcPanel.hidden = false;
+    }
+
+    function resetSelectedFileState(file) {
+      selectedFileRevision += 1;
+      activeAnalysisRevision = null;
+      isAnalyzing = false;
+      selectedFile = file || null;
+      stagedId = null;
+      headerQc = null;
+      hideHeaderQcPanel();
+      progressBar.value = 0;
+      progressText.innerText = '0%';
+      if (selectedFile) {
+        setUploadState('idle', `${selectedFile.name} selected.`, 'Analyze headers before opening this SEG-Y file.');
+      } else if (lastName) {
+        setUploadState('idle', `Last dataset: ${lastName}`, 'You can reopen it or upload a new SEG-Y file.');
+      } else {
+        setUploadState('idle', 'No previous dataset is stored in this browser.', 'Choose a SEG-Y file to upload and ingest.');
+      }
+      updateActionButtons();
+    }
+
+    async function analyzeHeaders() {
+      if (!selectedFile) {
+        setUploadState('failed', 'Please select a SEG-Y file first.');
+        return;
+      }
+      const analysisFile = selectedFile;
+      const analysisRevision = selectedFileRevision;
+      activeAnalysisRevision = analysisRevision;
+      isAnalyzing = true;
+      stagedId = null;
+      headerQc = null;
+      hideHeaderQcPanel();
+      progressBar.value = 0;
+      progressText.innerText = 'Analyzing headers...';
+      setUploadState('analyzing', 'Analyzing headers...', 'Inspecting SEG-Y trace headers.');
+      updateActionButtons();
+
+      try {
+        const form = new FormData();
+        form.append('file', analysisFile);
+        const response = await fetch('/stage_segy', { method: 'POST', body: form });
+        if (!isCurrentAnalysis(analysisFile, analysisRevision)) {
+          return;
+        }
+        if (!response.ok) {
+          const detail = mapUploadError(await readResponseDetail(response));
+          throw new Error(detail);
+        }
+        const payload = await response.json();
+        if (!isCurrentAnalysis(analysisFile, analysisRevision)) {
+          return;
+        }
+        stagedId = payload.staged_id;
+        headerQc = payload;
+        renderHeaderQc(payload);
+
+        const best = Array.isArray(payload.recommended_pairs) ? payload.recommended_pairs[0] : null;
+        if (best) {
+          applyRecommendedPair(best);
+          setUploadState('ready', 'Header analysis complete.', 'Review the recommended key pairs or adjust key bytes before opening.');
+        } else {
+          setUploadState('ready', 'No confident key pair found. Please choose key bytes manually.', 'Header analysis completed without a recommended pair.');
+        }
+        progressText.innerText = 'Ready';
+      } catch (err) {
+        if (!isCurrentAnalysis(analysisFile, analysisRevision)) {
+          return;
+        }
+        stagedId = null;
+        headerQc = null;
+        hideHeaderQcPanel();
+        const detail = mapUploadError(err && err.message);
+        setUploadState('failed', 'Failed to analyze SEG-Y headers.', detail);
+        progressText.innerText = '0%';
+      } finally {
+        if (activeAnalysisRevision === analysisRevision) {
+          activeAnalysisRevision = null;
+          isAnalyzing = false;
+          updateActionButtons();
+        }
+      }
+    }
+
+    async function openStagedSegy() {
+      if (!stagedId) {
+        setUploadState('failed', 'Please run Analyze headers first.');
+        updateActionButtons();
+        return;
+      }
+      const key1Byte = key1Select.value;
+      const key2Byte = key2Select.value;
+      if (key1Byte === key2Byte) {
+        setUploadState('failed', 'key1_byte and key2_byte must differ.');
+        return;
+      }
+
+      isOpening = true;
+      setUploadState('opening', 'Opening...', 'Building or reopening the TraceStore from the staged SEG-Y file.');
+      progressText.innerText = 'Opening...';
+      updateActionButtons();
+      try {
+        const form = new FormData();
+        form.append('staged_id', stagedId);
+        form.append('key1_byte', key1Byte);
+        form.append('key2_byte', key2Byte);
+        const response = await fetch('/ingest_staged_segy', { method: 'POST', body: form });
+        if (!response.ok) {
+          const detail = mapUploadError(await readResponseDetail(response));
+          if (response.status === 404 || response.status === 410) {
+            stagedId = null;
+            headerQc = null;
+            hideHeaderQcPanel();
+            throw new Error('Staged SEG-Y expired. Please run Analyze headers again.');
+          }
+          throw new Error(detail || 'Failed to open staged SEG-Y.');
+        }
+        const payload = await response.json();
+        const originalName = headerQc && headerQc.file && headerQc.file.original_name
+          ? headerQc.file.original_name
+          : selectedFile.name;
+        handleSuccess(payload.file_id, originalName, key1Byte, key2Byte);
+      } catch (err) {
+        setUploadState('failed', 'Failed to open staged SEG-Y.', mapUploadError(err && err.message));
+        progressText.innerText = 'Ready';
+      } finally {
+        isOpening = false;
+        updateActionButtons();
+      }
+    }
+
     function formatRecentExtra(item) {
       const parts = [];
       if (typeof item.dt === 'number') parts.push(`dt ${item.dt}`);
@@ -322,7 +720,8 @@
         button.type = 'button';
         button.textContent = 'Open';
         button.addEventListener('click', async () => {
-          uploadBtn.disabled = true;
+          isOpening = true;
+          updateActionButtons();
           button.disabled = true;
           syncKeyByteSelectors(item.key1_byte, item.key2_byte);
           progressBar.value = 0;
@@ -345,8 +744,9 @@
           } catch (err) {
             setUploadState('failed', 'Open failed.', mapUploadError(err && err.message));
           } finally {
+            isOpening = false;
             button.disabled = false;
-            uploadBtn.disabled = false;
+            updateActionButtons();
           }
         });
 
@@ -396,124 +796,52 @@
       return fetch('/open_segy', { method: 'POST', body: fd });
     }
 
-    async function uploadSegy(file, key1Byte, key2Byte) {
-      return new Promise((resolve) => {
-        const formData = new FormData();
-        formData.append('file', file);
-        formData.append('key1_byte', key1Byte);
-        formData.append('key2_byte', key2Byte);
-        const xhr = new XMLHttpRequest();
-        xhr.open('POST', '/upload_segy', true);
-        xhr.upload.onloadstart = function () {
-          setUploadState('uploading', 'Uploading SEG-Y file...', 'The file is being sent to the server.');
-        };
-        xhr.upload.onprogress = function (e) {
-          if (e.lengthComputable) {
-            const percent = (e.loaded / e.total) * 100;
-            progressBar.value = percent;
-            progressText.innerText = `${percent.toFixed(1)}%`;
-            setUploadState('uploading', 'Uploading SEG-Y file...', `${percent.toFixed(1)}% transferred.`);
-          }
-        };
-        xhr.upload.onloadend = function () {
-          progressBar.value = 100;
-          progressText.innerText = '100.0%';
-          setUploadState('uploaded', 'Upload finished.', 'Server-side ingest has started. Building TraceStore...');
-          window.setTimeout(() => {
-            if (statusPanel.classList.contains('stage-uploaded')) {
-              setUploadState('ingesting', 'Building TraceStore...', 'The upload is complete. The server is preparing the dataset now.');
-            }
-          }, 250);
-        };
-        xhr.onload = async function () {
-          if (xhr.status === 200) {
-            const result = JSON.parse(xhr.responseText);
-            handleSuccess(result.file_id, file.name, key1Byte, key2Byte);
-          } else if (xhr.status === 409) {
-            try {
-              setUploadState('ingesting', 'Upload finished.', 'An existing TraceStore was detected. Reopening the prepared dataset...');
-              const res = await openSegy(file.name, key1Byte, key2Byte);
-              if (res.ok) {
-                const result = await res.json();
-                handleSuccess(result.file_id, file.name, key1Byte, key2Byte);
-              } else {
-                const text = mapUploadError(await readResponseDetail(res));
-                setUploadState('failed', 'Open failed.', text);
-              }
-            } catch (err) {
-              setUploadState('failed', 'Open failed.', mapUploadError(err && err.message));
-            }
-          } else {
-            let detail = xhr.responseText || '';
-            try {
-              const payload = JSON.parse(xhr.responseText || '{}');
-              if (payload && typeof payload.detail === 'string') {
-                detail = payload.detail;
-              }
-            } catch {
-              detail = xhr.responseText || '';
-            }
-            setUploadState('failed', 'Upload failed.', mapUploadError(detail));
-          }
-          resolve();
-        };
-        xhr.onerror = function () {
-          setUploadState('failed', 'Upload failed.', 'Network error while uploading the file. Check the connection and retry.');
-          resolve();
-        };
-        xhr.send(formData);
-      });
-    }
-
     loadRecentDatasets().catch((err) => {
       recentState.textContent = `Unable to load recent datasets: ${mapUploadError(err && err.message)}`;
     });
 
     uploadBtn.addEventListener('click', async () => {
-      uploadBtn.disabled = true;
-      const file = document.getElementById('upload_segy').files[0];
+      if (selectedFile) {
+        await openStagedSegy();
+        return;
+      }
+      isOpening = true;
+      updateActionButtons();
       const key1Byte = key1Select.value;
       const key2Byte = key2Select.value;
       progressBar.value = 0;
       progressText.innerText = '0%';
       try {
-        if (file) {
-          setUploadState('opening', 'Checking for an existing TraceStore...', 'If a prepared dataset already exists, it will be reopened instead of re-ingested.');
-          const res = await openSegy(file.name, key1Byte, key2Byte);
+        const savedName = localStorage.getItem('last_original_name');
+        if (!savedName) {
+          setUploadState('failed', 'No dataset selected.', 'Choose a SEG-Y file to upload, or reopen a previously ingested dataset.');
+        } else {
+          setUploadState('opening', `Opening ${savedName}...`, 'Loading the prepared TraceStore from the server.');
+          const res = await openSegy(savedName, key1Byte, key2Byte);
           if (res.ok) {
             const result = await res.json();
-            handleSuccess(result.file_id, file.name, key1Byte, key2Byte);
+            handleSuccess(result.file_id, savedName, key1Byte, key2Byte);
           } else if (res.status === 404) {
-            setUploadState('uploading', 'No prepared TraceStore found.', 'Uploading the SEG-Y file now.');
-            await uploadSegy(file, key1Byte, key2Byte);
+            setUploadState('failed', 'Prepared dataset not found.', 'Choose the SEG-Y file and upload it again to rebuild the TraceStore.');
           } else {
             const text = mapUploadError(await readResponseDetail(res));
             setUploadState('failed', 'Open failed.', text);
-          }
-        } else {
-          const savedName = localStorage.getItem('last_original_name');
-          if (!savedName) {
-            setUploadState('failed', 'No dataset selected.', 'Choose a SEG-Y file to upload, or reopen a previously ingested dataset.');
-          } else {
-            setUploadState('opening', `Opening ${savedName}...`, 'Loading the prepared TraceStore from the server.');
-            const res = await openSegy(savedName, key1Byte, key2Byte);
-            if (res.ok) {
-              const result = await res.json();
-              handleSuccess(result.file_id, savedName, key1Byte, key2Byte);
-            } else if (res.status === 404) {
-              setUploadState('failed', 'Prepared dataset not found.', 'Choose the SEG-Y file and upload it again to rebuild the TraceStore.');
-            } else {
-              const text = mapUploadError(await readResponseDetail(res));
-              setUploadState('failed', 'Open failed.', text);
-            }
           }
         }
       } catch (err) {
         setUploadState('failed', 'Open failed.', mapUploadError(err && err.message));
       } finally {
-        uploadBtn.disabled = false;
+        isOpening = false;
+        updateActionButtons();
       }
     });
+
+    uploadInput.addEventListener('change', () => {
+      resetSelectedFileState(uploadInput.files && uploadInput.files[0]);
+    });
+
+    analyzeHeadersBtn.addEventListener('click', analyzeHeaders);
+    updateActionButtons();
   </script>
 </body>
 </html>

--- a/app/tests/e2e/test_compare_mode.py
+++ b/app/tests/e2e/test_compare_mode.py
@@ -11,6 +11,8 @@ def test_playwright_compare_mode_toggle_and_diff_panel(
     page.select_option("#key1_byte", "189")
     page.select_option("#key2_byte", "193")
     page.set_input_files("#upload_segy", str(tiny_segy_path))
+    page.click("#analyzeHeadersBtn")
+    page.wait_for_function("() => !document.getElementById('upload_btn')?.disabled")
     page.click("#upload_btn")
     page.wait_for_url("**/?file_id=*", timeout=60_000)
     page.wait_for_load_state("domcontentloaded")

--- a/app/tests/e2e/test_picks_e2e.py
+++ b/app/tests/e2e/test_picks_e2e.py
@@ -42,6 +42,8 @@ def test_add_single_pick_then_get(page, base_url, tiny_segy_path, e2e_debug):
     page.select_option("#key1_byte", "189")
     page.select_option("#key2_byte", "193")
     page.set_input_files("#upload_segy", str(tiny_segy_path))
+    page.click("#analyzeHeadersBtn")
+    page.wait_for_function("() => !document.getElementById('upload_btn')?.disabled")
     page.click("#upload_btn")
 
     page.wait_for_url("**/?file_id=*", timeout=60_000)
@@ -130,6 +132,8 @@ def test_pending_pick_anchors_are_visible_without_write(
     page.select_option("#key1_byte", "189")
     page.select_option("#key2_byte", "193")
     page.set_input_files("#upload_segy", str(tiny_segy_path))
+    page.click("#analyzeHeadersBtn")
+    page.wait_for_function("() => !document.getElementById('upload_btn')?.disabled")
     page.click("#upload_btn")
 
     page.wait_for_url("**/?file_id=*", timeout=60_000)

--- a/app/tests/e2e/test_section_navigation.py
+++ b/app/tests/e2e/test_section_navigation.py
@@ -19,6 +19,8 @@ def _upload_tiny_dataset_and_wait(page, base_url, tiny_segy_path) -> None:
     page.select_option("#key1_byte", "189")
     page.select_option("#key2_byte", "193")
     page.set_input_files("#upload_segy", str(tiny_segy_path))
+    page.click("#analyzeHeadersBtn")
+    page.wait_for_function("() => !document.getElementById('upload_btn')?.disabled")
     page.click("#upload_btn")
 
     page.wait_for_url("**/?file_id=*", timeout=60_000)

--- a/app/tests/e2e/test_shortcut_help_overlay.py
+++ b/app/tests/e2e/test_shortcut_help_overlay.py
@@ -20,6 +20,8 @@ def _upload_tiny_dataset_and_render_plot(page, base_url, tiny_segy_path) -> None
     page.select_option("#key1_byte", "189")
     page.select_option("#key2_byte", "193")
     page.set_input_files("#upload_segy", str(tiny_segy_path))
+    page.click("#analyzeHeadersBtn")
+    page.wait_for_function("() => !document.getElementById('upload_btn')?.disabled")
     page.click("#upload_btn")
 
     page.wait_for_url("**/?file_id=*", timeout=120_000)

--- a/app/tests/e2e/test_upload_and_plot.py
+++ b/app/tests/e2e/test_upload_and_plot.py
@@ -10,6 +10,8 @@ def test_upload_redirect_and_plot(page, base_url, tiny_segy_path, e2e_debug):
     page.select_option("#key1_byte", "189")
     page.select_option("#key2_byte", "193")
     page.set_input_files("#upload_segy", str(tiny_segy_path))
+    page.click("#analyzeHeadersBtn")
+    page.wait_for_function("() => !document.getElementById('upload_btn')?.disabled")
 
     page.click("#upload_btn")
     page.wait_for_url("**/?file_id=*", timeout=60_000)

--- a/tests/e2e/upload_headers.spec.ts
+++ b/tests/e2e/upload_headers.spec.ts
@@ -1,0 +1,333 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:8000';
+
+function headerQcPayload(stagedId: string, recommendedPairs = [
+	{
+		key1_byte: 189,
+		key1_name: 'INLINE_3D',
+		key2_byte: 193,
+		key2_name: 'CROSSLINE_3D',
+		score: 0.94,
+		confidence: 'high',
+		reasons: ['key1 has 120 sections with median 200 traces/section'],
+		warnings: [],
+	},
+	{
+		key1_byte: 21,
+		key1_name: 'CDP',
+		key2_byte: 25,
+		key2_name: 'CDP_TRACE',
+		score: 0.82,
+		confidence: 'medium',
+		reasons: ['key2 is mostly unique within key1 sections'],
+		warnings: ['small sections detected'],
+	},
+]) {
+	return {
+		staged_id: stagedId,
+		file: {
+			original_name: 'line001.sgy',
+			safe_name: 'line001.sgy',
+			size: 4096,
+			sha256: 'abc123',
+		},
+		segy: {
+			n_traces: 24000,
+			n_samples: 1500,
+			dt: 0.002,
+		},
+		recommended_pairs: recommendedPairs,
+		headers: [
+			{
+				byte: 189,
+				name: 'INLINE_3D',
+				available: true,
+				min: 1001,
+				max: 1120,
+				unique_count: 120,
+				unique_ratio: 0.005,
+				key1_score: 0.91,
+				group_size: {
+					min: 200,
+					p05: 200,
+					p50: 200,
+					p95: 200,
+					max: 200,
+				},
+				warnings: [],
+			},
+		],
+		warnings: [],
+	};
+}
+
+async function gotoUpload(page: Page) {
+	await page.route('**/recent_datasets', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ datasets: [] }),
+		});
+	});
+	await page.goto(`${BASE_URL}/upload`);
+}
+
+async function selectSegyFile(page: Page, name = 'line001.sgy') {
+	await page.setInputFiles('#upload_segy', {
+		name,
+		mimeType: 'application/octet-stream',
+		buffer: Buffer.from('mock segy'),
+	});
+}
+
+function expectMultipartValue(body: string, field: string, value: string) {
+	expect(body).toContain(`name="${field}"`);
+	expect(body).toContain(value);
+}
+
+test('upload page analyzes headers and opens staged SEG-Y', async ({ page }) => {
+	let stageCalls = 0;
+	let ingestBody = '';
+
+	await page.route('**/stage_segy', async (route) => {
+		stageCalls += 1;
+		expect(route.request().method()).toBe('POST');
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(headerQcPayload('staged-123')),
+		});
+	});
+	await page.route('**/ingest_staged_segy', async (route) => {
+		ingestBody = route.request().postData() ?? '';
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ file_id: 'viewer-file', reused_trace_store: false }),
+		});
+	});
+	await page.route(/\/\?file_id=/, async (route) => {
+		await route.fulfill({ status: 200, contentType: 'text/html', body: '<html></html>' });
+	});
+
+	await gotoUpload(page);
+
+	await expect(page.locator('#analyzeHeadersBtn')).toBeDisabled();
+	await expect(page.locator('#headerQcPanel')).toBeHidden();
+
+	await selectSegyFile(page);
+
+	await expect(page.locator('#analyzeHeadersBtn')).toBeEnabled();
+	await expect(page.locator('#upload_btn')).toBeDisabled();
+	expect(stageCalls).toBe(0);
+
+	await page.locator('#analyzeHeadersBtn').click();
+
+	await expect(page.locator('#headerQcPanel')).toBeVisible();
+	await expect(page.getByText('INLINE_3D byte 189 / CROSSLINE_3D byte 193')).toBeVisible();
+	await expect(page.locator('#key1_byte')).toHaveValue('189');
+	await expect(page.locator('#key2_byte')).toHaveValue('193');
+	await expect(page.locator('#upload_btn')).toBeEnabled();
+
+	const cdpPair = page.getByTestId('recommended-pair').filter({ hasText: 'CDP byte 21' });
+	await cdpPair.getByTestId('use-recommended-pair').click();
+	await expect(page.locator('#key1_byte')).toHaveValue('21');
+	await expect(page.locator('#key2_byte')).toHaveValue('25');
+
+	await page.locator('#upload_btn').click();
+	await expect.poll(() => ingestBody).toContain('staged-123');
+	expectMultipartValue(ingestBody, 'key1_byte', '21');
+	expectMultipartValue(ingestBody, 'key2_byte', '25');
+	await page.waitForURL('**/?file_id=viewer-file&key1_byte=21&key2_byte=25');
+});
+
+test('changing selected file resets staged QC state', async ({ page }) => {
+	await page.route('**/stage_segy', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(headerQcPayload('staged-reset')),
+		});
+	});
+
+	await gotoUpload(page);
+	await selectSegyFile(page, 'line-a.sgy');
+	await page.locator('#analyzeHeadersBtn').click();
+
+	await expect(page.locator('#headerQcPanel')).toBeVisible();
+	await expect(page.locator('#upload_btn')).toBeEnabled();
+
+	await selectSegyFile(page, 'line-b.sgy');
+
+	await expect(page.locator('#headerQcPanel')).toBeHidden();
+	await expect(page.locator('#upload_btn')).toBeDisabled();
+	await expect(page.locator('#analyzeHeadersBtn')).toBeEnabled();
+	await expect(page.locator('#status_summary')).toContainText('line-b.sgy selected.');
+});
+
+test('stale analyze response is ignored after selected file changes', async ({ page }) => {
+	let releaseStageResponse!: () => void;
+	const stageCanFinish = new Promise<void>((resolve) => {
+		releaseStageResponse = resolve;
+	});
+	let markStageStarted!: () => void;
+	const stageStarted = new Promise<void>((resolve) => {
+		markStageStarted = resolve;
+	});
+	let ingestCalls = 0;
+
+	await page.route('**/stage_segy', async (route) => {
+		markStageStarted();
+		await stageCanFinish;
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(headerQcPayload('staged-old')),
+		});
+	});
+	await page.route('**/ingest_staged_segy', async (route) => {
+		ingestCalls += 1;
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ file_id: 'old-file', reused_trace_store: false }),
+		});
+	});
+
+	await gotoUpload(page);
+	await selectSegyFile(page, 'line-a.sgy');
+	await page.locator('#analyzeHeadersBtn').click();
+	await stageStarted;
+	await selectSegyFile(page, 'line-b.sgy');
+
+	const staleStageResponse = page.waitForResponse('**/stage_segy');
+	releaseStageResponse();
+	await staleStageResponse;
+	await page.evaluate(() => new Promise((resolve) => window.setTimeout(resolve, 0)));
+
+	await expect(page.locator('#headerQcPanel')).toBeHidden();
+	await expect(page.locator('#upload_btn')).toBeDisabled();
+	await expect(page.locator('#status_summary')).toContainText('line-b.sgy selected.');
+	await expect.poll(() => ingestCalls).toBe(0);
+});
+
+test('empty recommended pairs still allow manual staged open', async ({ page }) => {
+	let ingestBody = '';
+
+	await page.route('**/stage_segy', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(headerQcPayload('staged-empty', [])),
+		});
+	});
+	await page.route('**/ingest_staged_segy', async (route) => {
+		ingestBody = route.request().postData() ?? '';
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ file_id: 'manual-file', reused_trace_store: false }),
+		});
+	});
+	await page.route(/\/\?file_id=/, async (route) => {
+		await route.fulfill({ status: 200, contentType: 'text/html', body: '<html></html>' });
+	});
+
+	await gotoUpload(page);
+	await selectSegyFile(page);
+	await page.locator('#analyzeHeadersBtn').click();
+
+	await expect(page.locator('#recommendedPairs')).toContainText('No confident key pair found. Please choose key bytes manually.');
+	await expect(page.locator('#upload_btn')).toBeEnabled();
+
+	await page.selectOption('#key1_byte', '189');
+	await page.selectOption('#key2_byte', '193');
+	await page.locator('#upload_btn').click();
+
+	await expect.poll(() => ingestBody).toContain('staged-empty');
+	expectMultipartValue(ingestBody, 'key1_byte', '189');
+	expectMultipartValue(ingestBody, 'key2_byte', '193');
+	await page.waitForURL('**/?file_id=manual-file&key1_byte=189&key2_byte=193');
+});
+
+test('analyze failure shows error and keeps open disabled', async ({ page }) => {
+	await page.route('**/stage_segy', async (route) => {
+		await route.fulfill({
+			status: 500,
+			contentType: 'application/json',
+			body: JSON.stringify({ detail: 'header scanner failed' }),
+		});
+	});
+
+	await gotoUpload(page);
+	await selectSegyFile(page);
+	await page.locator('#analyzeHeadersBtn').click();
+
+	await expect(page.locator('#status_summary')).toHaveText('Failed to analyze SEG-Y headers.');
+	await expect(page.locator('#status_detail')).toHaveText('header scanner failed');
+	await expect(page.locator('#headerQcPanel')).toBeHidden();
+	await expect(page.locator('#upload_btn')).toBeDisabled();
+});
+
+test('same key byte validation prevents staged ingest', async ({ page }) => {
+	let ingestCalls = 0;
+
+	await page.route('**/stage_segy', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(headerQcPayload('staged-validation')),
+		});
+	});
+	await page.route('**/ingest_staged_segy', async (route) => {
+		ingestCalls += 1;
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ file_id: 'should-not-open', reused_trace_store: false }),
+		});
+	});
+
+	await gotoUpload(page);
+	await selectSegyFile(page);
+	await page.locator('#analyzeHeadersBtn').click();
+	await expect(page.locator('#upload_btn')).toBeEnabled();
+
+	await page.selectOption('#key1_byte', '189');
+	await page.selectOption('#key2_byte', '189');
+	await page.locator('#upload_btn').click();
+
+	await expect(page.locator('#status_summary')).toHaveText('key1_byte and key2_byte must differ.');
+	await expect.poll(() => ingestCalls).toBe(0);
+});
+
+test('expired staged SEG-Y error resets staged open state', async ({ page }) => {
+	await page.route('**/stage_segy', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(headerQcPayload('staged-expired')),
+		});
+	});
+	await page.route('**/ingest_staged_segy', async (route) => {
+		await route.fulfill({
+			status: 404,
+			contentType: 'application/json',
+			body: JSON.stringify({ detail: 'Staged SEG-Y not found' }),
+		});
+	});
+
+	await gotoUpload(page);
+	await selectSegyFile(page);
+	await page.locator('#analyzeHeadersBtn').click();
+	await expect(page.locator('#upload_btn')).toBeEnabled();
+
+	await page.locator('#upload_btn').click();
+
+	await expect(page.locator('#status_summary')).toHaveText('Failed to open staged SEG-Y.');
+	await expect(page.locator('#status_detail')).toHaveText('Staged SEG-Y expired. Please run Analyze headers again.');
+	await expect(page.locator('#headerQcPanel')).toBeHidden();
+	await expect(page.locator('#upload_btn')).toBeDisabled();
+	await expect(page.locator('#analyzeHeadersBtn')).toBeEnabled();
+});


### PR DESCRIPTION
Closes #250

## Summary
- Frontend MVP: add Analyze headers workflow to upload page

## Changed files
- `app/static/upload.html`
- `app/tests/e2e/test_compare_mode.py`
- `app/tests/e2e/test_picks_e2e.py`
- `app/tests/e2e/test_section_navigation.py`
- `app/tests/e2e/test_shortcut_help_overlay.py`
- `app/tests/e2e/test_upload_and_plot.py`
- `tests/e2e/upload_headers.spec.ts`

## Checks
- `.work/codex/checks.log`: 255 passed in 40.73s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
