### PR TITLE
[PR1/follow-up] TraceStore index / baseline / time-shift utility の validation を強化する

### DIFF
--- a/app/services/corrected_trace_store.py
+++ b/app/services/corrected_trace_store.py
@@ -16,8 +16,12 @@ import numpy as np
 from app.services.reader import coerce_section_f32
 from app.services.trace_store_baselines import write_trace_store_raw_baseline_artifacts
 from app.services.trace_store_headers import write_header_array_atomic
+from app.services.trace_store_index_validation import validate_sorted_to_original
 from app.trace_store.reader import TraceStoreSectionReader
-from app.utils.time_shift import shift_traces_linear
+from app.utils.time_shift import (
+    coerce_finite_float32_fill_value,
+    shift_traces_linear,
+)
 
 _HEADER_FILENAME_RE = re.compile(r'^headers_byte_(\d+)\.npy$')
 _RESERVED_DERIVED_KEYS = {
@@ -225,9 +229,10 @@ def _load_and_validate_index(source_path: Path, *, n_traces: int) -> _IndexData:
             key1_values = _ensure_index_i64('key1_values', index['key1_values'])
             key1_offsets = _ensure_index_i64('key1_offsets', index['key1_offsets'])
             key1_counts = _ensure_index_i64('key1_counts', index['key1_counts'])
-            sorted_to_original = _ensure_index_i64(
-                'sorted_to_original',
+            sorted_to_original = validate_sorted_to_original(
                 index['sorted_to_original'],
+                expected_n_traces=n_traces,
+                role='source',
             )
     except ValueError:
         raise
@@ -243,12 +248,6 @@ def _load_and_validate_index(source_path: Path, *, n_traces: int) -> _IndexData:
         raise ValueError(msg)
     if key1_values.size == 0:
         msg = 'source index.npz must contain at least one key1 section'
-        raise ValueError(msg)
-    if sorted_to_original.shape != (int(n_traces),):
-        msg = (
-            'sorted_to_original shape mismatch: '
-            f'expected {(int(n_traces),)}, got {sorted_to_original.shape}'
-        )
         raise ValueError(msg)
     if np.any(key1_offsets < 0):
         msg = 'key1_offsets must not contain negative values'
@@ -507,10 +506,7 @@ def build_time_shifted_trace_store(
     if output_dtype != 'float32':
         msg = 'output_dtype must be "float32"'
         raise ValueError(msg)
-    fill = float(fill_value)
-    if not np.isfinite(fill):
-        msg = 'fill_value must be finite'
-        raise ValueError(msg)
+    fill = coerce_finite_float32_fill_value(fill_value)
     if isinstance(chunk_size, bool):
         msg = 'chunk_size must be positive'
         raise ValueError(msg)

--- a/app/services/trace_store_baselines.py
+++ b/app/services/trace_store_baselines.py
@@ -49,11 +49,15 @@ def _ensure_finite_f64(name: str, value: np.ndarray) -> np.ndarray:
 
 def _ensure_index_i64(name: str, value: np.ndarray) -> np.ndarray:
     arr = _ensure_1d_array(name, value)
-    arr_f64 = _ensure_finite_f64(name, arr)
-    if not np.all(arr_f64 == np.trunc(arr_f64)):
-        msg = f'{name} must contain integer values'
+    if np.issubdtype(arr.dtype, np.floating):
+        arr_f64 = _ensure_finite_f64(name, arr)
+        if not np.all(arr_f64 == np.trunc(arr_f64)):
+            msg = f'{name} must contain integer values'
+            raise ValueError(msg)
+    if not np.issubdtype(arr.dtype, np.integer):
+        msg = f'{name} must have an integer dtype'
         raise ValueError(msg)
-    return arr_f64.astype(np.int64, copy=False)
+    return np.ascontiguousarray(arr, dtype=np.int64)
 
 
 def _validate_section_spans(
@@ -110,16 +114,16 @@ def compute_raw_baseline_stats(
     trace_sum_f64 = _ensure_finite_f64('trace_sum', trace_sum_arr)
     trace_sumsq_f64 = _ensure_finite_f64('trace_sumsq', trace_sumsq_arr)
 
-    key1_values_arr = _ensure_1d_array('key1_values', key1_values)
+    key1_values_i64 = _ensure_index_i64('key1_values', key1_values)
     key1_offsets_i64 = _ensure_index_i64('key1_offsets', key1_offsets)
     key1_counts_i64 = _ensure_index_i64('key1_counts', key1_counts)
     if (
-        key1_values_arr.shape != key1_offsets_i64.shape
-        or key1_values_arr.shape != key1_counts_i64.shape
+        key1_values_i64.shape != key1_offsets_i64.shape
+        or key1_values_i64.shape != key1_counts_i64.shape
     ):
         msg = 'key1_values, key1_offsets, and key1_counts must have matching shapes'
         raise ValueError(msg)
-    if key1_values_arr.size == 0:
+    if key1_values_i64.size == 0:
         msg = 'key1 sections must not be empty'
         raise ValueError(msg)
 
@@ -158,7 +162,7 @@ def compute_raw_baseline_stats(
         mu_sections=np.asarray(mu_sections, dtype=np.float32),
         sigma_sections=np.asarray(sigma_sections, dtype=np.float32),
         trace_spans_by_key1=build_trace_spans_by_key1(
-            key1_values_arr.astype(np.int64, copy=False),
+            key1_values_i64,
             key1_offsets_i64,
             key1_counts_i64,
         ),

--- a/app/services/trace_store_headers.py
+++ b/app/services/trace_store_headers.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 
 import numpy as np
 
+from app.services.trace_store_index_validation import validate_sorted_to_original
+
 
 def _non_empty_path_value(
     derived: Mapping[str, Any],
@@ -65,16 +67,11 @@ def _load_sorted_to_original(
         if 'sorted_to_original' not in index.files:
             msg = f'{role} TraceStore index.npz is missing sorted_to_original: {index_path}'
             raise ValueError(msg)
-        sorted_to_original = np.asarray(index['sorted_to_original'])
-
-    expected_shape = (int(expected_n_traces),)
-    if sorted_to_original.shape != expected_shape:
-        msg = (
-            f'{role} sorted_to_original shape mismatch: '
-            f'expected {expected_shape}, got {sorted_to_original.shape}'
+        return validate_sorted_to_original(
+            index['sorted_to_original'],
+            expected_n_traces=expected_n_traces,
+            role=role,
         )
-        raise ValueError(msg)
-    return sorted_to_original
 
 
 def validate_same_sorted_trace_order(

--- a/app/services/trace_store_index_validation.py
+++ b/app/services/trace_store_index_validation.py
@@ -1,0 +1,53 @@
+"""Validation helpers for TraceStore index metadata."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def validate_sorted_to_original(
+    values: np.ndarray,
+    *,
+    expected_n_traces: int,
+    role: str,
+) -> np.ndarray:
+    """Return ``sorted_to_original`` as int64 after permutation validation."""
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        msg = f'{role} sorted_to_original must be 1-dimensional'
+        raise ValueError(msg)
+    if not np.issubdtype(arr.dtype, np.integer):
+        msg = f'{role} sorted_to_original must have an integer dtype'
+        raise ValueError(msg)
+
+    expected_shape = (int(expected_n_traces),)
+    if arr.shape != expected_shape:
+        msg = (
+            f'{role} sorted_to_original shape mismatch: '
+            f'expected {expected_shape}, got {arr.shape}'
+        )
+        raise ValueError(msg)
+
+    out = np.ascontiguousarray(arr, dtype=np.int64)
+    if out.size == 0:
+        return out
+
+    if int(out.min()) < 0 or int(out.max()) >= int(expected_n_traces):
+        msg = (
+            f'{role} sorted_to_original contains indices outside 0..'
+            f'{int(expected_n_traces) - 1}'
+        )
+        raise ValueError(msg)
+
+    expected = np.arange(int(expected_n_traces), dtype=np.int64)
+    if not np.array_equal(np.sort(out), expected):
+        msg = (
+            f'{role} sorted_to_original must be a permutation of '
+            f'0..{int(expected_n_traces) - 1}'
+        )
+        raise ValueError(msg)
+
+    return out
+
+
+__all__ = ['validate_sorted_to_original']

--- a/app/tests/test_corrected_trace_store.py
+++ b/app/tests/test_corrected_trace_store.py
@@ -126,6 +126,11 @@ def _tmp_stores(tmp_path: Path) -> list[Path]:
     return list(tmp_path.glob('corrected.tmp-*'))
 
 
+def _assert_no_corrected_store(output: Path, tmp_path: Path) -> None:
+    assert not output.exists()
+    assert not _tmp_stores(tmp_path)
+
+
 def test_build_time_shifted_trace_store_writes_expected_shifted_traces(
     tmp_path: Path,
 ) -> None:
@@ -507,6 +512,104 @@ def test_build_time_shifted_trace_store_rejects_index_without_sorted_to_original
             output_store_path=output,
             trace_shift_s_sorted=np.zeros(traces.shape[0], dtype=np.float64),
         )
+
+
+def test_build_time_shifted_trace_store_rejects_duplicate_sorted_to_original(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / 'source'
+    output = tmp_path / 'corrected'
+    traces = _write_source_store(
+        source,
+        sorted_to_original=np.asarray([0, 1, 1], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match='permutation'):
+        build_time_shifted_trace_store(
+            source_store_path=source,
+            output_store_path=output,
+            trace_shift_s_sorted=np.zeros(traces.shape[0], dtype=np.float64),
+        )
+
+    _assert_no_corrected_store(output, tmp_path)
+
+
+def test_build_time_shifted_trace_store_rejects_out_of_range_sorted_to_original(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / 'source'
+    output = tmp_path / 'corrected'
+    traces = _write_source_store(
+        source,
+        sorted_to_original=np.asarray([0, 1, 3], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match='outside'):
+        build_time_shifted_trace_store(
+            source_store_path=source,
+            output_store_path=output,
+            trace_shift_s_sorted=np.zeros(traces.shape[0], dtype=np.float64),
+        )
+
+    _assert_no_corrected_store(output, tmp_path)
+
+
+def test_build_time_shifted_trace_store_rejects_negative_sorted_to_original(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / 'source'
+    output = tmp_path / 'corrected'
+    traces = _write_source_store(
+        source,
+        sorted_to_original=np.asarray([-1, 0, 1], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match='outside'):
+        build_time_shifted_trace_store(
+            source_store_path=source,
+            output_store_path=output,
+            trace_shift_s_sorted=np.zeros(traces.shape[0], dtype=np.float64),
+        )
+
+    _assert_no_corrected_store(output, tmp_path)
+
+
+def test_build_time_shifted_trace_store_rejects_non_integer_sorted_to_original(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / 'source'
+    output = tmp_path / 'corrected'
+    traces = _write_source_store(
+        source,
+        sorted_to_original=np.asarray([0.0, 1.0, 2.0], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match='integer dtype'):
+        build_time_shifted_trace_store(
+            source_store_path=source,
+            output_store_path=output,
+            trace_shift_s_sorted=np.zeros(traces.shape[0], dtype=np.float64),
+        )
+
+    _assert_no_corrected_store(output, tmp_path)
+
+
+def test_build_time_shifted_trace_store_rejects_fill_value_not_representable_as_float32(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / 'source'
+    output = tmp_path / 'corrected'
+    traces = _write_source_store(source)
+
+    with pytest.raises(ValueError, match='float32'):
+        build_time_shifted_trace_store(
+            source_store_path=source,
+            output_store_path=output,
+            trace_shift_s_sorted=np.zeros(traces.shape[0], dtype=np.float64),
+            fill_value=float(np.finfo(np.float64).max),
+        )
+
+    _assert_no_corrected_store(output, tmp_path)
 
 
 def test_build_time_shifted_trace_store_cleans_tmp_store_on_shift_failure(

--- a/app/tests/test_time_shift.py
+++ b/app/tests/test_time_shift.py
@@ -154,3 +154,15 @@ def test_shift_traces_linear_rejects_non_finite_fill_value(fill_value: float) ->
             dt=1.0,
             fill_value=fill_value,
         )
+
+
+def test_shift_traces_linear_rejects_fill_value_not_representable_as_float32() -> None:
+    traces = np.zeros((1, 3), dtype=np.float32)
+
+    with pytest.raises(ValueError, match='float32'):
+        shift_traces_linear(
+            traces,
+            np.zeros((1,), dtype=np.float64),
+            dt=1.0,
+            fill_value=float(np.finfo(np.float64).max),
+        )

--- a/app/tests/test_trace_store_baselines.py
+++ b/app/tests/test_trace_store_baselines.py
@@ -288,6 +288,16 @@ def test_compute_raw_baseline_stats_rejects_non_finite_trace_stats(
         _compute_with(**overrides)
 
 
+def test_compute_raw_baseline_stats_rejects_float_key1_values() -> None:
+    with pytest.raises(ValueError, match='integer dtype'):
+        _compute_with(key1_values=np.asarray([10.0, 20.0], dtype=np.float64))
+
+
+def test_compute_raw_baseline_stats_rejects_non_finite_key1_values() -> None:
+    with pytest.raises(ValueError, match='finite'):
+        _compute_with(key1_values=np.asarray([10.0, np.inf], dtype=np.float64))
+
+
 @pytest.mark.parametrize(
     'overrides',
     [

--- a/app/tests/test_trace_store_header_inheritance.py
+++ b/app/tests/test_trace_store_header_inheritance.py
@@ -271,6 +271,102 @@ def test_derived_reader_rejects_missing_sorted_to_original_in_parent_index(
         _reader(child).ensure_header(HEADER_BYTE)
 
 
+def test_derived_reader_rejects_non_integer_sorted_to_original_in_child_index(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(parent, header_values=np.array([1, 2, 3], dtype=np.int32))
+    _write_store(
+        child,
+        sorted_to_original=np.array([0.0, 1.0, 2.0], dtype=np.float64),
+        derived={'header_source_store_path': str(parent)},
+    )
+
+    with pytest.raises(ValueError, match='target.*integer dtype'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_non_integer_sorted_to_original_in_parent_index(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(
+        parent,
+        sorted_to_original=np.array([0.0, 1.0, 2.0], dtype=np.float64),
+        header_values=np.array([1, 2, 3], dtype=np.int32),
+    )
+    _write_store(child, derived={'header_source_store_path': str(parent)})
+
+    with pytest.raises(ValueError, match='source.*integer dtype'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_duplicate_sorted_to_original_in_child_index(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(parent, header_values=np.array([1, 2, 3], dtype=np.int32))
+    _write_store(
+        child,
+        sorted_to_original=np.array([0, 1, 1], dtype=np.int64),
+        derived={'header_source_store_path': str(parent)},
+    )
+
+    with pytest.raises(ValueError, match='target.*permutation'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_duplicate_sorted_to_original_in_parent_index(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(
+        parent,
+        sorted_to_original=np.array([0, 1, 1], dtype=np.int64),
+        header_values=np.array([1, 2, 3], dtype=np.int32),
+    )
+    _write_store(child, derived={'header_source_store_path': str(parent)})
+
+    with pytest.raises(ValueError, match='source.*permutation'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_out_of_range_sorted_to_original_in_child_index(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(parent, header_values=np.array([1, 2, 3], dtype=np.int32))
+    _write_store(
+        child,
+        sorted_to_original=np.array([0, 1, 3], dtype=np.int64),
+        derived={'header_source_store_path': str(parent)},
+    )
+
+    with pytest.raises(ValueError, match='target.*outside'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
+def test_derived_reader_rejects_out_of_range_sorted_to_original_in_parent_index(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / 'parent'
+    child = tmp_path / 'child'
+    _write_store(
+        parent,
+        sorted_to_original=np.array([0, 1, 3], dtype=np.int64),
+        header_values=np.array([1, 2, 3], dtype=np.int32),
+    )
+    _write_store(child, derived={'header_source_store_path': str(parent)})
+
+    with pytest.raises(ValueError, match='source.*outside'):
+        _reader(child).ensure_header(HEADER_BYTE)
+
+
 def test_derived_reader_rejects_sorted_to_original_mismatch(tmp_path: Path) -> None:
     parent = tmp_path / 'parent'
     child = tmp_path / 'child'

--- a/app/utils/time_shift.py
+++ b/app/utils/time_shift.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 import numpy as np
 
 
+def coerce_finite_float32_fill_value(fill_value: float) -> np.float32:
+    """Validate and return ``fill_value`` as a finite float32 scalar."""
+    fill = float(fill_value)
+    if not np.isfinite(fill):
+        raise ValueError('fill_value must be finite')
+    if abs(fill) > float(np.finfo(np.float32).max):
+        raise ValueError('fill_value must be representable as finite float32')
+    return np.float32(fill)
+
+
 def shift_traces_linear(
     traces: np.ndarray,
     shifts_s: np.ndarray,
@@ -33,9 +43,7 @@ def shift_traces_linear(
     if not np.all(np.isfinite(shifts)):
         raise ValueError('shifts_s must contain only finite values')
 
-    fill = float(fill_value)
-    if not np.isfinite(fill):
-        raise ValueError('fill_value must be finite')
+    fill = coerce_finite_float32_fill_value(fill_value)
 
     arr_f32 = np.asarray(arr, dtype=np.float32)
     out = np.full((n_traces, n_samples), fill, dtype=np.float32)
@@ -58,4 +66,4 @@ def shift_traces_linear(
     return np.ascontiguousarray(out, dtype=np.float32)
 
 
-__all__ = ['shift_traces_linear']
+__all__ = ['coerce_finite_float32_fill_value', 'shift_traces_linear']


### PR DESCRIPTION
Closes #285

## Summary
- [PR1/follow-up] TraceStore index / baseline / time-shift utility の validation を強化する

## Changed files
- `app/services/corrected_trace_store.py`
- `app/services/trace_store_baselines.py`
- `app/services/trace_store_headers.py`
- `app/services/trace_store_index_validation.py`
- `app/tests/test_corrected_trace_store.py`
- `app/tests/test_time_shift.py`
- `app/tests/test_trace_store_baselines.py`
- `app/tests/test_trace_store_header_inheritance.py`
- `app/utils/time_shift.py`

## Checks
- `.work/codex/checks.log`: 453 passed in 45.40s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
