### PR TITLE
[PR1/trace-store] 派生 TraceStore の header 継承・materialize 処理を追加する

### DIFF
--- a/app/services/trace_store_headers.py
+++ b/app/services/trace_store_headers.py
@@ -1,0 +1,152 @@
+"""Helpers for TraceStore header materialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+from uuid import uuid4
+
+import numpy as np
+
+
+def _non_empty_path_value(
+    derived: Mapping[str, Any],
+    field: str,
+) -> str | None:
+    if field not in derived:
+        return None
+    value = derived[field]
+    if not isinstance(value, str):
+        msg = f'derived.{field} must be a string when used as a header source'
+        raise ValueError(msg)
+    if not value.strip():
+        return None
+    return value
+
+
+def resolve_header_source_store_path(
+    meta: Mapping[str, Any],
+    *,
+    target_store_dir: str | Path,
+) -> Path | None:
+    """Return the derived TraceStore header source path, if one is configured."""
+    derived = meta.get('derived')
+    if not isinstance(derived, Mapping):
+        return None
+
+    value = _non_empty_path_value(derived, 'header_source_store_path')
+    if value is None:
+        value = _non_empty_path_value(derived, 'from_store_path')
+    if value is None:
+        return None
+
+    source_path = Path(value)
+    if not source_path.is_absolute():
+        msg = (
+            'TraceStore header source path must be absolute: '
+            f'{source_path!s} for {Path(target_store_dir)!s}'
+        )
+        raise ValueError(msg)
+    return source_path
+
+
+def _load_sorted_to_original(
+    store_dir: Path,
+    *,
+    role: str,
+    expected_n_traces: int,
+) -> np.ndarray:
+    index_path = store_dir / 'index.npz'
+    if not index_path.exists():
+        msg = f'{role} TraceStore index.npz is missing: {index_path}'
+        raise ValueError(msg)
+
+    with np.load(index_path, allow_pickle=False) as index:
+        if 'sorted_to_original' not in index.files:
+            msg = f'{role} TraceStore index.npz is missing sorted_to_original: {index_path}'
+            raise ValueError(msg)
+        sorted_to_original = np.asarray(index['sorted_to_original'])
+
+    expected_shape = (int(expected_n_traces),)
+    if sorted_to_original.shape != expected_shape:
+        msg = (
+            f'{role} sorted_to_original shape mismatch: '
+            f'expected {expected_shape}, got {sorted_to_original.shape}'
+        )
+        raise ValueError(msg)
+    return sorted_to_original
+
+
+def validate_same_sorted_trace_order(
+    *,
+    target_store_dir: str | Path,
+    source_store_dir: str | Path,
+    expected_n_traces: int,
+) -> None:
+    """Validate that target and source stores use the same sorted trace order."""
+    target_sorted = _load_sorted_to_original(
+        Path(target_store_dir),
+        role='target',
+        expected_n_traces=expected_n_traces,
+    )
+    source_sorted = _load_sorted_to_original(
+        Path(source_store_dir),
+        role='source',
+        expected_n_traces=expected_n_traces,
+    )
+    if not np.array_equal(target_sorted, source_sorted):
+        msg = 'target and source sorted_to_original arrays do not match'
+        raise ValueError(msg)
+
+
+def write_header_array_atomic(
+    *,
+    store_dir: str | Path,
+    header_byte: int,
+    values: np.ndarray,
+    expected_n_traces: int,
+) -> np.ndarray:
+    """Atomically write a validated int32 header array and return it as a memmap."""
+    arr = np.asarray(values)
+    expected_shape = (int(expected_n_traces),)
+    if arr.ndim != 1:
+        msg = f'header byte {header_byte} values must be 1-dimensional'
+        raise ValueError(msg)
+    if arr.shape != expected_shape:
+        msg = (
+            f'header byte {header_byte} shape mismatch: '
+            f'expected {expected_shape}, got {arr.shape}'
+        )
+        raise ValueError(msg)
+    if not np.issubdtype(arr.dtype, np.integer):
+        msg = f'header byte {header_byte} values must have an integer dtype'
+        raise ValueError(msg)
+
+    int32_info = np.iinfo(np.int32)
+    if arr.size:
+        min_value = int(arr.min())
+        max_value = int(arr.max())
+        if min_value < int32_info.min or max_value > int32_info.max:
+            msg = f'header byte {header_byte} values are outside the int32 range'
+            raise ValueError(msg)
+
+    out = np.ascontiguousarray(arr, dtype=np.int32)
+    store_path = Path(store_dir)
+    path = store_path / f'headers_byte_{header_byte}.npy'
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+
+    try:
+        with tmp_path.open('wb') as handle:
+            np.save(handle, out)
+        tmp_path.replace(path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    return np.load(path, mmap_mode='r')
+
+
+__all__ = [
+    'resolve_header_source_store_path',
+    'validate_same_sorted_trace_order',
+    'write_header_array_atomic',
+]

--- a/app/tests/test_trace_store_header_inheritance.py
+++ b/app/tests/test_trace_store_header_inheritance.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.trace_store.reader import TraceStoreSectionReader
+
+KEY1 = 189
+KEY2 = 193
+HEADER_BYTE = 37
+
+
+class _Attr:
+    def __init__(self, values: np.ndarray) -> None:
+        self._values = np.asarray(values)
+
+    def __getitem__(self, _key):
+        return self._values
+
+
+class _FakeSegy:
+    def __init__(self, headers: dict[int, np.ndarray]) -> None:
+        self._headers = {int(key): np.asarray(value) for key, value in headers.items()}
+
+    def mmap(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def attributes(self, byte: int):
+        return _Attr(self._headers[int(byte)])
+
+
+def _patch_segyio_header(monkeypatch, headers: dict[int, np.ndarray]) -> None:
+    import segyio
+
+    def _open_stub(_path, _mode='r', ignore_geometry=True):
+        return _FakeSegy(headers)
+
+    monkeypatch.setattr(segyio, 'open', _open_stub, raising=True)
+
+
+def _write_store(
+    store: Path,
+    *,
+    sorted_to_original: np.ndarray | None = None,
+    include_sorted_to_original: bool = True,
+    original_segy_path: str | None = None,
+    derived: dict | None = None,
+    header_values: np.ndarray | None = None,
+    n_traces: int | None = None,
+) -> None:
+    store.mkdir(parents=True, exist_ok=True)
+    if sorted_to_original is None:
+        if n_traces is None:
+            n_traces = 3
+        sorted_to_original = np.arange(n_traces, dtype=np.int64)
+    else:
+        sorted_to_original = np.asarray(sorted_to_original)
+        if n_traces is None:
+            n_traces = int(sorted_to_original.shape[0])
+
+    np.save(store / 'traces.npy', np.zeros((n_traces, 4), dtype=np.float32))
+    np.save(store / f'headers_byte_{KEY1}.npy', np.full(n_traces, 10, dtype=np.int32))
+    np.save(store / f'headers_byte_{KEY2}.npy', np.arange(n_traces, dtype=np.int32))
+    if header_values is not None:
+        np.save(store / f'headers_byte_{HEADER_BYTE}.npy', np.asarray(header_values))
+
+    index_values = {
+        'key1_values': np.array([10], dtype=np.int32),
+        'key1_offsets': np.array([0], dtype=np.int64),
+        'key1_counts': np.array([n_traces], dtype=np.int64),
+    }
+    if include_sorted_to_original:
+        index_values['sorted_to_original'] = sorted_to_original
+    np.savez(store / 'index.npz', **index_values)
+
+    meta: dict = {
+        'schema_version': 1,
+        'dtype': 'float32',
+        'n_traces': n_traces,
+        'n_samples': 4,
+        'key_bytes': {'key1': KEY1, 'key2': KEY2},
+        'sorted_by': ['key1', 'key2'],
+        'dt': 0.004,
+        'original_segy_path': original_segy_path,
+        'source_sha256': None,
+    }
+    if derived is not None:
+        meta['derived'] = derived
+    (store / 'meta.json').write_text(json.dumps(meta), encoding='utf-8')
+
+
+def _reader(store: Path) -> TraceStoreSectionReader:
+    return TraceStoreSectionReader(store, key1_byte=KEY1, key2_byte=KEY2)
+
+
+def test_derived_reader_materializes_missing_header_from_header_source_store_path(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    sorted_to_original = np.array([2, 0, 1], dtype=np.int64)
+    parent_header_sorted = np.array([900, 100, 500], dtype=np.int32)
+    _write_store(
+        parent,
+        sorted_to_original=sorted_to_original,
+        header_values=parent_header_sorted,
+    )
+    _write_store(
+        child,
+        sorted_to_original=sorted_to_original,
+        derived={
+            'kind': 'time_shifted_trace_store',
+            'from_store_path': str(parent),
+            'header_source_store_path': str(parent),
+        },
+    )
+
+    got = _reader(child).ensure_header(HEADER_BYTE)
+
+    np.testing.assert_array_equal(got, parent_header_sorted)
+    assert (child / f'headers_byte_{HEADER_BYTE}.npy').exists()
+
+
+def test_derived_reader_materializes_missing_header_from_from_store_path_when_header_source_missing(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    parent_header = np.array([11, 22, 33], dtype=np.int32)
+    _write_store(parent, header_values=parent_header)
+    _write_store(
+        child,
+        derived={
+            'kind': 'time_shifted_trace_store',
+            'from_store_path': str(parent),
+        },
+    )
+
+    got = _reader(child).ensure_header(HEADER_BYTE)
+
+    np.testing.assert_array_equal(got, parent_header)
+
+
+def test_derived_reader_prefers_local_header_without_touching_parent(
+    tmp_path: Path,
+) -> None:
+    child = tmp_path / 'child'
+    local_header = np.array([7, 8, 9], dtype=np.int32)
+    _write_store(
+        child,
+        derived={'header_source_store_path': str(tmp_path / 'missing-parent')},
+        header_values=local_header,
+    )
+
+    got = _reader(child).ensure_header(HEADER_BYTE)
+
+    np.testing.assert_array_equal(got, local_header)
+
+
+def test_derived_reader_does_not_apply_sorted_to_original_to_parent_header(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    sorted_to_original = np.array([2, 0, 1], dtype=np.int64)
+    parent_header_sorted = np.array([20, 30, 10], dtype=np.int32)
+    _write_store(
+        parent,
+        sorted_to_original=sorted_to_original,
+        header_values=parent_header_sorted,
+    )
+    _write_store(
+        child,
+        sorted_to_original=sorted_to_original,
+        derived={'header_source_store_path': str(parent)},
+    )
+
+    got = _reader(child).ensure_header(HEADER_BYTE)
+
+    np.testing.assert_array_equal(got, parent_header_sorted)
+    np.testing.assert_raises(
+        AssertionError,
+        np.testing.assert_array_equal,
+        got,
+        parent_header_sorted[sorted_to_original],
+    )
+
+
+def test_derived_reader_writes_materialized_header_as_int32_mmap(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(parent, header_values=np.array([1, 2, 3], dtype=np.int64))
+    _write_store(child, derived={'header_source_store_path': str(parent)})
+
+    got = _reader(child).ensure_header(HEADER_BYTE)
+
+    assert isinstance(got, np.memmap)
+    assert got.dtype == np.int32
+    assert got.shape == (3,)
+    assert got.flags.c_contiguous
+    assert not list(child.glob(f'headers_byte_{HEADER_BYTE}.npy.*.tmp'))
+
+
+def test_derived_reader_rejects_relative_header_source_path(tmp_path: Path) -> None:
+    child = tmp_path / 'child'
+    _write_store(child, derived={'header_source_store_path': 'relative/store'})
+
+    with pytest.raises(ValueError, match='absolute'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_missing_header_source_store(tmp_path: Path) -> None:
+    child = tmp_path / 'child'
+    _write_store(
+        child,
+        derived={'header_source_store_path': str(tmp_path / 'missing-parent')},
+    )
+
+    with pytest.raises(ValueError, match='does not exist'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_self_header_source_store(tmp_path: Path) -> None:
+    child = tmp_path / 'child'
+    _write_store(child, derived={'header_source_store_path': str(child)})
+
+    with pytest.raises(ValueError, match='target store'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_missing_sorted_to_original_in_child_index(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(parent, header_values=np.array([1, 2, 3], dtype=np.int32))
+    _write_store(
+        child,
+        include_sorted_to_original=False,
+        derived={'header_source_store_path': str(parent)},
+    )
+
+    with pytest.raises(ValueError, match='target.*sorted_to_original'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_missing_sorted_to_original_in_parent_index(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(
+        parent,
+        include_sorted_to_original=False,
+        header_values=np.array([1, 2, 3], dtype=np.int32),
+    )
+    _write_store(child, derived={'header_source_store_path': str(parent)})
+
+    with pytest.raises(ValueError, match='source.*sorted_to_original'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_sorted_to_original_mismatch(tmp_path: Path) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(
+        parent,
+        sorted_to_original=np.array([0, 2, 1], dtype=np.int64),
+        header_values=np.array([1, 2, 3], dtype=np.int32),
+    )
+    _write_store(
+        child,
+        sorted_to_original=np.array([0, 1, 2], dtype=np.int64),
+        derived={'header_source_store_path': str(parent)},
+    )
+
+    with pytest.raises(ValueError, match='do not match'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_parent_header_shape_mismatch(tmp_path: Path) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(parent, header_values=np.array([1, 2], dtype=np.int32))
+    _write_store(child, derived={'header_source_store_path': str(parent)})
+
+    with pytest.raises(ValueError, match='shape mismatch'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_parent_header_non_integer_dtype(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(parent, header_values=np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    _write_store(child, derived={'header_source_store_path': str(parent)})
+
+    with pytest.raises(ValueError, match='integer dtype'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_when_no_parent_and_no_original_segy(
+    tmp_path: Path,
+) -> None:
+    child = tmp_path / 'child'
+    _write_store(child, original_segy_path=None)
+
+    with pytest.raises(ValueError, match='No usable header source'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_raw_reader_keeps_existing_segy_header_materialization_behavior(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = tmp_path / 'raw'
+    segy_path = tmp_path / 'raw.sgy'
+    segy_path.write_bytes(b'stub')
+    sorted_to_original = np.array([2, 0, 1], dtype=np.int64)
+    raw_header_original_order = np.array([100, 500, 900], dtype=np.int64)
+    _write_store(
+        store,
+        sorted_to_original=sorted_to_original,
+        original_segy_path=str(segy_path),
+    )
+    _patch_segyio_header(monkeypatch, {HEADER_BYTE: raw_header_original_order})
+
+    got = _reader(store).ensure_header(HEADER_BYTE)
+
+    np.testing.assert_array_equal(got, raw_header_original_order[sorted_to_original])
+    assert got.dtype == np.int32
+    assert (store / f'headers_byte_{HEADER_BYTE}.npy').exists()

--- a/app/trace_store/reader.py
+++ b/app/trace_store/reader.py
@@ -10,6 +10,11 @@ from pathlib import Path
 import numpy as np
 import segyio
 
+from app.services.trace_store_headers import (
+    resolve_header_source_store_path,
+    validate_same_sorted_trace_order,
+    write_header_array_atomic,
+)
 from app.trace_store.types import SectionView
 
 logger = logging.getLogger(__name__)
@@ -239,14 +244,75 @@ class TraceStoreSectionReader:
         if path.exists():
             return np.load(path, mmap_mode='r')
 
+        inherited = self._ensure_header_from_parent_store(header_byte)
+        if inherited is not None:
+            return inherited
+
+        return self._ensure_header_from_original_segy(header_byte)
+
+    def _ensure_header_from_parent_store(self, header_byte: int) -> np.ndarray | None:
+        """Materialize ``header_byte`` from a derived TraceStore parent, if configured."""
+        source_path = resolve_header_source_store_path(
+            self.meta,
+            target_store_dir=self.store_dir,
+        )
+        if source_path is None:
+            return None
+        if not source_path.exists():
+            msg = f'Header source TraceStore does not exist: {source_path}'
+            raise ValueError(msg)
+        if not source_path.is_dir():
+            msg = f'Header source TraceStore is not a directory: {source_path}'
+            raise ValueError(msg)
+        if source_path.resolve() == self.store_dir.resolve():
+            msg = f'Header source TraceStore points to the target store: {source_path}'
+            raise ValueError(msg)
+
+        expected_n_traces = int(self.traces.shape[0])
+        validate_same_sorted_trace_order(
+            target_store_dir=self.store_dir,
+            source_store_dir=source_path,
+            expected_n_traces=expected_n_traces,
+        )
+        parent_reader = TraceStoreSectionReader(
+            source_path,
+            self.key1_byte,
+            self.key2_byte,
+        )
+        values = parent_reader.ensure_header(header_byte)
+        return write_header_array_atomic(
+            store_dir=self.store_dir,
+            header_byte=header_byte,
+            values=values,
+            expected_n_traces=expected_n_traces,
+        )
+
+    def _ensure_header_from_original_segy(self, header_byte: int) -> np.ndarray:
+        """Materialize ``header_byte`` from the original SEG-Y source."""
+        original_segy_path = self.meta.get('original_segy_path')
+        if not isinstance(original_segy_path, str) or not original_segy_path.strip():
+            msg = (
+                f'No usable header source for byte {header_byte} in {self.store_dir}: '
+                'missing derived header source and original_segy_path'
+            )
+            raise ValueError(msg)
+
+        segy_path = Path(original_segy_path)
+        if not segy_path.is_file():
+            msg = (
+                f'No usable header source for byte {header_byte} in {self.store_dir}: '
+                f'original SEG-Y path is not a file: {segy_path}'
+            )
+            raise ValueError(msg)
+
         logger.info('Extracting header byte %s for %s', header_byte, self.store_dir)
         with segyio.open(
-            self.meta['original_segy_path'],
+            str(segy_path),
             'r',
             ignore_geometry=True,
         ) as f:
             f.mmap()
-            values = f.attributes(header_byte)[:].astype(np.int32)
+            values = np.asarray(f.attributes(header_byte)[:])
 
         sorted_to_original = self._get_sorted_to_original()
         if sorted_to_original is not None:
@@ -260,10 +326,12 @@ class TraceStoreSectionReader:
                 raise ValueError(msg)
             values = values[sorted_to_original]
 
-        tmp_path = path.with_name(path.stem + '_tmp.npy')
-        np.save(tmp_path, values)
-        tmp_path.replace(path)
-        return np.load(path, mmap_mode='r')
+        return write_header_array_atomic(
+            store_dir=self.store_dir,
+            header_byte=header_byte,
+            values=values,
+            expected_n_traces=int(self.traces.shape[0]),
+        )
 
     def get_header(self, byte: int) -> np.ndarray:
         """Return the header array for ``byte``."""


### PR DESCRIPTION
Closes #281

## Summary
- [PR1/trace-store] 派生 TraceStore の header 継承・materialize 処理を追加する

## Changed files
- `app/services/trace_store_headers.py`
- `app/tests/test_trace_store_header_inheritance.py`
- `app/trace_store/reader.py`

## Checks
- `.work/codex/checks.log`: 412 passed in 44.16s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
