### PR TITLE
[PR2/statics] source/receiver elevation header 読み取りと geometry validation を実装する

### DIFF
--- a/app/services/datum_static_geometry.py
+++ b/app/services/datum_static_geometry.py
@@ -178,8 +178,7 @@ def _validate_header_array(
         msg = f'{name} header byte {byte} must have a numeric dtype'
         raise ValueError(msg)
 
-    arr_f64 = arr.astype(np.float64, copy=False)
-    if not np.all(np.isfinite(arr_f64)):
+    if np.issubdtype(arr.dtype, np.floating) and not np.all(np.isfinite(arr)):
         msg = f'{name} header byte {byte} must contain only finite values'
         raise ValueError(msg)
     return arr

--- a/app/services/datum_static_geometry.py
+++ b/app/services/datum_static_geometry.py
@@ -1,0 +1,229 @@
+"""Datum static geometry loading from TraceStore headers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from app.trace_store.reader import TraceStoreSectionReader
+from app.utils.segy_scalars import (
+    apply_segy_scalar,
+    count_zero_segy_scalars,
+    normalize_elevation_unit,
+)
+
+
+@dataclass(frozen=True)
+class DatumStaticGeometryConfig:
+    source_elevation_byte: int = 45
+    receiver_elevation_byte: int = 41
+    elevation_scalar_byte: int = 69
+    source_depth_byte: int | None = None
+    elevation_unit: Literal['m', 'ft'] = 'm'
+
+
+@dataclass(frozen=True)
+class DatumStaticGeometry:
+    source_surface_elevation_m_sorted: np.ndarray
+    receiver_elevation_m_sorted: np.ndarray
+    source_depth_m_sorted: np.ndarray
+    source_depth_used_sorted: np.ndarray
+    elevation_scalar_sorted: np.ndarray
+    elevation_scalar_zero_count: int
+    source_elevation_byte: int
+    receiver_elevation_byte: int
+    elevation_scalar_byte: int
+    source_depth_byte: int | None
+    elevation_unit: str
+    n_traces: int
+
+
+def load_datum_static_geometry(
+    *,
+    reader: TraceStoreSectionReader,
+    config: DatumStaticGeometryConfig,
+) -> DatumStaticGeometry:
+    """Load datum static geometry arrays in TraceStore sorted trace order."""
+    _validate_config(config)
+    n_traces = int(reader.traces.shape[0])
+
+    source_surface_raw = _validate_header_array(
+        reader.ensure_header(config.source_elevation_byte),
+        name='source_elevation',
+        byte=config.source_elevation_byte,
+        n_traces=n_traces,
+    )
+    receiver_raw = _validate_header_array(
+        reader.ensure_header(config.receiver_elevation_byte),
+        name='receiver_elevation',
+        byte=config.receiver_elevation_byte,
+        n_traces=n_traces,
+    )
+    elevation_scalar_raw = _validate_header_array(
+        reader.ensure_header(config.elevation_scalar_byte),
+        name='elevation_scalar',
+        byte=config.elevation_scalar_byte,
+        n_traces=n_traces,
+    )
+    elevation_scalar = _coerce_integer_scalar_header(elevation_scalar_raw)
+
+    source_surface = _apply_scalar_and_normalize(
+        source_surface_raw,
+        elevation_scalar,
+        unit=config.elevation_unit,
+    )
+    receiver = _apply_scalar_and_normalize(
+        receiver_raw,
+        elevation_scalar,
+        unit=config.elevation_unit,
+    )
+
+    if config.source_depth_byte is None:
+        source_depth = np.zeros(n_traces, dtype=np.float64)
+        source_depth_used = np.zeros(n_traces, dtype=bool)
+    else:
+        source_depth_raw = _validate_header_array(
+            reader.ensure_header(config.source_depth_byte),
+            name='source_depth',
+            byte=config.source_depth_byte,
+            n_traces=n_traces,
+        )
+        source_depth = _apply_scalar_and_normalize(
+            source_depth_raw,
+            elevation_scalar,
+            unit=config.elevation_unit,
+        )
+        source_depth_used = np.ones(n_traces, dtype=bool)
+
+    return DatumStaticGeometry(
+        source_surface_elevation_m_sorted=np.ascontiguousarray(
+            source_surface,
+            dtype=np.float64,
+        ),
+        receiver_elevation_m_sorted=np.ascontiguousarray(
+            receiver,
+            dtype=np.float64,
+        ),
+        source_depth_m_sorted=np.ascontiguousarray(source_depth, dtype=np.float64),
+        source_depth_used_sorted=np.ascontiguousarray(source_depth_used, dtype=bool),
+        elevation_scalar_sorted=np.ascontiguousarray(elevation_scalar, dtype=np.int64),
+        elevation_scalar_zero_count=count_zero_segy_scalars(elevation_scalar),
+        source_elevation_byte=config.source_elevation_byte,
+        receiver_elevation_byte=config.receiver_elevation_byte,
+        elevation_scalar_byte=config.elevation_scalar_byte,
+        source_depth_byte=config.source_depth_byte,
+        elevation_unit=config.elevation_unit,
+        n_traces=n_traces,
+    )
+
+
+def _validate_config(config: DatumStaticGeometryConfig) -> None:
+    header_bytes = [
+        _validate_required_header_byte(
+            config.source_elevation_byte,
+            name='source_elevation_byte',
+        ),
+        _validate_required_header_byte(
+            config.receiver_elevation_byte,
+            name='receiver_elevation_byte',
+        ),
+        _validate_required_header_byte(
+            config.elevation_scalar_byte,
+            name='elevation_scalar_byte',
+        ),
+    ]
+    if config.source_depth_byte is not None:
+        header_bytes.append(
+            _validate_required_header_byte(
+                config.source_depth_byte,
+                name='source_depth_byte',
+            )
+        )
+    if len(set(header_bytes)) != len(header_bytes):
+        msg = 'datum static geometry header bytes must be unique'
+        raise ValueError(msg)
+
+
+def _validate_required_header_byte(value: int, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f'{name} must be an integer SEG-Y trace header byte'
+        raise ValueError(msg)
+    if value < 1 or value > 240:
+        msg = f'{name} must be between 1 and 240'
+        raise ValueError(msg)
+    return value
+
+
+def _validate_header_array(
+    values: np.ndarray,
+    *,
+    name: str,
+    byte: int,
+    n_traces: int,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        msg = f'{name} header byte {byte} must be a 1D array'
+        raise ValueError(msg)
+    expected_shape = (n_traces,)
+    if arr.shape != expected_shape:
+        msg = (
+            f'{name} header byte {byte} shape mismatch: '
+            f'expected {expected_shape}, got {arr.shape}'
+        )
+        raise ValueError(msg)
+    if not _is_real_numeric_dtype(arr.dtype):
+        msg = f'{name} header byte {byte} must have a numeric dtype'
+        raise ValueError(msg)
+
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(arr_f64)):
+        msg = f'{name} header byte {byte} must contain only finite values'
+        raise ValueError(msg)
+    return arr
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+def _coerce_integer_scalar_header(values: np.ndarray) -> np.ndarray:
+    arr = np.asarray(values)
+    if np.issubdtype(arr.dtype, np.integer):
+        return np.asarray(arr, dtype=np.int64)
+
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(arr_f64 == np.rint(arr_f64)):
+        msg = 'elevation_scalar header values must be integers'
+        raise ValueError(msg)
+
+    int64_info = np.iinfo(np.int64)
+    if arr_f64.size and (
+        float(arr_f64.min()) < int64_info.min
+        or float(arr_f64.max()) > int64_info.max
+    ):
+        msg = 'elevation_scalar header values are outside the int64 range'
+        raise ValueError(msg)
+    return np.asarray(arr_f64, dtype=np.int64)
+
+
+def _apply_scalar_and_normalize(
+    values: np.ndarray,
+    scalars: np.ndarray,
+    *,
+    unit: str,
+) -> np.ndarray:
+    scaled = apply_segy_scalar(values, scalars)
+    return normalize_elevation_unit(scaled, unit)
+
+
+__all__ = [
+    'DatumStaticGeometry',
+    'DatumStaticGeometryConfig',
+    'load_datum_static_geometry',
+]

--- a/app/tests/test_datum_static_geometry.py
+++ b/app/tests/test_datum_static_geometry.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.datum_static_geometry import (
+    DatumStaticGeometryConfig,
+    load_datum_static_geometry,
+)
+from app.services.datum_static_math import compute_datum_static_shifts
+
+
+class FakeTraceStoreReader:
+    def __init__(self, headers: dict[int, np.ndarray], n_traces: int) -> None:
+        self.headers = headers
+        self.traces = np.zeros((n_traces, 1), dtype=np.float32)
+        self.ensure_calls: list[int] = []
+
+    def ensure_header(self, byte: int) -> np.ndarray:
+        self.ensure_calls.append(byte)
+        if byte not in self.headers:
+            raise ValueError(f'missing header byte {byte}')
+        return self.headers[byte]
+
+
+def _reader(headers: dict[int, np.ndarray] | None = None) -> FakeTraceStoreReader:
+    base_headers = {
+        45: np.array([100.0, 200.0, 300.0], dtype=np.float64),
+        41: np.array([10.0, 20.0, 30.0], dtype=np.float64),
+        69: np.array([1, 1, 1], dtype=np.int16),
+    }
+    if headers is not None:
+        base_headers.update(headers)
+    return FakeTraceStoreReader(base_headers, n_traces=3)
+
+
+def test_load_datum_static_geometry_defaults_without_source_depth() -> None:
+    reader = _reader()
+
+    geometry = load_datum_static_geometry(
+        reader=reader,
+        config=DatumStaticGeometryConfig(),
+    )
+
+    np.testing.assert_allclose(
+        geometry.source_surface_elevation_m_sorted,
+        np.array([100.0, 200.0, 300.0]),
+    )
+    np.testing.assert_allclose(
+        geometry.receiver_elevation_m_sorted,
+        np.array([10.0, 20.0, 30.0]),
+    )
+    np.testing.assert_allclose(geometry.source_depth_m_sorted, np.zeros(3))
+    np.testing.assert_array_equal(
+        geometry.source_depth_used_sorted,
+        np.array([False, False, False]),
+    )
+    np.testing.assert_array_equal(geometry.elevation_scalar_sorted, np.array([1, 1, 1]))
+    assert geometry.elevation_scalar_zero_count == 0
+    assert geometry.source_elevation_byte == 45
+    assert geometry.receiver_elevation_byte == 41
+    assert geometry.elevation_scalar_byte == 69
+    assert geometry.source_depth_byte is None
+    assert geometry.elevation_unit == 'm'
+    assert geometry.n_traces == 3
+    assert reader.ensure_calls == [45, 41, 69]
+    for arr in (
+        geometry.source_surface_elevation_m_sorted,
+        geometry.receiver_elevation_m_sorted,
+        geometry.source_depth_m_sorted,
+        geometry.source_depth_used_sorted,
+        geometry.elevation_scalar_sorted,
+    ):
+        assert arr.ndim == 1
+        assert arr.shape == (3,)
+
+
+def test_load_datum_static_geometry_with_source_depth() -> None:
+    reader = _reader(
+        {
+            49: np.array([10.0, 20.0, 30.0], dtype=np.float64),
+            69: np.array([2, -4, 0], dtype=np.int16),
+        }
+    )
+
+    geometry = load_datum_static_geometry(
+        reader=reader,
+        config=DatumStaticGeometryConfig(source_depth_byte=49),
+    )
+
+    np.testing.assert_allclose(
+        geometry.source_depth_m_sorted,
+        np.array([20.0, 5.0, 30.0], dtype=np.float64),
+    )
+    np.testing.assert_array_equal(
+        geometry.source_depth_used_sorted,
+        np.array([True, True, True]),
+    )
+    assert geometry.source_depth_byte == 49
+    assert reader.ensure_calls == [45, 41, 69, 49]
+
+
+def test_load_datum_static_geometry_applies_positive_negative_zero_scalar() -> None:
+    reader = _reader(
+        {
+            45: np.array([10.0, 10.0, 10.0], dtype=np.float64),
+            41: np.array([20.0, 20.0, 20.0], dtype=np.float64),
+            69: np.array([2, -4, 0], dtype=np.int16),
+        }
+    )
+
+    geometry = load_datum_static_geometry(
+        reader=reader,
+        config=DatumStaticGeometryConfig(),
+    )
+
+    np.testing.assert_allclose(
+        geometry.source_surface_elevation_m_sorted,
+        np.array([20.0, 2.5, 10.0]),
+    )
+    np.testing.assert_allclose(
+        geometry.receiver_elevation_m_sorted,
+        np.array([40.0, 5.0, 20.0]),
+    )
+
+
+def test_load_datum_static_geometry_counts_zero_scalar() -> None:
+    reader = _reader({69: np.array([0, 1, 0], dtype=np.int16)})
+
+    geometry = load_datum_static_geometry(
+        reader=reader,
+        config=DatumStaticGeometryConfig(),
+    )
+
+    assert geometry.elevation_scalar_zero_count == 2
+
+
+def test_load_datum_static_geometry_accepts_integer_valued_float_scalar() -> None:
+    reader = _reader({69: np.array([2.0, -4.0, 0.0], dtype=np.float64)})
+
+    geometry = load_datum_static_geometry(
+        reader=reader,
+        config=DatumStaticGeometryConfig(),
+    )
+
+    np.testing.assert_array_equal(geometry.elevation_scalar_sorted, np.array([2, -4, 0]))
+    np.testing.assert_allclose(
+        geometry.source_surface_elevation_m_sorted,
+        np.array([200.0, 50.0, 300.0]),
+    )
+
+
+def test_load_datum_static_geometry_converts_ft_to_m() -> None:
+    reader = _reader(
+        {
+            45: np.array([10.0, 20.0, 30.0], dtype=np.float64),
+            41: np.array([5.0, 15.0, 25.0], dtype=np.float64),
+            49: np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        }
+    )
+
+    geometry = load_datum_static_geometry(
+        reader=reader,
+        config=DatumStaticGeometryConfig(source_depth_byte=49, elevation_unit='ft'),
+    )
+
+    np.testing.assert_allclose(
+        geometry.source_surface_elevation_m_sorted,
+        np.array([3.048, 6.096, 9.144]),
+    )
+    np.testing.assert_allclose(
+        geometry.receiver_elevation_m_sorted,
+        np.array([1.524, 4.572, 7.62]),
+    )
+    np.testing.assert_allclose(
+        geometry.source_depth_m_sorted,
+        np.array([0.3048, 0.6096, 0.9144]),
+    )
+
+
+def test_load_datum_static_geometry_rejects_unknown_unit() -> None:
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(
+            reader=_reader(),
+            config=DatumStaticGeometryConfig(elevation_unit='km'),  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    'field',
+    [
+        'source_elevation_byte',
+        'receiver_elevation_byte',
+        'elevation_scalar_byte',
+        'source_depth_byte',
+    ],
+)
+def test_load_datum_static_geometry_rejects_bool_header_byte(field: str) -> None:
+    config = DatumStaticGeometryConfig()
+    kwargs = {
+        'source_elevation_byte': config.source_elevation_byte,
+        'receiver_elevation_byte': config.receiver_elevation_byte,
+        'elevation_scalar_byte': config.elevation_scalar_byte,
+        'source_depth_byte': config.source_depth_byte,
+    }
+    kwargs[field] = True
+
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(
+            reader=_reader(),
+            config=DatumStaticGeometryConfig(**kwargs),
+        )
+
+
+@pytest.mark.parametrize('bad_byte', [0, 241])
+def test_load_datum_static_geometry_rejects_out_of_range_header_byte(
+    bad_byte: int,
+) -> None:
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(
+            reader=_reader(),
+            config=DatumStaticGeometryConfig(source_elevation_byte=bad_byte),
+        )
+
+
+@pytest.mark.parametrize(
+    'config',
+    [
+        DatumStaticGeometryConfig(source_elevation_byte=41),
+        DatumStaticGeometryConfig(source_depth_byte=69),
+    ],
+)
+def test_load_datum_static_geometry_rejects_duplicate_header_bytes(
+    config: DatumStaticGeometryConfig,
+) -> None:
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(reader=_reader(), config=config)
+
+
+def test_load_datum_static_geometry_rejects_missing_required_header() -> None:
+    reader = FakeTraceStoreReader(
+        {
+            41: np.array([10.0, 20.0, 30.0], dtype=np.float64),
+            69: np.array([1, 1, 1], dtype=np.int16),
+        },
+        n_traces=3,
+    )
+
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(
+            reader=reader,
+            config=DatumStaticGeometryConfig(),
+        )
+
+
+def test_load_datum_static_geometry_rejects_header_shape_mismatch() -> None:
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(
+            reader=_reader({45: np.array([1.0, 2.0], dtype=np.float64)}),
+            config=DatumStaticGeometryConfig(),
+        )
+
+
+def test_load_datum_static_geometry_rejects_non_numeric_header() -> None:
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(
+            reader=_reader({45: np.array(['high', 'mid', 'low'])}),
+            config=DatumStaticGeometryConfig(),
+        )
+
+
+def test_load_datum_static_geometry_rejects_non_finite_header() -> None:
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(
+            reader=_reader({45: np.array([1.0, np.nan, 3.0], dtype=np.float64)}),
+            config=DatumStaticGeometryConfig(),
+        )
+
+
+def test_load_datum_static_geometry_rejects_non_integer_scalar() -> None:
+    with pytest.raises(ValueError):
+        load_datum_static_geometry(
+            reader=_reader({69: np.array([1.0, 1.5, 2.0], dtype=np.float64)}),
+            config=DatumStaticGeometryConfig(),
+        )
+
+
+def test_load_datum_static_geometry_preserves_sorted_order() -> None:
+    reader = _reader(
+        {
+            45: np.array([300.0, 100.0, 200.0], dtype=np.float64),
+            41: np.array([30.0, 10.0, 20.0], dtype=np.float64),
+        }
+    )
+
+    geometry = load_datum_static_geometry(
+        reader=reader,
+        config=DatumStaticGeometryConfig(),
+    )
+
+    np.testing.assert_allclose(
+        geometry.source_surface_elevation_m_sorted,
+        np.array([300.0, 100.0, 200.0]),
+    )
+    np.testing.assert_allclose(
+        geometry.receiver_elevation_m_sorted,
+        np.array([30.0, 10.0, 20.0]),
+    )
+
+
+def test_load_datum_static_geometry_connects_to_datum_static_math() -> None:
+    geometry = load_datum_static_geometry(
+        reader=_reader(),
+        config=DatumStaticGeometryConfig(),
+    )
+
+    from_geometry = compute_datum_static_shifts(
+        source_surface_elevation_m_sorted=geometry.source_surface_elevation_m_sorted,
+        receiver_elevation_m_sorted=geometry.receiver_elevation_m_sorted,
+        datum_elevation_m=0.0,
+        replacement_velocity_m_s=2000.0,
+        source_depth_m_sorted=geometry.source_depth_m_sorted,
+    )
+    without_depth_arg = compute_datum_static_shifts(
+        source_surface_elevation_m_sorted=geometry.source_surface_elevation_m_sorted,
+        receiver_elevation_m_sorted=geometry.receiver_elevation_m_sorted,
+        datum_elevation_m=0.0,
+        replacement_velocity_m_s=2000.0,
+    )
+
+    np.testing.assert_allclose(
+        from_geometry.trace_shift_s_sorted,
+        without_depth_arg.trace_shift_s_sorted,
+    )


### PR DESCRIPTION
Closes #289

## Summary
- [PR2/statics] source/receiver elevation header 読み取りと geometry validation を実装する

## Changed files
- `app/services/datum_static_geometry.py`
- `app/tests/test_datum_static_geometry.py`

## Checks
- `.work/codex/checks.log`: 514 passed in 45.40s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
