### PR TITLE
Staged SEG-Y uploads can leak disk files when cache entries expire or are evicted

### DIFF
--- a/app/api/routers/upload.py
+++ b/app/api/routers/upload.py
@@ -9,6 +9,7 @@ import logging
 import re
 import shutil
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
@@ -23,6 +24,10 @@ from app.core.paths import (
     get_upload_dir,
 )
 from app.core.state import AppState
+from app.services.staged_upload_cleanup import (
+    cleanup_staged_upload,
+    cleanup_stale_staged_upload_dirs,
+)
 from app.utils.ingest import SegyIngestor
 from app.utils.baseline_artifacts import has_split_baseline_artifacts
 from app.utils.header_qc import inspect_segy_header_qc
@@ -35,6 +40,8 @@ UPLOAD_DIR = get_upload_dir()
 PROCESSED_DIR = get_processed_upload_dir()
 TRACE_DIR = get_trace_store_dir()
 UPLOAD_CHUNK_SIZE = 4 * 1024 * 1024
+STAGED_UPLOAD_CLEANUP_INTERVAL_SEC = 600
+_last_staged_cleanup_ts = 0.0
 
 
 @dataclass(frozen=True)
@@ -61,15 +68,49 @@ def _staged_upload_dir() -> Path:
 
 
 def _cleanup_staged_upload(raw_path: Path) -> None:
-    try:
-        raw_path.unlink(missing_ok=True)
-    except OSError:
-        logger.warning('Unable to delete staged SEG-Y file: %s', raw_path)
+    cleanup_staged_upload(raw_path, staged_root=_staged_upload_dir())
 
-    staged_dir = raw_path.parent
-    if staged_dir.parent != _staged_upload_dir():
+
+def _cleanup_discarded_staged_upload(_key, value, _reason: str) -> None:
+    if not isinstance(value, dict):
         return
-    shutil.rmtree(staged_dir, ignore_errors=True)
+    raw_path = value.get('raw_path')
+    if not isinstance(raw_path, (str, Path)):
+        return
+    _cleanup_staged_upload(Path(raw_path))
+
+
+def _ensure_staged_upload_cleanup_callback(state: AppState) -> None:
+    state.staged_uploads.set_on_discard(_cleanup_discarded_staged_upload)
+
+
+def cleanup_staged_uploads(
+    state: AppState,
+    *,
+    force: bool = False,
+    now_ts: float | None = None,
+) -> int:
+    """Purge expired staged records and stale staged directories."""
+    global _last_staged_cleanup_ts
+
+    now = time.time() if now_ts is None else float(now_ts)
+    with state.lock:
+        _ensure_staged_upload_cleanup_callback(state)
+        removed = state.staged_uploads.purge_expired()
+        active_ids = set(state.staged_uploads.keys())
+        ttl_sec = state.staged_uploads.ttl_sec
+
+    if not force and now - _last_staged_cleanup_ts < STAGED_UPLOAD_CLEANUP_INTERVAL_SEC:
+        return removed
+
+    _last_staged_cleanup_ts = now
+    removed += cleanup_stale_staged_upload_dirs(
+        staged_root=_staged_upload_dir(),
+        ttl_sec=ttl_sec,
+        active_ids=active_ids,
+        now_ts=now,
+    )
+    return removed
 
 
 def _sha256_file(path: Path) -> str:
@@ -560,6 +601,7 @@ async def stage_segy(
     file: Annotated[UploadFile, File(...)],
 ):
     state = get_state(request.app)
+    cleanup_staged_uploads(state)
     if not file.filename:
         raise HTTPException(
             status_code=400, detail='Uploaded file must have a filename'
@@ -609,6 +651,7 @@ async def ingest_staged_segy(
     key2_byte: Annotated[int, Form()] = 193,
 ):
     state = get_state(request.app)
+    cleanup_staged_uploads(state)
     with state.lock:
         staged = state.staged_uploads.get(staged_id)
     if staged is None:

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -6,7 +6,7 @@ import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 from app.core.settings import Settings
 from app.services.file_registry import FileRegistry
@@ -48,6 +48,7 @@ class ExpiringLRUCache(OrderedDict):
         ttl_sec: int = 1800,
         *,
         time_fn: Any = time.time,
+        on_discard: Callable[[Any, Any, str], None] | None = None,
     ):
         super().__init__()
         if capacity <= 0:
@@ -57,13 +58,35 @@ class ExpiringLRUCache(OrderedDict):
         self.capacity = capacity
         self.ttl_sec = ttl_sec
         self._time_fn = time_fn
+        self._on_discard = on_discard
+
+    def set_on_discard(
+        self, on_discard: Callable[[Any, Any, str], None] | None
+    ) -> None:
+        """Set a callback invoked when an entry is expired or evicted."""
+        self._on_discard = on_discard
+
+    def _notify_discard(self, key, item, reason: str) -> None:
+        if self._on_discard is None:
+            return
+        _, value = item
+        self._on_discard(key, value, reason)
+
+    def _pop_stored_item(self, key):
+        if not super().__contains__(key):
+            return None
+        item = super().__getitem__(key)
+        super().__delitem__(key)
+        return item
 
     def __contains__(self, key) -> bool:
         if not super().__contains__(key):
             return False
         expires_at, _ = super().__getitem__(key)
         if expires_at <= self._time_fn():
-            super().pop(key, None)
+            item = self._pop_stored_item(key)
+            if item is not None:
+                self._notify_discard(key, item, 'expired')
             return False
         return True
 
@@ -73,7 +96,8 @@ class ExpiringLRUCache(OrderedDict):
         expires_at = float(self._time_fn()) + float(self.ttl_sec)
         super().__setitem__(key, (expires_at, value))
         if len(self) > self.capacity:
-            self.popitem(last=False)
+            evicted_key, evicted_item = self.popitem(last=False)
+            self._notify_discard(evicted_key, evicted_item, 'capacity')
 
     def get(self, key, default=None):
         item = super().get(key)
@@ -81,19 +105,34 @@ class ExpiringLRUCache(OrderedDict):
             return default
         expires_at, value = item
         if expires_at <= self._time_fn():
-            super().pop(key, None)
+            item = self._pop_stored_item(key)
+            if item is not None:
+                self._notify_discard(key, item, 'expired')
             return default
         self.move_to_end(key)
         return value
 
     def pop(self, key, default=None):
-        item = super().pop(key, None)
+        item = self._pop_stored_item(key)
         if item is None:
             return default
         expires_at, value = item
         if expires_at <= self._time_fn():
+            self._notify_discard(key, item, 'expired')
             return default
         return value
+
+    def purge_expired(self) -> int:
+        """Remove expired entries and return the number removed."""
+        now = self._time_fn()
+        expired_keys = [
+            key for key, (expires_at, _) in super().items() if expires_at <= now
+        ]
+        for key in expired_keys:
+            item = self._pop_stored_item(key)
+            if item is not None:
+                self._notify_discard(key, item, 'expired')
+        return len(expired_keys)
 
     def set(self, key, value):
         self[key] = value

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,7 @@
 """FastAPI application entry point."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -15,12 +17,20 @@ from app.api.routers import (
     section_router,
     upload_router,
 )
+from app.api.routers.upload import cleanup_staged_uploads
 from app.core.state import create_app_state
 from app.services.errors import DomainError
 
 STATIC_DIR = (Path(__file__).parent / 'static').resolve()
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    cleanup_staged_uploads(app.state.sv, force=True)
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 app.state.sv = create_app_state()
 
 # 静的ファイル (HTML, JS)

--- a/app/services/staged_upload_cleanup.py
+++ b/app/services/staged_upload_cleanup.py
@@ -1,0 +1,114 @@
+"""Disk cleanup helpers for staged SEG-Y uploads."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import time
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+def _resolved(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _safe_direct_staged_dir(path: Path, staged_root: Path) -> Path | None:
+    root = _resolved(staged_root)
+    candidate = path.expanduser()
+    if candidate.parent.resolve(strict=False) != root:
+        logger.warning(
+            'Refusing to delete staged upload path outside staged root: %s',
+            path,
+        )
+        return None
+    safe_dir = root / candidate.name
+    if safe_dir.is_symlink():
+        logger.warning('Refusing to delete staged upload symlink: %s', safe_dir)
+        return None
+    return safe_dir
+
+
+def _safe_staged_file(raw_path: Path, staged_root: Path) -> Path | None:
+    candidate = raw_path.expanduser()
+    staged_dir = _safe_direct_staged_dir(candidate.parent, staged_root)
+    if staged_dir is None:
+        return None
+    return staged_dir / candidate.name
+
+
+def remove_staged_upload_dir(staged_dir: Path, *, staged_root: Path) -> bool:
+    """Remove one direct child directory below ``staged_root``."""
+    safe_dir = _safe_direct_staged_dir(staged_dir, staged_root)
+    if safe_dir is None:
+        return False
+    if not safe_dir.exists():
+        return True
+    try:
+        shutil.rmtree(safe_dir)
+    except OSError as exc:
+        logger.warning('Unable to delete staged SEG-Y directory: %s: %s', safe_dir, exc)
+        return False
+    return True
+
+
+def cleanup_staged_upload(raw_path: Path, *, staged_root: Path) -> bool:
+    """Remove a staged SEG-Y file and its direct staged directory."""
+    safe_raw_path = _safe_staged_file(raw_path, staged_root)
+    if safe_raw_path is None:
+        return False
+
+    try:
+        safe_raw_path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning('Unable to delete staged SEG-Y file: %s: %s', safe_raw_path, exc)
+        return False
+
+    return remove_staged_upload_dir(safe_raw_path.parent, staged_root=staged_root)
+
+
+def cleanup_stale_staged_upload_dirs(
+    *,
+    staged_root: Path,
+    ttl_sec: int | float,
+    active_ids: Iterable[str] = (),
+    now_ts: float | None = None,
+) -> int:
+    """Remove stale staged-upload directories with no active in-memory record."""
+    if not staged_root.is_dir():
+        return 0
+
+    now = time.time() if now_ts is None else float(now_ts)
+    active = {str(item) for item in active_ids}
+    removed = 0
+
+    for child in staged_root.iterdir():
+        if child.name in active:
+            continue
+        safe_dir = _safe_direct_staged_dir(child, staged_root)
+        if safe_dir is None or not safe_dir.is_dir():
+            continue
+        try:
+            age = now - safe_dir.stat().st_mtime
+        except OSError as exc:
+            logger.warning(
+                'Unable to inspect staged SEG-Y directory: %s: %s',
+                safe_dir,
+                exc,
+            )
+            continue
+        if age <= float(ttl_sec):
+            continue
+        if remove_staged_upload_dir(safe_dir, staged_root=staged_root):
+            removed += 1
+
+    return removed
+
+
+__all__ = [
+    'cleanup_staged_upload',
+    'cleanup_stale_staged_upload_dirs',
+    'remove_staged_upload_dir',
+]

--- a/app/tests/test_staged_segy_upload.py
+++ b/app/tests/test_staged_segy_upload.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from pathlib import Path
 
 import numpy as np
@@ -209,6 +210,85 @@ def test_stage_segy_qc_failure_removes_staged_file(_staged_env, monkeypatch):
     assert len(app.state.sv.staged_uploads) == 0
     staged_root = Path(upload_mod.UPLOAD_DIR) / 'staged'
     assert not staged_root.exists() or list(staged_root.iterdir()) == []
+
+
+def test_staged_upload_capacity_eviction_removes_staged_file(
+    _staged_env,
+    monkeypatch,
+):
+    client, _upload_mod, _calls = _staged_env
+    cache = app.state.sv.staged_uploads
+    monkeypatch.setattr(cache, 'capacity', 1)
+
+    first = _stage(client, name='first.sgy', data=b'first')
+    first_record = app.state.sv.staged_uploads.get(first['staged_id'])
+    assert isinstance(first_record, dict)
+    first_path = Path(first_record['raw_path'])
+    first_dir = first_path.parent
+
+    second = _stage(client, name='second.sgy', data=b'second')
+    second_record = app.state.sv.staged_uploads.get(second['staged_id'])
+    assert isinstance(second_record, dict)
+    second_path = Path(second_record['raw_path'])
+
+    assert app.state.sv.staged_uploads.get(first['staged_id']) is None
+    assert not first_path.exists()
+    assert not first_dir.exists()
+    assert second_path.exists()
+
+
+def test_staged_upload_ttl_expiry_removes_staged_file(_staged_env, monkeypatch):
+    client, _upload_mod, _calls = _staged_env
+    cache = app.state.sv.staged_uploads
+    clock = {'now': 1000.0}
+    monkeypatch.setattr(cache, 'ttl_sec', 1)
+    monkeypatch.setattr(cache, '_time_fn', lambda: clock['now'])
+
+    staged = _stage(client)
+    record = app.state.sv.staged_uploads.get(staged['staged_id'])
+    assert isinstance(record, dict)
+    staged_path = Path(record['raw_path'])
+    staged_dir = staged_path.parent
+
+    clock['now'] = 1002.0
+    assert app.state.sv.staged_uploads.get(staged['staged_id']) is None
+    assert not staged_path.exists()
+    assert not staged_dir.exists()
+
+
+def test_stale_staged_upload_dir_cleanup_removes_orphan(_staged_env):
+    _client, upload_mod, _calls = _staged_env
+    state = app.state.sv
+    now = 10_000.0
+    staged_root = Path(upload_mod.UPLOAD_DIR) / 'staged'
+    stale_dir = staged_root / 'orphaned-stage'
+    stale_file = stale_dir / 'orphan.sgy'
+    stale_dir.mkdir(parents=True)
+    stale_file.write_bytes(b'orphan')
+    stale_mtime = now - float(state.staged_uploads.ttl_sec) - 1.0
+    os.utime(stale_dir, (stale_mtime, stale_mtime))
+    os.utime(stale_file, (stale_mtime, stale_mtime))
+
+    removed = upload_mod.cleanup_staged_uploads(state, force=True, now_ts=now)
+
+    assert removed == 1
+    assert not stale_dir.exists()
+
+
+def test_staged_upload_cleanup_refuses_paths_outside_staged_root(
+    _staged_env,
+    tmp_path: Path,
+):
+    _client, upload_mod, _calls = _staged_env
+    outside_dir = tmp_path / 'outside'
+    outside_path = outside_dir / 'unsafe.sgy'
+    outside_dir.mkdir()
+    outside_path.write_bytes(b'unsafe')
+
+    upload_mod._cleanup_staged_upload(outside_path)
+
+    assert outside_path.exists()
+    assert outside_dir.exists()
 
 
 def test_ingest_staged_segy_reused_store_metadata_points_to_durable_raw(


### PR DESCRIPTION
Closes #253

## Summary
- Staged SEG-Y uploads can leak disk files when cache entries expire or are evicted

## Changed files
- `app/api/routers/upload.py`
- `app/core/state.py`
- `app/main.py`
- `app/services/staged_upload_cleanup.py`
- `app/tests/test_staged_segy_upload.py`

## Checks
- `.work/codex/checks.log`: 259 passed in 40.77s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
