### PR TITLE
Backend: section offset 配列取得 API を追加する

### DIFF
--- a/app/api/routers/section.py
+++ b/app/api/routers/section.py
@@ -25,6 +25,7 @@ from app.services.pipeline_taps import (
 from app.services.reader import get_reader
 from app.services.section_service import (
     SectionServiceInternalError,
+    build_section_offsets_payload,
     build_section_window_payload,
 )
 
@@ -151,6 +152,25 @@ def _build_window_section_cache_key(
         str(lmo_ref_mode),
         None if lmo_ref_trace is None else int(lmo_ref_trace),
         int(lmo_polarity),
+    )
+
+
+def _build_section_offsets_cache_key(
+    *,
+    file_id: str,
+    key1: int,
+    key1_byte: int,
+    key2_byte: int,
+    offset_byte: int,
+) -> tuple[object, ...]:
+    """Build the canonical cache key for section-offset binary payloads."""
+    return (
+        'section_offsets',
+        file_id,
+        int(key1),
+        int(key1_byte),
+        int(key2_byte),
+        int(offset_byte),
     )
 
 
@@ -292,6 +312,75 @@ def get_section_meta(
             baseline_ms=baseline_ms,
             baseline_source=baseline_status.get('source', 'unknown'),
         ),
+    )
+
+
+@router.get(
+    '/get_section_offsets_bin', dependencies=[Depends(reject_legacy_key1_query_params)]
+)
+def get_section_offsets_bin(
+    request: Request,
+    file_id: Annotated[str, Query(...)],
+    key1: Annotated[int, Query(...)],
+    key1_byte: Annotated[int, Query(ge=1, le=240)] = 189,
+    key2_byte: Annotated[int, Query(ge=1, le=240)] = 193,
+    offset_byte: Annotated[int, Query(ge=1, le=240)] = OFFSET_BYTE_FIXED,
+) -> Response:
+    """Return per-trace offsets for a section as float32 bytes."""
+    state = get_state(request.app)
+    cache_key = _build_section_offsets_cache_key(
+        file_id=file_id,
+        key1=key1,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        offset_byte=offset_byte,
+    )
+
+    with state.lock:
+        cached_payload = state.window_section_cache.get(cache_key)
+    if cached_payload is not None:
+        return Response(
+            cached_payload,
+            media_type='application/octet-stream',
+            headers={
+                'Content-Encoding': 'gzip',
+                'X-SV-Cache': 'hit',
+                'X-SV-Bytes': str(len(cached_payload)),
+            },
+        )
+
+    try:
+        compressed = build_section_offsets_payload(
+            file_id=file_id,
+            key1=key1,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
+            offset_byte=offset_byte,
+            reader_getter=lambda fid, kb1, kb2: get_reader(
+                fid, kb1, kb2, state=state
+            ),
+        )
+    except SectionServiceInternalError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    with state.lock:
+        cached_payload = state.window_section_cache.get(cache_key)
+        if cached_payload is None:
+            state.window_section_cache.set(cache_key, compressed)
+            cache_state = 'miss'
+        else:
+            compressed = cached_payload
+            cache_state = 'hit-after-build'
+    return Response(
+        compressed,
+        media_type='application/octet-stream',
+        headers={
+            'Content-Encoding': 'gzip',
+            'X-SV-Cache': cache_state,
+            'X-SV-Bytes': str(len(compressed)),
+        },
     )
 
 

--- a/app/services/section_service.py
+++ b/app/services/section_service.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Literal
 
 import numpy as np
 
-from app.api.binary_codec import pack_quantized_array_gzip
+from app.api.binary_codec import pack_msgpack_gzip, pack_quantized_array_gzip
 from app.services.linear_moveout import (
     compute_lmo_raw_sample_bounds,
     compute_lmo_shift_seconds,
@@ -26,6 +26,77 @@ from app.trace_store.types import SectionView
 
 class SectionServiceInternalError(RuntimeError):
     """Raised when service detects an internal data/state inconsistency."""
+
+
+def _validate_section_offsets(
+    offsets_raw: object,
+    *,
+    n_traces: int,
+) -> np.ndarray:
+    try:
+        offsets = np.asarray(offsets_raw, dtype=np.float32)
+    except (TypeError, ValueError) as exc:
+        raise ValueError('Offsets must be numeric') from exc
+    if offsets.ndim != 1:
+        raise ValueError('Offsets must be a 1D array')
+    if offsets.size == 0:
+        raise ValueError('Offsets must not be empty')
+    if not np.all(np.isfinite(offsets)):
+        raise ValueError('Offsets contain NaN or Inf')
+    if int(offsets.shape[0]) != int(n_traces):
+        raise ValueError('Offsets length does not match section trace count')
+    return np.ascontiguousarray(offsets, dtype=np.float32)
+
+
+def build_section_offsets_payload(
+    *,
+    file_id: str,
+    key1: int,
+    key1_byte: int,
+    key2_byte: int,
+    offset_byte: int,
+    reader_getter: Callable[[str, int, int], TraceStoreSectionReader],
+) -> bytes:
+    """Build the compressed binary payload for per-trace section offsets."""
+    reader = reader_getter(file_id, key1_byte, key2_byte)
+
+    try:
+        trace_indices = reader.get_trace_seq_for_value(key1, align_to='display')
+    except ValueError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError('Failed to resolve section trace count') from exc
+
+    trace_indices_arr = np.asarray(trace_indices)
+    if trace_indices_arr.ndim != 1:
+        raise SectionServiceInternalError('Section trace index must be 1D')
+    n_traces = int(trace_indices_arr.shape[0])
+    if n_traces <= 0:
+        raise ValueError('Section trace count must be greater than 0')
+
+    get_offsets = getattr(reader, 'get_offsets_for_section', None)
+    if not callable(get_offsets):
+        raise ValueError('Offset header unavailable')
+    try:
+        offsets_raw = get_offsets(key1, int(offset_byte))
+    except ValueError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError('Failed to read offsets') from exc
+
+    offsets = _validate_section_offsets(offsets_raw, n_traces=n_traces)
+    return pack_msgpack_gzip(
+        {
+            'file_id': str(file_id),
+            'key1': int(key1),
+            'key1_byte': int(key1_byte),
+            'key2_byte': int(key2_byte),
+            'offset_byte': int(offset_byte),
+            'dtype': 'float32',
+            'shape': [int(offsets.shape[0])],
+            'offsets': offsets.tobytes(),
+        }
+    )
 
 
 def _load_section_view(
@@ -346,4 +417,8 @@ def build_section_window_payload(
     return payload
 
 
-__all__ = ['SectionServiceInternalError', 'build_section_window_payload']
+__all__ = [
+    'SectionServiceInternalError',
+    'build_section_offsets_payload',
+    'build_section_window_payload',
+]

--- a/app/tests/_stubs.py
+++ b/app/tests/_stubs.py
@@ -35,6 +35,11 @@ def make_stub_reader(
             arr = np.array(section, dtype=np.float32, copy=True)
             return SectionView(arr=arr, dtype=arr.dtype, scale=None)
 
+        def get_trace_seq_for_value(self, _key1_val: int, align_to: str = 'display'):
+            if align_to not in {'display', 'original'}:
+                raise ValueError("align_to must be 'display' or 'original'")
+            return np.arange(section.shape[0], dtype=np.int64)
+
         def get_offsets_for_section(self, _key1_val: int, _offset_byte: int):
             if offsets_arr is None:
                 raise ValueError('offsets unavailable')

--- a/app/tests/test_section_offsets_bin.py
+++ b/app/tests/test_section_offsets_bin.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from typing import Any
+
+import msgpack
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.routers import section as sec
+from app.main import app
+from app.services.fbpick_support import OFFSET_BYTE_FIXED
+
+
+def _decode_payload(resp) -> tuple[dict[str, Any], np.ndarray]:
+    assert resp.headers.get('content-encoding') == 'gzip'
+    payload = msgpack.unpackb(resp.content, raw=False)
+    offsets = np.frombuffer(payload['offsets'], dtype=np.float32)
+    return payload, offsets
+
+
+class _OffsetsReader:
+    def __init__(
+        self,
+        *,
+        n_traces: int = 3,
+        offsets: object = (100.0, 200.0, 350.0),
+        missing_key1: bool = False,
+        offset_error: Exception | None = None,
+    ) -> None:
+        self.n_traces = int(n_traces)
+        self.offsets = offsets
+        self.missing_key1 = bool(missing_key1)
+        self.offset_error = offset_error
+        self.requested_offset_bytes: list[int] = []
+
+    def get_trace_seq_for_value(self, key1: int, align_to: str = 'display'):
+        if align_to != 'display':
+            raise ValueError("align_to must be 'display'")
+        if self.missing_key1:
+            raise ValueError(f'Key1 value {int(key1)} not found')
+        return np.arange(self.n_traces, dtype=np.int64)
+
+    def get_offsets_for_section(self, _key1: int, offset_byte: int):
+        self.requested_offset_bytes.append(int(offset_byte))
+        if self.offset_error is not None:
+            raise self.offset_error
+        return self.offsets
+
+
+class _ReaderWithoutOffsets:
+    def get_trace_seq_for_value(self, _key1: int, align_to: str = 'display'):
+        if align_to != 'display':
+            raise ValueError("align_to must be 'display'")
+        return np.arange(2, dtype=np.int64)
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    app.state.sv.file_registry.clear()
+    state = sec.get_state(app)
+    state.cached_readers.clear()
+    state.window_section_cache.clear()
+    state.trace_stats_cache.clear()
+    yield
+    app.state.sv.file_registry.clear()
+    state.cached_readers.clear()
+    state.window_section_cache.clear()
+    state.trace_stats_cache.clear()
+
+
+def _install_reader(monkeypatch, reader):
+    monkeypatch.setattr(
+        sec,
+        'get_reader',
+        lambda _fid, _kb1, _kb2, state=None: reader,
+        raising=True,
+    )
+
+
+def test_get_section_offsets_bin_returns_float32_payload(monkeypatch):
+    reader = _OffsetsReader(offsets=np.array([10.5, 20.25, 30.0], dtype=np.float64))
+    _install_reader(monkeypatch, reader)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            '/get_section_offsets_bin',
+            params={
+                'file_id': 'f',
+                'key1': 7,
+                'key1_byte': 189,
+                'key2_byte': 193,
+                'offset_byte': 41,
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers['x-sv-cache'] == 'miss'
+    payload, offsets = _decode_payload(resp)
+    assert payload['file_id'] == 'f'
+    assert payload['key1'] == 7
+    assert payload['key1_byte'] == 189
+    assert payload['key2_byte'] == 193
+    assert payload['offset_byte'] == 41
+    assert payload['dtype'] == 'float32'
+    assert payload['shape'] == [3]
+    assert offsets.dtype == np.float32
+    np.testing.assert_allclose(offsets, np.array([10.5, 20.25, 30.0], dtype=np.float32))
+    assert reader.requested_offset_bytes == [41]
+
+
+def test_get_section_offsets_bin_defaults_offset_byte_to_37(monkeypatch):
+    reader = _OffsetsReader()
+    _install_reader(monkeypatch, reader)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            '/get_section_offsets_bin',
+            params={
+                'file_id': 'f',
+                'key1': 7,
+                'key1_byte': 189,
+                'key2_byte': 193,
+            },
+        )
+
+    assert resp.status_code == 200
+    payload, offsets = _decode_payload(resp)
+    assert payload['offset_byte'] == OFFSET_BYTE_FIXED == 37
+    assert payload['shape'] == [3]
+    np.testing.assert_allclose(offsets, np.array([100.0, 200.0, 350.0], dtype=np.float32))
+    assert reader.requested_offset_bytes == [OFFSET_BYTE_FIXED]
+
+
+def test_get_section_offsets_bin_uses_cache_key_metadata(monkeypatch):
+    reader = _OffsetsReader(offsets=[1.0, 2.0, 3.0])
+    _install_reader(monkeypatch, reader)
+    params = {
+        'file_id': 'f',
+        'key1': 7,
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'offset_byte': 37,
+    }
+
+    with TestClient(app) as client:
+        first = client.get('/get_section_offsets_bin', params=params)
+        reader.offsets = [9.0, 9.0, 9.0]
+        second = client.get('/get_section_offsets_bin', params=params)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.headers['x-sv-cache'] == 'miss'
+    assert second.headers['x-sv-cache'] == 'hit'
+    _, first_offsets = _decode_payload(first)
+    _, second_offsets = _decode_payload(second)
+    np.testing.assert_allclose(first_offsets, np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    np.testing.assert_allclose(second_offsets, first_offsets)
+    assert reader.requested_offset_bytes == [37]
+
+
+def test_get_section_offsets_bin_unknown_file_id_returns_404():
+    with TestClient(app) as client:
+        resp = client.get(
+            '/get_section_offsets_bin',
+            params={'file_id': 'missing', 'key1': 7},
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()['detail'] == 'File ID not found'
+
+
+@pytest.mark.parametrize(
+    'params',
+    [
+        {'key1_byte': 0},
+        {'key2_byte': 0},
+        {'offset_byte': 0},
+        {'offset_byte': 241},
+    ],
+)
+def test_get_section_offsets_bin_invalid_byte_query_is_422(monkeypatch, params):
+    _install_reader(monkeypatch, _OffsetsReader())
+    base_params = {
+        'file_id': 'f',
+        'key1': 7,
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'offset_byte': 37,
+    }
+    base_params.update(params)
+
+    with TestClient(app) as client:
+        resp = client.get('/get_section_offsets_bin', params=base_params)
+
+    assert resp.status_code == 422
+
+
+def test_get_section_offsets_bin_missing_key1_returns_400(monkeypatch):
+    _install_reader(monkeypatch, _OffsetsReader(missing_key1=True))
+
+    with TestClient(app) as client:
+        resp = client.get(
+            '/get_section_offsets_bin',
+            params={'file_id': 'f', 'key1': 999},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()['detail'] == 'Key1 value 999 not found'
+
+
+def test_get_section_offsets_bin_missing_offset_reader_returns_400(monkeypatch):
+    _install_reader(monkeypatch, _ReaderWithoutOffsets())
+
+    with TestClient(app) as client:
+        resp = client.get(
+            '/get_section_offsets_bin',
+            params={'file_id': 'f', 'key1': 7},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()['detail'] == 'Offset header unavailable'
+
+
+def test_get_section_offsets_bin_offset_read_failure_returns_400(monkeypatch):
+    _install_reader(
+        monkeypatch,
+        _OffsetsReader(offset_error=RuntimeError('header load failed')),
+    )
+
+    with TestClient(app) as client:
+        resp = client.get(
+            '/get_section_offsets_bin',
+            params={'file_id': 'f', 'key1': 7},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()['detail'] == 'Failed to read offsets'
+
+
+@pytest.mark.parametrize(
+    ('offsets', 'detail'),
+    [
+        ([], 'Offsets must not be empty'),
+        ([[1.0, 2.0, 3.0]], 'Offsets must be a 1D array'),
+        ([1.0, np.nan, 3.0], 'Offsets contain NaN or Inf'),
+        ([1.0, np.inf, 3.0], 'Offsets contain NaN or Inf'),
+        ([1.0, 2.0], 'Offsets length does not match section trace count'),
+    ],
+)
+def test_get_section_offsets_bin_invalid_offsets_return_400(
+    monkeypatch,
+    offsets,
+    detail: str,
+):
+    _install_reader(monkeypatch, _OffsetsReader(offsets=offsets))
+
+    with TestClient(app) as client:
+        resp = client.get(
+            '/get_section_offsets_bin',
+            params={'file_id': 'f', 'key1': 7},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()['detail'] == detail


### PR DESCRIPTION
Closes #261

## Summary
- Backend: section offset 配列取得 API を追加する

## Changed files
- `app/api/routers/section.py`
- `app/services/section_service.py`
- `app/tests/_stubs.py`
- `app/tests/test_section_offsets_bin.py`

## Checks
- `.work/codex/checks.log`: 330 passed in 40.92s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
