### PR TITLE
[PR3/pick-source] first-break pick source loader を追加し、batch/manual/memmap を sorted order に正規化する

### DIFF
--- a/app/services/pick_source_loader.py
+++ b/app/services/pick_source_loader.py
@@ -1,0 +1,386 @@
+"""First-break pick source loading and sorted-order normalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+
+from app.core.state import AppState
+from app.services.reader import get_reader
+from app.services.trace_store_index_validation import validate_sorted_to_original
+from app.trace_store.reader import TraceStoreSectionReader
+from app.utils.pick_cache_file1d_mem import path_for_file
+
+NpzPickSourceKind = Literal['batch_npz', 'manual_npz']
+PickSourceKind = Literal['batch_npz', 'manual_npz', 'manual_memmap']
+
+
+@dataclass(frozen=True)
+class LoadedPickSource:
+    picks_time_s_sorted: np.ndarray
+    valid_mask_sorted: np.ndarray
+    source_kind: PickSourceKind
+    n_traces: int
+    n_samples: int
+    dt: float
+    n_valid: int
+    n_nan: int
+    metadata: dict[str, object]
+
+
+def _coerce_nonnegative_int(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        msg = f'{name} must be an integer'
+        raise ValueError(msg)
+    out = int(value)
+    if out < 0:
+        msg = f'{name} must be non-negative'
+        raise ValueError(msg)
+    return out
+
+
+def _coerce_positive_int(value: object, *, name: str) -> int:
+    out = _coerce_nonnegative_int(value, name=name)
+    if out <= 0:
+        msg = f'{name} must be greater than 0'
+        raise ValueError(msg)
+    return out
+
+
+def _coerce_positive_float(value: object, *, name: str) -> float:
+    if isinstance(value, bool):
+        msg = f'{name} must be a positive finite float'
+        raise ValueError(msg)
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        msg = f'{name} must be a positive finite float'
+        raise ValueError(msg) from exc
+    if not np.isfinite(out) or out <= 0.0:
+        msg = f'{name} must be a positive finite float'
+        raise ValueError(msg)
+    return out
+
+
+def _reader_n_traces(reader: TraceStoreSectionReader) -> int:
+    n_traces = getattr(reader, 'ntraces', None)
+    if n_traces is None:
+        meta = getattr(reader, 'meta', None)
+        if isinstance(meta, dict):
+            n_traces = meta.get('n_traces')
+    if n_traces is None and hasattr(reader, 'traces'):
+        n_traces = getattr(reader.traces, 'shape', (None,))[0]
+    if n_traces is None:
+        msg = 'reader cannot provide number of traces'
+        raise ValueError(msg)
+    return _coerce_nonnegative_int(n_traces, name='reader n_traces')
+
+
+def _reader_n_samples(reader: TraceStoreSectionReader) -> int:
+    getter = getattr(reader, 'get_n_samples', None)
+    if callable(getter):
+        return _coerce_positive_int(getter(), name='reader n_samples')
+    if hasattr(reader, 'traces'):
+        shape = getattr(reader.traces, 'shape', ())
+        if len(shape) >= 2:
+            return _coerce_positive_int(shape[-1], name='reader n_samples')
+    msg = 'reader cannot provide number of samples'
+    raise ValueError(msg)
+
+
+def _read_int_scalar(npz: np.lib.npyio.NpzFile, key: str) -> int:
+    arr = np.asarray(npz[key])
+    if arr.size != 1:
+        msg = f'{key} must be a scalar'
+        raise ValueError(msg)
+    if not np.issubdtype(arr.dtype, np.integer):
+        msg = f'{key} must have an integer dtype'
+        raise ValueError(msg)
+    return int(arr.reshape(-1)[0])
+
+
+def _read_float_scalar(npz: np.lib.npyio.NpzFile, key: str) -> float:
+    arr = np.asarray(npz[key])
+    if arr.size != 1:
+        msg = f'{key} must be a scalar'
+        raise ValueError(msg)
+    if not np.issubdtype(arr.dtype, np.number):
+        msg = f'{key} must be numeric'
+        raise ValueError(msg)
+    return float(arr.reshape(-1)[0])
+
+
+def _validate_npz_metadata(
+    npz: np.lib.npyio.NpzFile,
+    *,
+    n_traces: int,
+    n_samples: int,
+    dt: float,
+) -> dict[str, object]:
+    metadata: dict[str, object] = {'npz_keys': tuple(npz.files)}
+    if 'n_traces' in npz.files:
+        npz_n_traces = _read_int_scalar(npz, 'n_traces')
+        metadata['n_traces'] = npz_n_traces
+        if npz_n_traces != n_traces:
+            msg = f'n_traces mismatch: expected {n_traces}, got {npz_n_traces}'
+            raise ValueError(msg)
+    if 'n_samples' in npz.files:
+        npz_n_samples = _read_int_scalar(npz, 'n_samples')
+        metadata['n_samples'] = npz_n_samples
+        if npz_n_samples != n_samples:
+            msg = f'n_samples mismatch: expected {n_samples}, got {npz_n_samples}'
+            raise ValueError(msg)
+    if 'dt' in npz.files:
+        npz_dt = _read_float_scalar(npz, 'dt')
+        metadata['dt'] = npz_dt
+        if not np.isfinite(npz_dt) or abs(npz_dt - dt) > 1e-9:
+            msg = f'dt mismatch: expected {dt}, got {npz_dt}'
+            raise ValueError(msg)
+    return metadata
+
+
+def _reader_sorted_to_original(
+    reader: TraceStoreSectionReader,
+    *,
+    n_traces: int,
+) -> np.ndarray:
+    values = reader.get_sorted_to_original()
+    return validate_sorted_to_original(
+        np.asarray(values),
+        expected_n_traces=n_traces,
+        role='reader',
+    )
+
+
+def _build_loaded_pick_source(
+    picks_time_s_sorted: np.ndarray,
+    *,
+    source_kind: PickSourceKind,
+    n_traces: int,
+    n_samples: int,
+    dt: float,
+    metadata: dict[str, object],
+) -> LoadedPickSource:
+    picks, valid_mask = validate_picks_time_s(
+        picks_time_s_sorted,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt=dt,
+    )
+    return LoadedPickSource(
+        picks_time_s_sorted=picks,
+        valid_mask_sorted=valid_mask,
+        source_kind=source_kind,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt=dt,
+        n_valid=int(np.count_nonzero(valid_mask)),
+        n_nan=int(np.count_nonzero(np.isnan(picks))),
+        metadata=metadata,
+    )
+
+
+def normalize_picks_original_to_sorted(
+    picks_time_s_original: np.ndarray,
+    *,
+    sorted_to_original: np.ndarray,
+) -> np.ndarray:
+    """Return picks reindexed from original trace order to sorted trace order."""
+    picks = np.asarray(picks_time_s_original)
+    if picks.ndim != 1:
+        msg = 'picks_time_s_original must be 1D'
+        raise ValueError(msg)
+    order = validate_sorted_to_original(
+        np.asarray(sorted_to_original),
+        expected_n_traces=int(picks.shape[0]),
+        role='sorted_to_original',
+    )
+    return np.ascontiguousarray(picks[order])
+
+
+def validate_picks_time_s(
+    picks_time_s: np.ndarray,
+    *,
+    n_traces: int,
+    n_samples: int,
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Validate pick times and return a float64 copy plus finite-value mask."""
+    expected_n_traces = _coerce_nonnegative_int(n_traces, name='n_traces')
+    expected_n_samples = _coerce_positive_int(n_samples, name='n_samples')
+    sample_interval = _coerce_positive_float(dt, name='dt')
+
+    arr = np.asarray(picks_time_s)
+    if arr.ndim != 1:
+        msg = 'picks_time_s must be 1D'
+        raise ValueError(msg)
+    if arr.shape != (expected_n_traces,):
+        msg = (
+            'picks_time_s shape mismatch: '
+            f'expected {(expected_n_traces,)}, got {arr.shape}'
+        )
+        raise ValueError(msg)
+    if not np.issubdtype(arr.dtype, np.floating):
+        msg = 'picks_time_s must have a floating dtype'
+        raise ValueError(msg)
+
+    out = np.ascontiguousarray(arr, dtype=np.float64)
+    if np.any(np.isinf(out)):
+        msg = 'picks_time_s contains inf'
+        raise ValueError(msg)
+
+    valid_mask = np.isfinite(out)
+    finite = out[valid_mask]
+    if finite.size:
+        if np.any(finite < 0.0):
+            msg = 'picks_time_s contains negative pick times'
+            raise ValueError(msg)
+        max_time = float(expected_n_samples - 1) * sample_interval
+        if np.any(finite > max_time + 1e-9):
+            msg = 'picks_time_s contains pick times beyond n_samples'
+            raise ValueError(msg)
+    return out, valid_mask
+
+
+def load_npz_pick_source(
+    npz_path: Path,
+    *,
+    reader: TraceStoreSectionReader,
+    expected_dt: float,
+    expected_n_samples: int,
+    source_kind: NpzPickSourceKind,
+) -> LoadedPickSource:
+    """Load a batch/manual NPZ pick source and normalize it to sorted order."""
+    if source_kind not in ('batch_npz', 'manual_npz'):
+        msg = "source_kind must be 'batch_npz' or 'manual_npz'"
+        raise ValueError(msg)
+
+    path = Path(npz_path)
+    n_traces = _reader_n_traces(reader)
+    n_samples = _coerce_positive_int(expected_n_samples, name='expected_n_samples')
+    reader_n_samples = _reader_n_samples(reader)
+    if reader_n_samples != n_samples:
+        msg = f'expected_n_samples mismatch: reader has {reader_n_samples}, got {n_samples}'
+        raise ValueError(msg)
+    dt = _coerce_positive_float(expected_dt, name='expected_dt')
+    reader_sorted_to_original = _reader_sorted_to_original(
+        reader,
+        n_traces=n_traces,
+    )
+
+    try:
+        npz_file = np.load(path, allow_pickle=False)
+    except Exception as exc:  # noqa: BLE001
+        msg = f'Could not read npz pick source: {path}'
+        raise ValueError(msg) from exc
+
+    with npz_file as npz:
+        if 'picks_time_s' not in npz.files:
+            msg = 'Missing key: picks_time_s'
+            raise ValueError(msg)
+
+        metadata = _validate_npz_metadata(
+            npz,
+            n_traces=n_traces,
+            n_samples=n_samples,
+            dt=dt,
+        )
+        metadata['npz_path'] = str(path)
+        metadata['has_sorted_to_original'] = 'sorted_to_original' in npz.files
+
+        if 'sorted_to_original' in npz.files:
+            npz_sorted_to_original = validate_sorted_to_original(
+                np.asarray(npz['sorted_to_original']),
+                expected_n_traces=n_traces,
+                role='npz',
+            )
+            if not np.array_equal(npz_sorted_to_original, reader_sorted_to_original):
+                msg = 'sorted_to_original mismatch'
+                raise ValueError(msg)
+
+        picks_time_s_original, _ = validate_picks_time_s(
+            np.asarray(npz['picks_time_s']),
+            n_traces=n_traces,
+            n_samples=n_samples,
+            dt=dt,
+        )
+
+    picks_time_s_sorted = normalize_picks_original_to_sorted(
+        picks_time_s_original,
+        sorted_to_original=reader_sorted_to_original,
+    )
+    return _build_loaded_pick_source(
+        picks_time_s_sorted,
+        source_kind=source_kind,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt=dt,
+        metadata=metadata,
+    )
+
+
+def load_manual_memmap_pick_source(
+    *,
+    file_id: str,
+    key1_byte: int,
+    key2_byte: int,
+    state: AppState,
+) -> LoadedPickSource:
+    """Load manual picks from the sorted-order memmap without reindexing."""
+    file_name = state.file_registry.filename(file_id)
+    if not file_name:
+        msg = f'manual memmap file_id could not be resolved: {file_id}'
+        raise ValueError(msg)
+
+    try:
+        reader = get_reader(file_id, key1_byte, key2_byte, state=state)
+    except Exception as exc:  # noqa: BLE001
+        msg = f'manual memmap reader could not be resolved: {file_id}'
+        raise ValueError(msg) from exc
+
+    n_traces = _reader_n_traces(reader)
+    n_samples = _reader_n_samples(reader)
+    dt = _coerce_positive_float(state.file_registry.get_dt(file_id), name='dt')
+    memmap_path = path_for_file(file_name)
+    if not memmap_path.is_file():
+        msg = f'manual pick memmap not found: {memmap_path}'
+        raise ValueError(msg)
+
+    try:
+        memmap = np.load(memmap_path, mmap_mode='r', allow_pickle=False)
+    except Exception as exc:  # noqa: BLE001
+        msg = f'Could not read manual pick memmap: {memmap_path}'
+        raise ValueError(msg) from exc
+
+    try:
+        picks_time_s_sorted = np.asarray(memmap)
+        return _build_loaded_pick_source(
+            picks_time_s_sorted,
+            source_kind='manual_memmap',
+            n_traces=n_traces,
+            n_samples=n_samples,
+            dt=dt,
+            metadata={
+                'file_id': file_id,
+                'file_name': file_name,
+                'memmap_path': str(memmap_path),
+                'key1_byte': int(key1_byte),
+                'key2_byte': int(key2_byte),
+            },
+        )
+    finally:
+        del memmap
+
+
+__all__ = [
+    'LoadedPickSource',
+    'NpzPickSourceKind',
+    'PickSourceKind',
+    'load_manual_memmap_pick_source',
+    'load_npz_pick_source',
+    'normalize_picks_original_to_sorted',
+    'validate_picks_time_s',
+]

--- a/app/tests/test_pick_source_loader.py
+++ b/app/tests/test_pick_source_loader.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.core.state import AppState
+from app.services.pick_source_loader import (
+    load_manual_memmap_pick_source,
+    load_npz_pick_source,
+)
+from app.trace_store.reader import TraceStoreSectionReader
+from app.utils.pick_cache_file1d_mem import open_for_write
+
+KEY1 = 189
+KEY2 = 193
+DT = 0.002
+N_SAMPLES = 5
+SORTED_TO_ORIGINAL = np.asarray([2, 0, 3, 1], dtype=np.int64)
+PICKS_ORIGINAL = np.asarray([0.002, np.nan, 0.006, 0.008], dtype=np.float32)
+PICKS_SORTED = np.asarray([0.006, 0.002, 0.008, np.nan], dtype=np.float64)
+_ABSENT = object()
+
+
+def _write_store(
+    tmp_path: Path,
+    *,
+    sorted_to_original: np.ndarray = SORTED_TO_ORIGINAL,
+    n_samples: int = N_SAMPLES,
+) -> Path:
+    store = tmp_path / 'store'
+    store.mkdir(parents=True, exist_ok=True)
+    n_traces = int(np.asarray(sorted_to_original).shape[0])
+    np.save(store / 'traces.npy', np.zeros((n_traces, n_samples), dtype=np.float32))
+    np.savez(
+        store / 'index.npz',
+        sorted_to_original=np.asarray(sorted_to_original),
+    )
+    meta = {
+        'schema_version': 1,
+        'dtype': 'float32',
+        'n_traces': n_traces,
+        'n_samples': int(n_samples),
+        'key_bytes': {'key1': KEY1, 'key2': KEY2},
+        'dt': DT,
+        'original_segy_path': str(tmp_path / 'line.sgy'),
+    }
+    (store / 'meta.json').write_text(json.dumps(meta), encoding='utf-8')
+    return store
+
+
+def _reader(tmp_path: Path) -> TraceStoreSectionReader:
+    return TraceStoreSectionReader(_write_store(tmp_path), KEY1, KEY2)
+
+
+def _write_npz(
+    path: Path,
+    *,
+    picks_time_s: np.ndarray | object = PICKS_ORIGINAL,
+    n_traces: int | object = 4,
+    n_samples: int | object = N_SAMPLES,
+    dt: float | object = DT,
+    sorted_to_original: np.ndarray | object = _ABSENT,
+) -> Path:
+    payload: dict[str, object] = {}
+    if picks_time_s is not _ABSENT:
+        payload['picks_time_s'] = picks_time_s
+    if n_traces is not _ABSENT:
+        payload['n_traces'] = np.int64(n_traces)
+    if n_samples is not _ABSENT:
+        payload['n_samples'] = np.int64(n_samples)
+    if dt is not _ABSENT:
+        payload['dt'] = np.float64(dt)
+    if sorted_to_original is not _ABSENT:
+        payload['sorted_to_original'] = sorted_to_original
+    np.savez(path, **payload)
+    return path
+
+
+def _load_npz(
+    path: Path,
+    reader: TraceStoreSectionReader,
+    *,
+    source_kind='batch_npz',
+):
+    return load_npz_pick_source(
+        path,
+        reader=reader,
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+        source_kind=source_kind,
+    )
+
+
+def test_pick_source_loader_batch_npz_original_to_sorted(tmp_path: Path) -> None:
+    path = _write_npz(tmp_path / 'batch.npz')
+
+    loaded = _load_npz(path, _reader(tmp_path), source_kind='batch_npz')
+
+    assert loaded.source_kind == 'batch_npz'
+    np.testing.assert_allclose(
+        loaded.picks_time_s_sorted,
+        PICKS_SORTED,
+        equal_nan=True,
+    )
+
+
+def test_pick_source_loader_manual_npz_original_to_sorted(tmp_path: Path) -> None:
+    path = _write_npz(
+        tmp_path / 'manual.npz',
+        sorted_to_original=SORTED_TO_ORIGINAL,
+    )
+
+    loaded = _load_npz(path, _reader(tmp_path), source_kind='manual_npz')
+
+    assert loaded.source_kind == 'manual_npz'
+    np.testing.assert_allclose(
+        loaded.picks_time_s_sorted,
+        PICKS_SORTED,
+        equal_nan=True,
+    )
+
+
+def test_pick_source_loader_manual_npz_validates_sorted_to_original(
+    tmp_path: Path,
+) -> None:
+    reader = _reader(tmp_path)
+    path = _write_npz(
+        tmp_path / 'manual.npz',
+        sorted_to_original=SORTED_TO_ORIGINAL,
+    )
+
+    loaded = _load_npz(path, reader, source_kind='manual_npz')
+
+    assert loaded.metadata['has_sorted_to_original'] is True
+    bad_path = _write_npz(
+        tmp_path / 'manual_bad_order.npz',
+        sorted_to_original=np.asarray([0, 1, 2, 3], dtype=np.int64),
+    )
+    with pytest.raises(ValueError, match='sorted_to_original mismatch'):
+        _load_npz(bad_path, reader, source_kind='manual_npz')
+
+
+def test_pick_source_loader_manual_memmap_already_sorted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('PICKS_NPY_DIR', str(tmp_path / 'picks_npy'))
+    store = _write_store(tmp_path)
+    file_id = 'manual-file'
+    file_name = 'LineA.sgy'
+    values_sorted = np.asarray([0.008, 0.002, np.nan, 0.006], dtype=np.float32)
+    mm = open_for_write(file_name, int(values_sorted.shape[0]))
+    mm[:] = values_sorted
+    mm.flush()
+    del mm
+
+    state = AppState()
+    state.file_registry.set_record(
+        file_id,
+        {
+            'path': str(tmp_path / file_name),
+            'store_path': str(store),
+            'dt': DT,
+        },
+    )
+
+    loaded = load_manual_memmap_pick_source(
+        file_id=file_id,
+        key1_byte=KEY1,
+        key2_byte=KEY2,
+        state=state,
+    )
+
+    assert loaded.source_kind == 'manual_memmap'
+    np.testing.assert_allclose(
+        loaded.picks_time_s_sorted,
+        values_sorted.astype(np.float64),
+        equal_nan=True,
+    )
+
+
+def test_pick_source_loader_allows_nan_and_reports_counts(tmp_path: Path) -> None:
+    picks = np.asarray([np.nan, 0.002, np.nan, 0.006], dtype=np.float32)
+    path = _write_npz(tmp_path / 'picks.npz', picks_time_s=picks)
+
+    loaded = _load_npz(path, _reader(tmp_path))
+
+    assert loaded.n_valid == 2
+    assert loaded.n_nan == 2
+    np.testing.assert_array_equal(
+        loaded.valid_mask_sorted,
+        np.asarray([False, False, True, True]),
+    )
+
+
+def test_pick_source_loader_rejects_missing_picks_time_s(tmp_path: Path) -> None:
+    path = _write_npz(tmp_path / 'picks.npz', picks_time_s=_ABSENT)
+
+    with pytest.raises(ValueError, match='Missing key: picks_time_s'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_non_1d_picks(tmp_path: Path) -> None:
+    path = _write_npz(
+        tmp_path / 'picks.npz',
+        picks_time_s=np.zeros((2, 2), dtype=np.float32),
+    )
+
+    with pytest.raises(ValueError, match='picks_time_s must be 1D'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_non_float_picks(tmp_path: Path) -> None:
+    path = _write_npz(
+        tmp_path / 'picks.npz',
+        picks_time_s=np.asarray([0, 1, 2, 3], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match='floating dtype'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_inf(tmp_path: Path) -> None:
+    picks = PICKS_ORIGINAL.copy()
+    picks[1] = np.inf
+    path = _write_npz(tmp_path / 'picks.npz', picks_time_s=picks)
+
+    with pytest.raises(ValueError, match='contains inf'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_negative_pick_time(tmp_path: Path) -> None:
+    picks = PICKS_ORIGINAL.copy()
+    picks[0] = -0.002
+    path = _write_npz(tmp_path / 'picks.npz', picks_time_s=picks)
+
+    with pytest.raises(ValueError, match='negative pick times'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_pick_time_beyond_n_samples(
+    tmp_path: Path,
+) -> None:
+    picks = PICKS_ORIGINAL.copy()
+    picks[0] = 0.010
+    path = _write_npz(tmp_path / 'picks.npz', picks_time_s=picks)
+
+    with pytest.raises(ValueError, match='beyond n_samples'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_n_traces_mismatch(tmp_path: Path) -> None:
+    path = _write_npz(tmp_path / 'picks.npz', n_traces=5)
+
+    with pytest.raises(ValueError, match='n_traces mismatch'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_n_samples_mismatch(tmp_path: Path) -> None:
+    path = _write_npz(tmp_path / 'picks.npz', n_samples=6)
+
+    with pytest.raises(ValueError, match='n_samples mismatch'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_dt_mismatch(tmp_path: Path) -> None:
+    path = _write_npz(tmp_path / 'picks.npz', dt=0.003)
+
+    with pytest.raises(ValueError, match='dt mismatch'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_sorted_to_original_mismatch(
+    tmp_path: Path,
+) -> None:
+    path = _write_npz(
+        tmp_path / 'picks.npz',
+        sorted_to_original=np.asarray([0, 1, 2, 3], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match='sorted_to_original mismatch'):
+        _load_npz(path, _reader(tmp_path))
+
+
+def test_pick_source_loader_rejects_non_permutation_sorted_to_original(
+    tmp_path: Path,
+) -> None:
+    path = _write_npz(
+        tmp_path / 'picks.npz',
+        sorted_to_original=np.asarray([0, 0, 2, 3], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match='must be a permutation'):
+        _load_npz(path, _reader(tmp_path))

--- a/app/utils/pick_cache_file1d_mem.py
+++ b/app/utils/pick_cache_file1d_mem.py
@@ -23,6 +23,10 @@ def ensure_root_dir() -> Path:
     return root
 
 
+def path_for_file(file_name: str) -> Path:
+    return get_root_dir() / f'{_safe(file_name)}.npy'
+
+
 def _p(file_name: str) -> Path:
     return ensure_root_dir() / f'{_safe(file_name)}.npy'
 


### PR DESCRIPTION
Closes #299

## Summary
- [PR3/pick-source] first-break pick source loader を追加し、batch/manual/memmap を sorted order に正規化する

## Changed files
- `app/services/pick_source_loader.py`
- `app/tests/test_pick_source_loader.py`
- `app/utils/pick_cache_file1d_mem.py`

## Checks
- `.work/codex/checks.log`: 635 passed in 44.13s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
