### PR TITLE
Backend: section window fetch に LMO 表示変換を組み込む

### DIFF
--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -109,27 +109,17 @@ def _build_window_section_cache_key(
     reference_pipeline_key: str | None,
     reference_tap_label: str | None,
     scaling_mode: str,
-) -> tuple[
-    str,
-    int,
-    int,
-    int,
-    int | None,
-    int,
-    int,
-    int,
-    int,
-    int,
-    int,
-    bool,
-    str | None,
-    str | None,
-    str | None,
-    str | None,
-    str,
-]:
+    lmo_enabled: bool = False,
+    lmo_velocity_mps: float | None = None,
+    lmo_offset_byte: int = 37,
+    lmo_offset_scale: float = 1.0,
+    lmo_offset_mode: str = 'absolute',
+    lmo_ref_mode: str = 'min',
+    lmo_ref_trace: int | None = None,
+    lmo_polarity: int = 1,
+) -> tuple[object, ...]:
     """Build the canonical cache key for section-window binary payloads."""
-    return (
+    base_key: tuple[object, ...] = (
         file_id,
         int(key1),
         int(key1_byte),
@@ -147,6 +137,20 @@ def _build_window_section_cache_key(
         reference_pipeline_key,
         reference_tap_label,
         str(scaling_mode),
+    )
+    if not bool(lmo_enabled):
+        return base_key
+    return (
+        *base_key,
+        'lmo',
+        True,
+        None if lmo_velocity_mps is None else float(lmo_velocity_mps),
+        int(lmo_offset_byte),
+        float(lmo_offset_scale),
+        str(lmo_offset_mode),
+        str(lmo_ref_mode),
+        None if lmo_ref_trace is None else int(lmo_ref_trace),
+        int(lmo_polarity),
     )
 
 
@@ -315,6 +319,14 @@ def get_section_window_bin(
     scaling: Annotated[
         Literal['amax', 'tracewise'] | None, Query(description='Normalization mode')
     ] = None,
+    lmo_enabled: Annotated[bool, Query()] = False,
+    lmo_velocity_mps: Annotated[float | None, Query()] = None,
+    lmo_offset_byte: Annotated[int, Query()] = 37,
+    lmo_offset_scale: Annotated[float, Query()] = 1.0,
+    lmo_offset_mode: Annotated[str, Query()] = 'absolute',
+    lmo_ref_mode: Annotated[str, Query()] = 'min',
+    lmo_ref_trace: Annotated[int | None, Query()] = None,
+    lmo_polarity: Annotated[int, Query()] = 1,
 ) -> Response:
     """Return a quantized window of a section, optionally via a pipeline tap."""
     route_started = time.perf_counter()
@@ -343,6 +355,14 @@ def get_section_window_bin(
         reference_pipeline_key=reference_pipeline_key,
         reference_tap_label=reference_tap_label,
         scaling_mode=mode,
+        lmo_enabled=lmo_enabled,
+        lmo_velocity_mps=lmo_velocity_mps,
+        lmo_offset_byte=lmo_offset_byte,
+        lmo_offset_scale=lmo_offset_scale,
+        lmo_offset_mode=lmo_offset_mode,
+        lmo_ref_mode=lmo_ref_mode,
+        lmo_ref_trace=lmo_ref_trace,
+        lmo_polarity=lmo_polarity,
     )
 
     with state.lock:
@@ -380,6 +400,14 @@ def get_section_window_bin(
             reference_pipeline_key=reference_pipeline_key,
             reference_tap_label=reference_tap_label,
             scaling_mode=mode,
+            lmo_enabled=lmo_enabled,
+            lmo_velocity_mps=lmo_velocity_mps,
+            lmo_offset_byte=lmo_offset_byte,
+            lmo_offset_scale=lmo_offset_scale,
+            lmo_offset_mode=lmo_offset_mode,
+            lmo_ref_mode=lmo_ref_mode,
+            lmo_ref_trace=lmo_ref_trace,
+            lmo_polarity=lmo_polarity,
             trace_stats_cache=state.trace_stats_cache,
             trace_stats_lock=state.lock,
             reader_getter=lambda fid, kb1, kb2: get_reader(fid, kb1, kb2, state=state),

--- a/app/services/linear_moveout.py
+++ b/app/services/linear_moveout.py
@@ -39,6 +39,78 @@ def compute_lmo_shift_seconds(
     return np.asarray(shifts, dtype=np.float64)
 
 
+def compute_lmo_raw_sample_bounds(
+    *,
+    y0: int,
+    y1: int,
+    shift_samples: np.ndarray,
+    n_samples: int,
+) -> tuple[int, int]:
+    """Return the clamped raw sample range needed for an LMO display window."""
+    shifts = np.asarray(shift_samples, dtype=np.float64)
+    if shifts.ndim != 1 or shifts.size == 0:
+        raise ValueError('shift_samples must be a non-empty 1D array')
+    if not np.all(np.isfinite(shifts)):
+        raise ValueError('shift_samples contain NaN or Inf')
+    sample_count = int(n_samples)
+    if sample_count <= 0:
+        raise ValueError('n_samples must be greater than 0')
+
+    raw_y0 = int(np.floor(int(y0) + float(np.min(shifts)))) - 1
+    raw_y1 = int(np.ceil(int(y1) + float(np.max(shifts)))) + 1
+    raw_y0 = min(sample_count - 1, max(0, raw_y0))
+    raw_y1 = min(sample_count - 1, max(0, raw_y1))
+    return raw_y0, raw_y1
+
+
+def resample_lmo_window(
+    expanded: np.ndarray,
+    *,
+    y0: int,
+    y1: int,
+    step_y: int,
+    raw_y0: int,
+    shift_samples: np.ndarray,
+) -> np.ndarray:
+    """Interpolate an expanded raw window onto the LMO display sample grid."""
+    arr = np.asarray(expanded, dtype=np.float32)
+    if arr.ndim != 2:
+        raise ValueError('expanded window must be 2D')
+    if int(step_y) < 1:
+        raise ValueError('step_y must be >= 1')
+
+    shifts = np.asarray(shift_samples, dtype=np.float64)
+    if shifts.ndim != 1:
+        raise ValueError('shift_samples must be a 1D array')
+    if shifts.shape[0] != arr.shape[0]:
+        raise ValueError('shift_samples length must match trace count')
+    if not np.all(np.isfinite(shifts)):
+        raise ValueError('shift_samples contain NaN or Inf')
+
+    display_samples = np.arange(int(y0), int(y1) + 1, int(step_y), dtype=np.float64)
+    if display_samples.size == 0:
+        raise ValueError('Requested window is empty')
+
+    out = np.zeros((arr.shape[0], display_samples.size), dtype=np.float32)
+    raw_width = int(arr.shape[1])
+    if raw_width == 0:
+        return out
+
+    max_source = float(raw_width - 1)
+    for trace_idx, shift in enumerate(shifts):
+        source = display_samples + float(shift) - float(raw_y0)
+        valid = (source >= 0.0) & (source <= max_source)
+        if not np.any(valid):
+            continue
+        source_valid = source[valid]
+        lo = np.floor(source_valid).astype(np.int64)
+        hi = np.minimum(lo + 1, raw_width - 1)
+        frac = (source_valid - lo).astype(np.float32, copy=False)
+        row = arr[trace_idx]
+        out[trace_idx, valid] = row[lo] * (1.0 - frac) + row[hi] * frac
+    return out
+
+
 def _validate_offsets(offsets: np.ndarray) -> np.ndarray:
     arr = np.asarray(offsets)
     if arr.ndim != 1:
@@ -114,4 +186,8 @@ def _reference_offset(
     return float(x[int(ref_trace)])
 
 
-__all__ = ['compute_lmo_shift_seconds']
+__all__ = [
+    'compute_lmo_raw_sample_bounds',
+    'compute_lmo_shift_seconds',
+    'resample_lmo_window',
+]

--- a/app/services/section_service.py
+++ b/app/services/section_service.py
@@ -10,6 +10,11 @@ from typing import Any, Callable, Literal
 import numpy as np
 
 from app.api.binary_codec import pack_quantized_array_gzip
+from app.services.linear_moveout import (
+    compute_lmo_raw_sample_bounds,
+    compute_lmo_shift_seconds,
+    resample_lmo_window,
+)
 from app.services.reader import EXPECTED_SECTION_NDIM, coerce_section_f32
 from app.services.scaling import (
     apply_scaling_from_baseline,
@@ -103,6 +108,57 @@ def _source_matches(
     )
 
 
+def _load_lmo_shift_samples(
+    *,
+    reader: TraceStoreSectionReader,
+    key1: int,
+    n_traces: int,
+    dt: float,
+    velocity_mps: float | None,
+    offset_byte: int,
+    offset_scale: float,
+    offset_mode: str,
+    ref_mode: str,
+    ref_trace: int | None,
+    polarity: int,
+) -> np.ndarray:
+    """Load raw offsets and return per-section LMO shifts in sample units."""
+    if velocity_mps is None:
+        raise ValueError('lmo_velocity_mps is required when lmo_enabled=true')
+    dt_val = float(dt)
+    if not np.isfinite(dt_val) or dt_val <= 0.0:
+        raise ValueError('dt must be finite and greater than 0 for LMO')
+
+    get_offsets = getattr(reader, 'get_offsets_for_section', None)
+    if not callable(get_offsets):
+        raise ValueError('Offset header unavailable for LMO')
+    try:
+        offsets_raw = get_offsets(key1, int(offset_byte))
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError('Failed to read offsets for LMO') from exc
+    if offsets_raw is None:
+        raise ValueError('Offsets are required for LMO')
+
+    offsets = np.asarray(offsets_raw)
+    if offsets.ndim == 1 and offsets.size == 0:
+        raise ValueError('offsets must not be empty')
+    if offsets.ndim == 1 and offsets.shape[0] != int(n_traces):
+        raise ValueError('Offsets length does not match section trace count')
+
+    shift_seconds = compute_lmo_shift_seconds(
+        offsets,
+        velocity_mps=velocity_mps,
+        offset_scale=offset_scale,
+        offset_mode=offset_mode,
+        ref_mode=ref_mode,
+        ref_trace=ref_trace,
+        polarity=polarity,
+    )
+    if shift_seconds.shape[0] != int(n_traces):
+        raise ValueError('Offsets length does not match section trace count')
+    return shift_seconds / dt_val
+
+
 def build_section_window_payload(
     *,
     file_id: str,
@@ -128,6 +184,14 @@ def build_section_window_payload(
     dt_resolver: Callable[[str], float] | None = None,
     reference_pipeline_key: str | None = None,
     reference_tap_label: str | None = None,
+    lmo_enabled: bool = False,
+    lmo_velocity_mps: float | None = None,
+    lmo_offset_byte: int = 37,
+    lmo_offset_scale: float = 1.0,
+    lmo_offset_mode: str = 'absolute',
+    lmo_ref_mode: str = 'min',
+    lmo_ref_trace: int | None = None,
+    lmo_polarity: int = 1,
     perf_timings_ms: dict[str, float] | None = None,
 ) -> bytes:
     """Build the compressed binary payload for a section window."""
@@ -162,14 +226,48 @@ def build_section_window_payload(
         raise ValueError('Sample range out of bounds')
     if step_x < 1 or step_y < 1:
         raise ValueError('Steps must be >= 1')
+    if dt_resolver is None:
+        raise SectionServiceInternalError('dt resolver is required')
+    dt_val = dt_resolver(file_id)
 
-    sub = base[x0 : x1 + 1 : step_x, y0 : y1 + 1 : step_y]
+    raw_reader = reader
+    selected_shift_samples: np.ndarray | None = None
+    raw_y0 = int(y0)
+    raw_y1 = int(y1)
+    if bool(lmo_enabled):
+        if raw_reader is None:
+            raw_reader = reader_getter(file_id, key1_byte, key2_byte)
+        shift_samples = _load_lmo_shift_samples(
+            reader=raw_reader,
+            key1=key1,
+            n_traces=n_traces,
+            dt=dt_val,
+            velocity_mps=lmo_velocity_mps,
+            offset_byte=lmo_offset_byte,
+            offset_scale=lmo_offset_scale,
+            offset_mode=lmo_offset_mode,
+            ref_mode=lmo_ref_mode,
+            ref_trace=lmo_ref_trace,
+            polarity=lmo_polarity,
+        )
+        selected_shift_samples = shift_samples[x0 : x1 + 1 : step_x]
+        raw_y0, raw_y1 = compute_lmo_raw_sample_bounds(
+            y0=y0,
+            y1=y1,
+            shift_samples=selected_shift_samples,
+            n_samples=n_samples,
+        )
+
+    sample_slice = (
+        slice(raw_y0, raw_y1 + 1)
+        if selected_shift_samples is not None
+        else slice(y0, y1 + 1, step_y)
+    )
+    sub = base[x0 : x1 + 1 : step_x, sample_slice]
     if sub.size == 0:
         raise ValueError('Requested window is empty')
 
     prepared = coerce_section_f32(sub, section_view.scale)
-    if dt_resolver is None:
-        raise SectionServiceInternalError('dt resolver is required')
     if reference_pipeline_key and reference_tap_label:
         if _source_matches(
             pipeline_key=pipeline_key,
@@ -207,7 +305,7 @@ def build_section_window_payload(
     else:
         store_dir = _resolve_store_dir(
             file_id=file_id,
-            reader=reader,
+            reader=raw_reader if raw_reader is not None else reader,
             store_dir_resolver=store_dir_resolver,
         )
         prepared = apply_scaling_from_baseline(
@@ -224,7 +322,15 @@ def build_section_window_payload(
             x1=x1,
             step_x=step_x,
         )
-    dt_val = dt_resolver(file_id)
+    if selected_shift_samples is not None:
+        prepared = resample_lmo_window(
+            prepared,
+            y0=y0,
+            y1=y1,
+            step_y=step_y,
+            raw_y0=raw_y0,
+            shift_samples=selected_shift_samples,
+        )
     build_ms = (time.perf_counter() - build_started) * 1000.0
     pack_started = time.perf_counter()
     payload = pack_quantized_array_gzip(

--- a/app/tests/_stubs.py
+++ b/app/tests/_stubs.py
@@ -13,10 +13,16 @@ from app.utils.baseline_artifacts import build_raw_baseline_payload, write_raw_b
 def make_stub_reader(
     section_arr: np.ndarray,
     *,
+    offsets: Sequence[float] | np.ndarray | None = None,
     key1_values: Sequence[int] = (7,),
     key_bytes: tuple[int, int] = (189, 193),
 ):
     section = np.asarray(section_arr, dtype=np.float32)
+    offsets_arr = (
+        None
+        if offsets is None
+        else np.asarray(offsets, dtype=np.float32)
+    )
     key1_values_arr = np.asarray(key1_values, dtype=np.int32)
     key1_byte = int(key_bytes[0])
     key2_byte = int(key_bytes[1])
@@ -28,6 +34,11 @@ def make_stub_reader(
         def get_section(self, _key1_val: int):
             arr = np.array(section, dtype=np.float32, copy=True)
             return SectionView(arr=arr, dtype=arr.dtype, scale=None)
+
+        def get_offsets_for_section(self, _key1_val: int, _offset_byte: int):
+            if offsets_arr is None:
+                raise ValueError('offsets unavailable')
+            return np.array(offsets_arr, dtype=np.float32, copy=True)
 
     _StubReader.key1_byte = key1_byte
     _StubReader.key2_byte = key2_byte

--- a/app/tests/test_section_window_lmo.py
+++ b/app/tests/test_section_window_lmo.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import gzip
+from types import SimpleNamespace
+
+import msgpack
+import numpy as np
+import pytest
+from fastapi import HTTPException
+
+from app.api.routers import section as sec
+from app.main import app
+from app.tests._stubs import make_stub_reader, write_baseline_raw
+
+
+def _decode_window_payload(resp) -> tuple[np.ndarray, tuple[int, int], float]:
+    assert resp.headers.get('Content-Encoding') == 'gzip'
+    payload = msgpack.unpackb(gzip.decompress(resp.body))
+    shape = tuple(int(x) for x in payload['shape'])
+    scale = float(payload['scale'])
+    data = np.frombuffer(payload['data'], dtype=np.int8).reshape(shape)
+    return data, (shape[0], shape[1]), scale
+
+
+@pytest.fixture(autouse=True)
+def _clean_section_lmo_env(monkeypatch):
+    monkeypatch.setenv('FIXED_INT8_SCALE', '1')
+
+    app.state.sv.file_registry.clear()
+    state = sec.get_state(app)
+    state.window_section_cache.clear()
+    state.pipeline_tap_cache.clear()
+    state.trace_stats_cache.clear()
+    state.cached_readers.clear()
+
+    monkeypatch.setattr(
+        app.state.sv.file_registry,
+        'get_dt',
+        lambda _fid: 1.0,
+        raising=True,
+    )
+    yield
+    app.state.sv.file_registry.clear()
+    state.window_section_cache.clear()
+    state.pipeline_tap_cache.clear()
+    state.trace_stats_cache.clear()
+    state.cached_readers.clear()
+
+
+def _install_reader(
+    monkeypatch,
+    tmp_path,
+    section: np.ndarray,
+    *,
+    offsets: np.ndarray | list[float] | None = None,
+):
+    reader = make_stub_reader(section, offsets=offsets)
+    monkeypatch.setattr(
+        sec,
+        'get_reader',
+        lambda _fid, _kb1, _kb2, state=None: reader,
+        raising=True,
+    )
+    app.state.sv.file_registry.set_record(
+        'f',
+        {'store_path': str(tmp_path), 'dt': 1.0},
+    )
+    write_baseline_raw(
+        tmp_path,
+        key1=7,
+        section_mean=0.0,
+        section_std=1.0,
+        trace_means=[0.0] * int(section.shape[0]),
+        trace_stds=[1.0] * int(section.shape[0]),
+    )
+    return reader
+
+
+def _window_response(**overrides):
+    params = dict(
+        file_id='f',
+        key1=7,
+        key1_byte=189,
+        key2_byte=193,
+        offset_byte=None,
+        x0=0,
+        x1=1,
+        y0=0,
+        y1=3,
+        step_x=1,
+        step_y=1,
+        transpose=False,
+        pipeline_key=None,
+        tap_label=None,
+        scaling='amax',
+        request=SimpleNamespace(app=app),
+    )
+    params.update(overrides)
+    return sec.get_section_window_bin(**params)
+
+
+def test_lmo_disabled_ignores_lmo_params_for_payload_and_cache(monkeypatch, tmp_path):
+    section = np.arange(2 * 4, dtype=np.float32).reshape(2, 4)
+    _install_reader(monkeypatch, tmp_path, section)
+
+    first = _window_response(
+        lmo_enabled=False,
+        lmo_velocity_mps=1000.0,
+        lmo_offset_mode='invalid',
+    )
+    second = _window_response(
+        lmo_enabled=False,
+        lmo_velocity_mps=2500.0,
+        lmo_offset_mode='signed',
+        lmo_ref_mode='trace',
+        lmo_ref_trace=None,
+    )
+
+    assert first.body == second.body
+    assert first.headers['X-SV-Cache'] == 'miss'
+    assert second.headers['X-SV-Cache'] == 'hit'
+
+
+def test_lmo_zero_shift_matches_existing_window(monkeypatch, tmp_path):
+    section = np.arange(3 * 5, dtype=np.float32).reshape(3, 5)
+    _install_reader(monkeypatch, tmp_path, section, offsets=[10.0, 10.0, 10.0])
+
+    plain = _window_response(x0=0, x1=2, y0=1, y1=4)
+    lmo = _window_response(
+        x0=0,
+        x1=2,
+        y0=1,
+        y1=4,
+        lmo_enabled=True,
+        lmo_velocity_mps=1000.0,
+    )
+
+    assert plain.body == lmo.body
+
+
+def test_lmo_fractional_sample_shift_uses_linear_interpolation(monkeypatch, tmp_path):
+    section = np.array(
+        [
+            [0.0, 10.0, 20.0, 30.0, 40.0, 50.0],
+            [0.0, 10.0, 20.0, 30.0, 40.0, 50.0],
+        ],
+        dtype=np.float32,
+    )
+    _install_reader(monkeypatch, tmp_path, section, offsets=[0.0, 2.0])
+
+    resp = _window_response(
+        x0=0,
+        x1=1,
+        y0=1,
+        y1=3,
+        lmo_enabled=True,
+        lmo_velocity_mps=4.0,
+        lmo_offset_mode='signed',
+        lmo_ref_mode='zero',
+    )
+
+    q, shape, scale = _decode_window_payload(resp)
+    assert scale == pytest.approx(1.0)
+    assert shape == (2, 3)
+    assert np.array_equal(
+        q,
+        np.array(
+            [
+                [10, 20, 30],
+                [15, 25, 35],
+            ],
+            dtype=np.int8,
+        ),
+    )
+
+
+def test_lmo_out_of_range_samples_are_filled_with_zero(monkeypatch, tmp_path):
+    section = np.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]], dtype=np.float32)
+    _install_reader(monkeypatch, tmp_path, section, offsets=[3.0])
+
+    resp = _window_response(
+        x0=0,
+        x1=0,
+        y0=3,
+        y1=5,
+        lmo_enabled=True,
+        lmo_velocity_mps=1.0,
+        lmo_offset_mode='signed',
+        lmo_ref_mode='zero',
+    )
+
+    q, shape, _ = _decode_window_payload(resp)
+    assert shape == (1, 3)
+    assert np.array_equal(q, np.zeros((1, 3), dtype=np.int8))
+
+
+def test_lmo_downsampled_transposed_window_uses_display_grid(monkeypatch, tmp_path):
+    section = np.array(
+        [
+            [0.0, 10.0, 20.0, 30.0, 40.0, 50.0],
+            [0.0, 10.0, 20.0, 30.0, 40.0, 50.0],
+            [0.0, 10.0, 20.0, 30.0, 40.0, 50.0],
+        ],
+        dtype=np.float32,
+    )
+    _install_reader(monkeypatch, tmp_path, section, offsets=[0.0, 2.0, 4.0])
+
+    resp = _window_response(
+        x0=0,
+        x1=2,
+        y0=0,
+        y1=4,
+        step_x=2,
+        step_y=2,
+        transpose=True,
+        lmo_enabled=True,
+        lmo_velocity_mps=2.0,
+        lmo_offset_mode='signed',
+        lmo_ref_mode='zero',
+    )
+
+    q, shape, _ = _decode_window_payload(resp)
+    assert shape == (3, 2)
+    assert np.array_equal(
+        q,
+        np.array(
+            [
+                [0, 20],
+                [20, 40],
+                [40, 0],
+            ],
+            dtype=np.int8,
+        ),
+    )
+
+
+def test_lmo_pipeline_tap_uses_raw_reader_offsets(monkeypatch, tmp_path):
+    state = sec.get_state(app)
+    tap = np.array(
+        [
+            [0.0, 10.0, 20.0, 30.0],
+            [0.0, 10.0, 20.0, 30.0],
+        ],
+        dtype=np.float32,
+    )
+    raw = tap + 100.0
+    _install_reader(monkeypatch, tmp_path, raw, offsets=[0.0, 1.0])
+    pipeline_key = 'pk-lmo'
+    base_key = ('f', 7, 189, 193, pipeline_key, None, None)
+    state.pipeline_tap_cache.set((*base_key, 'tapA'), {'data': tap})
+
+    resp = _window_response(
+        x0=0,
+        x1=1,
+        y0=0,
+        y1=2,
+        pipeline_key=pipeline_key,
+        tap_label='tapA',
+        lmo_enabled=True,
+        lmo_velocity_mps=1.0,
+        lmo_offset_mode='signed',
+        lmo_ref_mode='zero',
+    )
+
+    q, shape, _ = _decode_window_payload(resp)
+    assert shape == (2, 3)
+    assert np.array_equal(
+        q,
+        np.array(
+            [
+                [0, 10, 20],
+                [10, 20, 30],
+            ],
+            dtype=np.int8,
+        ),
+    )
+
+
+def test_lmo_enabled_cache_key_includes_lmo_params(monkeypatch, tmp_path):
+    section = np.array(
+        [
+            [0.0, 10.0, 20.0, 30.0],
+            [0.0, 10.0, 20.0, 30.0],
+        ],
+        dtype=np.float32,
+    )
+    _install_reader(monkeypatch, tmp_path, section, offsets=[0.0, 2.0])
+
+    slow = _window_response(
+        y0=0,
+        y1=2,
+        lmo_enabled=True,
+        lmo_velocity_mps=2.0,
+        lmo_offset_mode='signed',
+        lmo_ref_mode='zero',
+    )
+    fast = _window_response(
+        y0=0,
+        y1=2,
+        lmo_enabled=True,
+        lmo_velocity_mps=1.0,
+        lmo_offset_mode='signed',
+        lmo_ref_mode='zero',
+    )
+
+    assert slow.headers['X-SV-Cache'] == 'miss'
+    assert fast.headers['X-SV-Cache'] == 'miss'
+    assert slow.body != fast.body
+
+
+@pytest.mark.parametrize(
+    ('overrides', 'detail'),
+    [
+        ({'lmo_velocity_mps': None}, 'lmo_velocity_mps is required'),
+        ({'lmo_velocity_mps': 0.0}, 'velocity_mps must be finite'),
+        ({'lmo_offset_scale': 0.0}, 'offset_scale must be finite'),
+        ({'lmo_offset_mode': 'bad'}, 'offset_mode must be'),
+        ({'lmo_ref_mode': 'bad'}, 'ref_mode must be'),
+        ({'lmo_ref_mode': 'trace'}, 'ref_trace is required'),
+        ({'lmo_ref_mode': 'trace', 'lmo_ref_trace': 9}, 'ref_trace is out of range'),
+        ({'lmo_polarity': 0}, 'polarity must be 1 or -1'),
+    ],
+)
+def test_lmo_invalid_parameters_return_400(
+    monkeypatch,
+    tmp_path,
+    overrides: dict[str, object],
+    detail: str,
+):
+    section = np.arange(2 * 4, dtype=np.float32).reshape(2, 4)
+    _install_reader(monkeypatch, tmp_path, section, offsets=[0.0, 1.0])
+
+    params = {'lmo_enabled': True, 'lmo_velocity_mps': 1.0}
+    params.update(overrides)
+    with pytest.raises(HTTPException) as exc_info:
+        _window_response(**params)
+
+    assert exc_info.value.status_code == 400
+    assert detail in str(exc_info.value.detail)
+
+
+@pytest.mark.parametrize(
+    ('offsets', 'detail'),
+    [
+        ([], 'offsets must not be empty'),
+        ([0.0], 'Offsets length does not match section trace count'),
+        ([0.0, np.nan], 'offsets contain NaN or Inf'),
+    ],
+)
+def test_lmo_invalid_offsets_return_400(monkeypatch, tmp_path, offsets, detail: str):
+    section = np.arange(2 * 4, dtype=np.float32).reshape(2, 4)
+    _install_reader(monkeypatch, tmp_path, section, offsets=offsets)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _window_response(lmo_enabled=True, lmo_velocity_mps=1.0)
+
+    assert exc_info.value.status_code == 400
+    assert detail in str(exc_info.value.detail)


### PR DESCRIPTION
Closes #257

## Summary
- Backend: section window fetch に LMO 表示変換を組み込む

## Changed files
- `app/api/routers/section.py`
- `app/services/linear_moveout.py`
- `app/services/section_service.py`
- `app/tests/_stubs.py`
- `app/tests/test_section_window_lmo.py`

## Checks
- `.work/codex/checks.log`: 314 passed in 40.67s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
