### PR TITLE
[PR2/statics] `/statics/datum/apply` で補正済み TraceStore を生成・登録する

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
+from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import FileResponse
 
 from app.api._helpers import get_state
-from app.api.schemas import StaticJobFilesResponse, StaticJobStatusResponse
+from app.api.schemas import (
+    DatumStaticApplyRequest,
+    DatumStaticApplyResponse,
+    StaticJobFilesResponse,
+    StaticJobStatusResponse,
+)
 from app.core.state import AppState
+from app.services.datum_static_service import run_datum_static_apply_job
 from app.services.in_memory_cleanup import cleanup_in_memory_state
 from app.services.job_manager import JobManager
-from app.services.job_runner import request_job_cancel
-from app.services.pipeline_artifacts import maybe_cleanup_expired_jobs
+from app.services.job_runner import request_job_cancel, start_job_thread
+from app.services.pipeline_artifacts import get_job_dir, maybe_cleanup_expired_jobs
 
 router = APIRouter()
 
@@ -48,6 +56,36 @@ def _static_job_status_payload(
         'progress': float(progress) if isinstance(progress, (int, float)) else 0.0,
         'message': message if isinstance(message, str) else '',
     }
+
+
+@router.post('/statics/datum/apply', response_model=DatumStaticApplyResponse)
+def datum_static_apply(
+    req: DatumStaticApplyRequest,
+    request: Request,
+) -> DatumStaticApplyResponse:
+    state = get_state(request.app)
+    cleanup_in_memory_state(state)
+    maybe_cleanup_expired_jobs()
+
+    job_id = str(uuid4())
+    with state.lock:
+        job_state = state.jobs.create_static_job(
+            job_id,
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            statics_kind='datum',
+            artifacts_dir=str(get_job_dir(job_id)),
+        )
+        status = job_state['status']
+
+    start_job_thread(
+        thread_factory=threading.Thread,
+        target=run_datum_static_apply_job,
+        args=(job_id, req, state),
+    )
+
+    return {'job_id': job_id, 'state': status}
 
 
 @router.get(

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,5 +1,6 @@
 """Pydantic models for describing pipeline operations."""
 
+import math
 from pathlib import Path
 from typing import Any, Literal
 
@@ -273,3 +274,83 @@ class StaticJobFilesResponse(BaseModel):
     """Response model for static correction job files listing."""
 
     files: list[StaticJobFile]
+
+
+class DatumStaticGeometryRequest(BaseModel):
+    """Geometry header configuration for datum static correction."""
+
+    source_elevation_byte: int = 45
+    receiver_elevation_byte: int = 41
+    elevation_scalar_byte: int = 69
+    source_depth_byte: int | None = None
+    elevation_unit: Literal['m', 'ft'] = 'm'
+
+
+class DatumStaticDatumRequest(BaseModel):
+    """Datum plane and replacement velocity parameters."""
+
+    mode: Literal['constant'] = 'constant'
+    elevation_m: float
+    replacement_velocity_m_s: float
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'DatumStaticDatumRequest':
+        if not math.isfinite(float(self.elevation_m)):
+            raise ValueError('datum.elevation_m must be finite')
+        velocity = float(self.replacement_velocity_m_s)
+        if not math.isfinite(velocity) or velocity <= 0.0:
+            raise ValueError('datum.replacement_velocity_m_s must be finite and > 0')
+        return self
+
+
+class DatumStaticExistingStaticsRequest(BaseModel):
+    """Existing static-header validation options."""
+
+    policy: Literal['fail_if_nonzero'] = 'fail_if_nonzero'
+    source_static_byte: int | None = 99
+    receiver_static_byte: int | None = 101
+    total_static_byte: int | None = 103
+
+
+class DatumStaticApplyOptions(BaseModel):
+    """Options for building the corrected TraceStore."""
+
+    interpolation: Literal['linear'] = 'linear'
+    fill_value: float = 0.0
+    max_abs_shift_ms: float = 250.0
+    output_dtype: Literal['float32'] = 'float32'
+    register_corrected_file: bool = True
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'DatumStaticApplyOptions':
+        if not math.isfinite(float(self.fill_value)):
+            raise ValueError('apply.fill_value must be finite')
+        max_abs_shift_ms = float(self.max_abs_shift_ms)
+        if not math.isfinite(max_abs_shift_ms) or max_abs_shift_ms <= 0.0:
+            raise ValueError('apply.max_abs_shift_ms must be finite and > 0')
+        if self.register_corrected_file is not True:
+            raise ValueError('apply.register_corrected_file must be true')
+        return self
+
+
+class DatumStaticApplyRequest(BaseModel):
+    """Request model for ``/statics/datum/apply``."""
+
+    file_id: str
+    key1_byte: int = 189
+    key2_byte: int = 193
+    geometry: DatumStaticGeometryRequest = Field(
+        default_factory=DatumStaticGeometryRequest
+    )
+    datum: DatumStaticDatumRequest
+    existing_statics: DatumStaticExistingStaticsRequest = Field(
+        default_factory=DatumStaticExistingStaticsRequest,
+    )
+    apply: DatumStaticApplyOptions = Field(default_factory=DatumStaticApplyOptions)
+
+
+class DatumStaticApplyResponse(BaseModel):
+    """Response model for creating a datum static apply job."""
+
+    job_id: str
+    state: str

--- a/app/services/datum_static_service.py
+++ b/app/services/datum_static_service.py
@@ -1,0 +1,568 @@
+"""Datum static correction background job service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+import re
+import shutil
+import time
+from typing import Any
+from uuid import uuid4
+
+import numpy as np
+
+from app.api.schemas import DatumStaticApplyRequest
+from app.core.paths import get_trace_store_dir
+from app.core.state import AppState
+from app.services.corrected_trace_store import (
+    TimeShiftedTraceStoreResult,
+    build_time_shifted_trace_store,
+)
+from app.services.datum_static_geometry import (
+    DatumStaticGeometryConfig,
+    load_datum_static_geometry,
+)
+from app.services.datum_static_math import compute_datum_static_shifts
+from app.services.datum_static_validation import (
+    ExistingStaticHeaderConfig,
+    validate_existing_static_headers,
+    validate_trace_shift_limits,
+)
+from app.services.job_runner import (
+    JobCancelledError,
+    JobCompletion,
+    JobFailure,
+    ensure_job_not_cancelled,
+    run_job_with_lifecycle,
+)
+from app.services.pipeline_artifacts import get_job_dir
+from app.services.reader import get_reader
+from app.services.static_artifacts import (
+    QC_JSON_NAME,
+    SOLUTION_NPZ_NAME,
+    STATICS_CSV_NAME,
+    write_datum_static_artifacts,
+)
+from app.services.trace_store_registration import (
+    register_trace_store,
+    trace_store_cache_key,
+)
+
+_SAFE_STORE_NAME_RE = re.compile(r'[^A-Za-z0-9_.-]+')
+_CORRECTED_FILE_NAME = 'corrected_file.json'
+
+
+@dataclass
+class _DatumStaticLifecycle:
+    created_ts: float
+    job_dir: Path | None = None
+    corrected_store_path: Path | None = None
+    corrected_store_built: bool = False
+    corrected_file_id: str | None = None
+    key1_byte: int | None = None
+    key2_byte: int | None = None
+
+
+def _resolve_created_ts(state: AppState, job_id: str) -> float:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        if job is None:
+            return time.time()
+        created_ts_obj = job.get('created_ts')
+    return (
+        float(created_ts_obj)
+        if isinstance(created_ts_obj, (int, float))
+        else time.time()
+    )
+
+
+def _resolve_job_dir(state: AppState, job_id: str) -> Path:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        artifacts_dir = job.get('artifacts_dir') if isinstance(job, dict) else None
+    if isinstance(artifacts_dir, str) and artifacts_dir:
+        return Path(artifacts_dir)
+    return get_job_dir(job_id)
+
+
+def _set_job_progress_message(
+    state: AppState,
+    job_id: str,
+    *,
+    progress: float,
+    message: str,
+) -> None:
+    with state.lock:
+        if state.jobs.get(job_id) is None:
+            return
+        state.jobs.set_progress(job_id, progress)
+        state.jobs.set_message(job_id, message)
+
+
+def _is_cancel_requested(state: AppState, job_id: str) -> bool:
+    with state.lock:
+        return state.jobs.is_cancel_requested(job_id)
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+    try:
+        tmp_path.write_text(
+            json.dumps(payload, ensure_ascii=True, sort_keys=True),
+            encoding='utf-8',
+        )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _write_job_meta(
+    *,
+    job_id: str,
+    job_dir: Path,
+    req: DatumStaticApplyRequest,
+) -> None:
+    _write_json_atomic(
+        job_dir / 'job_meta.json',
+        {
+            'job_id': job_id,
+            'job_type': 'statics',
+            'statics_kind': 'datum',
+            'source_file_id': req.file_id,
+            'key1_byte': req.key1_byte,
+            'key2_byte': req.key2_byte,
+            'request': req.model_dump(mode='json'),
+        },
+    )
+
+
+def _safe_store_name_component(name: str) -> str:
+    safe = _SAFE_STORE_NAME_RE.sub('_', name)
+    if safe in {'', '.', '..'}:
+        raise ValueError('source TraceStore name cannot be made filesystem-safe')
+    return safe
+
+
+def _corrected_store_path(*, source_store_path: Path, job_id: str) -> Path:
+    trace_store_dir = get_trace_store_dir()
+    trace_store_dir.mkdir(parents=True, exist_ok=True)
+    source_name = _safe_store_name_component(source_store_path.name)
+    job_prefix = _safe_store_name_component(str(job_id)[:8])
+    store_name = f'{source_name}.statics.datum.{job_prefix}'
+    path = trace_store_dir / store_name
+    if path.exists() or path.is_symlink():
+        raise ValueError(f'corrected output path already exists: {path}')
+    return path
+
+
+def _source_store_path(reader: object) -> Path:
+    store_dir = getattr(reader, 'store_dir', None)
+    try:
+        path = Path(store_dir)
+    except TypeError as exc:
+        raise ValueError('source TraceStore path is not available') from exc
+    if not path.is_dir():
+        raise ValueError(f'source TraceStore does not exist: {path}')
+    return path
+
+
+def _resolve_dt(state: AppState, file_id: str) -> float:
+    dt = float(state.file_registry.get_dt(file_id))
+    if not math.isfinite(dt) or dt <= 0.0:
+        raise ValueError('dt must be finite and greater than 0')
+    return dt
+
+
+def _header_bytes_to_materialize(req: DatumStaticApplyRequest) -> tuple[int, ...]:
+    values = [
+        req.key1_byte,
+        req.key2_byte,
+        req.geometry.source_elevation_byte,
+        req.geometry.receiver_elevation_byte,
+        req.geometry.elevation_scalar_byte,
+    ]
+    if req.geometry.source_depth_byte is not None:
+        values.append(req.geometry.source_depth_byte)
+    for byte in (
+        req.existing_statics.source_static_byte,
+        req.existing_statics.receiver_static_byte,
+        req.existing_statics.total_static_byte,
+    ):
+        if byte is not None:
+            values.append(byte)
+    return tuple(dict.fromkeys(int(value) for value in values))
+
+
+def _reader_original_segy_path(reader: object) -> str | None:
+    meta = getattr(reader, 'meta', None)
+    if not isinstance(meta, dict):
+        return None
+    original = meta.get('original_segy_path')
+    return original if isinstance(original, str) else None
+
+
+def _load_sorted_header(reader: object, byte: int, *, name: str) -> np.ndarray:
+    get_header = getattr(reader, 'get_header')
+    values = np.asarray(get_header(int(byte)))
+    n_traces = int(getattr(reader, 'traces').shape[0])
+    if values.shape != (n_traces,):
+        raise ValueError(
+            f'{name} header byte {byte} shape mismatch: '
+            f'expected {(n_traces,)}, got {values.shape}'
+        )
+    return values
+
+
+def _build_corrected_file_payload(
+    *,
+    corrected_file_id: str,
+    build_result: TimeShiftedTraceStoreResult,
+    source_store_path: Path,
+    req: DatumStaticApplyRequest,
+    job_id: str,
+) -> dict[str, object]:
+    return {
+        'file_id': corrected_file_id,
+        'store_path': str(build_result.store_path),
+        'store_name': build_result.store_path.name,
+        'derived_from_file_id': req.file_id,
+        'derived_from_store_path': str(source_store_path),
+        'derived_by': 'datum_static_correction',
+        'job_id': job_id,
+        'key1_byte': req.key1_byte,
+        'key2_byte': req.key2_byte,
+        'dt': build_result.dt,
+        'n_traces': build_result.n_traces,
+        'n_samples': build_result.n_samples,
+        'solution_artifact': SOLUTION_NPZ_NAME,
+        'qc_artifact': QC_JSON_NAME,
+        'statics_csv': STATICS_CSV_NAME,
+    }
+
+
+def _cleanup_corrected_outputs(
+    state: AppState,
+    lifecycle: _DatumStaticLifecycle,
+) -> None:
+    if lifecycle.corrected_file_id is not None:
+        with state.lock:
+            state.file_registry.pop(lifecycle.corrected_file_id, None)
+            if lifecycle.key1_byte is not None and lifecycle.key2_byte is not None:
+                state.cached_readers.pop(
+                    trace_store_cache_key(
+                        lifecycle.corrected_file_id,
+                        lifecycle.key1_byte,
+                        lifecycle.key2_byte,
+                    ),
+                    None,
+                )
+    if lifecycle.corrected_store_path is None:
+        return
+    for tmp_path in lifecycle.corrected_store_path.parent.glob(
+        f'{lifecycle.corrected_store_path.name}.tmp-*'
+    ):
+        if tmp_path.is_dir():
+            shutil.rmtree(tmp_path, ignore_errors=True)
+    if lifecycle.corrected_store_built and lifecycle.corrected_store_path.exists():
+        shutil.rmtree(lifecycle.corrected_store_path, ignore_errors=True)
+
+
+def _run_datum_static_apply_job_body(
+    job_id: str,
+    req: DatumStaticApplyRequest,
+    state: AppState,
+    *,
+    lifecycle: _DatumStaticLifecycle,
+) -> JobCompletion | None:
+    lifecycle.key1_byte = req.key1_byte
+    lifecycle.key2_byte = req.key2_byte
+    job_dir = _resolve_job_dir(state, job_id)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    lifecycle.job_dir = job_dir
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.05,
+        message='resolving_source_trace_store',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    reader = get_reader(req.file_id, req.key1_byte, req.key2_byte, state=state)
+    source_store_path = _source_store_path(reader)
+    dt = _resolve_dt(state, req.file_id)
+    _write_job_meta(job_id=job_id, job_dir=job_dir, req=req)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.10,
+        message='loading_geometry_headers',
+    )
+    geometry = load_datum_static_geometry(
+        reader=reader,
+        config=DatumStaticGeometryConfig(
+            source_elevation_byte=req.geometry.source_elevation_byte,
+            receiver_elevation_byte=req.geometry.receiver_elevation_byte,
+            elevation_scalar_byte=req.geometry.elevation_scalar_byte,
+            source_depth_byte=req.geometry.source_depth_byte,
+            elevation_unit=req.geometry.elevation_unit,
+        ),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.20,
+        message='computing_datum_static_shifts',
+    )
+    result = compute_datum_static_shifts(
+        source_surface_elevation_m_sorted=(
+            geometry.source_surface_elevation_m_sorted
+        ),
+        receiver_elevation_m_sorted=geometry.receiver_elevation_m_sorted,
+        source_depth_m_sorted=(
+            geometry.source_depth_m_sorted
+            if req.geometry.source_depth_byte is not None
+            else None
+        ),
+        datum_elevation_m=req.datum.elevation_m,
+        replacement_velocity_m_s=req.datum.replacement_velocity_m_s,
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.25,
+        message='validating_existing_static_headers',
+    )
+    existing_check = validate_existing_static_headers(
+        reader=reader,
+        config=ExistingStaticHeaderConfig(
+            policy=req.existing_statics.policy,
+            source_static_byte=req.existing_statics.source_static_byte,
+            receiver_static_byte=req.existing_statics.receiver_static_byte,
+            total_static_byte=req.existing_statics.total_static_byte,
+        ),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.30,
+        message='validating_shift_limits',
+    )
+    shift_validation = validate_trace_shift_limits(
+        trace_shift_s_sorted=result.trace_shift_s_sorted,
+        max_abs_shift_ms=req.apply.max_abs_shift_ms,
+        expected_n_traces=geometry.n_traces,
+    )
+    key1_sorted = _load_sorted_header(reader, req.key1_byte, name='key1')
+    key2_sorted = _load_sorted_header(reader, req.key2_byte, name='key2')
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.35,
+        message='writing_datum_static_artifacts',
+    )
+    write_datum_static_artifacts(
+        job_dir=job_dir,
+        trace_shift_s_sorted=result.trace_shift_s_sorted,
+        source_shift_s_sorted=result.source_shift_s_sorted,
+        receiver_shift_s_sorted=result.receiver_shift_s_sorted,
+        source_surface_elevation_m_sorted=result.source_surface_elevation_m_sorted,
+        source_depth_m_sorted=result.source_depth_m_sorted,
+        source_depth_used_sorted=result.source_depth_used_sorted,
+        source_elevation_m_sorted=result.source_elevation_m_sorted,
+        receiver_elevation_m_sorted=result.receiver_elevation_m_sorted,
+        key1_sorted=key1_sorted,
+        key2_sorted=key2_sorted,
+        datum_elevation_m=req.datum.elevation_m,
+        replacement_velocity_m_s=req.datum.replacement_velocity_m_s,
+        dt=dt,
+        key1_byte=req.key1_byte,
+        key2_byte=req.key2_byte,
+        source_elevation_byte=req.geometry.source_elevation_byte,
+        receiver_elevation_byte=req.geometry.receiver_elevation_byte,
+        elevation_scalar_byte=req.geometry.elevation_scalar_byte,
+        source_depth_byte=req.geometry.source_depth_byte,
+        source_depth_enabled=req.geometry.source_depth_byte is not None,
+        elevation_unit=req.geometry.elevation_unit,
+        elevation_scalar_zero_count=geometry.elevation_scalar_zero_count,
+        existing_static_check=existing_check,
+        trace_shift_validation=shift_validation,
+        header_source_segy_path=_reader_original_segy_path(reader),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    header_bytes_to_materialize = _header_bytes_to_materialize(req)
+    corrected_store_path = _corrected_store_path(
+        source_store_path=source_store_path,
+        job_id=job_id,
+    )
+    lifecycle.corrected_store_path = corrected_store_path
+
+    def progress_callback(builder_progress: float, message: str) -> None:
+        mapped = 0.40 + (0.50 * max(0.0, min(1.0, float(builder_progress))))
+        _set_job_progress_message(
+            state,
+            job_id,
+            progress=mapped,
+            message=message,
+        )
+
+    def cancel_check() -> bool:
+        return _is_cancel_requested(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.40,
+        message='building_corrected_trace_store',
+    )
+    try:
+        build_result = build_time_shifted_trace_store(
+            source_store_path=source_store_path,
+            output_store_path=corrected_store_path,
+            trace_shift_s_sorted=result.trace_shift_s_sorted,
+            fill_value=req.apply.fill_value,
+            output_dtype=req.apply.output_dtype,
+            from_file_id=req.file_id,
+            header_bytes_to_materialize=header_bytes_to_materialize,
+            derived_metadata={
+                'statics_kind': 'datum',
+                'job_id': job_id,
+                'solution_artifact': SOLUTION_NPZ_NAME,
+                'qc_artifact': QC_JSON_NAME,
+                'statics_csv': STATICS_CSV_NAME,
+                'shift_field': 'trace_shift_s_sorted',
+                'value_kind': 'applied_event_time_shift_s',
+                'datum_elevation_m': req.datum.elevation_m,
+                'replacement_velocity_m_s': req.datum.replacement_velocity_m_s,
+                'geometry': {
+                    'source_elevation_byte': req.geometry.source_elevation_byte,
+                    'receiver_elevation_byte': req.geometry.receiver_elevation_byte,
+                    'elevation_scalar_byte': req.geometry.elevation_scalar_byte,
+                    'source_depth_byte': req.geometry.source_depth_byte,
+                    'elevation_unit': req.geometry.elevation_unit,
+                },
+            },
+            progress_callback=progress_callback,
+            cancel_check=cancel_check,
+        )
+    except RuntimeError as exc:
+        if 'cancelled' in str(exc).lower() and cancel_check():
+            raise JobCancelledError() from exc
+        raise
+    lifecycle.corrected_store_built = True
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.90,
+        message='registering_corrected_trace_store',
+    )
+    corrected_file_id = str(uuid4())
+    register_trace_store(
+        state=state,
+        file_id=corrected_file_id,
+        store_dir=build_result.store_path,
+        key1_byte=req.key1_byte,
+        key2_byte=req.key2_byte,
+        dt=build_result.dt,
+        update_registry=True,
+        touch_meta=True,
+        preload_header_bytes=header_bytes_to_materialize,
+    )
+    lifecycle.corrected_file_id = corrected_file_id
+    with state.lock:
+        state.jobs.set_static_corrected_file(
+            job_id,
+            corrected_file_id=corrected_file_id,
+            corrected_store_path=str(build_result.store_path),
+        )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.95,
+        message='writing_corrected_file_manifest',
+    )
+    _write_json_atomic(
+        job_dir / _CORRECTED_FILE_NAME,
+        _build_corrected_file_payload(
+            corrected_file_id=corrected_file_id,
+            build_result=build_result,
+            source_store_path=source_store_path,
+            req=req,
+            job_id=job_id,
+        ),
+    )
+    _set_job_progress_message(state, job_id, progress=1.0, message='done')
+    return JobCompletion(finished_ts=time.time())
+
+
+def _handle_datum_static_job_error(
+    *,
+    state: AppState,
+    lifecycle: _DatumStaticLifecycle,
+) -> JobFailure:
+    _cleanup_corrected_outputs(state, lifecycle)
+    return JobFailure(finished_ts=time.time())
+
+
+def _handle_datum_static_job_cancel(
+    *,
+    state: AppState,
+    lifecycle: _DatumStaticLifecycle,
+    exc: JobCancelledError,
+) -> JobCompletion:
+    _cleanup_corrected_outputs(state, lifecycle)
+    finished_ts = float(exc.finished_ts) if exc.finished_ts is not None else time.time()
+    return JobCompletion(finished_ts=finished_ts)
+
+
+def run_datum_static_apply_job(
+    job_id: str,
+    req: DatumStaticApplyRequest,
+    state: AppState,
+) -> None:
+    """Run one datum static correction job and register the corrected TraceStore."""
+    lifecycle = _DatumStaticLifecycle(created_ts=_resolve_created_ts(state, job_id))
+    run_job_with_lifecycle(
+        state=state,
+        job_id=job_id,
+        worker=lambda: _run_datum_static_apply_job_body(
+            job_id,
+            req,
+            state,
+            lifecycle=lifecycle,
+        ),
+        progress_1_on_done=True,
+        start_progress=0.0,
+        clear_message_on_start=True,
+        on_error=lambda _exc: _handle_datum_static_job_error(
+            state=state,
+            lifecycle=lifecycle,
+        ),
+        on_cancel=lambda exc: _handle_datum_static_job_cancel(
+            state=state,
+            lifecycle=lifecycle,
+            exc=exc,
+        ),
+    )
+
+
+__all__ = ['run_datum_static_apply_job']

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -316,6 +316,19 @@ class JobManager:
             return
         job['message'] = message
 
+    def set_static_corrected_file(
+        self,
+        job_id: str,
+        *,
+        corrected_file_id: str,
+        corrected_store_path: str,
+    ) -> None:
+        job = self._jobs.get(job_id)
+        if job is None:
+            return
+        job['corrected_file_id'] = corrected_file_id
+        job['corrected_store_path'] = corrected_store_path
+
     def request_cancel(
         self,
         job_id: str,

--- a/app/tests/test_datum_static_apply_job_api.py
+++ b/app/tests/test_datum_static_apply_job_api.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.routers.statics as statics_router_module
+from app.main import app
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv('PIPELINE_JOBS_DIR', str(tmp_path / 'jobs'))
+    state = app.state.sv
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        'file_id': 'source-file-id',
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'datum': {
+            'mode': 'constant',
+            'elevation_m': 0.0,
+            'replacement_velocity_m_s': 2000.0,
+        },
+        'apply': {
+            'interpolation': 'linear',
+            'fill_value': 0.0,
+            'max_abs_shift_ms': 250.0,
+            'output_dtype': 'float32',
+            'register_corrected_file': True,
+        },
+    }
+
+
+def test_datum_static_apply_endpoint_starts_job(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+
+    def _capture_start_job_thread(**kwargs: Any) -> object:
+        started.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        _capture_start_job_thread,
+    )
+
+    response = client.post('/statics/datum/apply', json=_payload())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['state'] == 'queued'
+    assert isinstance(payload['job_id'], str)
+    assert len(started) == 1
+    assert started[0]['target'] is statics_router_module.run_datum_static_apply_job
+
+    state = client.app.state.sv
+    with state.lock:
+        job = dict(state.jobs[payload['job_id']])
+
+    assert job['status'] == 'queued'
+    assert job['job_type'] == 'statics'
+    assert job['statics_kind'] == 'datum'
+    assert job['file_id'] == 'source-file-id'
+    assert job['key1_byte'] == 189
+    assert job['key2_byte'] == 193
+
+
+@pytest.mark.parametrize(
+    'mutator',
+    [
+        lambda payload: payload['datum'].update({'mode': 'floating'}),
+        lambda payload: payload['apply'].update({'interpolation': 'nearest'}),
+        lambda payload: payload['apply'].update({'output_dtype': 'float64'}),
+        lambda payload: payload['apply'].update({'register_corrected_file': False}),
+        lambda payload: payload['apply'].update({'max_abs_shift_ms': 0.0}),
+        lambda payload: payload['datum'].update({'replacement_velocity_m_s': 0.0}),
+    ],
+)
+def test_datum_static_apply_endpoint_rejects_unsupported_mvp_options(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    mutator,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+    payload = _payload()
+    mutator(payload)
+
+    response = client.post('/statics/datum/apply', json=payload)
+
+    assert response.status_code == 422
+    assert started == []

--- a/app/tests/test_datum_static_apply_trace_store.py
+++ b/app/tests/test_datum_static_apply_trace_store.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import app.services.datum_static_service as service
+from app.api.schemas import DatumStaticApplyRequest
+from app.core.state import AppState, create_app_state
+from app.services.datum_static_service import run_datum_static_apply_job
+from app.services.trace_store_registration import trace_store_cache_key
+
+KEY1 = 189
+KEY2 = 193
+SOURCE_ELEVATION = 45
+RECEIVER_ELEVATION = 41
+ELEVATION_SCALAR = 69
+SOURCE_STATIC = 99
+RECEIVER_STATIC = 101
+TOTAL_STATIC = 103
+SOURCE_FILE_ID = 'source-file-id'
+
+
+def _write_source_store(
+    store: Path,
+    *,
+    traces: np.ndarray | None = None,
+    source_elevation_m: float = 100.0,
+    receiver_elevation_m: float = 100.0,
+    existing_static_value: int = 0,
+    sorted_to_original: np.ndarray | None = None,
+    dt: float = 0.004,
+) -> np.ndarray:
+    store.mkdir(parents=True, exist_ok=True)
+    if traces is None:
+        traces = np.zeros((4, 96), dtype=np.float32)
+        traces[:, 40] = 1.0
+    traces = np.asarray(traces, dtype=np.float32)
+    n_traces, n_samples = traces.shape
+    np.save(store / 'traces.npy', traces)
+
+    if sorted_to_original is None:
+        sorted_to_original = np.asarray([2, 0, 3, 1], dtype=np.int64)
+    np.savez(
+        store / 'index.npz',
+        key1_values=np.asarray([100], dtype=np.int64),
+        key1_offsets=np.asarray([0], dtype=np.int64),
+        key1_counts=np.asarray([n_traces], dtype=np.int64),
+        sorted_to_original=np.asarray(sorted_to_original, dtype=np.int64),
+    )
+
+    headers = {
+        KEY1: np.full(n_traces, 100, dtype=np.int32),
+        KEY2: np.arange(10, 10 + n_traces, dtype=np.int32),
+        SOURCE_ELEVATION: np.full(n_traces, source_elevation_m, dtype=np.int32),
+        RECEIVER_ELEVATION: np.full(n_traces, receiver_elevation_m, dtype=np.int32),
+        ELEVATION_SCALAR: np.ones(n_traces, dtype=np.int16),
+        SOURCE_STATIC: np.full(n_traces, existing_static_value, dtype=np.int16),
+        RECEIVER_STATIC: np.zeros(n_traces, dtype=np.int16),
+        TOTAL_STATIC: np.zeros(n_traces, dtype=np.int16),
+    }
+    for byte, values in headers.items():
+        np.save(store / f'headers_byte_{byte}.npy', values)
+
+    meta = {
+        'schema_version': 1,
+        'dtype': 'float32',
+        'n_traces': int(n_traces),
+        'n_samples': int(n_samples),
+        'key_bytes': {'key1': KEY1, 'key2': KEY2},
+        'sorted_by': ['key1', 'key2'],
+        'dt': dt,
+        'original_segy_path': None,
+        'source_sha256': None,
+        'original_name': 'line001.sgy',
+    }
+    (store / 'meta.json').write_text(json.dumps(meta), encoding='utf-8')
+    return traces
+
+
+def _state_with_source_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    **source_kwargs: Any,
+) -> tuple[AppState, Path, Path]:
+    trace_dir = tmp_path / 'trace_stores'
+    jobs_dir = tmp_path / 'jobs'
+    monkeypatch.setenv('SV_TRACE_DIR', str(trace_dir))
+    monkeypatch.setenv('PIPELINE_JOBS_DIR', str(jobs_dir))
+
+    source_store = trace_dir / 'line001.sgy'
+    _write_source_store(source_store, **source_kwargs)
+
+    state = create_app_state()
+    state.file_registry.update(
+        SOURCE_FILE_ID,
+        store_path=str(source_store),
+        dt=0.004,
+    )
+    return state, source_store, trace_dir
+
+
+def _request(**overrides: Any) -> DatumStaticApplyRequest:
+    payload: dict[str, Any] = {
+        'file_id': SOURCE_FILE_ID,
+        'key1_byte': KEY1,
+        'key2_byte': KEY2,
+        'datum': {
+            'mode': 'constant',
+            'elevation_m': 0.0,
+            'replacement_velocity_m_s': 2000.0,
+        },
+        'apply': {
+            'interpolation': 'linear',
+            'fill_value': 0.0,
+            'max_abs_shift_ms': 250.0,
+            'output_dtype': 'float32',
+            'register_corrected_file': True,
+        },
+    }
+    payload.update(overrides)
+    return DatumStaticApplyRequest(**payload)
+
+
+def _create_job(
+    state: AppState,
+    tmp_path: Path,
+    *,
+    job_id: str,
+    req: DatumStaticApplyRequest,
+) -> Path:
+    job_dir = tmp_path / 'jobs' / job_id
+    with state.lock:
+        state.jobs.create_static_job(
+            job_id,
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            statics_kind='datum',
+            artifacts_dir=str(job_dir),
+        )
+    return job_dir
+
+
+def _run_job(
+    state: AppState,
+    tmp_path: Path,
+    *,
+    job_id: str = '11111111-2222-3333-4444-555555555555',
+    req: DatumStaticApplyRequest | None = None,
+) -> tuple[DatumStaticApplyRequest, Path]:
+    if req is None:
+        req = _request()
+    job_dir = _create_job(state, tmp_path, job_id=job_id, req=req)
+    run_datum_static_apply_job(job_id, req, state)
+    return req, job_dir
+
+
+def test_datum_static_apply_job_success_builds_and_registers_corrected_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, source_store, _trace_dir = _state_with_source_store(tmp_path, monkeypatch)
+    req, job_dir = _run_job(state, tmp_path)
+
+    with state.lock:
+        job = dict(state.jobs['11111111-2222-3333-4444-555555555555'])
+
+    assert job['status'] == 'done'
+    corrected_file_id = job['corrected_file_id']
+    corrected_store_path = Path(str(job['corrected_store_path']))
+    assert corrected_store_path.name == 'line001.sgy.statics.datum.11111111'
+    assert corrected_store_path.is_dir()
+    assert state.file_registry.get_store_path(str(corrected_file_id)) == str(
+        corrected_store_path
+    )
+    assert state.file_registry.get_dt(str(corrected_file_id)) == pytest.approx(0.004)
+    with state.lock:
+        assert (
+            trace_store_cache_key(str(corrected_file_id), KEY1, KEY2)
+            in state.cached_readers
+        )
+
+    corrected = np.load(corrected_store_path / 'traces.npy')
+    assert int(np.argmax(corrected[0])) == 15
+    assert corrected[0, 15] == pytest.approx(1.0)
+
+    with np.load(source_store / 'index.npz', allow_pickle=False) as src:
+        with np.load(corrected_store_path / 'index.npz', allow_pickle=False) as dst:
+            np.testing.assert_array_equal(
+                dst['sorted_to_original'],
+                src['sorted_to_original'],
+            )
+
+    meta = json.loads((corrected_store_path / 'meta.json').read_text(encoding='utf-8'))
+    assert meta['derived']['statics_kind'] == 'datum'
+    assert meta['derived']['from_file_id'] == req.file_id
+    assert meta['derived']['datum_elevation_m'] == pytest.approx(0.0)
+    assert meta['derived']['replacement_velocity_m_s'] == pytest.approx(2000.0)
+
+    corrected_manifest = json.loads(
+        (job_dir / 'corrected_file.json').read_text(encoding='utf-8')
+    )
+    assert corrected_manifest['file_id'] == corrected_file_id
+    assert corrected_manifest['store_path'] == str(corrected_store_path)
+    assert corrected_manifest['derived_from_file_id'] == SOURCE_FILE_ID
+    assert corrected_manifest['derived_from_store_path'] == str(source_store)
+    assert corrected_manifest['job_id'] == '11111111-2222-3333-4444-555555555555'
+    assert corrected_manifest['key1_byte'] == KEY1
+    assert corrected_manifest['key2_byte'] == KEY2
+    assert corrected_manifest['dt'] == pytest.approx(0.004)
+
+    for name in (
+        'job_meta.json',
+        'datum_static_solution.npz',
+        'datum_static_qc.json',
+        'datum_statics.csv',
+        'corrected_file.json',
+    ):
+        assert (job_dir / name).is_file()
+
+
+def test_datum_static_apply_job_writes_job_meta_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, _source_store, _trace_dir = _state_with_source_store(tmp_path, monkeypatch)
+    _req, job_dir = _run_job(state, tmp_path)
+
+    meta = json.loads((job_dir / 'job_meta.json').read_text(encoding='utf-8'))
+
+    assert meta['job_type'] == 'statics'
+    assert meta['statics_kind'] == 'datum'
+    assert meta['source_file_id'] == SOURCE_FILE_ID
+    assert meta['key1_byte'] == KEY1
+    assert meta['key2_byte'] == KEY2
+    assert meta['request']['datum']['mode'] == 'constant'
+
+
+def test_datum_static_apply_job_materializes_required_headers_in_corrected_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, _source_store, _trace_dir = _state_with_source_store(tmp_path, monkeypatch)
+    _run_job(state, tmp_path)
+    with state.lock:
+        corrected_store_path = Path(str(state.jobs[
+            '11111111-2222-3333-4444-555555555555'
+        ]['corrected_store_path']))
+
+    for byte in (
+        KEY1,
+        KEY2,
+        SOURCE_ELEVATION,
+        RECEIVER_ELEVATION,
+        ELEVATION_SCALAR,
+        SOURCE_STATIC,
+        RECEIVER_STATIC,
+        TOTAL_STATIC,
+    ):
+        assert (corrected_store_path / f'headers_byte_{byte}.npy').is_file()
+
+
+def test_datum_static_apply_job_errors_on_existing_static_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, _source_store, trace_dir = _state_with_source_store(
+        tmp_path,
+        monkeypatch,
+        existing_static_value=1,
+    )
+    req = _request()
+    job_id = '22222222-nonzero'
+    _run_job(state, tmp_path, job_id=job_id, req=req)
+
+    with state.lock:
+        job = dict(state.jobs[job_id])
+
+    assert job['status'] == 'error'
+    assert 'existing SEG-Y static headers contain nonzero values' in str(
+        job['message']
+    )
+    assert 'corrected_file_id' not in job
+    assert not (trace_dir / 'line001.sgy.statics.datum.22222222').exists()
+
+
+def test_datum_static_apply_job_errors_on_large_shift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, _source_store, trace_dir = _state_with_source_store(tmp_path, monkeypatch)
+    req = _request(
+        apply={
+            'interpolation': 'linear',
+            'fill_value': 0.0,
+            'max_abs_shift_ms': 50.0,
+            'output_dtype': 'float32',
+            'register_corrected_file': True,
+        }
+    )
+    job_id = '33333333-large-shift'
+    _run_job(state, tmp_path, job_id=job_id, req=req)
+
+    with state.lock:
+        job = dict(state.jobs[job_id])
+
+    assert job['status'] == 'error'
+    assert 'exceeds max_abs_shift_ms' in str(job['message'])
+    assert not (trace_dir / 'line001.sgy.statics.datum.33333333').exists()
+
+
+def test_datum_static_apply_job_failure_after_build_removes_corrected_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, _source_store, trace_dir = _state_with_source_store(tmp_path, monkeypatch)
+
+    def _fail_register(**_kwargs: Any) -> None:
+        raise RuntimeError('registration failed')
+
+    monkeypatch.setattr(service, 'register_trace_store', _fail_register)
+    job_id = '44444444-register-fails'
+    _run_job(state, tmp_path, job_id=job_id)
+
+    with state.lock:
+        job = dict(state.jobs[job_id])
+
+    assert job['status'] == 'error'
+    assert job['message'] == 'registration failed'
+    assert not (trace_dir / 'line001.sgy.statics.datum.44444444').exists()
+
+
+def test_datum_static_apply_job_cancel_removes_partial_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, _source_store, trace_dir = _state_with_source_store(tmp_path, monkeypatch)
+    job_id = '55555555-cancelled'
+
+    def _cancelled_build(**kwargs: Any) -> None:
+        output_path = Path(kwargs['output_store_path'])
+        tmp_store = output_path.with_name(f'{output_path.name}.tmp-test')
+        tmp_store.mkdir()
+        with state.lock:
+            state.jobs.request_cancel(job_id)
+        assert kwargs['cancel_check']() is True
+        raise RuntimeError('time-shifted TraceStore build cancelled')
+
+    monkeypatch.setattr(
+        service,
+        'build_time_shifted_trace_store',
+        _cancelled_build,
+    )
+    _run_job(state, tmp_path, job_id=job_id)
+
+    with state.lock:
+        job = dict(state.jobs[job_id])
+
+    output = trace_dir / 'line001.sgy.statics.datum.55555555'
+    assert job['status'] == 'cancelled'
+    assert not output.exists()
+    assert not (trace_dir / f'{output.name}.tmp-test').exists()

--- a/app/tests/test_static_job_api.py
+++ b/app/tests/test_static_job_api.py
@@ -380,4 +380,4 @@ def test_statics_router_registered() -> None:
     assert '/statics/job/{job_id}/cancel' in paths
     assert '/statics/job/{job_id}/files' in paths
     assert '/statics/job/{job_id}/download' in paths
-    assert '/statics/datum/apply' not in paths
+    assert '/statics/datum/apply' in paths


### PR DESCRIPTION
Closes #297

## Summary
- [PR2/statics] `/statics/datum/apply` で補正済み TraceStore を生成・登録する

## Changed files
- `app/api/routers/statics.py`
- `app/api/schemas.py`
- `app/services/datum_static_service.py`
- `app/services/job_manager.py`
- `app/tests/test_datum_static_apply_job_api.py`
- `app/tests/test_datum_static_apply_trace_store.py`
- `app/tests/test_static_job_api.py`

## Checks
- `.work/codex/checks.log`: 619 passed in 44.93s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
