### PR TITLE
[PR2/statics] existing static header の nonzero 検出と max shift validation を実装する

### DIFF
--- a/app/services/datum_static_validation.py
+++ b/app/services/datum_static_validation.py
@@ -1,0 +1,269 @@
+"""Validation helpers for datum static correction inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from app.trace_store.reader import TraceStoreSectionReader
+
+
+@dataclass(frozen=True)
+class ExistingStaticHeaderConfig:
+    policy: Literal['fail_if_nonzero'] = 'fail_if_nonzero'
+    source_static_byte: int | None = 99
+    receiver_static_byte: int | None = 101
+    total_static_byte: int | None = 103
+
+    def __post_init__(self) -> None:
+        _validate_existing_static_config(self)
+
+
+@dataclass(frozen=True)
+class ExistingStaticHeaderCheck:
+    policy: str
+    checked: bool
+    source_static_byte: int | None
+    receiver_static_byte: int | None
+    total_static_byte: int | None
+    nonzero_source_static_count: int
+    nonzero_receiver_static_count: int
+    nonzero_total_static_count: int
+    nonzero_any_count: int
+    checked_bytes: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class TraceShiftValidationResult:
+    n_traces: int
+    max_abs_shift_ms: float
+    min_shift_ms: float
+    max_shift_ms: float
+    mean_shift_ms: float
+    max_abs_observed_shift_ms: float
+
+
+def validate_existing_static_headers(
+    *,
+    reader: TraceStoreSectionReader,
+    config: ExistingStaticHeaderConfig,
+) -> ExistingStaticHeaderCheck:
+    """Validate that configured existing SEG-Y static headers are all zero."""
+    _validate_existing_static_config(config)
+    n_traces = int(reader.traces.shape[0])
+    masks_by_name: dict[str, np.ndarray] = {}
+    counts_by_name = {
+        'source_static_byte': 0,
+        'receiver_static_byte': 0,
+        'total_static_byte': 0,
+    }
+    checked_bytes: list[int] = []
+
+    for field_name, byte in _configured_static_header_bytes(config):
+        if byte is None:
+            continue
+        values = _read_static_header(reader=reader, byte=byte)
+        arr = _validate_static_header_array(
+            values,
+            name=field_name,
+            byte=byte,
+            n_traces=n_traces,
+        )
+        nonzero_mask = np.asarray(arr != 0, dtype=bool)
+        masks_by_name[field_name] = nonzero_mask
+        counts_by_name[field_name] = int(np.count_nonzero(nonzero_mask))
+        checked_bytes.append(byte)
+
+    if masks_by_name:
+        nonzero_any_count = int(
+            np.count_nonzero(np.logical_or.reduce(tuple(masks_by_name.values())))
+        )
+    else:
+        nonzero_any_count = 0
+
+    if nonzero_any_count:
+        parts = [
+            f'{field_name}={getattr(config, field_name)} count={count}'
+            for field_name, count in counts_by_name.items()
+            if count
+        ]
+        msg = 'existing SEG-Y static headers contain nonzero values: ' + ', '.join(
+            parts
+        )
+        raise ValueError(msg)
+
+    return ExistingStaticHeaderCheck(
+        policy=config.policy,
+        checked=bool(checked_bytes),
+        source_static_byte=config.source_static_byte,
+        receiver_static_byte=config.receiver_static_byte,
+        total_static_byte=config.total_static_byte,
+        nonzero_source_static_count=counts_by_name['source_static_byte'],
+        nonzero_receiver_static_count=counts_by_name['receiver_static_byte'],
+        nonzero_total_static_count=counts_by_name['total_static_byte'],
+        nonzero_any_count=nonzero_any_count,
+        checked_bytes=tuple(checked_bytes),
+    )
+
+
+def validate_trace_shift_limits(
+    *,
+    trace_shift_s_sorted: np.ndarray,
+    max_abs_shift_ms: float,
+    expected_n_traces: int | None = None,
+) -> TraceShiftValidationResult:
+    """Validate sorted per-trace shifts against a maximum absolute shift limit."""
+    shifts_s = np.asarray(trace_shift_s_sorted)
+    if shifts_s.ndim != 1:
+        msg = 'trace_shift_s_sorted must be a 1D array'
+        raise ValueError(msg)
+    if expected_n_traces is not None and shifts_s.shape != (expected_n_traces,):
+        msg = (
+            'trace_shift_s_sorted shape mismatch: '
+            f'expected {(expected_n_traces,)}, got {shifts_s.shape}'
+        )
+        raise ValueError(msg)
+    if not _is_real_numeric_dtype(shifts_s.dtype):
+        msg = 'trace_shift_s_sorted must have a numeric dtype'
+        raise ValueError(msg)
+
+    shifts_ms = shifts_s.astype(np.float64, copy=False) * 1000.0
+    if not np.all(np.isfinite(shifts_ms)):
+        msg = 'trace_shift_s_sorted must contain only finite values'
+        raise ValueError(msg)
+
+    try:
+        limit_ms = float(max_abs_shift_ms)
+    except (TypeError, ValueError) as exc:
+        msg = 'max_abs_shift_ms must be finite'
+        raise ValueError(msg) from exc
+    if not np.isfinite(limit_ms) or limit_ms <= 0.0:
+        msg = 'max_abs_shift_ms must be finite and greater than 0'
+        raise ValueError(msg)
+
+    abs_shift_ms = np.abs(shifts_ms)
+    observed_ms = float(abs_shift_ms.max()) if abs_shift_ms.size else 0.0
+    exceeding_mask = abs_shift_ms > limit_ms
+    exceeding_count = int(np.count_nonzero(exceeding_mask))
+    if exceeding_count:
+        msg = (
+            'trace_shift_s_sorted exceeds max_abs_shift_ms: '
+            f'limit={limit_ms} ms, observed={observed_ms} ms, '
+            f'count={exceeding_count}'
+        )
+        raise ValueError(msg)
+
+    return TraceShiftValidationResult(
+        n_traces=int(shifts_ms.size),
+        max_abs_shift_ms=limit_ms,
+        min_shift_ms=float(shifts_ms.min()) if shifts_ms.size else 0.0,
+        max_shift_ms=float(shifts_ms.max()) if shifts_ms.size else 0.0,
+        mean_shift_ms=float(shifts_ms.mean()) if shifts_ms.size else 0.0,
+        max_abs_observed_shift_ms=observed_ms,
+    )
+
+
+def _validate_existing_static_config(config: ExistingStaticHeaderConfig) -> None:
+    if config.policy != 'fail_if_nonzero':
+        msg = "existing static header policy must be 'fail_if_nonzero'"
+        raise ValueError(msg)
+
+    header_bytes = [
+        _validate_optional_static_header_byte(value, name=name)
+        for name, value in _configured_static_header_bytes(config)
+    ]
+    specified = [byte for byte in header_bytes if byte is not None]
+    if not specified:
+        msg = 'at least one existing static header byte must be specified'
+        raise ValueError(msg)
+    if len(set(specified)) != len(specified):
+        msg = 'existing static header bytes must be unique'
+        raise ValueError(msg)
+
+
+def _configured_static_header_bytes(
+    config: ExistingStaticHeaderConfig,
+) -> tuple[tuple[str, int | None], ...]:
+    return (
+        ('source_static_byte', config.source_static_byte),
+        ('receiver_static_byte', config.receiver_static_byte),
+        ('total_static_byte', config.total_static_byte),
+    )
+
+
+def _validate_optional_static_header_byte(value: int | None, *, name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f'{name} must be an integer SEG-Y trace header byte or None'
+        raise ValueError(msg)
+    if value < 1 or value > 240:
+        msg = f'{name} must be between 1 and 240'
+        raise ValueError(msg)
+    return value
+
+
+def _read_static_header(
+    *,
+    reader: TraceStoreSectionReader,
+    byte: int,
+) -> np.ndarray:
+    try:
+        reader.ensure_header(byte)
+        return reader.get_header(byte)
+    except Exception as exc:
+        msg = f'failed to read existing static header byte {byte}: {exc}'
+        raise ValueError(msg) from exc
+
+
+def _validate_static_header_array(
+    values: np.ndarray,
+    *,
+    name: str,
+    byte: int,
+    n_traces: int,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        msg = f'{name} header byte {byte} must be a 1D array'
+        raise ValueError(msg)
+    expected_shape = (n_traces,)
+    if arr.shape != expected_shape:
+        msg = (
+            f'{name} header byte {byte} shape mismatch: '
+            f'expected {expected_shape}, got {arr.shape}'
+        )
+        raise ValueError(msg)
+    if not _is_real_numeric_dtype(arr.dtype):
+        msg = f'{name} header byte {byte} must have a numeric dtype'
+        raise ValueError(msg)
+
+    if np.issubdtype(arr.dtype, np.integer):
+        return arr
+
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(arr_f64)):
+        msg = f'{name} header byte {byte} must contain only finite values'
+        raise ValueError(msg)
+    if not np.all(arr_f64 == np.rint(arr_f64)):
+        msg = f'{name} header byte {byte} must contain only integer values'
+        raise ValueError(msg)
+    return arr
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'ExistingStaticHeaderCheck',
+    'ExistingStaticHeaderConfig',
+    'TraceShiftValidationResult',
+    'validate_existing_static_headers',
+    'validate_trace_shift_limits',
+]

--- a/app/services/datum_static_validation.py
+++ b/app/services/datum_static_validation.py
@@ -51,7 +51,6 @@ def validate_existing_static_headers(
     config: ExistingStaticHeaderConfig,
 ) -> ExistingStaticHeaderCheck:
     """Validate that configured existing SEG-Y static headers are all zero."""
-    _validate_existing_static_config(config)
     n_traces = int(reader.traces.shape[0])
     masks_by_name: dict[str, np.ndarray] = {}
     counts_by_name = {
@@ -211,7 +210,6 @@ def _read_static_header(
     byte: int,
 ) -> np.ndarray:
     try:
-        reader.ensure_header(byte)
         return reader.get_header(byte)
     except Exception as exc:
         msg = f'failed to read existing static header byte {byte}: {exc}'

--- a/app/tests/test_datum_static_validation.py
+++ b/app/tests/test_datum_static_validation.py
@@ -18,10 +18,11 @@ class FakeReader:
         self.ensure_calls: list[int] = []
         self.get_calls: list[int] = []
 
-    def ensure_header(self, byte: int) -> None:
+    def ensure_header(self, byte: int) -> np.ndarray:
         self.ensure_calls.append(byte)
         if byte not in self.headers:
             raise ValueError(f'missing header byte {byte}')
+        return self.headers[byte]
 
     def get_header(self, byte: int) -> np.ndarray:
         self.get_calls.append(byte)
@@ -104,7 +105,7 @@ def test_validate_existing_static_headers_all_zero() -> None:
     assert result.nonzero_receiver_static_count == 0
     assert result.nonzero_total_static_count == 0
     assert result.nonzero_any_count == 0
-    assert reader.ensure_calls == [99, 101, 103]
+    assert reader.ensure_calls == []
     assert reader.get_calls == [99, 101, 103]
 
 
@@ -162,7 +163,7 @@ def test_validate_existing_static_headers_skips_none_byte() -> None:
     assert result.checked_bytes == (99, 103)
     assert result.receiver_static_byte is None
     assert result.nonzero_receiver_static_count == 0
-    assert reader.ensure_calls == [99, 103]
+    assert reader.ensure_calls == []
     assert reader.get_calls == [99, 103]
 
 

--- a/app/tests/test_datum_static_validation.py
+++ b/app/tests/test_datum_static_validation.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.datum_static_math import compute_datum_static_shifts
+from app.services.datum_static_validation import (
+    ExistingStaticHeaderConfig,
+    validate_existing_static_headers,
+    validate_trace_shift_limits,
+)
+
+
+class FakeReader:
+    def __init__(self, headers: dict[int, np.ndarray], n_traces: int) -> None:
+        self.headers = headers
+        self.traces = np.zeros((n_traces, 4), dtype=np.float32)
+        self.ensure_calls: list[int] = []
+        self.get_calls: list[int] = []
+
+    def ensure_header(self, byte: int) -> None:
+        self.ensure_calls.append(byte)
+        if byte not in self.headers:
+            raise ValueError(f'missing header byte {byte}')
+
+    def get_header(self, byte: int) -> np.ndarray:
+        self.get_calls.append(byte)
+        return self.headers[byte]
+
+
+def _reader(headers: dict[int, np.ndarray] | None = None) -> FakeReader:
+    base_headers = {
+        99: np.zeros(3, dtype=np.int16),
+        101: np.zeros(3, dtype=np.int16),
+        103: np.zeros(3, dtype=np.int16),
+    }
+    if headers is not None:
+        base_headers.update(headers)
+    return FakeReader(base_headers, n_traces=3)
+
+
+def test_existing_static_config_defaults() -> None:
+    config = ExistingStaticHeaderConfig()
+
+    assert config.policy == 'fail_if_nonzero'
+    assert config.source_static_byte == 99
+    assert config.receiver_static_byte == 101
+    assert config.total_static_byte == 103
+
+
+def test_existing_static_config_rejects_unsupported_policy() -> None:
+    with pytest.raises(ValueError, match='fail_if_nonzero'):
+        ExistingStaticHeaderConfig(policy='ignore')  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    'field',
+    ['source_static_byte', 'receiver_static_byte', 'total_static_byte'],
+)
+def test_existing_static_config_rejects_bool_byte(field: str) -> None:
+    kwargs = {
+        'source_static_byte': 99,
+        'receiver_static_byte': 101,
+        'total_static_byte': 103,
+    }
+    kwargs[field] = True
+
+    with pytest.raises(ValueError):
+        ExistingStaticHeaderConfig(**kwargs)
+
+
+@pytest.mark.parametrize('bad_byte', [0, 241])
+def test_existing_static_config_rejects_out_of_range_byte(bad_byte: int) -> None:
+    with pytest.raises(ValueError):
+        ExistingStaticHeaderConfig(source_static_byte=bad_byte)
+
+
+def test_existing_static_config_rejects_duplicate_bytes() -> None:
+    with pytest.raises(ValueError, match='unique'):
+        ExistingStaticHeaderConfig(source_static_byte=99, receiver_static_byte=99)
+
+
+def test_existing_static_config_rejects_all_bytes_none() -> None:
+    with pytest.raises(ValueError, match='at least one'):
+        ExistingStaticHeaderConfig(
+            source_static_byte=None,
+            receiver_static_byte=None,
+            total_static_byte=None,
+        )
+
+
+def test_validate_existing_static_headers_all_zero() -> None:
+    reader = _reader()
+
+    result = validate_existing_static_headers(
+        reader=reader,
+        config=ExistingStaticHeaderConfig(),
+    )
+
+    assert result.checked is True
+    assert result.policy == 'fail_if_nonzero'
+    assert result.checked_bytes == (99, 101, 103)
+    assert result.nonzero_source_static_count == 0
+    assert result.nonzero_receiver_static_count == 0
+    assert result.nonzero_total_static_count == 0
+    assert result.nonzero_any_count == 0
+    assert reader.ensure_calls == [99, 101, 103]
+    assert reader.get_calls == [99, 101, 103]
+
+
+def test_validate_existing_static_headers_nonzero_source_fails() -> None:
+    with pytest.raises(ValueError, match=r'source_static_byte=99 count=1'):
+        validate_existing_static_headers(
+            reader=_reader({99: np.array([0, 7, 0], dtype=np.int16)}),
+            config=ExistingStaticHeaderConfig(),
+        )
+
+
+def test_validate_existing_static_headers_nonzero_receiver_fails() -> None:
+    with pytest.raises(ValueError, match=r'receiver_static_byte=101 count=1'):
+        validate_existing_static_headers(
+            reader=_reader({101: np.array([0, -4, 0], dtype=np.int16)}),
+            config=ExistingStaticHeaderConfig(),
+        )
+
+
+def test_validate_existing_static_headers_nonzero_total_fails() -> None:
+    with pytest.raises(ValueError, match=r'total_static_byte=103 count=1'):
+        validate_existing_static_headers(
+            reader=_reader({103: np.array([0, 0, 3], dtype=np.int16)}),
+            config=ExistingStaticHeaderConfig(),
+        )
+
+
+def test_validate_existing_static_headers_reports_multiple_nonzero_counts() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        validate_existing_static_headers(
+            reader=_reader(
+                {
+                    99: np.array([1, 0, 1], dtype=np.int16),
+                    101: np.array([0, 2, 0], dtype=np.int16),
+                    103: np.array([3, 0, 4], dtype=np.int16),
+                }
+            ),
+            config=ExistingStaticHeaderConfig(),
+        )
+
+    message = str(exc_info.value)
+    assert 'source_static_byte=99 count=2' in message
+    assert 'receiver_static_byte=101 count=1' in message
+    assert 'total_static_byte=103 count=2' in message
+
+
+def test_validate_existing_static_headers_skips_none_byte() -> None:
+    reader = _reader()
+
+    result = validate_existing_static_headers(
+        reader=reader,
+        config=ExistingStaticHeaderConfig(receiver_static_byte=None),
+    )
+
+    assert result.checked_bytes == (99, 103)
+    assert result.receiver_static_byte is None
+    assert result.nonzero_receiver_static_count == 0
+    assert reader.ensure_calls == [99, 103]
+    assert reader.get_calls == [99, 103]
+
+
+def test_validate_existing_static_headers_rejects_shape_mismatch() -> None:
+    with pytest.raises(ValueError, match='shape mismatch'):
+        validate_existing_static_headers(
+            reader=_reader({99: np.array([0, 0], dtype=np.int16)}),
+            config=ExistingStaticHeaderConfig(),
+        )
+
+
+def test_validate_existing_static_headers_rejects_non_numeric() -> None:
+    with pytest.raises(ValueError, match='numeric dtype'):
+        validate_existing_static_headers(
+            reader=_reader({99: np.array(['0', '0', '0'])}),
+            config=ExistingStaticHeaderConfig(),
+        )
+
+
+def test_validate_existing_static_headers_rejects_non_integer_values() -> None:
+    with pytest.raises(ValueError, match='integer values'):
+        validate_existing_static_headers(
+            reader=_reader({99: np.array([0.0, 1.5, 0.0], dtype=np.float64)}),
+            config=ExistingStaticHeaderConfig(),
+        )
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf, -np.inf])
+def test_validate_existing_static_headers_rejects_nan_inf(bad_value: float) -> None:
+    with pytest.raises(ValueError, match='finite'):
+        validate_existing_static_headers(
+            reader=_reader({99: np.array([0.0, bad_value, 0.0], dtype=np.float64)}),
+            config=ExistingStaticHeaderConfig(),
+        )
+
+
+def test_validate_trace_shift_limits_accepts_within_limit() -> None:
+    summary = validate_trace_shift_limits(
+        trace_shift_s_sorted=np.array([-0.1, 0.05, 0.0], dtype=np.float64),
+        max_abs_shift_ms=100.1,
+        expected_n_traces=3,
+    )
+
+    assert summary.n_traces == 3
+    assert summary.max_abs_shift_ms == pytest.approx(100.1)
+    assert summary.max_abs_observed_shift_ms == pytest.approx(100.0)
+
+
+def test_validate_trace_shift_limits_accepts_equal_to_limit() -> None:
+    summary = validate_trace_shift_limits(
+        trace_shift_s_sorted=np.array([-0.25, 0.25], dtype=np.float64),
+        max_abs_shift_ms=250.0,
+        expected_n_traces=2,
+    )
+
+    assert summary.max_abs_observed_shift_ms == pytest.approx(250.0)
+
+
+def test_validate_trace_shift_limits_rejects_exceeding_limit() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        validate_trace_shift_limits(
+            trace_shift_s_sorted=np.array([-0.1, 0.3012, -0.26], dtype=np.float64),
+            max_abs_shift_ms=250.0,
+            expected_n_traces=3,
+        )
+
+    message = str(exc_info.value)
+    assert 'limit=250.0 ms' in message
+    assert 'observed=301.2' in message
+    assert 'count=2' in message
+
+
+def test_validate_trace_shift_limits_rejects_shape_mismatch() -> None:
+    with pytest.raises(ValueError, match='shape mismatch'):
+        validate_trace_shift_limits(
+            trace_shift_s_sorted=np.array([0.0, 0.1], dtype=np.float64),
+            max_abs_shift_ms=250.0,
+            expected_n_traces=3,
+        )
+
+
+def test_validate_trace_shift_limits_rejects_non_1d_shift() -> None:
+    with pytest.raises(ValueError, match='1D array'):
+        validate_trace_shift_limits(
+            trace_shift_s_sorted=np.array([[0.0, 0.1]], dtype=np.float64),
+            max_abs_shift_ms=250.0,
+        )
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf, -np.inf])
+def test_validate_trace_shift_limits_rejects_non_finite_shift(
+    bad_value: float,
+) -> None:
+    with pytest.raises(ValueError, match='finite values'):
+        validate_trace_shift_limits(
+            trace_shift_s_sorted=np.array([0.0, bad_value], dtype=np.float64),
+            max_abs_shift_ms=250.0,
+        )
+
+
+def test_validate_trace_shift_limits_rejects_non_numeric_shift() -> None:
+    with pytest.raises(ValueError, match='numeric dtype'):
+        validate_trace_shift_limits(
+            trace_shift_s_sorted=np.array(['0.0', '0.1']),
+            max_abs_shift_ms=250.0,
+        )
+
+
+@pytest.mark.parametrize('bad_limit', [0.0, -1.0, np.nan, np.inf, -np.inf])
+def test_validate_trace_shift_limits_rejects_non_positive_limit(
+    bad_limit: float,
+) -> None:
+    with pytest.raises(ValueError, match='greater than 0'):
+        validate_trace_shift_limits(
+            trace_shift_s_sorted=np.array([0.0], dtype=np.float64),
+            max_abs_shift_ms=bad_limit,
+        )
+
+
+def test_validate_trace_shift_limits_summarizes_min_max_mean() -> None:
+    summary = validate_trace_shift_limits(
+        trace_shift_s_sorted=np.array([-0.1, 0.025, 0.05], dtype=np.float64),
+        max_abs_shift_ms=250.0,
+    )
+
+    assert summary.n_traces == 3
+    assert summary.min_shift_ms == pytest.approx(-100.0)
+    assert summary.max_shift_ms == pytest.approx(50.0)
+    assert summary.mean_shift_ms == pytest.approx(-25.0 / 3.0)
+    assert summary.max_abs_observed_shift_ms == pytest.approx(100.0)
+
+
+def test_validate_trace_shift_limits_accepts_datum_static_math_output() -> None:
+    result = compute_datum_static_shifts(
+        source_surface_elevation_m_sorted=np.array([100.0, 110.0]),
+        receiver_elevation_m_sorted=np.array([100.0, 120.0]),
+        datum_elevation_m=0.0,
+        replacement_velocity_m_s=2000.0,
+    )
+
+    summary = validate_trace_shift_limits(
+        trace_shift_s_sorted=result.trace_shift_s_sorted,
+        max_abs_shift_ms=250.0,
+        expected_n_traces=2,
+    )
+
+    assert summary.max_abs_observed_shift_ms <= 250.0


### PR DESCRIPTION
Closes #291

## Summary
- [PR2/statics] existing static header の nonzero 検出と max shift validation を実装する

## Changed files
- `app/services/datum_static_validation.py`
- `app/tests/test_datum_static_validation.py`

## Checks
- `.work/codex/checks.log`: 551 passed in 44.48s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
