### PR TITLE
[PR1/trace-store] raw baseline artifact 用の統計計算を再利用可能 helper へ切り出す

### DIFF
--- a/app/services/trace_store_baselines.py
+++ b/app/services/trace_store_baselines.py
@@ -1,0 +1,220 @@
+"""Reusable helpers for TraceStore raw baseline artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from app.utils.baseline_artifacts import (
+    build_raw_baseline_payload,
+    build_trace_spans_by_key1,
+    write_raw_baseline_artifacts,
+)
+
+ZERO_STD_EPS = 1e-12
+
+
+@dataclass(frozen=True)
+class RawBaselineStats:
+    mu_traces: np.ndarray
+    sigma_traces: np.ndarray
+    zero_var_mask: np.ndarray
+    mu_sections: np.ndarray
+    sigma_sections: np.ndarray
+    trace_spans_by_key1: dict[str, list[list[int]]]
+
+
+def _ensure_1d_array(name: str, value: np.ndarray) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.ndim != 1:
+        msg = f'{name} must be 1-dimensional'
+        raise ValueError(msg)
+    return arr
+
+
+def _ensure_finite_f64(name: str, value: np.ndarray) -> np.ndarray:
+    try:
+        arr = np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        msg = f'{name} must contain finite numeric values'
+        raise ValueError(msg) from exc
+    if not np.all(np.isfinite(arr)):
+        msg = f'{name} must contain finite values'
+        raise ValueError(msg)
+    return arr
+
+
+def _ensure_index_i64(name: str, value: np.ndarray) -> np.ndarray:
+    arr = _ensure_1d_array(name, value)
+    arr_f64 = _ensure_finite_f64(name, arr)
+    if not np.all(arr_f64 == np.trunc(arr_f64)):
+        msg = f'{name} must contain integer values'
+        raise ValueError(msg)
+    return arr_f64.astype(np.int64, copy=False)
+
+
+def _validate_section_spans(
+    *,
+    key1_offsets: np.ndarray,
+    key1_counts: np.ndarray,
+    n_traces: int,
+) -> None:
+    if np.any(key1_offsets < 0):
+        msg = 'key1_offsets must not contain negative values'
+        raise ValueError(msg)
+    if np.any(key1_counts <= 0):
+        msg = 'key1_counts must contain positive values'
+        raise ValueError(msg)
+    if key1_offsets.size > 1 and np.any(np.diff(key1_offsets) <= 0):
+        msg = 'key1_offsets must be ascending'
+        raise ValueError(msg)
+
+    expected_offsets = np.empty_like(key1_offsets)
+    expected_offsets[0] = 0
+    if key1_offsets.size > 1:
+        expected_offsets[1:] = key1_offsets[:-1] + key1_counts[:-1]
+    if not np.array_equal(key1_offsets, expected_offsets):
+        msg = 'section spans must be contiguous'
+        raise ValueError(msg)
+
+    last_end = int(key1_offsets[-1] + key1_counts[-1])
+    if last_end != int(n_traces):
+        msg = 'section spans must cover all traces'
+        raise ValueError(msg)
+
+
+def compute_raw_baseline_stats(
+    *,
+    key1_values: np.ndarray,
+    key1_offsets: np.ndarray,
+    key1_counts: np.ndarray,
+    trace_sum: np.ndarray,
+    trace_sumsq: np.ndarray,
+    n_samples: int,
+) -> RawBaselineStats:
+    if n_samples <= 0:
+        msg = 'n_samples must be positive'
+        raise ValueError(msg)
+
+    trace_sum_arr = _ensure_1d_array('trace_sum', trace_sum)
+    trace_sumsq_arr = _ensure_1d_array('trace_sumsq', trace_sumsq)
+    if trace_sum_arr.shape != trace_sumsq_arr.shape:
+        msg = 'trace_sum and trace_sumsq must have matching shapes'
+        raise ValueError(msg)
+    if trace_sum_arr.size == 0:
+        msg = 'trace_sum and trace_sumsq must not be empty'
+        raise ValueError(msg)
+    trace_sum_f64 = _ensure_finite_f64('trace_sum', trace_sum_arr)
+    trace_sumsq_f64 = _ensure_finite_f64('trace_sumsq', trace_sumsq_arr)
+
+    key1_values_arr = _ensure_1d_array('key1_values', key1_values)
+    key1_offsets_i64 = _ensure_index_i64('key1_offsets', key1_offsets)
+    key1_counts_i64 = _ensure_index_i64('key1_counts', key1_counts)
+    if (
+        key1_values_arr.shape != key1_offsets_i64.shape
+        or key1_values_arr.shape != key1_counts_i64.shape
+    ):
+        msg = 'key1_values, key1_offsets, and key1_counts must have matching shapes'
+        raise ValueError(msg)
+    if key1_values_arr.size == 0:
+        msg = 'key1 sections must not be empty'
+        raise ValueError(msg)
+
+    _validate_section_spans(
+        key1_offsets=key1_offsets_i64,
+        key1_counts=key1_counts_i64,
+        n_traces=int(trace_sum_f64.size),
+    )
+
+    n_samples_f64 = float(n_samples)
+    mu_traces = trace_sum_f64 / n_samples_f64
+    trace_var = np.maximum(
+        (trace_sumsq_f64 / n_samples_f64) - np.square(mu_traces),
+        0.0,
+    )
+    sigma_traces = np.sqrt(trace_var)
+    zero_var_mask = sigma_traces <= ZERO_STD_EPS
+    if zero_var_mask.any():
+        sigma_traces = sigma_traces.copy()
+        sigma_traces[zero_var_mask] = 1.0
+
+    section_sum = np.add.reduceat(trace_sum_f64, key1_offsets_i64)
+    section_sumsq = np.add.reduceat(trace_sumsq_f64, key1_offsets_i64)
+    total_samples = key1_counts_i64.astype(np.float64, copy=False) * n_samples_f64
+    mu_sections = section_sum / total_samples
+    section_var = np.maximum(
+        (section_sumsq / total_samples) - np.square(mu_sections),
+        0.0,
+    )
+    sigma_sections = np.sqrt(section_var)
+
+    return RawBaselineStats(
+        mu_traces=np.asarray(mu_traces, dtype=np.float32),
+        sigma_traces=np.asarray(sigma_traces, dtype=np.float32),
+        zero_var_mask=np.asarray(zero_var_mask, dtype=bool),
+        mu_sections=np.asarray(mu_sections, dtype=np.float32),
+        sigma_sections=np.asarray(sigma_sections, dtype=np.float32),
+        trace_spans_by_key1=build_trace_spans_by_key1(
+            key1_values_arr.astype(np.int64, copy=False),
+            key1_offsets_i64,
+            key1_counts_i64,
+        ),
+    )
+
+
+def write_trace_store_raw_baseline_artifacts(
+    *,
+    store_path: str | Path,
+    key1_byte: int,
+    key2_byte: int,
+    dtype_base: str,
+    dt: float | None,
+    key1_values: np.ndarray,
+    key1_offsets: np.ndarray,
+    key1_counts: np.ndarray,
+    trace_sum: np.ndarray,
+    trace_sumsq: np.ndarray,
+    n_samples: int,
+    source_sha256: str | None,
+) -> dict[str, Any]:
+    stats = compute_raw_baseline_stats(
+        key1_values=key1_values,
+        key1_offsets=key1_offsets,
+        key1_counts=key1_counts,
+        trace_sum=trace_sum,
+        trace_sumsq=trace_sumsq,
+        n_samples=n_samples,
+    )
+    payload = build_raw_baseline_payload(
+        dtype_base=dtype_base,
+        dt=dt,
+        key1_values=key1_values,
+        mu_sections=stats.mu_sections,
+        sigma_sections=stats.sigma_sections,
+        mu_traces=stats.mu_traces,
+        sigma_traces=stats.sigma_traces,
+        zero_var_mask=stats.zero_var_mask,
+        trace_spans_by_key1=stats.trace_spans_by_key1,
+        source_sha256=source_sha256,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        serialize_arrays=False,
+    )
+    write_raw_baseline_artifacts(
+        store_path,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        payload=payload,
+    )
+    return payload
+
+
+__all__ = [
+    'RawBaselineStats',
+    'ZERO_STD_EPS',
+    'compute_raw_baseline_stats',
+    'write_trace_store_raw_baseline_artifacts',
+]

--- a/app/tests/test_trace_store_baselines.py
+++ b/app/tests/test_trace_store_baselines.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import numpy as np
+import pytest
+
+from app.services.trace_store_baselines import (
+    compute_raw_baseline_stats,
+    write_trace_store_raw_baseline_artifacts,
+)
+from app.utils.baseline_artifacts import (
+    BASELINE_ARRAY_KEYS,
+    BASELINE_ARTIFACT_ID_FIELD,
+    BASELINE_STAGE_RAW,
+    build_baseline_manifest_path,
+    build_baseline_npz_path,
+)
+
+
+def _trace_stats(traces: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    return (
+        traces.sum(axis=1, dtype=np.float64),
+        np.einsum('ij,ij->i', traces, traces, dtype=np.float64),
+    )
+
+
+def _valid_compute_args() -> dict[str, Any]:
+    traces = np.asarray(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+        ],
+        dtype=np.float32,
+    )
+    trace_sum, trace_sumsq = _trace_stats(traces)
+    return {
+        'key1_values': np.asarray([10, 20], dtype=np.int64),
+        'key1_offsets': np.asarray([0, 2], dtype=np.int64),
+        'key1_counts': np.asarray([2, 1], dtype=np.int64),
+        'trace_sum': trace_sum,
+        'trace_sumsq': trace_sumsq,
+        'n_samples': traces.shape[1],
+    }
+
+
+def _compute_with(**overrides: Any):
+    args = _valid_compute_args()
+    args.update(overrides)
+    return compute_raw_baseline_stats(**args)
+
+
+def test_compute_raw_baseline_stats_matches_existing_formula() -> None:
+    traces = np.asarray(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [2.0, 4.0, 6.0, 8.0],
+            [-1.0, 0.0, 1.0, 2.0],
+            [4.0, 4.0, 4.0, 4.0],
+            [10.0, 12.0, 14.0, 16.0],
+        ],
+        dtype=np.float32,
+    )
+    trace_sum, trace_sumsq = _trace_stats(traces)
+    key1_values = np.asarray([10, 20], dtype=np.int64)
+    key1_offsets = np.asarray([0, 3], dtype=np.int64)
+    key1_counts = np.asarray([3, 2], dtype=np.int64)
+
+    stats = compute_raw_baseline_stats(
+        key1_values=key1_values,
+        key1_offsets=key1_offsets,
+        key1_counts=key1_counts,
+        trace_sum=trace_sum,
+        trace_sumsq=trace_sumsq,
+        n_samples=traces.shape[1],
+    )
+
+    n_samples_f64 = float(traces.shape[1])
+    expected_mu_traces = trace_sum / n_samples_f64
+    expected_trace_var = np.maximum(
+        (trace_sumsq / n_samples_f64) - np.square(expected_mu_traces),
+        0.0,
+    )
+    expected_sigma_traces = np.sqrt(expected_trace_var)
+    expected_zero_var_mask = expected_sigma_traces <= 1e-12
+    expected_sigma_traces[expected_zero_var_mask] = 1.0
+
+    section_sum = np.add.reduceat(trace_sum, key1_offsets)
+    section_sumsq = np.add.reduceat(trace_sumsq, key1_offsets)
+    total_samples = key1_counts.astype(np.float64) * n_samples_f64
+    expected_mu_sections = section_sum / total_samples
+    expected_section_var = np.maximum(
+        (section_sumsq / total_samples) - np.square(expected_mu_sections),
+        0.0,
+    )
+    expected_sigma_sections = np.sqrt(expected_section_var)
+
+    assert stats.mu_traces.dtype == np.float32
+    assert stats.sigma_traces.dtype == np.float32
+    assert stats.zero_var_mask.dtype == bool
+    assert stats.mu_sections.dtype == np.float32
+    assert stats.sigma_sections.dtype == np.float32
+    np.testing.assert_allclose(stats.mu_traces, expected_mu_traces.astype(np.float32))
+    np.testing.assert_allclose(
+        stats.sigma_traces,
+        expected_sigma_traces.astype(np.float32),
+    )
+    np.testing.assert_array_equal(stats.zero_var_mask, expected_zero_var_mask)
+    np.testing.assert_allclose(
+        stats.mu_sections,
+        expected_mu_sections.astype(np.float32),
+    )
+    np.testing.assert_allclose(
+        stats.sigma_sections,
+        expected_sigma_sections.astype(np.float32),
+    )
+
+
+def test_compute_raw_baseline_stats_sets_zero_variance_trace_sigma_to_one() -> None:
+    traces = np.asarray(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, 4.0, 4.0],
+            [10.0, 12.0, 14.0],
+        ],
+        dtype=np.float32,
+    )
+    trace_sum, trace_sumsq = _trace_stats(traces)
+
+    stats = compute_raw_baseline_stats(
+        key1_values=np.asarray([10, 20], dtype=np.int64),
+        key1_offsets=np.asarray([0, 2], dtype=np.int64),
+        key1_counts=np.asarray([2, 1], dtype=np.int64),
+        trace_sum=trace_sum,
+        trace_sumsq=trace_sumsq,
+        n_samples=3,
+    )
+
+    np.testing.assert_array_equal(
+        stats.zero_var_mask,
+        np.asarray([False, True, False], dtype=bool),
+    )
+    np.testing.assert_allclose(stats.sigma_traces[1], np.float32(1.0))
+
+
+def test_compute_raw_baseline_stats_does_not_replace_zero_variance_section_sigma() -> None:
+    traces = np.full((2, 3), 5.0, dtype=np.float32)
+    trace_sum, trace_sumsq = _trace_stats(traces)
+
+    stats = compute_raw_baseline_stats(
+        key1_values=np.asarray([10], dtype=np.int64),
+        key1_offsets=np.asarray([0], dtype=np.int64),
+        key1_counts=np.asarray([2], dtype=np.int64),
+        trace_sum=trace_sum,
+        trace_sumsq=trace_sumsq,
+        n_samples=3,
+    )
+
+    np.testing.assert_allclose(stats.sigma_traces, np.asarray([1.0, 1.0]))
+    np.testing.assert_allclose(stats.sigma_sections, np.asarray([0.0]))
+
+
+def test_compute_raw_baseline_stats_builds_trace_spans_by_key1() -> None:
+    stats = _compute_with(
+        key1_values=np.asarray([10, 20], dtype=np.int64),
+        key1_offsets=np.asarray([0, 2], dtype=np.int64),
+        key1_counts=np.asarray([2, 1], dtype=np.int64),
+    )
+
+    assert stats.trace_spans_by_key1 == {'10': [[0, 2]], '20': [[2, 3]]}
+
+
+def test_write_trace_store_raw_baseline_artifacts_writes_split_manifest_and_npz(
+    tmp_path,
+) -> None:
+    args = _valid_compute_args()
+    payload = write_trace_store_raw_baseline_artifacts(
+        store_path=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        dtype_base='float32',
+        dt=0.004,
+        source_sha256='abc123',
+        **args,
+    )
+
+    manifest_path = build_baseline_manifest_path(
+        tmp_path,
+        stage=BASELINE_STAGE_RAW,
+        key1_byte=189,
+        key2_byte=193,
+    )
+    npz_path = build_baseline_npz_path(
+        tmp_path,
+        stage=BASELINE_STAGE_RAW,
+        key1_byte=189,
+        key2_byte=193,
+    )
+
+    assert manifest_path.is_file()
+    assert npz_path.is_file()
+    manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    assert manifest['stage'] == BASELINE_STAGE_RAW
+    assert manifest['key1_byte'] == 189
+    assert manifest['key2_byte'] == 193
+    assert manifest['dtype_base'] == 'float32'
+    assert manifest['dt'] == 0.004
+    assert manifest['source_sha256'] == 'abc123'
+    assert manifest['key1_values'] == [10, 20]
+    assert manifest['trace_spans_by_key1'] == {'10': [[0, 2]], '20': [[2, 3]]}
+    for key in BASELINE_ARRAY_KEYS:
+        assert key not in manifest
+
+    with np.load(npz_path, allow_pickle=False) as arrays:
+        assert set(BASELINE_ARRAY_KEYS).issubset(arrays.files)
+        assert BASELINE_ARTIFACT_ID_FIELD in arrays.files
+        np.testing.assert_allclose(arrays['mu_traces'], payload['mu_traces'])
+        np.testing.assert_allclose(arrays['sigma_traces'], payload['sigma_traces'])
+        np.testing.assert_array_equal(arrays['zero_var_mask'], payload['zero_var_mask'])
+        assert str(arrays[BASELINE_ARTIFACT_ID_FIELD]) == manifest[BASELINE_ARTIFACT_ID_FIELD]
+
+
+def test_write_trace_store_raw_baseline_artifacts_returns_numpy_array_payload(
+    tmp_path,
+) -> None:
+    payload = write_trace_store_raw_baseline_artifacts(
+        store_path=tmp_path,
+        key1_byte=189,
+        key2_byte=193,
+        dtype_base='float32',
+        dt=None,
+        source_sha256=None,
+        **_valid_compute_args(),
+    )
+
+    assert isinstance(payload['mu_traces'], np.ndarray)
+    assert payload['mu_traces'].dtype == np.float32
+    assert isinstance(payload['sigma_traces'], np.ndarray)
+    assert payload['sigma_traces'].dtype == np.float32
+    assert isinstance(payload['zero_var_mask'], np.ndarray)
+    assert payload['zero_var_mask'].dtype == bool
+
+
+@pytest.mark.parametrize('n_samples', [0, -1])
+def test_compute_raw_baseline_stats_rejects_non_positive_n_samples(
+    n_samples: int,
+) -> None:
+    with pytest.raises(ValueError):
+        _compute_with(n_samples=n_samples)
+
+
+@pytest.mark.parametrize(
+    'overrides',
+    [
+        {'trace_sum': np.ones((3, 1), dtype=np.float64)},
+        {'trace_sumsq': np.ones((3, 1), dtype=np.float64)},
+        {'trace_sumsq': np.ones(2, dtype=np.float64)},
+    ],
+)
+def test_compute_raw_baseline_stats_rejects_trace_sum_shape_mismatch(
+    overrides: dict[str, Any],
+) -> None:
+    with pytest.raises(ValueError):
+        _compute_with(**overrides)
+
+
+def test_compute_raw_baseline_stats_rejects_empty_trace_stats() -> None:
+    with pytest.raises(ValueError):
+        _compute_with(
+            trace_sum=np.asarray([], dtype=np.float64),
+            trace_sumsq=np.asarray([], dtype=np.float64),
+        )
+
+
+@pytest.mark.parametrize(
+    'overrides',
+    [
+        {'trace_sum': np.asarray([1.0, np.nan, 3.0])},
+        {'trace_sumsq': np.asarray([1.0, np.inf, 3.0])},
+    ],
+)
+def test_compute_raw_baseline_stats_rejects_non_finite_trace_stats(
+    overrides: dict[str, Any],
+) -> None:
+    with pytest.raises(ValueError):
+        _compute_with(**overrides)
+
+
+@pytest.mark.parametrize(
+    'overrides',
+    [
+        {'key1_values': np.asarray([[10, 20]], dtype=np.int64)},
+        {'key1_offsets': np.asarray([[0, 2]], dtype=np.int64)},
+        {'key1_counts': np.asarray([[2, 1]], dtype=np.int64)},
+        {'key1_values': np.asarray([10], dtype=np.int64)},
+        {'key1_offsets': np.asarray([0], dtype=np.int64)},
+        {'key1_counts': np.asarray([3], dtype=np.int64)},
+    ],
+)
+def test_compute_raw_baseline_stats_rejects_key1_shape_mismatch(
+    overrides: dict[str, Any],
+) -> None:
+    with pytest.raises(ValueError):
+        _compute_with(**overrides)
+
+
+def test_compute_raw_baseline_stats_rejects_empty_key1_sections() -> None:
+    with pytest.raises(ValueError):
+        _compute_with(
+            key1_values=np.asarray([], dtype=np.int64),
+            key1_offsets=np.asarray([], dtype=np.int64),
+            key1_counts=np.asarray([], dtype=np.int64),
+        )
+
+
+def test_compute_raw_baseline_stats_rejects_negative_offsets() -> None:
+    with pytest.raises(ValueError):
+        _compute_with(
+            key1_offsets=np.asarray([0, -2], dtype=np.int64),
+            key1_counts=np.asarray([1, 2], dtype=np.int64),
+        )
+
+
+@pytest.mark.parametrize('counts', [[2, 0], [2, -1]])
+def test_compute_raw_baseline_stats_rejects_non_positive_counts(
+    counts: list[int],
+) -> None:
+    with pytest.raises(ValueError):
+        _compute_with(key1_counts=np.asarray(counts, dtype=np.int64))
+
+
+def test_compute_raw_baseline_stats_rejects_non_contiguous_spans() -> None:
+    with pytest.raises(ValueError):
+        _compute_with(
+            key1_offsets=np.asarray([0, 3], dtype=np.int64),
+            key1_counts=np.asarray([2, 1], dtype=np.int64),
+        )
+
+
+def test_compute_raw_baseline_stats_rejects_spans_not_covering_all_traces() -> None:
+    traces = np.asarray(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+        ],
+        dtype=np.float32,
+    )
+    trace_sum, trace_sumsq = _trace_stats(traces)
+
+    with pytest.raises(ValueError):
+        compute_raw_baseline_stats(
+            key1_values=np.asarray([10, 20], dtype=np.int64),
+            key1_offsets=np.asarray([0, 2], dtype=np.int64),
+            key1_counts=np.asarray([2, 1], dtype=np.int64),
+            trace_sum=trace_sum,
+            trace_sumsq=trace_sumsq,
+            n_samples=3,
+        )

--- a/app/utils/ingest.py
+++ b/app/utils/ingest.py
@@ -10,13 +10,7 @@ from typing import Any
 import numpy as np
 import segyio
 
-from app.utils.baseline_artifacts import (
-    build_raw_baseline_payload,
-    build_trace_spans_by_key1,
-    write_raw_baseline_artifacts,
-)
-
-ZERO_STD_EPS = 1e-12
+from app.services.trace_store_baselines import write_trace_store_raw_baseline_artifacts
 
 
 class SegyIngestor:
@@ -212,56 +206,19 @@ class SegyIngestor:
             if quantize:
                 meta['scale'] = scale_val
 
-            n_samples_f64 = float(n_samples)
-            mu_traces = trace_sum / n_samples_f64
-            trace_var = np.maximum(
-                (trace_sumsq / n_samples_f64) - np.square(mu_traces),
-                0.0,
-            )
-            sigma_traces = np.sqrt(trace_var)
-            zero_var_mask = sigma_traces <= ZERO_STD_EPS
-            if zero_var_mask.any():
-                sigma_traces = sigma_traces.copy()
-                sigma_traces[zero_var_mask] = 1.0
-            section_sum = np.add.reduceat(
-                trace_sum,
-                key1_offsets.astype(np.int64, copy=False),
-            )
-            section_sumsq = np.add.reduceat(
-                trace_sumsq,
-                key1_offsets.astype(np.int64, copy=False),
-            )
-            total_samples = key1_counts.astype(np.float64, copy=False) * n_samples_f64
-            mu_sections = section_sum / total_samples
-            section_var = np.maximum(
-                (section_sumsq / total_samples) - np.square(mu_sections),
-                0.0,
-            )
-            sigma_sections = np.sqrt(section_var)
-            baseline_payload = build_raw_baseline_payload(
+            write_trace_store_raw_baseline_artifacts(
+                store_path=store_path,
+                key1_byte=key1_byte,
+                key2_byte=key2_byte,
                 dtype_base=str(final_dtype),
                 dt=dt_seconds,
                 key1_values=key1_values,
-                mu_sections=mu_sections,
-                sigma_sections=sigma_sections,
-                mu_traces=mu_traces,
-                sigma_traces=sigma_traces,
-                zero_var_mask=zero_var_mask,
-                trace_spans_by_key1=build_trace_spans_by_key1(
-                    key1_values.astype(np.int64, copy=False),
-                    key1_offsets.astype(np.int64, copy=False),
-                    key1_counts.astype(np.int64, copy=False),
-                ),
+                key1_offsets=key1_offsets,
+                key1_counts=key1_counts,
+                trace_sum=trace_sum,
+                trace_sumsq=trace_sumsq,
+                n_samples=n_samples,
                 source_sha256=(str(source_sha256) if source_sha256 else None),
-                key1_byte=key1_byte,
-                key2_byte=key2_byte,
-                serialize_arrays=False,
-            )
-            write_raw_baseline_artifacts(
-                store_path,
-                key1_byte=key1_byte,
-                key2_byte=key2_byte,
-                payload=baseline_payload,
             )
             with meta_tmp.open('w', encoding='utf-8') as fh:
                 json.dump(meta, fh)


### PR DESCRIPTION
Closes #279

## Summary
- [PR1/trace-store] raw baseline artifact 用の統計計算を再利用可能 helper へ切り出す

## Changed files
- `app/services/trace_store_baselines.py`
- `app/tests/test_trace_store_baselines.py`
- `app/utils/ingest.py`

## Checks
- `.work/codex/checks.log`: 397 passed in 44.19s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
