### PR TITLE
[PR2/statics] SEG-Y elevation scalar utility と datum static 計算ロジックを追加する

### DIFF
--- a/app/services/datum_static_math.py
+++ b/app/services/datum_static_math.py
@@ -1,0 +1,118 @@
+"""Datum static correction math helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class DatumStaticResult:
+    source_shift_s_sorted: np.ndarray
+    receiver_shift_s_sorted: np.ndarray
+    trace_shift_s_sorted: np.ndarray
+    source_surface_elevation_m_sorted: np.ndarray
+    source_depth_m_sorted: np.ndarray
+    source_depth_used_sorted: np.ndarray
+    source_elevation_m_sorted: np.ndarray
+    receiver_elevation_m_sorted: np.ndarray
+
+
+def compute_datum_static_shifts(
+    *,
+    source_surface_elevation_m_sorted: np.ndarray,
+    receiver_elevation_m_sorted: np.ndarray,
+    datum_elevation_m: float,
+    replacement_velocity_m_s: float,
+    source_depth_m_sorted: np.ndarray | None = None,
+) -> DatumStaticResult:
+    """Compute sorted per-trace datum static shifts in seconds."""
+    source_surface = _coerce_1d_finite_float64(
+        source_surface_elevation_m_sorted,
+        name='source_surface_elevation_m_sorted',
+    )
+    receiver = _coerce_1d_finite_float64(
+        receiver_elevation_m_sorted,
+        name='receiver_elevation_m_sorted',
+    )
+    if source_surface.shape != receiver.shape:
+        raise ValueError(
+            'source_surface_elevation_m_sorted and receiver_elevation_m_sorted must have the same shape'
+        )
+
+    if source_depth_m_sorted is None:
+        source_depth = np.zeros(source_surface.shape, dtype=np.float64)
+        source_depth_used = np.zeros(source_surface.shape, dtype=bool)
+    else:
+        source_depth = _coerce_1d_finite_float64(
+            source_depth_m_sorted,
+            name='source_depth_m_sorted',
+        )
+        if source_depth.shape != source_surface.shape:
+            raise ValueError('source_depth_m_sorted must have the same shape as elevations')
+        source_depth_used = np.ones(source_surface.shape, dtype=bool)
+
+    datum = _coerce_finite_float(datum_elevation_m, name='datum_elevation_m')
+    velocity = _coerce_positive_finite_float(
+        replacement_velocity_m_s,
+        name='replacement_velocity_m_s',
+    )
+
+    source_elevation = source_surface - source_depth
+    if not np.all(np.isfinite(source_elevation)):
+        raise ValueError('source_elevation_m_sorted contains NaN or Inf')
+
+    source_shift = (datum - source_elevation) / velocity
+    receiver_shift = (datum - receiver) / velocity
+    trace_shift = source_shift + receiver_shift
+    if (
+        not np.all(np.isfinite(source_shift))
+        or not np.all(np.isfinite(receiver_shift))
+        or not np.all(np.isfinite(trace_shift))
+    ):
+        raise ValueError('datum static shifts contain NaN or Inf')
+
+    return DatumStaticResult(
+        source_shift_s_sorted=np.asarray(source_shift, dtype=np.float64),
+        receiver_shift_s_sorted=np.asarray(receiver_shift, dtype=np.float64),
+        trace_shift_s_sorted=np.asarray(trace_shift, dtype=np.float64),
+        source_surface_elevation_m_sorted=np.asarray(source_surface, dtype=np.float64),
+        source_depth_m_sorted=np.asarray(source_depth, dtype=np.float64),
+        source_depth_used_sorted=np.asarray(source_depth_used, dtype=bool),
+        source_elevation_m_sorted=np.asarray(source_elevation, dtype=np.float64),
+        receiver_elevation_m_sorted=np.asarray(receiver, dtype=np.float64),
+    )
+
+
+def _coerce_1d_finite_float64(values: np.ndarray, *, name: str) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    try:
+        arr_f64 = arr.astype(np.float64, copy=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be numeric') from exc
+    if not np.all(np.isfinite(arr_f64)):
+        raise ValueError(f'{name} must contain only finite values')
+    return arr_f64
+
+
+def _coerce_finite_float(value: float, *, name: str) -> float:
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite') from exc
+    if not np.isfinite(scalar):
+        raise ValueError(f'{name} must be finite')
+    return scalar
+
+
+def _coerce_positive_finite_float(value: float, *, name: str) -> float:
+    scalar = _coerce_finite_float(value, name=name)
+    if scalar <= 0.0:
+        raise ValueError(f'{name} must be greater than 0')
+    return scalar
+
+
+__all__ = ['DatumStaticResult', 'compute_datum_static_shifts']

--- a/app/tests/test_datum_static_math.py
+++ b/app/tests/test_datum_static_math.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.datum_static_math import compute_datum_static_shifts
+
+
+def test_datum_static_math_without_source_depth() -> None:
+    result = compute_datum_static_shifts(
+        source_surface_elevation_m_sorted=np.array([100.0, 50.0], dtype=np.float64),
+        receiver_elevation_m_sorted=np.array([80.0, -20.0], dtype=np.float64),
+        datum_elevation_m=0.0,
+        replacement_velocity_m_s=1000.0,
+    )
+
+    np.testing.assert_allclose(result.source_depth_m_sorted, np.array([0.0, 0.0]))
+    np.testing.assert_array_equal(result.source_depth_used_sorted, np.array([False, False]))
+    np.testing.assert_allclose(result.source_elevation_m_sorted, np.array([100.0, 50.0]))
+    np.testing.assert_allclose(result.source_shift_s_sorted, np.array([-0.1, -0.05]))
+    np.testing.assert_allclose(result.receiver_shift_s_sorted, np.array([-0.08, 0.02]))
+    np.testing.assert_allclose(result.trace_shift_s_sorted, np.array([-0.18, -0.03]))
+
+
+def test_datum_static_math_with_source_depth() -> None:
+    result = compute_datum_static_shifts(
+        source_surface_elevation_m_sorted=np.array([100.0, 50.0], dtype=np.float64),
+        source_depth_m_sorted=np.array([10.0, 5.0], dtype=np.float64),
+        receiver_elevation_m_sorted=np.array([80.0, -20.0], dtype=np.float64),
+        datum_elevation_m=0.0,
+        replacement_velocity_m_s=1000.0,
+    )
+
+    np.testing.assert_allclose(result.source_depth_m_sorted, np.array([10.0, 5.0]))
+    np.testing.assert_array_equal(result.source_depth_used_sorted, np.array([True, True]))
+    np.testing.assert_allclose(result.source_elevation_m_sorted, np.array([90.0, 45.0]))
+    np.testing.assert_allclose(result.source_shift_s_sorted, np.array([-0.09, -0.045]))
+    np.testing.assert_allclose(result.receiver_shift_s_sorted, np.array([-0.08, 0.02]))
+    np.testing.assert_allclose(result.trace_shift_s_sorted, np.array([-0.17, -0.025]))
+
+
+def test_datum_static_sign_canonical_case() -> None:
+    result = compute_datum_static_shifts(
+        source_surface_elevation_m_sorted=np.array([100.0], dtype=np.float64),
+        source_depth_m_sorted=np.array([0.0], dtype=np.float64),
+        receiver_elevation_m_sorted=np.array([100.0], dtype=np.float64),
+        datum_elevation_m=0.0,
+        replacement_velocity_m_s=2000.0,
+    )
+
+    np.testing.assert_allclose(result.source_shift_s_sorted, np.array([-0.05]))
+    np.testing.assert_allclose(result.receiver_shift_s_sorted, np.array([-0.05]))
+    np.testing.assert_allclose(result.trace_shift_s_sorted, np.array([-0.10]))
+
+
+@pytest.mark.parametrize(
+    'array_name',
+    [
+        'source_shift_s_sorted',
+        'receiver_shift_s_sorted',
+        'trace_shift_s_sorted',
+        'source_surface_elevation_m_sorted',
+        'source_depth_m_sorted',
+        'source_depth_used_sorted',
+        'source_elevation_m_sorted',
+        'receiver_elevation_m_sorted',
+    ],
+)
+def test_datum_static_outputs_are_sorted_trace_order_1d_arrays(array_name: str) -> None:
+    result = compute_datum_static_shifts(
+        source_surface_elevation_m_sorted=np.array([1.0, 2.0], dtype=np.float64),
+        receiver_elevation_m_sorted=np.array([3.0, 4.0], dtype=np.float64),
+        datum_elevation_m=0.0,
+        replacement_velocity_m_s=1000.0,
+    )
+
+    arr = getattr(result, array_name)
+    assert isinstance(arr, np.ndarray)
+    assert arr.ndim == 1
+    assert arr.shape == (2,)
+
+
+def test_datum_static_rejects_shape_mismatch() -> None:
+    with pytest.raises(ValueError):
+        compute_datum_static_shifts(
+            source_surface_elevation_m_sorted=np.array([1.0, 2.0], dtype=np.float64),
+            receiver_elevation_m_sorted=np.array([1.0], dtype=np.float64),
+            datum_elevation_m=0.0,
+            replacement_velocity_m_s=1000.0,
+        )
+
+
+def test_datum_static_rejects_source_depth_shape_mismatch() -> None:
+    with pytest.raises(ValueError):
+        compute_datum_static_shifts(
+            source_surface_elevation_m_sorted=np.array([1.0, 2.0], dtype=np.float64),
+            source_depth_m_sorted=np.array([1.0], dtype=np.float64),
+            receiver_elevation_m_sorted=np.array([1.0, 2.0], dtype=np.float64),
+            datum_elevation_m=0.0,
+            replacement_velocity_m_s=1000.0,
+        )
+
+
+def test_datum_static_rejects_non_1d_elevations() -> None:
+    with pytest.raises(ValueError):
+        compute_datum_static_shifts(
+            source_surface_elevation_m_sorted=np.array([[1.0, 2.0]], dtype=np.float64),
+            receiver_elevation_m_sorted=np.array([[1.0, 2.0]], dtype=np.float64),
+            datum_elevation_m=0.0,
+            replacement_velocity_m_s=1000.0,
+        )
+
+
+@pytest.mark.parametrize('replacement_velocity_m_s', [0.0, -1.0, np.nan, np.inf])
+def test_datum_static_rejects_non_positive_replacement_velocity(
+    replacement_velocity_m_s: float,
+) -> None:
+    with pytest.raises(ValueError):
+        compute_datum_static_shifts(
+            source_surface_elevation_m_sorted=np.array([1.0], dtype=np.float64),
+            receiver_elevation_m_sorted=np.array([1.0], dtype=np.float64),
+            datum_elevation_m=0.0,
+            replacement_velocity_m_s=replacement_velocity_m_s,
+        )
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('source_surface_elevation_m_sorted', np.nan),
+        ('source_surface_elevation_m_sorted', np.inf),
+        ('receiver_elevation_m_sorted', np.nan),
+        ('receiver_elevation_m_sorted', np.inf),
+        ('source_depth_m_sorted', np.nan),
+        ('source_depth_m_sorted', np.inf),
+    ],
+)
+def test_datum_static_rejects_non_finite_elevation_or_depth(
+    field: str,
+    value: float,
+) -> None:
+    kwargs = {
+        'source_surface_elevation_m_sorted': np.array([1.0], dtype=np.float64),
+        'receiver_elevation_m_sorted': np.array([1.0], dtype=np.float64),
+        'source_depth_m_sorted': np.array([1.0], dtype=np.float64),
+        'datum_elevation_m': 0.0,
+        'replacement_velocity_m_s': 1000.0,
+    }
+    kwargs[field] = np.array([value], dtype=np.float64)
+
+    with pytest.raises(ValueError):
+        compute_datum_static_shifts(**kwargs)
+
+
+@pytest.mark.parametrize('datum_elevation_m', [np.nan, np.inf])
+def test_datum_static_rejects_non_finite_datum(datum_elevation_m: float) -> None:
+    with pytest.raises(ValueError):
+        compute_datum_static_shifts(
+            source_surface_elevation_m_sorted=np.array([1.0], dtype=np.float64),
+            receiver_elevation_m_sorted=np.array([1.0], dtype=np.float64),
+            datum_elevation_m=datum_elevation_m,
+            replacement_velocity_m_s=1000.0,
+        )

--- a/app/tests/test_segy_scalars.py
+++ b/app/tests/test_segy_scalars.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.utils.segy_scalars import (
+    apply_segy_scalar,
+    count_zero_segy_scalars,
+    normalize_elevation_unit,
+)
+
+
+def test_apply_segy_scalar_positive_negative_zero() -> None:
+    values = np.array([10, 10, 10], dtype=np.int32)
+    scalars = np.array([2, -4, 0], dtype=np.int16)
+
+    scaled = apply_segy_scalar(values, scalars)
+
+    np.testing.assert_allclose(scaled, np.array([20.0, 2.5, 10.0], dtype=np.float64))
+    assert scaled.dtype == np.float64
+
+
+def test_apply_segy_scalar_shape_mismatch() -> None:
+    with pytest.raises(ValueError):
+        apply_segy_scalar(
+            np.array([1.0, 2.0], dtype=np.float64),
+            np.array([1], dtype=np.int16),
+        )
+
+
+@pytest.mark.parametrize(
+    'scalars',
+    [
+        np.array([1.0], dtype=np.float64),
+        np.array([1.5], dtype=np.float64),
+    ],
+)
+def test_apply_segy_scalar_rejects_non_integer_scalar(scalars: np.ndarray) -> None:
+    with pytest.raises(ValueError):
+        apply_segy_scalar(np.array([1.0], dtype=np.float64), scalars)
+
+
+def test_apply_segy_scalar_rejects_non_numeric_values() -> None:
+    with pytest.raises(ValueError):
+        apply_segy_scalar(np.array(['not numeric']), np.array([1], dtype=np.int16))
+
+
+@pytest.mark.parametrize(
+    'values',
+    [
+        np.array([np.nan], dtype=np.float64),
+        np.array([np.inf], dtype=np.float64),
+    ],
+)
+def test_apply_segy_scalar_rejects_non_finite_result(values: np.ndarray) -> None:
+    with pytest.raises(ValueError):
+        apply_segy_scalar(values, np.array([1], dtype=np.int16))
+
+
+def test_count_zero_segy_scalars() -> None:
+    assert count_zero_segy_scalars(np.array([0, 1, -1, 0], dtype=np.int16)) == 2
+
+
+def test_normalize_elevation_unit_m() -> None:
+    elevations = normalize_elevation_unit(np.array([1.0, -2.5], dtype=np.float64), 'm')
+
+    np.testing.assert_allclose(elevations, np.array([1.0, -2.5], dtype=np.float64))
+    assert elevations.dtype == np.float64
+
+
+def test_normalize_elevation_unit_ft() -> None:
+    elevations = normalize_elevation_unit(np.array([10.0, -5.0], dtype=np.float64), 'ft')
+
+    np.testing.assert_allclose(elevations, np.array([3.048, -1.524], dtype=np.float64))
+
+
+def test_normalize_elevation_unit_rejects_unknown_unit() -> None:
+    with pytest.raises(ValueError):
+        normalize_elevation_unit(np.array([1.0], dtype=np.float64), 'km')
+
+
+@pytest.mark.parametrize(
+    'values',
+    [
+        np.array([np.nan], dtype=np.float64),
+        np.array([np.inf], dtype=np.float64),
+    ],
+)
+def test_normalize_elevation_unit_rejects_non_finite_result(values: np.ndarray) -> None:
+    with pytest.raises(ValueError):
+        normalize_elevation_unit(values, 'm')

--- a/app/utils/segy_scalars.py
+++ b/app/utils/segy_scalars.py
@@ -13,13 +13,11 @@ def apply_segy_scalar(values: np.ndarray, scalars: np.ndarray) -> np.ndarray:
         raise ValueError('values and scalars must have the same shape')
 
     scalar_f64 = scalar_arr.astype(np.float64, copy=False)
-    scale = np.ones(scalar_arr.shape, dtype=np.float64)
+    result = np.array(arr, dtype=np.float64, copy=True)
     positive = scalar_f64 > 0.0
     negative = scalar_f64 < 0.0
-    scale[positive] = scalar_f64[positive]
-    scale[negative] = 1.0 / np.abs(scalar_f64[negative])
-
-    result = arr * scale
+    result[positive] *= scalar_f64[positive]
+    result[negative] /= np.abs(scalar_f64[negative])
     if not np.all(np.isfinite(result)):
         raise ValueError('scaled values contain NaN or Inf')
     return np.asarray(result, dtype=np.float64)

--- a/app/utils/segy_scalars.py
+++ b/app/utils/segy_scalars.py
@@ -1,0 +1,69 @@
+"""SEG-Y header scalar utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def apply_segy_scalar(values: np.ndarray, scalars: np.ndarray) -> np.ndarray:
+    """Apply SEG-Y scalar rules to raw header values."""
+    arr = _coerce_numeric_float64(values, name='values')
+    scalar_arr = _validate_integer_scalars(scalars)
+    if arr.shape != scalar_arr.shape:
+        raise ValueError('values and scalars must have the same shape')
+
+    scalar_f64 = scalar_arr.astype(np.float64, copy=False)
+    scale = np.ones(scalar_arr.shape, dtype=np.float64)
+    positive = scalar_f64 > 0.0
+    negative = scalar_f64 < 0.0
+    scale[positive] = scalar_f64[positive]
+    scale[negative] = 1.0 / np.abs(scalar_f64[negative])
+
+    result = arr * scale
+    if not np.all(np.isfinite(result)):
+        raise ValueError('scaled values contain NaN or Inf')
+    return np.asarray(result, dtype=np.float64)
+
+
+def count_zero_segy_scalars(scalars: np.ndarray) -> int:
+    """Return the number of zero SEG-Y scalar header values."""
+    scalar_arr = _validate_integer_scalars(scalars)
+    return int(np.count_nonzero(scalar_arr == 0))
+
+
+def normalize_elevation_unit(values: np.ndarray, unit: str) -> np.ndarray:
+    """Normalize elevation values to meters."""
+    arr = _coerce_numeric_float64(values, name='values')
+    if unit == 'm':
+        result = arr
+    elif unit == 'ft':
+        result = arr * 0.3048
+    else:
+        raise ValueError('unit must be "m" or "ft"')
+
+    if not np.all(np.isfinite(result)):
+        raise ValueError('normalized elevations contain NaN or Inf')
+    return np.asarray(result, dtype=np.float64)
+
+
+def _coerce_numeric_float64(values: np.ndarray, *, name: str) -> np.ndarray:
+    arr = np.asarray(values)
+    try:
+        arr_f64 = arr.astype(np.float64, copy=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be numeric') from exc
+    return arr_f64
+
+
+def _validate_integer_scalars(scalars: np.ndarray) -> np.ndarray:
+    scalar_arr = np.asarray(scalars)
+    if not np.issubdtype(scalar_arr.dtype, np.integer):
+        raise ValueError('scalars must have an integer dtype')
+    return scalar_arr
+
+
+__all__ = [
+    'apply_segy_scalar',
+    'count_zero_segy_scalars',
+    'normalize_elevation_unit',
+]


### PR DESCRIPTION
Closes #287

## Summary
- [PR2/statics] SEG-Y elevation scalar utility と datum static 計算ロジックを追加する

## Changed files
- `app/services/datum_static_math.py`
- `app/tests/test_datum_static_math.py`
- `app/tests/test_segy_scalars.py`
- `app/utils/segy_scalars.py`

## Checks
- `.work/codex/checks.log`: 492 passed in 44.34s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
