### PR TITLE
[PR1/trace-store] TraceStore 登録・meta 更新処理を upload router から service へ移す

### DIFF
--- a/app/api/routers/upload.py
+++ b/app/api/routers/upload.py
@@ -8,7 +8,6 @@ import json
 import logging
 import re
 import shutil
-import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,10 +27,10 @@ from app.services.staged_upload_cleanup import (
     cleanup_staged_upload,
     cleanup_stale_staged_upload_dirs,
 )
+from app.services.trace_store_registration import register_trace_store
 from app.utils.ingest import SegyIngestor
 from app.utils.baseline_artifacts import has_split_baseline_artifacts
 from app.utils.header_qc import inspect_segy_header_qc
-from app.trace_store.reader import TraceStoreSectionReader
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -278,13 +277,6 @@ def _archive_trace_store(store_dir: Path) -> None:
     store_dir.rename(archive_dir)
 
 
-def _touch_trace_store_meta(store_dir: Path) -> None:
-    meta_path = store_dir / 'meta.json'
-    if not meta_path.exists():
-        return
-    meta_path.touch()
-
-
 def _trace_store_summary(store_dir: Path) -> dict | None:
     meta_path = store_dir / 'meta.json'
     meta = _load_trace_store_meta(meta_path)
@@ -351,24 +343,6 @@ def _list_recent_dataset_summaries() -> list[dict]:
 
     summaries.sort(key=lambda item: item['last_used_ts'], reverse=True)
     return summaries
-
-
-def _register_trace_store(
-    file_id: str,
-    store_dir: Path,
-    key1_byte: int,
-    key2_byte: int,
-    *,
-    state: AppState,
-) -> TraceStoreSectionReader:
-    reader = TraceStoreSectionReader(store_dir, key1_byte, key2_byte)
-    cache_key = f'{file_id}_{key1_byte}_{key2_byte}'
-    with state.lock:
-        state.cached_readers[cache_key] = reader
-    threading.Thread(target=reader.preload_all_sections, daemon=True).start()
-    for b in {key1_byte, key2_byte}:
-        threading.Thread(target=reader.ensure_header, args=(b,), daemon=True).start()
-    return reader
 
 
 async def _save_upload_file(
@@ -447,12 +421,15 @@ async def _ingest_saved_segy(
             source_size=source_size,
         )
         logger.info('Reusing trace store for %s', original_name)
-        _register_trace_store(file_id, store_dir, key1_byte, key2_byte, state=state)
-        _touch_trace_store_meta(store_dir)
-        state.file_registry.update(
-            file_id,
-            store_path=str(store_dir),
-            dt=meta.get('dt'),
+        register_trace_store(
+            state=state,
+            file_id=file_id,
+            store_dir=store_dir,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
+            dt=meta.get('dt') if isinstance(meta, dict) else None,
+            update_registry=True,
+            touch_meta=True,
         )
         return {'file_id': file_id, 'reused_trace_store': True}
 
@@ -465,16 +442,16 @@ async def _ingest_saved_segy(
         key2_byte,
         source_sha256=source_sha256,
     )
-    _register_trace_store(file_id, store_dir, key1_byte, key2_byte, state=state)
-    _touch_trace_store_meta(store_dir)
-    if isinstance(meta, dict):
-        state.file_registry.update(
-            file_id,
-            store_path=str(store_dir),
-            dt=meta.get('dt'),
-        )
-    else:
-        state.file_registry.update(file_id, store_path=str(store_dir))
+    register_trace_store(
+        state=state,
+        file_id=file_id,
+        store_dir=store_dir,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        dt=meta.get('dt') if isinstance(meta, dict) else None,
+        update_registry=True,
+        touch_meta=True,
+    )
     return {'file_id': file_id, 'reused_trace_store': False}
 
 
@@ -558,14 +535,16 @@ async def open_segy(
             key2_byte,
             source_sha256=source_sha256,
         )
-    _register_trace_store(file_id, store_dir, key1_byte, key2_byte, state=state)
-    _touch_trace_store_meta(store_dir)
-    if isinstance(meta, dict):
-        state.file_registry.update(
-            file_id,
-            store_path=str(store_dir),
-            dt=meta.get('dt'),
-        )
+    register_trace_store(
+        state=state,
+        file_id=file_id,
+        store_dir=store_dir,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        dt=meta.get('dt') if isinstance(meta, dict) else None,
+        update_registry=True,
+        touch_meta=True,
+    )
     return {'file_id': file_id, 'reused_trace_store': reused}
 
 

--- a/app/services/trace_store_registration.py
+++ b/app/services/trace_store_registration.py
@@ -1,0 +1,63 @@
+"""Trace store reader registration helpers."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from pathlib import Path
+
+from app.core.state import AppState
+from app.trace_store.reader import TraceStoreSectionReader
+
+
+def trace_store_cache_key(file_id: str, key1_byte: int, key2_byte: int) -> str:
+    return f'{file_id}_{key1_byte}_{key2_byte}'
+
+
+def touch_trace_store_meta(store_dir: str | Path) -> None:
+    meta_path = Path(store_dir) / 'meta.json'
+    if not meta_path.exists():
+        return
+    meta_path.touch()
+
+
+def register_trace_store(
+    *,
+    state: AppState,
+    file_id: str,
+    store_dir: str | Path,
+    key1_byte: int,
+    key2_byte: int,
+    dt: float | None = None,
+    update_registry: bool = True,
+    touch_meta: bool = True,
+    preload_header_bytes: Iterable[int] = (),
+) -> TraceStoreSectionReader:
+    store_path = Path(store_dir)
+    reader = TraceStoreSectionReader(store_path, key1_byte, key2_byte)
+    cache_key = trace_store_cache_key(file_id, key1_byte, key2_byte)
+    with state.lock:
+        state.cached_readers[cache_key] = reader
+
+    threading.Thread(target=reader.preload_all_sections, daemon=True).start()
+
+    header_bytes = dict.fromkeys((key1_byte, key2_byte, *preload_header_bytes))
+    for header_byte in header_bytes:
+        threading.Thread(
+            target=reader.ensure_header,
+            args=(header_byte,),
+            daemon=True,
+        ).start()
+
+    if touch_meta:
+        touch_trace_store_meta(store_path)
+    if update_registry:
+        state.file_registry.update(file_id, store_path=str(store_path), dt=dt)
+    return reader
+
+
+__all__ = [
+    'register_trace_store',
+    'touch_trace_store_meta',
+    'trace_store_cache_key',
+]

--- a/app/tests/test_open_segy_incomplete_store.py
+++ b/app/tests/test_open_segy_incomplete_store.py
@@ -90,7 +90,28 @@ def _open_env(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(upload_mod, 'TRACE_DIR', trace_dir, raising=True)
 
     # open_segy で segyio を触らないようにする（Thread/preload/ensure_header を止める）
-    monkeypatch.setattr(upload_mod, '_register_trace_store', lambda *a, **k: None)
+    def _fake_register(
+        *,
+        state,
+        file_id,
+        store_dir,
+        dt=None,
+        update_registry=True,
+        touch_meta=True,
+        **_kwargs,
+    ):
+        if touch_meta:
+            meta_path = Path(store_dir) / 'meta.json'
+            if meta_path.exists():
+                meta_path.touch()
+        if update_registry:
+            state.file_registry.update(
+                file_id,
+                store_path=str(store_dir),
+                dt=dt,
+            )
+
+    monkeypatch.setattr(upload_mod, 'register_trace_store', _fake_register)
 
     calls: dict[str, object] = {'ingest': 0, 'args': None, 'source_sha256': None}
 

--- a/app/tests/test_open_segy_reuse_complete_store.py
+++ b/app/tests/test_open_segy_reuse_complete_store.py
@@ -73,7 +73,16 @@ def _open_env(tmp_path: Path, monkeypatch):
     captured: dict[str, object] = {'register': None}
 
     def _fake_register(
-        file_id: str, store_dir: Path, key1_byte: int, key2_byte: int, *, state
+        *,
+        state,
+        file_id,
+        store_dir,
+        key1_byte,
+        key2_byte,
+        dt=None,
+        update_registry=True,
+        touch_meta=True,
+        **_kwargs,
     ):
         captured['register'] = (
             str(file_id),
@@ -81,10 +90,20 @@ def _open_env(tmp_path: Path, monkeypatch):
             int(key1_byte),
             int(key2_byte),
         )
+        if touch_meta:
+            meta_path = Path(store_dir) / 'meta.json'
+            if meta_path.exists():
+                meta_path.touch()
+        if update_registry:
+            state.file_registry.update(
+                file_id,
+                store_path=str(store_dir),
+                dt=dt,
+            )
         return None
 
     monkeypatch.setattr(
-        upload_mod, '_register_trace_store', _fake_register, raising=True
+        upload_mod, 'register_trace_store', _fake_register, raising=True
     )
 
     calls: dict[str, int] = {'ingest': 0}

--- a/app/tests/test_staged_segy_upload.py
+++ b/app/tests/test_staged_segy_upload.py
@@ -63,7 +63,28 @@ def _staged_env(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(upload_mod, 'UPLOAD_DIR', upload_root, raising=True)
     monkeypatch.setattr(upload_mod, 'PROCESSED_DIR', processed, raising=True)
     monkeypatch.setattr(upload_mod, 'TRACE_DIR', trace_dir, raising=True)
-    monkeypatch.setattr(upload_mod, '_register_trace_store', lambda *a, **k: None)
+    def _fake_register(
+        *,
+        state,
+        file_id,
+        store_dir,
+        dt=None,
+        update_registry=True,
+        touch_meta=True,
+        **_kwargs,
+    ):
+        if touch_meta:
+            meta_path = Path(store_dir) / 'meta.json'
+            if meta_path.exists():
+                meta_path.touch()
+        if update_registry:
+            state.file_registry.update(
+                file_id,
+                store_path=str(store_dir),
+                dt=dt,
+            )
+
+    monkeypatch.setattr(upload_mod, 'register_trace_store', _fake_register)
 
     calls = {'qc': 0, 'ingest': 0}
 

--- a/app/tests/test_trace_store_registration.py
+++ b/app/tests/test_trace_store_registration.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.state import create_app_state
+
+
+class _StubReader:
+    created: list["_StubReader"] = []
+
+    def __init__(self, store_dir: Path, key1_byte: int, key2_byte: int):
+        self.store_dir = Path(store_dir)
+        self.key1_byte = key1_byte
+        self.key2_byte = key2_byte
+        _StubReader.created.append(self)
+
+    def preload_all_sections(self) -> None:
+        pass
+
+    def ensure_header(self, _header_byte: int) -> None:
+        pass
+
+
+class _CapturedThread:
+    created: list["_CapturedThread"] = []
+
+    def __init__(self, *, target, args=(), daemon=None):
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+        _CapturedThread.created.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+
+@pytest.fixture()
+def registration_env(monkeypatch):
+    from app.services import trace_store_registration as registration
+
+    _StubReader.created.clear()
+    _CapturedThread.created.clear()
+    monkeypatch.setattr(
+        registration,
+        'TraceStoreSectionReader',
+        _StubReader,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        registration,
+        'threading',
+        SimpleNamespace(Thread=_CapturedThread),
+        raising=True,
+    )
+    return registration, create_app_state()
+
+
+def _target_name(thread: _CapturedThread) -> str:
+    return getattr(thread.target, '__name__', '')
+
+
+def test_trace_store_cache_key_keeps_existing_format(registration_env):
+    registration, _state = registration_env
+
+    assert registration.trace_store_cache_key('file-a', 189, 193) == 'file-a_189_193'
+
+
+def test_register_trace_store_adds_reader_to_state_cache(
+    registration_env,
+    tmp_path: Path,
+):
+    registration, state = registration_env
+
+    reader = registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        update_registry=False,
+        touch_meta=False,
+    )
+
+    assert reader is _StubReader.created[0]
+    assert reader.store_dir == tmp_path
+    with state.lock:
+        assert state.cached_readers['file-a_189_193'] is reader
+
+
+def test_register_trace_store_starts_preload_all_sections_thread(
+    registration_env,
+    tmp_path: Path,
+):
+    registration, state = registration_env
+
+    reader = registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        update_registry=False,
+        touch_meta=False,
+    )
+
+    preload_threads = [
+        thread
+        for thread in _CapturedThread.created
+        if _target_name(thread) == 'preload_all_sections'
+    ]
+    assert len(preload_threads) == 1
+    thread = preload_threads[0]
+    assert thread.target.__self__ is reader
+    assert thread.daemon is True
+    assert thread.started is True
+
+
+def test_register_trace_store_starts_unique_header_preload_threads(
+    registration_env,
+    tmp_path: Path,
+):
+    registration, state = registration_env
+
+    reader = registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        update_registry=False,
+        touch_meta=False,
+        preload_header_bytes=[193, 201, 189, 201],
+    )
+
+    header_threads = [
+        thread
+        for thread in _CapturedThread.created
+        if _target_name(thread) == 'ensure_header'
+    ]
+    assert sorted(thread.args[0] for thread in header_threads) == [189, 193, 201]
+    assert all(thread.target.__self__ is reader for thread in header_threads)
+    assert all(thread.daemon is True for thread in header_threads)
+    assert all(thread.started is True for thread in header_threads)
+
+
+def test_register_trace_store_updates_file_registry_with_store_path_and_dt(
+    registration_env,
+    tmp_path: Path,
+):
+    registration, state = registration_env
+
+    registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        dt=0.004,
+        touch_meta=False,
+    )
+
+    record = state.file_registry.get_record('file-a')
+    assert isinstance(record, dict)
+    assert record['store_path'] == str(tmp_path)
+    assert record['dt'] == pytest.approx(0.004)
+
+
+def test_register_trace_store_updates_file_registry_with_store_path_when_dt_is_none(
+    registration_env,
+    tmp_path: Path,
+):
+    registration, state = registration_env
+
+    registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        dt=None,
+        touch_meta=False,
+    )
+
+    record = state.file_registry.get_record('file-a')
+    assert isinstance(record, dict)
+    assert record['store_path'] == str(tmp_path)
+    assert 'dt' not in record
+
+
+def test_register_trace_store_can_skip_file_registry_update(
+    registration_env,
+    tmp_path: Path,
+):
+    registration, state = registration_env
+
+    registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        dt=0.004,
+        update_registry=False,
+        touch_meta=False,
+    )
+
+    assert state.file_registry.get_record('file-a') is None
+
+
+def test_register_trace_store_touches_existing_meta(registration_env, tmp_path: Path):
+    registration, state = registration_env
+    meta_path = tmp_path / 'meta.json'
+    meta_path.write_text('{}', encoding='utf-8')
+    old_mtime = 1000.0
+    os.utime(meta_path, (old_mtime, old_mtime))
+
+    registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        update_registry=False,
+    )
+
+    assert meta_path.stat().st_mtime > old_mtime
+
+
+def test_register_trace_store_missing_meta_is_noop(registration_env, tmp_path: Path):
+    registration, state = registration_env
+
+    registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        update_registry=False,
+    )
+
+    assert not (tmp_path / 'meta.json').exists()
+
+
+def test_register_trace_store_can_skip_meta_touch(registration_env, tmp_path: Path):
+    registration, state = registration_env
+    meta_path = tmp_path / 'meta.json'
+    meta_path.write_text('{}', encoding='utf-8')
+    old_mtime = 1000.0
+    os.utime(meta_path, (old_mtime, old_mtime))
+
+    registration.register_trace_store(
+        state=state,
+        file_id='file-a',
+        store_dir=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        update_registry=False,
+        touch_meta=False,
+    )
+
+    assert meta_path.stat().st_mtime == pytest.approx(old_mtime)

--- a/app/tests/test_upload_segy_reuse_archive.py
+++ b/app/tests/test_upload_segy_reuse_archive.py
@@ -74,7 +74,28 @@ def _upload_env(
     monkeypatch.setattr(upload_mod, 'PROCESSED_DIR', processed, raising=True)
     monkeypatch.setattr(upload_mod, 'TRACE_DIR', trace_dir, raising=True)
 
-    monkeypatch.setattr(upload_mod, '_register_trace_store', lambda *a, **k: None)
+    def _fake_register(
+        *,
+        state,
+        file_id,
+        store_dir,
+        dt=None,
+        update_registry=True,
+        touch_meta=True,
+        **_kwargs,
+    ):
+        if touch_meta:
+            meta_path = Path(store_dir) / 'meta.json'
+            if meta_path.exists():
+                meta_path.touch()
+        if update_registry:
+            state.file_registry.update(
+                file_id,
+                store_path=str(store_dir),
+                dt=dt,
+            )
+
+    monkeypatch.setattr(upload_mod, 'register_trace_store', _fake_register)
 
     calls = {'ingest': 0}
 


### PR DESCRIPTION
Closes #277

## Summary
- [PR1/trace-store] TraceStore 登録・meta 更新処理を upload router から service へ移す

## Changed files
- `app/api/routers/upload.py`
- `app/services/trace_store_registration.py`
- `app/tests/test_open_segy_incomplete_store.py`
- `app/tests/test_open_segy_reuse_complete_store.py`
- `app/tests/test_staged_segy_upload.py`
- `app/tests/test_trace_store_registration.py`
- `app/tests/test_upload_segy_reuse_archive.py`

## Checks
- `.work/codex/checks.log`: 371 passed in 43.49s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
