### PR TITLE
Make SEG-Y header QC bounded and reduce key-byte candidates to nine

### DIFF
--- a/app/tests/test_header_qc.py
+++ b/app/tests/test_header_qc.py
@@ -5,15 +5,48 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from app.utils.header_qc import inspect_segy_header_qc
+from app.utils import header_qc
+from app.utils.header_qc import HEADER_CANDIDATES, inspect_segy_header_qc
 
 
 class _Attr:
-    def __init__(self, values: np.ndarray) -> None:
+    def __init__(
+        self,
+        values: np.ndarray,
+        *,
+        byte: int,
+        tracecount: int,
+        access_log: list[dict] | None = None,
+        reject_full_slice: bool = False,
+    ) -> None:
         self._values = np.asarray(values)
+        self._byte = int(byte)
+        self._tracecount = int(tracecount)
+        self._access_log = access_log
+        self._reject_full_slice = reject_full_slice
 
-    def __getitem__(self, _key):
-        return self._values
+    def __getitem__(self, key):
+        is_full_slice = (
+            isinstance(key, slice)
+            and key.start is None
+            and key.stop is None
+            and key.step is None
+        )
+        if self._reject_full_slice and is_full_slice:
+            raise AssertionError('full header slice was requested')
+        if isinstance(key, slice):
+            length = len(range(*key.indices(self._tracecount)))
+        else:
+            length = int(np.asarray(key).size)
+        if self._access_log is not None:
+            self._access_log.append(
+                {
+                    'byte': self._byte,
+                    'length': length,
+                    'full_slice': is_full_slice,
+                }
+            )
+        return self._values[key]
 
 
 class _FakeBin:
@@ -33,12 +66,19 @@ class _FakeSegy:
         headers: dict[int, np.ndarray],
         n_samples: int,
         interval_us: int | None,
+        tracecount: int | None = None,
+        access_log: list[dict] | None = None,
+        reject_full_slice: bool = False,
     ) -> None:
         self._headers = {int(k): np.asarray(v) for k, v in headers.items()}
-        first = next(iter(self._headers.values()))
-        self.tracecount = int(first.size)
+        if tracecount is None:
+            first = next(iter(self._headers.values()))
+            tracecount = int(first.size)
+        self.tracecount = int(tracecount)
         self.samples = np.arange(n_samples, dtype=np.int32)
         self.bin = _FakeBin(interval_us)
+        self.access_log = access_log if access_log is not None else []
+        self.reject_full_slice = reject_full_slice
 
     def __enter__(self):
         return self
@@ -50,7 +90,13 @@ class _FakeSegy:
         values = self._headers.get(int(byte))
         if values is None:
             values = np.zeros(self.tracecount, dtype=np.int32)
-        return _Attr(values)
+        return _Attr(
+            values,
+            byte=int(byte),
+            tracecount=self.tracecount,
+            access_log=self.access_log,
+            reject_full_slice=self.reject_full_slice,
+        )
 
 
 def _patch_segyio(
@@ -59,16 +105,24 @@ def _patch_segyio(
     headers: dict[int, np.ndarray],
     n_samples: int = 1500,
     interval_us: int | None = 2000,
-) -> None:
+    tracecount: int | None = None,
+    reject_full_slice: bool = False,
+) -> dict:
     import app.utils.header_qc as header_qc
+
+    opened: dict[str, _FakeSegy] = {}
 
     def _open_stub(_path, _mode='r', ignore_geometry=True):
         assert ignore_geometry is True
-        return _FakeSegy(
+        fake = _FakeSegy(
             headers=headers,
             n_samples=n_samples,
             interval_us=interval_us,
+            tracecount=tracecount,
+            reject_full_slice=reject_full_slice,
         )
+        opened['fake'] = fake
+        return fake
 
     monkeypatch.setattr(header_qc.segyio, 'open', _open_stub, raising=True)
 
@@ -76,6 +130,7 @@ def _patch_segyio(
         Interval = 'Interval'
 
     monkeypatch.setattr(header_qc.segyio, 'BinField', _BinField, raising=True)
+    return opened
 
 
 def _find_header(result: dict, byte: int) -> dict:
@@ -88,6 +143,34 @@ def _find_pair(result: dict, key1_byte: int, key2_byte: int) -> dict:
         for item in result['recommended_pairs']
         if item['key1_byte'] == key1_byte and item['key2_byte'] == key2_byte
     )
+
+
+def _all_candidate_headers(n_sections: int = 10, section_size: int = 20) -> dict[int, np.ndarray]:
+    n_traces = n_sections * section_size
+    headers: dict[int, np.ndarray] = {}
+    for idx, (byte, _name) in enumerate(HEADER_CANDIDATES):
+        offset = idx * 1_000
+        if idx % 2 == 0:
+            values = np.repeat(np.arange(n_sections), section_size)
+        else:
+            values = np.tile(np.arange(section_size), n_sections)
+        headers[byte] = (values + offset).astype(np.int32)
+    assert all(values.size == n_traces for values in headers.values())
+    return headers
+
+
+def test_header_candidates_are_reduced_to_nine_key_bytes():
+    assert HEADER_CANDIDATES == [
+        (1, "TRACE_SEQUENCE_LINE"),
+        (5, "TRACE_SEQUENCE_FILE"),
+        (9, "FIELD_RECORD"),
+        (13, "TRACE_NUMBER"),
+        (21, "CDP"),
+        (25, "CDP_TRACE"),
+        (37, "OFFSET"),
+        (189, "INLINE_3D"),
+        (193, "CROSSLINE_3D"),
+    ]
 
 
 def test_inline_crossline_headers_rank_highly(monkeypatch, tmp_path: Path):
@@ -111,6 +194,150 @@ def test_inline_crossline_headers_rank_highly(monkeypatch, tmp_path: Path):
     assert best['key2_byte'] == 193
     assert best['confidence'] == 'high'
     assert best['score'] > 0.8
+
+
+def test_excluded_metadata_headers_are_not_scored(monkeypatch, tmp_path: Path):
+    headers = _all_candidate_headers()
+    _patch_segyio(monkeypatch, headers=headers)
+
+    result = inspect_segy_header_qc(tmp_path / 'line.sgy')
+
+    excluded = {115, 117, 197}
+    assert {item['byte'] for item in result['headers']} == {
+        byte for byte, _name in HEADER_CANDIDATES
+    }
+    assert not excluded & {item['byte'] for item in result['headers']}
+    assert len(result['recommended_pairs']) == 72
+    for pair in result['recommended_pairs']:
+        assert pair['key1_byte'] not in excluded
+        assert pair['key2_byte'] not in excluded
+
+
+def test_cdp_headers_rank_as_useful_pair(monkeypatch, tmp_path: Path):
+    cdp = np.repeat(np.arange(12), 16)
+    cdp_trace = np.tile(np.arange(16), 12)
+    _patch_segyio(
+        monkeypatch,
+        headers={21: cdp, 25: cdp_trace},
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'cdp.sgy')
+    best = result['recommended_pairs'][0]
+
+    assert best['key1_byte'] == 21
+    assert best['key2_byte'] == 25
+    assert best['score'] >= 0.75
+
+
+def test_field_record_trace_number_headers_rank_as_useful_pair(
+    monkeypatch,
+    tmp_path: Path,
+):
+    field_record = np.repeat(np.arange(8), 24)
+    trace_number = np.tile(np.arange(24), 8)
+    _patch_segyio(
+        monkeypatch,
+        headers={9: field_record, 13: trace_number},
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'records.sgy')
+    best = result['recommended_pairs'][0]
+
+    assert best['key1_byte'] == 9
+    assert best['key2_byte'] == 13
+    assert best['score'] >= 0.75
+
+
+def test_trace_sequence_and_offset_can_participate_in_scoring(
+    monkeypatch,
+    tmp_path: Path,
+):
+    sequence_line = np.repeat(np.arange(10), 20)
+    offset = np.tile(np.arange(20) * 25, 10)
+    _patch_segyio(
+        monkeypatch,
+        headers={1: sequence_line, 37: offset},
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'offsets.sgy')
+    pair = _find_pair(result, 1, 37)
+
+    assert pair['score'] >= 0.55
+
+
+def test_dt_fallback_reads_metadata_header_without_scoring_it(
+    monkeypatch,
+    tmp_path: Path,
+):
+    inline = np.repeat(np.arange(10), 20)
+    crossline = np.tile(np.arange(20), 10)
+    dt = np.full(200, 4000)
+    _patch_segyio(
+        monkeypatch,
+        headers={189: inline, 193: crossline, 117: dt},
+        interval_us=None,
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'line.sgy')
+
+    assert result['segy']['dt'] == pytest.approx(0.004)
+    assert 117 not in {item['byte'] for item in result['headers']}
+    for pair in result['recommended_pairs']:
+        assert pair['key1_byte'] != 117
+        assert pair['key2_byte'] != 117
+
+
+def test_large_file_header_reads_are_bounded_to_sample(
+    monkeypatch,
+    tmp_path: Path,
+):
+    n_traces = header_qc._MAX_QC_TRACES + 123
+    headers = {
+        byte: np.arange(n_traces, dtype=np.int32)
+        for byte, _name in HEADER_CANDIDATES
+    }
+    opened = _patch_segyio(
+        monkeypatch,
+        headers=headers,
+        tracecount=n_traces,
+        reject_full_slice=True,
+    )
+
+    inspect_segy_header_qc(tmp_path / 'large.sgy')
+
+    fake = opened['fake']
+    assert len(fake.access_log) == len(HEADER_CANDIDATES)
+    assert {entry['byte'] for entry in fake.access_log} == {
+        byte for byte, _name in HEADER_CANDIDATES
+    }
+    assert all(entry['length'] <= header_qc._MAX_QC_TRACES for entry in fake.access_log)
+    assert not any(entry['full_slice'] for entry in fake.access_log)
+
+
+def test_pair_ranking_reuses_key1_grouping_per_candidate(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _patch_segyio(monkeypatch, headers=_all_candidate_headers())
+    calls = 0
+    original = header_qc._build_key1_grouping
+
+    def _spy_build_key1_grouping(values: np.ndarray):
+        nonlocal calls
+        calls += 1
+        return original(values)
+
+    monkeypatch.setattr(
+        header_qc,
+        '_build_key1_grouping',
+        _spy_build_key1_grouping,
+        raising=True,
+    )
+
+    result = inspect_segy_header_qc(tmp_path / 'line.sgy')
+
+    assert len(result['recommended_pairs']) == 72
+    assert calls == len(HEADER_CANDIDATES)
 
 
 def test_constant_header_gets_low_score_and_warning(monkeypatch, tmp_path: Path):

--- a/app/utils/header_qc.py
+++ b/app/utils/header_qc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -16,15 +17,17 @@ HEADER_CANDIDATES: list[tuple[int, str]] = [
     (21, "CDP"),
     (25, "CDP_TRACE"),
     (37, "OFFSET"),
-    (115, "NS"),
-    (117, "DT"),
     (189, "INLINE_3D"),
     (193, "CROSSLINE_3D"),
-    (197, "SHOT_POINT"),
+]
+
+METADATA_HEADER_CANDIDATES: list[tuple[int, str]] = [
+    (117, "DT"),
 ]
 
 _CANDIDATE_NAMES = dict(HEADER_CANDIDATES)
 _MAX_PAIR_GROUPS = 64
+_MAX_QC_TRACES = 50_000
 
 _KEY1_PRIOR = {
     1: 0.20,
@@ -34,11 +37,8 @@ _KEY1_PRIOR = {
     21: 0.70,
     25: 0.45,
     37: 0.20,
-    115: 0.0,
-    117: 0.0,
     189: 1.0,
     193: 0.65,
-    197: 0.65,
 }
 
 _KEY2_PRIOR = {
@@ -49,12 +49,16 @@ _KEY2_PRIOR = {
     21: 0.45,
     25: 0.80,
     37: 0.75,
-    115: 0.0,
-    117: 0.0,
     189: 0.45,
     193: 1.0,
-    197: 0.55,
 }
+
+
+@dataclass(frozen=True, slots=True)
+class Key1Grouping:
+    order: np.ndarray
+    starts: np.ndarray
+    ends: np.ndarray
 
 
 def inspect_segy_header_qc(path: str | Path) -> dict:
@@ -62,21 +66,24 @@ def inspect_segy_header_qc(path: str | Path) -> dict:
     segy_path = Path(path)
     header_values: dict[int, np.ndarray] = {}
     unavailable: dict[int, str] = {}
+    metadata_header_values: dict[int, np.ndarray] = {}
 
     with segyio.open(str(segy_path), 'r', ignore_geometry=True) as segy_file:
         n_traces = int(getattr(segy_file, 'tracecount', 0))
         n_samples = len(getattr(segy_file, 'samples', []))
         raw_dt = _read_binary_dt(segy_file)
+        trace_selector = _sample_trace_selector(n_traces)
+        expected_count = _selector_length(trace_selector, n_traces)
 
         for byte, _name in HEADER_CANDIDATES:
             try:
-                values = np.asarray(segy_file.attributes(byte)[:])
+                values = _read_header_values(segy_file, byte, trace_selector)
             except Exception as exc:  # noqa: BLE001
                 unavailable[byte] = f'Header could not be read: {exc}'
                 continue
 
-            if values.ndim != 1 or int(values.shape[0]) != n_traces:
-                unavailable[byte] = 'Header length does not match trace count'
+            if values.ndim != 1 or int(values.shape[0]) != expected_count:
+                unavailable[byte] = 'Header length does not match inspected trace count'
                 continue
 
             try:
@@ -84,9 +91,22 @@ def inspect_segy_header_qc(path: str | Path) -> dict:
             except (TypeError, ValueError) as exc:
                 unavailable[byte] = f'Header values are not integer-like: {exc}'
 
-    dt = _dt_seconds(raw_dt)
-    if dt is None and 117 in header_values:
-        dt = _dt_from_header_values(header_values[117])
+        dt = _dt_seconds(raw_dt)
+        if dt is None:
+            for byte, _name in METADATA_HEADER_CANDIDATES:
+                try:
+                    values = _read_header_values(segy_file, byte, trace_selector)
+                except Exception:  # noqa: BLE001
+                    continue
+                if values.ndim != 1 or int(values.shape[0]) != expected_count:
+                    continue
+                try:
+                    metadata_header_values[byte] = values.astype(np.int64, copy=False)
+                except (TypeError, ValueError):
+                    continue
+
+    if dt is None and 117 in metadata_header_values:
+        dt = _dt_from_header_values(metadata_header_values[117])
 
     return _build_qc_result(
         n_traces=n_traces,
@@ -95,6 +115,29 @@ def inspect_segy_header_qc(path: str | Path) -> dict:
         header_values=header_values,
         unavailable=unavailable,
     )
+
+
+def _sample_trace_selector(
+    n_traces: int,
+    max_qc_traces: int = _MAX_QC_TRACES,
+) -> slice | np.ndarray:
+    if n_traces <= max_qc_traces:
+        return slice(None)
+    return np.linspace(0, n_traces - 1, max_qc_traces, dtype=np.int64)
+
+
+def _selector_length(selector: slice | np.ndarray, n_traces: int) -> int:
+    if isinstance(selector, slice):
+        return len(range(*selector.indices(max(n_traces, 0))))
+    return int(selector.size)
+
+
+def _read_header_values(
+    segy_file: Any,
+    byte: int,
+    trace_selector: slice | np.ndarray,
+) -> np.ndarray:
+    return np.asarray(segy_file.attributes(byte)[trace_selector])
 
 
 def _read_binary_dt(segy_file: Any) -> Any:
@@ -136,7 +179,7 @@ def _build_qc_result(
             warning = unavailable.get(byte, 'Header is unavailable')
             item = _unavailable_header(byte, name, warning)
         else:
-            item = _score_key1_header(byte, name, values, n_traces)
+            item = _score_key1_header(byte, name, values, int(values.size))
         headers.append(item)
         headers_by_byte[byte] = item
 
@@ -304,6 +347,7 @@ def _rank_pairs(
         key1_stats = headers_by_byte[key1_byte]
         if key1_values is None:
             continue
+        key1_grouping = _build_key1_grouping(key1_values)
         for key2_byte, key2_name in HEADER_CANDIDATES:
             if key1_byte == key2_byte:
                 continue
@@ -314,7 +358,7 @@ def _rank_pairs(
                 _score_pair(
                     key1_byte=key1_byte,
                     key1_name=key1_name,
-                    key1_values=key1_values,
+                    key1_grouping=key1_grouping,
                     key1_stats=key1_stats,
                     key2_byte=key2_byte,
                     key2_name=key2_name,
@@ -329,13 +373,13 @@ def _score_pair(
     *,
     key1_byte: int,
     key1_name: str,
-    key1_values: np.ndarray,
+    key1_grouping: Key1Grouping,
     key1_stats: dict,
     key2_byte: int,
     key2_name: str,
     key2_values: np.ndarray,
 ) -> dict:
-    pair_metrics = _key2_within_group_metrics(key1_values, key2_values)
+    pair_metrics = _key2_within_group_metrics(key1_grouping, key2_values)
     key1_score = float(key1_stats.get('key1_score') or 0.0)
     key2_quality = (
         0.55 * pair_metrics['median_unique_ratio']
@@ -377,18 +421,10 @@ def _score_pair(
     }
 
 
-def _key2_within_group_metrics(
-    key1_values: np.ndarray,
-    key2_values: np.ndarray,
-) -> dict[str, float]:
-    if key1_values.size == 0 or key2_values.size == 0:
-        return {
-            'median_unique_ratio': 0.0,
-            'median_duplicate_rate': 1.0,
-            'monotonic_fraction': 0.0,
-            'constant_section_fraction': 1.0,
-            'evaluated_groups': 0.0,
-        }
+def _build_key1_grouping(key1_values: np.ndarray) -> Key1Grouping:
+    if key1_values.size == 0:
+        empty = np.asarray([], dtype=np.int64)
+        return Key1Grouping(order=empty, starts=empty, ends=empty)
 
     order = np.argsort(key1_values, kind='stable')
     sorted_key1 = key1_values[order]
@@ -402,14 +438,29 @@ def _key2_within_group_metrics(
         )
         starts = starts[sampled]
         ends = ends[sampled]
+    return Key1Grouping(order=order, starts=starts, ends=ends)
+
+
+def _key2_within_group_metrics(
+    key1_grouping: Key1Grouping,
+    key2_values: np.ndarray,
+) -> dict[str, float]:
+    if key1_grouping.order.size == 0 or key2_values.size == 0:
+        return {
+            'median_unique_ratio': 0.0,
+            'median_duplicate_rate': 1.0,
+            'monotonic_fraction': 0.0,
+            'constant_section_fraction': 1.0,
+            'evaluated_groups': 0.0,
+        }
 
     unique_ratios: list[float] = []
     duplicate_rates: list[float] = []
     monotonic: list[float] = []
     constant: list[float] = []
 
-    for start, end in zip(starts, ends):
-        group_order = order[int(start) : int(end)]
+    for start, end in zip(key1_grouping.starts, key1_grouping.ends):
+        group_order = key1_grouping.order[int(start) : int(end)]
         if group_order.size <= 1:
             continue
         values = key2_values[group_order]


### PR DESCRIPTION
Closes #255

## Summary
- Make SEG-Y header QC bounded and reduce key-byte candidates to nine

## Changed files
- `app/tests/test_header_qc.py`
- `app/utils/header_qc.py`

## Checks
- `.work/codex/checks.log`: 267 passed in 40.90s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
