### PR TITLE
Frontend: pick overlay と pick 保存を LMO 座標変換に対応させる

### DIFF
--- a/app/static/viewer/core/layout.js
+++ b/app/static/viewer/core/layout.js
@@ -71,9 +71,9 @@ export function buildPickShapes({
   xMin,
   xMax,
   showPredicted,
+  timeTransform = null,
 }) {
-  const manualShapes = (manualPicks || [])
-    .filter((p) => p && typeof p.trace === 'number' && p.trace >= xMin && p.trace <= xMax)
+  const manualShapes = resolvePicksInRange(manualPicks, xMin, xMax, timeTransform)
     .map((p) => ({
       xref: 'x',
       yref: 'y',
@@ -85,8 +85,7 @@ export function buildPickShapes({
       line: { color: 'red', width: 2 },
     }));
 
-  const predictedShapes = (predicted || [])
-    .filter((p) => p && typeof p.trace === 'number' && p.trace >= xMin && p.trace <= xMax)
+  const predictedShapes = resolvePicksInRange(predicted, xMin, xMax, timeTransform)
     .map((p) => ({
       xref: 'x',
       yref: 'y',
@@ -107,21 +106,10 @@ export function buildPickMarkerTraces({
   xMin,
   xMax,
   showPredicted,
+  timeTransform = null,
 }) {
-  const manualInRange = (manualPicks || []).filter((p) => (
-    p &&
-    typeof p.trace === 'number' &&
-    typeof p.time === 'number' &&
-    p.trace >= xMin &&
-    p.trace <= xMax
-  ));
-  const predInRange = (predicted || []).filter((p) => (
-    p &&
-    typeof p.trace === 'number' &&
-    typeof p.time === 'number' &&
-    p.trace >= xMin &&
-    p.trace <= xMax
-  ));
+  const manualInRange = resolvePicksInRange(manualPicks, xMin, xMax, timeTransform);
+  const predInRange = resolvePicksInRange(predicted, xMin, xMax, timeTransform);
 
   const manualX = new Float32Array(manualInRange.length);
   const manualY = new Float32Array(manualInRange.length);
@@ -173,6 +161,30 @@ export function buildPickMarkerTraces({
   };
 
   return [manualTrace, predTrace];
+}
+
+function resolvePickDisplayPoint(pick, timeTransform) {
+  if (!pick) return null;
+  const trace = Number(pick.trace);
+  const rawTime = Number(pick.time);
+  if (!Number.isFinite(trace) || !Number.isFinite(rawTime)) return null;
+
+  let displayTime = rawTime;
+  if (typeof timeTransform === 'function') {
+    displayTime = Number(timeTransform(trace, rawTime, pick));
+  }
+  if (!Number.isFinite(displayTime)) return null;
+  return { trace, time: displayTime };
+}
+
+function resolvePicksInRange(picks, xMin, xMax, timeTransform) {
+  return (picks || [])
+    .map((pick) => resolvePickDisplayPoint(pick, timeTransform))
+    .filter((point) => (
+      point &&
+      point.trace >= xMin &&
+      point.trace <= xMax
+    ));
 }
 
 export function buildPendingPickMarkerTrace({

--- a/app/static/viewer/legacy_globals.js
+++ b/app/static/viewer/legacy_globals.js
@@ -28,6 +28,10 @@
     });
     const LMO_OFFSET_MODES = new Set(['absolute', 'signed']);
     const LMO_REF_MODES = new Set(['min', 'first', 'center', 'trace', 'zero']);
+    const lmoSectionOffsetCache = new Map();
+    const lmoSectionOffsetInflight = new Map();
+    const lmoShiftSecondsCache = new Map();
+    const lmoPickOverlayWarningKeys = new Set();
     var currentLinearMoveout = { ...LMO_DEFAULTS };
     var savedXRange = null;
     var savedYRange = null;
@@ -277,6 +281,259 @@
       ].join('|');
     }
 
+    function currentKey1ValueForLmoPickTransform() {
+      const slider = document.getElementById('key1_slider');
+      const idxRaw = slider ? parseInt(slider.value, 10) : 0;
+      const idx = Number.isFinite(idxRaw) ? idxRaw : 0;
+      return Array.isArray(key1Values) ? key1Values[idx] : undefined;
+    }
+
+    function lmoPickOffsetCacheKey(context) {
+      return [
+        context.fileId,
+        context.key1,
+        context.key1Byte,
+        context.key2Byte,
+        context.offsetByte,
+      ].map((value) => encodeURIComponent(String(value))).join('|');
+    }
+
+    function lmoPickShiftCacheKey(context) {
+      return `${lmoPickOffsetCacheKey(context)}|${context.lmoKey}`;
+    }
+
+    function currentLmoPickContext() {
+      const lmo = getCurrentLinearMoveout();
+      if (!lmo.enabled) return { enabled: false, lmo, lmoKey: 'lmo:off' };
+      const key1 = currentKey1ValueForLmoPickTransform();
+      if (!currentFileId || key1 === undefined) {
+        return null;
+      }
+      return {
+        enabled: true,
+        fileId: currentFileId,
+        key1,
+        key1Byte: currentKey1Byte,
+        key2Byte: currentKey2Byte,
+        offsetByte: lmo.offsetByte,
+        lmo,
+        lmoKey: currentLmoKey(),
+      };
+    }
+
+    function decodeSectionOffsetsPayload(buffer) {
+      if (!window.msgpack || typeof window.msgpack.decode !== 'function') {
+        throw new Error('msgpack decoder is not available');
+      }
+      const payload = window.msgpack.decode(new Uint8Array(buffer));
+      if (!payload || payload.dtype !== 'float32') {
+        throw new Error('Unexpected section offsets payload dtype');
+      }
+      const shape = Array.isArray(payload.shape) ? payload.shape : [];
+      const n = Number(shape[0]);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error('Unexpected section offsets payload shape');
+      }
+      const rawOffsets = payload.offsets;
+      let bytes = null;
+      if (rawOffsets instanceof Uint8Array) {
+        bytes = rawOffsets;
+      } else if (rawOffsets instanceof ArrayBuffer) {
+        bytes = new Uint8Array(rawOffsets);
+      } else if (ArrayBuffer.isView(rawOffsets)) {
+        bytes = new Uint8Array(rawOffsets.buffer, rawOffsets.byteOffset, rawOffsets.byteLength);
+      }
+      if (!bytes || bytes.byteLength !== n * Float32Array.BYTES_PER_ELEMENT) {
+        throw new Error('Unexpected section offsets byte length');
+      }
+      const aligned = bytes.byteOffset % Float32Array.BYTES_PER_ELEMENT === 0
+        ? bytes
+        : new Uint8Array(bytes);
+      return new Float32Array(aligned.buffer, aligned.byteOffset, n).slice();
+    }
+
+    function requestSectionOffsetsForLmoPickTransform(context) {
+      const offsetKey = lmoPickOffsetCacheKey(context);
+      if (lmoSectionOffsetCache.has(offsetKey)) {
+        return Promise.resolve(lmoSectionOffsetCache.get(offsetKey));
+      }
+      if (lmoSectionOffsetInflight.has(offsetKey)) {
+        return lmoSectionOffsetInflight.get(offsetKey);
+      }
+
+      const params = new URLSearchParams({
+        file_id: String(context.fileId),
+        key1: String(context.key1),
+        key1_byte: String(context.key1Byte),
+        key2_byte: String(context.key2Byte),
+        offset_byte: String(context.offsetByte),
+      });
+      let loaded = false;
+      const promise = fetch(`/get_section_offsets_bin?${params.toString()}`)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`section offsets request failed with status ${response.status}`);
+          }
+          return response.arrayBuffer();
+        })
+        .then((buffer) => {
+          const offsets = decodeSectionOffsetsPayload(buffer);
+          lmoSectionOffsetCache.set(offsetKey, offsets);
+          loaded = true;
+          return offsets;
+        })
+        .catch((err) => {
+          console.warn('LMO section offsets fetch failed', err);
+          throw err;
+        })
+        .finally(() => {
+          lmoSectionOffsetInflight.delete(offsetKey);
+          if (loaded && typeof schedulePickOverlayUpdate === 'function') {
+            schedulePickOverlayUpdate();
+          }
+        });
+      lmoSectionOffsetInflight.set(offsetKey, promise);
+      return promise;
+    }
+
+    function lmoReferenceOffset(values, lmo) {
+      if (lmo.refMode === 'min') {
+        let best = Infinity;
+        for (const value of values) best = Math.min(best, value);
+        return best;
+      }
+      if (lmo.refMode === 'first') return values[0];
+      if (lmo.refMode === 'center') return values[Math.floor(values.length / 2)];
+      if (lmo.refMode === 'zero') return 0;
+      if (lmo.refMode === 'trace') {
+        const refTrace = lmo.refTrace | 0;
+        if (refTrace < 0 || refTrace >= values.length) return NaN;
+        return values[refTrace];
+      }
+      return NaN;
+    }
+
+    function computeLmoShiftSecondsForOffsets(offsets, lmo) {
+      const n = offsets ? offsets.length : 0;
+      const velocity = Number(lmo.velocityMps);
+      const scale = Number(lmo.offsetScale);
+      if (!n || !Number.isFinite(velocity) || velocity <= 0 || !Number.isFinite(scale) || scale === 0) {
+        return null;
+      }
+
+      const values = new Float64Array(n);
+      for (let i = 0; i < n; i++) {
+        const scaled = Number(offsets[i]) * scale;
+        if (!Number.isFinite(scaled)) return null;
+        values[i] = lmo.offsetMode === 'absolute' ? Math.abs(scaled) : scaled;
+      }
+
+      const ref = lmoReferenceOffset(values, lmo);
+      const polarity = Number(lmo.polarity) === -1 ? -1 : 1;
+      if (!Number.isFinite(ref)) return null;
+
+      const shifts = new Float64Array(n);
+      for (let i = 0; i < n; i++) {
+        const shift = polarity * (values[i] - ref) / velocity;
+        if (!Number.isFinite(shift)) return null;
+        shifts[i] = shift;
+      }
+      return shifts;
+    }
+
+    function warnLmoPickOverlaySkipped(context) {
+      const key = context?.lmoKey || currentLmoKey();
+      if (lmoPickOverlayWarningKeys.has(key)) return;
+      lmoPickOverlayWarningKeys.add(key);
+      console.warn('LMO pick overlay skipped because section offsets are not ready.');
+    }
+
+    function getCurrentLmoShiftSeconds() {
+      const context = currentLmoPickContext();
+      if (!context) return null;
+      if (!context.enabled) return { shifts: null, lmo: context.lmo, lmoKey: context.lmoKey };
+
+      const shiftKey = lmoPickShiftCacheKey(context);
+      if (lmoShiftSecondsCache.has(shiftKey)) {
+        return { shifts: lmoShiftSecondsCache.get(shiftKey), lmo: context.lmo, lmoKey: context.lmoKey };
+      }
+
+      const offsetKey = lmoPickOffsetCacheKey(context);
+      const offsets = lmoSectionOffsetCache.get(offsetKey);
+      if (!offsets) {
+        requestSectionOffsetsForLmoPickTransform(context).catch(() => {});
+        return null;
+      }
+
+      const shifts = computeLmoShiftSecondsForOffsets(offsets, context.lmo);
+      if (!shifts) return null;
+      lmoShiftSecondsCache.set(shiftKey, shifts);
+      return { shifts, lmo: context.lmo, lmoKey: context.lmoKey };
+    }
+
+    function ensureLmoPickOffsetsReady() {
+      const context = currentLmoPickContext();
+      if (!context) return Promise.resolve(false);
+      if (!context.enabled) return Promise.resolve(true);
+      const current = getCurrentLmoShiftSeconds();
+      if (current?.shifts) return Promise.resolve(true);
+      return requestSectionOffsetsForLmoPickTransform(context)
+        .then(() => {
+          const updated = getCurrentLmoShiftSeconds();
+          return !!updated?.shifts;
+        })
+        .catch(() => false);
+    }
+
+    function getLmoShiftSecondsForTrace(trace) {
+      const context = currentLmoPickContext();
+      if (!context) return NaN;
+      if (!context.enabled) return 0;
+
+      const current = getCurrentLmoShiftSeconds();
+      const shifts = current?.shifts;
+      const traceIndex = Math.round(Number(trace));
+      if (
+        !shifts ||
+        !Number.isInteger(traceIndex) ||
+        traceIndex < 0 ||
+        traceIndex >= shifts.length
+      ) {
+        warnLmoPickOverlaySkipped(context);
+        return NaN;
+      }
+      return shifts[traceIndex];
+    }
+
+    function rawTimeToDisplayTime(trace, rawTime) {
+      const raw = Number(rawTime);
+      if (!Number.isFinite(raw)) return NaN;
+      const context = currentLmoPickContext();
+      if (!context) return NaN;
+      if (!context.enabled) return raw;
+      const shift = getLmoShiftSecondsForTrace(trace);
+      return Number.isFinite(shift) ? raw - shift : NaN;
+    }
+
+    function displayTimeToRawTime(trace, displayTime) {
+      const display = Number(displayTime);
+      if (!Number.isFinite(display)) return NaN;
+      const context = currentLmoPickContext();
+      if (!context) return NaN;
+      if (!context.enabled) return display;
+      const shift = getLmoShiftSecondsForTrace(trace);
+      return Number.isFinite(shift) ? display + shift : NaN;
+    }
+
+    function pickRawTimeToDisplayTime(trace, rawTime) {
+      const display = rawTimeToDisplayTime(trace, rawTime);
+      if (!Number.isFinite(display)) {
+        const context = currentLmoPickContext();
+        if (context?.enabled) warnLmoPickOverlaySkipped(context);
+      }
+      return display;
+    }
+
     function onLinearMoveoutControlChange(options = {}) {
       return setCurrentLinearMoveout(getLinearMoveoutControlSnapshot(), options);
     }
@@ -315,6 +572,11 @@
     window.getCurrentLinearMoveout = getCurrentLinearMoveout;
     window.setCurrentLinearMoveout = setCurrentLinearMoveout;
     window.currentLmoKey = currentLmoKey;
+    window.rawTimeToDisplayTime = rawTimeToDisplayTime;
+    window.displayTimeToRawTime = displayTimeToRawTime;
+    window.getLmoShiftSecondsForTrace = getLmoShiftSecondsForTrace;
+    window.ensureLmoPickOffsetsReady = ensureLmoPickOffsetsReady;
+    window.pickRawTimeToDisplayTime = pickRawTimeToDisplayTime;
     window.onLinearMoveoutControlChange = onLinearMoveoutControlChange;
     persistLinearMoveoutState(currentLinearMoveout);
     initLinearMoveoutControls();

--- a/app/static/viewer/viewer_legacy.js
+++ b/app/static/viewer/viewer_legacy.js
@@ -85,10 +85,11 @@
           time: Number(linePickStart.time),
         };
       }
-      if (deleteRangeStart !== null && Number.isFinite(deleteRangeStart)) {
+      const deleteAnchor = normalizeDeleteRangeAnchor(deleteRangeStart);
+      if (deleteAnchor) {
         return {
           kind: 'delete-range',
-          trace: deleteRangeStart | 0,
+          trace: deleteAnchor.trace,
         };
       }
       return null;
@@ -139,8 +140,24 @@
       syncPendingPickUi();
     }
 
-    function setDeleteRangeAnchor(trace) {
-      deleteRangeStart = trace | 0;
+    function normalizeDeleteRangeAnchor(anchor) {
+      if (anchor === null || anchor === undefined) return null;
+      if (typeof anchor === 'object') {
+        const trace = Number(anchor.trace);
+        const time = Number(anchor.time);
+        if (!Number.isFinite(trace)) return null;
+        return {
+          trace: trace | 0,
+          time: Number.isFinite(time) ? time : NaN,
+        };
+      }
+      const trace = Number(anchor);
+      if (!Number.isFinite(trace)) return null;
+      return { trace: trace | 0, time: NaN };
+    }
+
+    function setDeleteRangeAnchor(trace, time) {
+      deleteRangeStart = { trace: trace | 0, time: Number(time) };
       linePickStart = null;
       syncPendingPickUi();
     }
@@ -942,6 +959,71 @@
       return cloneManualPick(found);
     }
 
+    function localPickDisplayTime(pick) {
+      const trace = Number(pick?.trace);
+      const rawTime = Number(pick?.time);
+      if (!Number.isFinite(trace) || !Number.isFinite(rawTime)) return NaN;
+      const converter = window.pickRawTimeToDisplayTime || window.rawTimeToDisplayTime;
+      if (typeof converter !== 'function') return NaN;
+      return Number(converter(trace, rawTime, pick));
+    }
+
+    function getLocalPickOnTraceForDisplayClick(traceInt, displayTime) {
+      const targetTime = Number(displayTime);
+      if (!Number.isFinite(targetTime)) return null;
+
+      let best = null;
+      let bestDistance = Infinity;
+      for (const pick of picks) {
+        if ((pick?.trace | 0) !== traceInt) continue;
+        const pickDisplayTime = localPickDisplayTime(pick);
+        if (!Number.isFinite(pickDisplayTime)) continue;
+        const distance = Math.abs(targetTime - pickDisplayTime);
+        if (distance < bestDistance) {
+          best = pick;
+          bestDistance = distance;
+        }
+      }
+      return best ? cloneManualPick(best) : null;
+    }
+
+    function getLocalPicksInTraceRangeForDisplayDelete(anchor, trace, displayTime) {
+      const startAnchor = normalizeDeleteRangeAnchor(anchor);
+      if (!startAnchor) return [];
+
+      const x0 = startAnchor.trace;
+      const x1 = trace | 0;
+      const y0 = Number(startAnchor.time);
+      const y1 = Number(displayTime);
+      const start = Math.min(x0, x1);
+      const end = Math.max(x0, x1);
+      const canInterpolateTime = Number.isFinite(y0) && Number.isFinite(y1);
+      const slope = canInterpolateTime && x1 !== x0 ? (y1 - y0) / (x1 - x0) : 0;
+      const nearestByTrace = new Map();
+
+      for (const pick of picks) {
+        const traceInt = pick?.trace | 0;
+        if (traceInt < start || traceInt > end) continue;
+
+        const pickDisplayTime = localPickDisplayTime(pick);
+        if (!Number.isFinite(pickDisplayTime)) continue;
+
+        const targetDisplayTime = canInterpolateTime
+          ? (x1 === x0 ? y1 : y0 + slope * (traceInt - x0))
+          : pickDisplayTime;
+        const distance = Math.abs(targetDisplayTime - pickDisplayTime);
+        const current = nearestByTrace.get(traceInt);
+        if (!current || distance < current.distance) {
+          nearestByTrace.set(traceInt, { pick, distance });
+        }
+      }
+
+      return Array.from(nearestByTrace.values())
+        .map(({ pick }) => cloneManualPick(pick))
+        .filter(Boolean)
+        .sort((a, b) => a.trace - b.trace);
+    }
+
     function manualPickStateEquals(a, b) {
       if (a == null && b == null) return true;
       if (!a || !b) return false;
@@ -1304,6 +1386,7 @@
         xMin,
         xMax,
         showPredicted: showPred,
+        timeTransform: window.pickRawTimeToDisplayTime,
       });
       const { yMin, yMax } = resolvePendingPickYRange(plotDiv);
       const pendingPickTr = buildPendingPickMarkerTrace({
@@ -2943,6 +3026,24 @@
       return Math.max(0, Math.round(t));
     }
 
+    async function displayPickTimeToRawTime(traceInt, displayTime) {
+      const converter = window.displayTimeToRawTime;
+      if (typeof converter !== 'function') {
+        console.warn('LMO pick save skipped because the display/raw time converter is not available.');
+        return null;
+      }
+      let rawTime = converter(traceInt, displayTime);
+      if (!Number.isFinite(rawTime) && typeof window.ensureLmoPickOffsetsReady === 'function') {
+        await window.ensureLmoPickOffsetsReady();
+        rawTime = converter(traceInt, displayTime);
+      }
+      if (!Number.isFinite(rawTime)) {
+        console.warn('LMO pick save skipped because section offsets are not ready.');
+        return null;
+      }
+      return rawTime;
+    }
+
     async function handlePickNormalized({ trace, time, shiftKey, ctrlKey, altKey }) {
       if (isPickMode && dragOverride === 'pan') return;
       if (!Number.isFinite(trace) || !Number.isFinite(time)) return;
@@ -2967,21 +3068,28 @@
 
         if (ctrlKey) {
           if (deleteRangeStart === null) {
-            setDeleteRangeAnchor(trInt);
+            setDeleteRangeAnchor(trInt, time);
             return;
           }
-          const x0 = deleteRangeStart;
+          const deleteAnchor = normalizeDeleteRangeAnchor(deleteRangeStart);
           clearPendingPickState('delete-range-complete');
+          if (!deleteAnchor) return;
+          const x0 = deleteAnchor.trace;
           const x1 = trInt;
           const start = Math.min(x0, x1);
           const end = Math.max(x0, x1);
-          const toDelete = picks.filter(p => Math.round(p.trace) >= start && Math.round(p.trace) <= end);
+          const toDelete = getLocalPicksInTraceRangeForDisplayDelete(deleteAnchor, trInt, time);
+          if (toDelete.length === 0) {
+            D('PICKS@handlePickNormalized:delete-range-empty', { range: [start, end] });
+            return;
+          }
+          const deleteTraces = new Set(toDelete.map((p) => p.trace | 0));
           const historyChanges = toDelete.map((p) => {
             const before = cloneManualPick(p);
             return { trace: before.trace, before, after: null };
           });
-          const promises = toDelete.map(p => deletePick(Math.round(p.trace)));
-          picks = picks.filter(p => Math.round(p.trace) < start || Math.round(p.trace) > end);
+          const promises = toDelete.map(p => deletePick(p.trace));
+          picks = picks.filter(p => !deleteTraces.has(p.trace | 0));
           await Promise.all(promises);
           recordManualPickHistory(historyChanges);
           D('PICKS@handlePickNormalized:line', { range: [start, end], count: picks.length });
@@ -3005,23 +3113,32 @@
 
           const promises = [];
           const historyChanges = [];
+          const linePickWrites = [];
           for (let x = xStart; x <= xEnd; x++) {
             const y = x1 === x0 ? y1 : y0 + slope * (x - x0);
             const snapped = snapTimeFromDataY(y);
-            const tAdj = adjustPickToFeature(x, snapped);
+            const displayTime = adjustPickToFeature(x, snapped);
+            const rawTime = await displayPickTimeToRawTime(x, displayTime);
+            if (rawTime === null) return;
 
-            const before = getLocalPickOnTrace(x);
+            const before = getLocalPickOnTraceForDisplayClick(x, displayTime);
+            linePickWrites.push({ trace: x, before, rawTime });
+          }
+
+          for (const write of linePickWrites) {
+            const x = write.trace;
+            const before = write.before;
             const hadExisting = !!before;
             removeAllPicksOnTrace(x);
             if (hadExisting) {
               promises.push(deletePick(x));
             }
-            upsertLocalPick(x, tAdj);
-            promises.push(postPick(x, tAdj));
+            upsertLocalPick(x, write.rawTime);
+            promises.push(postPick(x, write.rawTime));
             historyChanges.push({
               trace: x,
               before,
-              after: { trace: x, time: tAdj },
+              after: { trace: x, time: write.rawTime },
             });
           }
           await Promise.all(promises);
@@ -3033,19 +3150,26 @@
 
         clearPendingPickState('single-pick');
 
+        const displayTime = adjustPickToFeature(trInt, time);
+        const rawTime = await displayPickTimeToRawTime(trInt, displayTime);
+        if (rawTime === null) return;
+
         const promises = [];
-        const before = getLocalPickOnTrace(trInt);
+        const before = getLocalPickOnTraceForDisplayClick(trInt, displayTime);
         const hadExisting = !!before;
         removeAllPicksOnTrace(trInt);
         if (hadExisting) {
           promises.push(deletePick(trInt));
         }
-        const tAdj = adjustPickToFeature(trInt, time);
-        upsertLocalPick(trInt, tAdj);
-        promises.push(postPick(trInt, tAdj));
+        upsertLocalPick(trInt, rawTime);
+        promises.push(postPick(trInt, rawTime));
         await Promise.all(promises);
-        recordManualPickHistory([{ trace: trInt, before, after: { trace: trInt, time: tAdj } }]);
-        D('PICKS@handlePickNormalized:single', { add: { trace: trInt, time: tAdj }, count: picks.length });
+        recordManualPickHistory([{ trace: trInt, before, after: { trace: trInt, time: rawTime } }]);
+        D('PICKS@handlePickNormalized:single', {
+          add: { trace: trInt, time: rawTime },
+          displayTime,
+          count: picks.length,
+        });
         schedulePickOverlayUpdate();
       } finally {
         handlePickNormalized._busy = false;
@@ -3246,4 +3370,11 @@
       if (e.key === 'Shift') {
         clearPendingPickState('shift-keyup', { keepDeleteRange: true });
       }
+    });
+
+    window.addEventListener('lmo:change', () => {
+      if (linePickStart || deleteRangeStart !== null) {
+        clearPendingPickState('lmo-change');
+      }
+      schedulePickOverlayUpdate();
     });

--- a/app/static/viewer/window_render.js
+++ b/app/static/viewer/window_render.js
@@ -408,6 +408,7 @@
         xMin: x0,
         xMax: endTrace,
         showPredicted: showPred,
+        timeTransform: window.pickRawTimeToDisplayTime,
       });
       const pendingPickTr = buildPendingPickMarkerTrace({
         pending: typeof window.getPendingPickOverlayState === 'function'
@@ -697,6 +698,7 @@
         xMin: x0,
         xMax: x1,
         showPredicted: showPred,
+        timeTransform: window.pickRawTimeToDisplayTime,
       });
       const pendingPickTr = buildPendingPickMarkerTrace({
         pending: typeof window.getPendingPickOverlayState === 'function'

--- a/app/tests/e2e/test_lmo_pick_transforms.py
+++ b/app/tests/e2e/test_lmo_pick_transforms.py
@@ -1,0 +1,303 @@
+import pytest
+
+
+@pytest.mark.e2e
+def test_playwright_lmo_pick_helpers_apply_display_raw_transforms(
+    page, base_url, e2e_debug
+):
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => typeof window.rawTimeToDisplayTime === 'function' "
+        "&& typeof window.displayTimeToRawTime === 'function' "
+        "&& typeof window.buildPickMarkerTraces === 'function' "
+        "&& typeof window.msgpack?.encode === 'function'"
+    )
+
+    result = page.evaluate(
+        """async () => {
+            const originalFetch = window.fetch.bind(window);
+            let offsetFetches = 0;
+
+            window.fetch = (input, init) => {
+                const url = String(input instanceof Request ? input.url : input);
+                if (url.includes('/get_section_offsets_bin')) {
+                    offsetFetches += 1;
+                    const offsets = new Float32Array([10, 20, 40]);
+                    const payload = window.msgpack.encode({
+                        file_id: 'pick-lmo-file',
+                        key1: 7,
+                        key1_byte: 189,
+                        key2_byte: 193,
+                        offset_byte: 41,
+                        dtype: 'float32',
+                        shape: [offsets.length],
+                        offsets: new Uint8Array(offsets.buffer),
+                    });
+                    return Promise.resolve(new Response(payload, { status: 200 }));
+                }
+                return originalFetch(input, init);
+            };
+
+            try {
+                window.setCurrentLinearMoveout({
+                    enabled: true,
+                    velocityMps: 10,
+                    offsetByte: 41,
+                    offsetScale: 1,
+                    offsetMode: 'signed',
+                    refMode: 'zero',
+                    refTrace: 0,
+                    polarity: 1,
+                });
+                window.currentFileId = 'pick-lmo-file';
+                window.currentKey1Byte = 189;
+                window.currentKey2Byte = 193;
+                window.key1Values = [7];
+                document.getElementById('key1_slider').value = '0';
+
+                const beforeReady = window.rawTimeToDisplayTime(1, 7);
+                let display = NaN;
+                for (let i = 0; i < 50; i += 1) {
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                    display = window.rawTimeToDisplayTime(1, 7);
+                    if (Number.isFinite(display)) break;
+                }
+
+                const traces = window.buildPickMarkerTraces({
+                    manualPicks: [{ trace: 1, time: 7 }],
+                    predicted: [{ trace: 2, time: 9 }],
+                    xMin: 0,
+                    xMax: 2,
+                    showPredicted: true,
+                    timeTransform: window.pickRawTimeToDisplayTime,
+                });
+                const rawFromDisplay = window.displayTimeToRawTime(2, 5);
+
+                window.currentFileId = '';
+                window.key1Values = [];
+                window.setCurrentLinearMoveout({ enabled: false });
+                const offDisplay = window.rawTimeToDisplayTime(2, 9);
+                const offRaw = window.displayTimeToRawTime(2, 5);
+
+                return {
+                    beforeReadyIsNaN: Number.isNaN(beforeReady),
+                    display,
+                    rawFromDisplay,
+                    manualY: Array.from(traces[0].y),
+                    predictedY: Array.from(traces[1].y),
+                    offsetFetches,
+                    offDisplay,
+                    offRaw,
+                };
+            } finally {
+                window.fetch = originalFetch;
+            }
+        }"""
+    )
+
+    assert result == {
+        "beforeReadyIsNaN": True,
+        "display": 5,
+        "rawFromDisplay": 9,
+        "manualY": [5],
+        "predictedY": [5],
+        "offsetFetches": 1,
+        "offDisplay": 9,
+        "offRaw": 5,
+    }
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_playwright_lmo_failed_single_pick_conversion_keeps_existing_raw_pick(
+    page, base_url, e2e_debug
+):
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => typeof handlePickNormalized === 'function' "
+        "&& typeof window.debugDump === 'function' "
+        "&& typeof window.setCurrentLinearMoveout === 'function'"
+    )
+
+    result = page.evaluate(
+        """async () => {
+            const originalFetch = window.fetch.bind(window);
+            const calls = [];
+
+            window.fetch = (input, init = {}) => {
+                const url = String(input instanceof Request ? input.url : input);
+                const method = String(init.method || (input instanceof Request ? input.method : 'GET')).toUpperCase();
+                calls.push({ url, method });
+                if (url.includes('/get_section_offsets_bin')) {
+                    return Promise.resolve(new Response('{}', { status: 409 }));
+                }
+                if (url.includes('/get_section_meta')) {
+                    return Promise.resolve(new Response(JSON.stringify({
+                        shape: [3, 3],
+                        dt: 1,
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    }));
+                }
+                if (url.includes('/get_section_window_bin')) {
+                    return Promise.resolve(new Response('{}', { status: 409 }));
+                }
+                if (url.includes('/picks')) {
+                    return Promise.resolve(new Response('{}', {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    }));
+                }
+                return originalFetch(input, init);
+            };
+
+            try {
+                currentFileId = 'pick-lmo-missing-offsets-file';
+                currentKey1Byte = 189;
+                currentKey2Byte = 193;
+                key1Values = [7];
+                document.getElementById('key1_slider').value = '0';
+                document.getElementById('snap_mode').value = 'none';
+                document.getElementById('snap_refine').value = 'none';
+                picks = [{ trace: 1, time: 11 }];
+                isPickMode = true;
+
+                window.setCurrentLinearMoveout({
+                    enabled: true,
+                    velocityMps: 10,
+                    offsetByte: 41,
+                    offsetScale: 1,
+                    offsetMode: 'signed',
+                    refMode: 'zero',
+                    refTrace: 0,
+                    polarity: 1,
+                });
+
+                await handlePickNormalized({
+                    trace: 1,
+                    time: 5,
+                    shiftKey: false,
+                    ctrlKey: false,
+                    altKey: false,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 180));
+
+                return {
+                    picks: window.debugDump().picks,
+                    pickCalls: calls.filter((call) => call.url.includes('/picks')),
+                    offsetFetches: calls.filter((call) => call.url.includes('/get_section_offsets_bin')).length,
+                };
+            } finally {
+                isPickMode = false;
+                window.setCurrentLinearMoveout({ enabled: false });
+                window.fetch = originalFetch;
+            }
+        }"""
+    )
+
+    assert result["picks"] == [{"tr": 1, "t": 11}]
+    assert result["pickCalls"] == []
+    assert result["offsetFetches"] >= 1
+    e2e_debug.assert_clean()
+
+
+@pytest.mark.e2e
+def test_playwright_lmo_failed_delete_hit_test_keeps_existing_raw_pick(
+    page, base_url, e2e_debug
+):
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+    page.wait_for_function(
+        "() => typeof handlePickNormalized === 'function' "
+        "&& typeof window.debugDump === 'function' "
+        "&& typeof window.setCurrentLinearMoveout === 'function'"
+    )
+
+    result = page.evaluate(
+        """async () => {
+            const originalFetch = window.fetch.bind(window);
+            const calls = [];
+
+            window.fetch = (input, init = {}) => {
+                const url = String(input instanceof Request ? input.url : input);
+                const method = String(init.method || (input instanceof Request ? input.method : 'GET')).toUpperCase();
+                calls.push({ url, method });
+                if (url.includes('/get_section_offsets_bin')) {
+                    return Promise.resolve(new Response('{}', { status: 409 }));
+                }
+                if (url.includes('/get_section_meta')) {
+                    return Promise.resolve(new Response(JSON.stringify({
+                        shape: [3, 3],
+                        dt: 1,
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    }));
+                }
+                if (url.includes('/get_section_window_bin')) {
+                    return Promise.resolve(new Response('{}', { status: 409 }));
+                }
+                if (url.includes('/picks')) {
+                    return Promise.resolve(new Response('{}', {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    }));
+                }
+                return originalFetch(input, init);
+            };
+
+            try {
+                currentFileId = 'pick-lmo-missing-delete-offsets-file';
+                currentKey1Byte = 189;
+                currentKey2Byte = 193;
+                key1Values = [7];
+                document.getElementById('key1_slider').value = '0';
+                document.getElementById('snap_mode').value = 'none';
+                document.getElementById('snap_refine').value = 'none';
+                picks = [{ trace: 1, time: 11 }];
+                isPickMode = true;
+
+                window.setCurrentLinearMoveout({
+                    enabled: true,
+                    velocityMps: 10,
+                    offsetByte: 41,
+                    offsetScale: 1,
+                    offsetMode: 'signed',
+                    refMode: 'zero',
+                    refTrace: 0,
+                    polarity: 1,
+                });
+
+                await handlePickNormalized({
+                    trace: 1,
+                    time: 5,
+                    shiftKey: false,
+                    ctrlKey: true,
+                    altKey: false,
+                });
+                await handlePickNormalized({
+                    trace: 1,
+                    time: 5,
+                    shiftKey: false,
+                    ctrlKey: true,
+                    altKey: false,
+                });
+                await new Promise((resolve) => setTimeout(resolve, 180));
+
+                return {
+                    picks: window.debugDump().picks,
+                    pickCalls: calls.filter((call) => call.url.includes('/picks')),
+                    offsetFetches: calls.filter((call) => call.url.includes('/get_section_offsets_bin')).length,
+                };
+            } finally {
+                isPickMode = false;
+                window.setCurrentLinearMoveout({ enabled: false });
+                window.fetch = originalFetch;
+            }
+        }"""
+    )
+
+    assert result["picks"] == [{"tr": 1, "t": 11}]
+    assert result["pickCalls"] == []
+    assert result["offsetFetches"] >= 1
+    e2e_debug.assert_clean()


### PR DESCRIPTION
Closes #271

## Summary
- Frontend: pick overlay と pick 保存を LMO 座標変換に対応させる

## Changed files
- `app/static/viewer/core/layout.js`
- `app/static/viewer/legacy_globals.js`
- `app/static/viewer/viewer_legacy.js`
- `app/static/viewer/window_render.js`
- `app/tests/e2e/test_lmo_pick_transforms.py`

## Checks
- `.work/codex/checks.log`: 341 passed in 43.36s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
