### PR TITLE
Backend: Linear Moveout の offset / velocity shift 計算を追加する

### DIFF
--- a/app/services/linear_moveout.py
+++ b/app/services/linear_moveout.py
@@ -1,0 +1,117 @@
+"""Linear moveout calculation helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def compute_lmo_shift_seconds(
+    offsets: np.ndarray,
+    *,
+    velocity_mps: float,
+    offset_scale: float,
+    offset_mode: str,
+    ref_mode: str,
+    ref_trace: int | None,
+    polarity: int,
+) -> np.ndarray:
+    """Return per-trace linear moveout shifts in seconds."""
+    offsets_f64 = _validate_offsets(offsets)
+    velocity = _validate_velocity_mps(velocity_mps)
+    scale = _validate_offset_scale(offset_scale)
+    _validate_offset_mode(offset_mode)
+    _validate_ref_mode(ref_mode)
+    polarity_int = _validate_polarity(polarity)
+
+    scaled_offsets = offsets_f64 * scale
+    if not np.all(np.isfinite(scaled_offsets)):
+        raise ValueError('Scaled offsets contain NaN or Inf')
+
+    if offset_mode == 'absolute':
+        x = np.abs(scaled_offsets)
+    else:
+        x = scaled_offsets
+
+    x_ref = _reference_offset(x, ref_mode=ref_mode, ref_trace=ref_trace)
+    shifts = polarity_int * (x - x_ref) / velocity
+    if not np.all(np.isfinite(shifts)):
+        raise ValueError('LMO shifts contain NaN or Inf')
+    return np.asarray(shifts, dtype=np.float64)
+
+
+def _validate_offsets(offsets: np.ndarray) -> np.ndarray:
+    arr = np.asarray(offsets)
+    if arr.ndim != 1:
+        raise ValueError('offsets must be a 1D array')
+    if arr.size == 0:
+        raise ValueError('offsets must not be empty')
+    try:
+        arr_f64 = arr.astype(np.float64, copy=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError('offsets must be numeric') from exc
+    if not np.all(np.isfinite(arr_f64)):
+        raise ValueError('offsets contain NaN or Inf')
+    return arr_f64
+
+
+def _validate_velocity_mps(velocity_mps: float) -> float:
+    velocity = float(velocity_mps)
+    if not np.isfinite(velocity) or velocity <= 0.0:
+        raise ValueError('velocity_mps must be finite and greater than 0')
+    return velocity
+
+
+def _validate_offset_scale(offset_scale: float) -> float:
+    scale = float(offset_scale)
+    if not np.isfinite(scale) or scale == 0.0:
+        raise ValueError('offset_scale must be finite and non-zero')
+    return scale
+
+
+def _validate_offset_mode(offset_mode: str) -> None:
+    if offset_mode not in {'absolute', 'signed'}:
+        raise ValueError('offset_mode must be "absolute" or "signed"')
+
+
+def _validate_ref_mode(ref_mode: str) -> None:
+    if ref_mode not in {'min', 'first', 'center', 'trace', 'zero'}:
+        raise ValueError('ref_mode must be one of "min", "first", "center", "trace", "zero"')
+
+
+def _validate_polarity(polarity: int) -> int:
+    if (
+        isinstance(polarity, bool)
+        or not isinstance(polarity, (int, np.integer))
+        or int(polarity) not in {1, -1}
+    ):
+        raise ValueError('polarity must be 1 or -1')
+    return int(polarity)
+
+
+def _reference_offset(
+    x: np.ndarray,
+    *,
+    ref_mode: str,
+    ref_trace: int | None,
+) -> float:
+    if ref_mode == 'min':
+        return float(np.min(x))
+    if ref_mode == 'first':
+        return float(x[0])
+    if ref_mode == 'center':
+        return float(x[x.shape[0] // 2])
+    if ref_mode == 'zero':
+        return 0.0
+    if ref_trace is None:
+        raise ValueError('ref_trace is required when ref_mode is "trace"')
+    if (
+        isinstance(ref_trace, bool)
+        or not isinstance(ref_trace, (int, np.integer))
+        or int(ref_trace) < 0
+        or int(ref_trace) >= x.shape[0]
+    ):
+        raise ValueError('ref_trace is out of range')
+    return float(x[int(ref_trace)])
+
+
+__all__ = ['compute_lmo_shift_seconds']

--- a/app/tests/test_linear_moveout.py
+++ b/app/tests/test_linear_moveout.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.linear_moveout import compute_lmo_shift_seconds
+
+
+def test_absolute_offset_mode_uses_scaled_absolute_offsets() -> None:
+    offsets = np.array([-100.0, 50.0, -25.0], dtype=np.float32)
+
+    shifts = compute_lmo_shift_seconds(
+        offsets,
+        velocity_mps=1000.0,
+        offset_scale=2.0,
+        offset_mode='absolute',
+        ref_mode='zero',
+        ref_trace=None,
+        polarity=1,
+    )
+
+    np.testing.assert_allclose(shifts, np.array([0.2, 0.1, 0.05], dtype=np.float64))
+    assert shifts.dtype == np.float64
+
+
+def test_signed_offset_mode_keeps_signed_offsets() -> None:
+    offsets = np.array([-100.0, 50.0], dtype=np.float64)
+
+    shifts = compute_lmo_shift_seconds(
+        offsets,
+        velocity_mps=1000.0,
+        offset_scale=1.0,
+        offset_mode='signed',
+        ref_mode='zero',
+        ref_trace=None,
+        polarity=1,
+    )
+
+    np.testing.assert_allclose(shifts, np.array([-0.1, 0.05], dtype=np.float64))
+
+
+@pytest.mark.parametrize(
+    ('ref_mode', 'ref_trace', 'expected'),
+    [
+        ('min', None, [0.0, 1.0, 2.0, 3.0]),
+        ('first', None, [0.0, 1.0, 2.0, 3.0]),
+        ('center', None, [-2.0, -1.0, 0.0, 1.0]),
+        ('trace', 3, [-3.0, -2.0, -1.0, 0.0]),
+        ('zero', None, [1.0, 2.0, 3.0, 4.0]),
+    ],
+)
+def test_reference_modes(ref_mode: str, ref_trace: int | None, expected: list[float]) -> None:
+    offsets = np.array([10.0, 20.0, 30.0, 40.0], dtype=np.float64)
+
+    shifts = compute_lmo_shift_seconds(
+        offsets,
+        velocity_mps=10.0,
+        offset_scale=1.0,
+        offset_mode='signed',
+        ref_mode=ref_mode,
+        ref_trace=ref_trace,
+        polarity=1,
+    )
+
+    np.testing.assert_allclose(shifts, np.asarray(expected, dtype=np.float64))
+
+
+def test_polarity_minus_one_reverses_shift_sign() -> None:
+    offsets = np.array([0.0, 10.0, 20.0], dtype=np.float64)
+
+    shifts = compute_lmo_shift_seconds(
+        offsets,
+        velocity_mps=10.0,
+        offset_scale=1.0,
+        offset_mode='signed',
+        ref_mode='zero',
+        ref_trace=None,
+        polarity=-1,
+    )
+
+    np.testing.assert_allclose(shifts, np.array([0.0, -1.0, -2.0], dtype=np.float64))
+
+
+def test_velocity_scales_shift_inversely() -> None:
+    offsets = np.array([0.0, 10.0, 20.0], dtype=np.float64)
+
+    slow = compute_lmo_shift_seconds(
+        offsets,
+        velocity_mps=10.0,
+        offset_scale=1.0,
+        offset_mode='signed',
+        ref_mode='zero',
+        ref_trace=None,
+        polarity=1,
+    )
+    fast = compute_lmo_shift_seconds(
+        offsets,
+        velocity_mps=20.0,
+        offset_scale=1.0,
+        offset_mode='signed',
+        ref_mode='zero',
+        ref_trace=None,
+        polarity=1,
+    )
+
+    np.testing.assert_allclose(fast, slow / 2.0)
+
+
+@pytest.mark.parametrize(
+    'offsets',
+    [
+        np.array([[1.0, 2.0]], dtype=np.float64),
+        np.array([], dtype=np.float64),
+        np.array([1.0, np.nan], dtype=np.float64),
+        np.array([1.0, np.inf], dtype=np.float64),
+    ],
+)
+def test_invalid_offsets_raise_value_error(offsets: np.ndarray) -> None:
+    with pytest.raises(ValueError):
+        compute_lmo_shift_seconds(
+            offsets,
+            velocity_mps=1000.0,
+            offset_scale=1.0,
+            offset_mode='signed',
+            ref_mode='zero',
+            ref_trace=None,
+            polarity=1,
+        )
+
+
+@pytest.mark.parametrize('velocity_mps', [0.0, -1.0, np.nan, np.inf])
+def test_invalid_velocity_raises_value_error(velocity_mps: float) -> None:
+    with pytest.raises(ValueError):
+        compute_lmo_shift_seconds(
+            np.array([1.0], dtype=np.float64),
+            velocity_mps=velocity_mps,
+            offset_scale=1.0,
+            offset_mode='signed',
+            ref_mode='zero',
+            ref_trace=None,
+            polarity=1,
+        )
+
+
+@pytest.mark.parametrize('offset_scale', [0.0, np.nan, np.inf])
+def test_invalid_offset_scale_raises_value_error(offset_scale: float) -> None:
+    with pytest.raises(ValueError):
+        compute_lmo_shift_seconds(
+            np.array([1.0], dtype=np.float64),
+            velocity_mps=1000.0,
+            offset_scale=offset_scale,
+            offset_mode='signed',
+            ref_mode='zero',
+            ref_trace=None,
+            polarity=1,
+        )
+
+
+def test_invalid_offset_mode_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        compute_lmo_shift_seconds(
+            np.array([1.0], dtype=np.float64),
+            velocity_mps=1000.0,
+            offset_scale=1.0,
+            offset_mode='invalid',
+            ref_mode='zero',
+            ref_trace=None,
+            polarity=1,
+        )
+
+
+def test_invalid_ref_mode_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        compute_lmo_shift_seconds(
+            np.array([1.0], dtype=np.float64),
+            velocity_mps=1000.0,
+            offset_scale=1.0,
+            offset_mode='signed',
+            ref_mode='invalid',
+            ref_trace=None,
+            polarity=1,
+        )
+
+
+@pytest.mark.parametrize('ref_trace', [None, -1, 2])
+def test_invalid_ref_trace_raises_value_error(ref_trace: int | None) -> None:
+    with pytest.raises(ValueError):
+        compute_lmo_shift_seconds(
+            np.array([1.0, 2.0], dtype=np.float64),
+            velocity_mps=1000.0,
+            offset_scale=1.0,
+            offset_mode='signed',
+            ref_mode='trace',
+            ref_trace=ref_trace,
+            polarity=1,
+        )
+
+
+@pytest.mark.parametrize('polarity', [0, 2, -2, True])
+def test_invalid_polarity_raises_value_error(polarity: int) -> None:
+    with pytest.raises(ValueError):
+        compute_lmo_shift_seconds(
+            np.array([1.0], dtype=np.float64),
+            velocity_mps=1000.0,
+            offset_scale=1.0,
+            offset_mode='signed',
+            ref_mode='zero',
+            ref_trace=None,
+            polarity=polarity,
+        )


### PR DESCRIPTION
Closes #256

## Summary
- Backend: Linear Moveout の offset / velocity shift 計算を追加する

## Changed files
- `app/services/linear_moveout.py`
- `app/tests/test_linear_moveout.py`

## Checks
- `.work/codex/checks.log`: 296 passed in 40.37s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
