### PR TITLE
[PR3/api] /statics/first-break/qc job API を追加し、既存 statics job lifecycle に統合する

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -13,11 +13,14 @@ from app.api._helpers import get_state
 from app.api.schemas import (
     DatumStaticApplyRequest,
     DatumStaticApplyResponse,
+    FirstBreakQcJobResponse,
+    FirstBreakQcRequest,
     StaticJobFilesResponse,
     StaticJobStatusResponse,
 )
 from app.core.state import AppState
 from app.services.datum_static_service import run_datum_static_apply_job
+from app.services.first_break_qc_service import run_first_break_qc_job
 from app.services.in_memory_cleanup import cleanup_in_memory_state
 from app.services.job_manager import JobManager
 from app.services.job_runner import request_job_cancel, start_job_thread
@@ -82,6 +85,36 @@ def datum_static_apply(
     start_job_thread(
         thread_factory=threading.Thread,
         target=run_datum_static_apply_job,
+        args=(job_id, req, state),
+    )
+
+    return {'job_id': job_id, 'state': status}
+
+
+@router.post('/statics/first-break/qc', response_model=FirstBreakQcJobResponse)
+def first_break_qc(
+    req: FirstBreakQcRequest,
+    request: Request,
+) -> FirstBreakQcJobResponse:
+    state = get_state(request.app)
+    cleanup_in_memory_state(state)
+    maybe_cleanup_expired_jobs()
+
+    job_id = str(uuid4())
+    with state.lock:
+        job_state = state.jobs.create_static_job(
+            job_id,
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            statics_kind='first_break_qc',
+            artifacts_dir=str(get_job_dir(job_id)),
+        )
+        status = job_state['status']
+
+    start_job_thread(
+        thread_factory=threading.Thread,
+        target=run_first_break_qc_job,
         args=(job_id, req, state),
     )
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -354,3 +354,93 @@ class DatumStaticApplyResponse(BaseModel):
 
     job_id: str
     state: str
+
+
+def _validate_artifact_basename(name: str, field_name: str) -> str:
+    if not name:
+        raise ValueError(f'{field_name} must be a non-empty file name')
+    if name in {'.', '..'}:
+        raise ValueError(f'{field_name} must be a plain file name')
+    if Path(name).name != name:
+        raise ValueError(f'{field_name} must be a plain file name')
+    return name
+
+
+class FirstBreakQcDatumSolutionRequest(BaseModel):
+    """Datum static solution artifact reference for first-break QC."""
+
+    job_id: str
+    name: str = 'datum_static_solution.npz'
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'FirstBreakQcDatumSolutionRequest':
+        if not self.job_id:
+            raise ValueError('datum_solution.job_id must be a non-empty string')
+        _validate_artifact_basename(self.name, 'datum_solution.name')
+        return self
+
+
+class FirstBreakQcPickSourceRequest(BaseModel):
+    """First-break pick source reference for first-break QC."""
+
+    kind: Literal['batch_job_artifact', 'manual_npz_artifact', 'manual_memmap']
+    job_id: str | None = None
+    name: str | None = None
+
+    @model_validator(mode='after')
+    def _check_ref(self) -> 'FirstBreakQcPickSourceRequest':
+        if self.kind in {'batch_job_artifact', 'manual_npz_artifact'}:
+            if not self.job_id:
+                raise ValueError('pick_source.job_id is required for artifact sources')
+            if not self.name:
+                raise ValueError('pick_source.name is required for artifact sources')
+            _validate_artifact_basename(self.name, 'pick_source.name')
+            return self
+
+        if self.job_id is not None or self.name is not None:
+            raise ValueError('pick_source.job_id/name must be omitted for manual_memmap')
+        return self
+
+
+class FirstBreakQcOffsetRequest(BaseModel):
+    """Offset header configuration for first-break QC."""
+
+    offset_byte: int = 37
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'FirstBreakQcOffsetRequest':
+        require_positive_int(self.offset_byte, 'offset.offset_byte')
+        return self
+
+
+class FirstBreakQcOptionsRequest(BaseModel):
+    """QC options for first-break QC."""
+
+    require_linear_offset_model: bool = False
+
+
+class FirstBreakQcRequest(BaseModel):
+    """Request model for ``/statics/first-break/qc``."""
+
+    file_id: str
+    key1_byte: int = 189
+    key2_byte: int = 193
+    datum_solution: FirstBreakQcDatumSolutionRequest
+    pick_source: FirstBreakQcPickSourceRequest
+    offset: FirstBreakQcOffsetRequest = Field(default_factory=FirstBreakQcOffsetRequest)
+    qc: FirstBreakQcOptionsRequest = Field(default_factory=FirstBreakQcOptionsRequest)
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'FirstBreakQcRequest':
+        if not self.file_id:
+            raise ValueError('file_id must be a non-empty string')
+        require_positive_int(self.key1_byte, 'key1_byte')
+        require_positive_int(self.key2_byte, 'key2_byte')
+        return self
+
+
+class FirstBreakQcJobResponse(BaseModel):
+    """Response model for creating a first-break QC job."""
+
+    job_id: str
+    state: str

--- a/app/services/first_break_qc_service.py
+++ b/app/services/first_break_qc_service.py
@@ -1,0 +1,366 @@
+"""First-break QC background job service."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import numpy as np
+
+from app.api.schemas import FirstBreakQcRequest
+from app.core.state import AppState
+from app.services.first_break_qc_artifacts import (
+    FIRST_BREAK_QC_CSV_NAME,
+    FIRST_BREAK_QC_JSON_NAME,
+    RESIDUAL_BY_KEY1_CSV_NAME,
+    write_first_break_qc_artifacts,
+)
+from app.services.first_break_qc_inputs import build_first_break_qc_inputs
+from app.services.first_break_qc_math import compute_first_break_qc_metrics
+from app.services.job_artifact_refs import resolve_job_artifact_path
+from app.services.job_runner import (
+    JobCancelledError,
+    JobCompletion,
+    JobFailure,
+    ensure_job_not_cancelled,
+    run_job_with_lifecycle,
+)
+from app.services.pick_source_loader import (
+    LoadedPickSource,
+    load_manual_memmap_pick_source,
+    load_npz_pick_source,
+)
+from app.services.pipeline_artifacts import get_job_dir
+from app.services.reader import get_reader
+from app.trace_store.reader import TraceStoreSectionReader
+
+
+@dataclass
+class _FirstBreakQcLifecycle:
+    created_ts: float
+    job_dir: Path | None = None
+
+
+def _resolve_created_ts(state: AppState, job_id: str) -> float:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        if job is None:
+            return time.time()
+        created_ts_obj = job.get('created_ts')
+    return (
+        float(created_ts_obj)
+        if isinstance(created_ts_obj, (int, float))
+        else time.time()
+    )
+
+
+def _resolve_job_dir(state: AppState, job_id: str) -> Path:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        artifacts_dir = job.get('artifacts_dir') if isinstance(job, dict) else None
+    if isinstance(artifacts_dir, str) and artifacts_dir:
+        return Path(artifacts_dir)
+    return get_job_dir(job_id)
+
+
+def _set_job_progress_message(
+    state: AppState,
+    job_id: str,
+    *,
+    progress: float,
+    message: str,
+) -> None:
+    with state.lock:
+        if state.jobs.get(job_id) is None:
+            return
+        state.jobs.set_progress(job_id, progress)
+        state.jobs.set_message(job_id, message)
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+    try:
+        tmp_path.write_text(
+            json.dumps(payload, ensure_ascii=True, sort_keys=True),
+            encoding='utf-8',
+        )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _write_job_meta(
+    *,
+    job_id: str,
+    job_dir: Path,
+    req: FirstBreakQcRequest,
+) -> None:
+    pick_source = req.pick_source.model_dump(mode='json', exclude_none=True)
+    _write_json_atomic(
+        job_dir / 'job_meta.json',
+        {
+            'job_id': job_id,
+            'job_type': 'statics',
+            'statics_kind': 'first_break_qc',
+            'source_file_id': req.file_id,
+            'key1_byte': req.key1_byte,
+            'key2_byte': req.key2_byte,
+            'request': req.model_dump(mode='json'),
+            'inputs': {
+                'datum_solution': req.datum_solution.model_dump(mode='json'),
+                'pick_source': pick_source,
+                'offset_byte': req.offset.offset_byte,
+            },
+            'artifacts': {
+                'qc_json': FIRST_BREAK_QC_JSON_NAME,
+                'qc_csv': FIRST_BREAK_QC_CSV_NAME,
+                'residual_by_key1_csv': RESIDUAL_BY_KEY1_CSV_NAME,
+            },
+        },
+    )
+
+
+def _reader_n_samples(reader: TraceStoreSectionReader) -> int:
+    getter = getattr(reader, 'get_n_samples', None)
+    if callable(getter):
+        n_samples = int(getter())
+    else:
+        traces = getattr(reader, 'traces', None)
+        shape = getattr(traces, 'shape', ())
+        if len(shape) < 2:
+            raise ValueError('reader cannot provide number of samples')
+        n_samples = int(shape[-1])
+    if n_samples <= 0:
+        raise ValueError('reader n_samples must be greater than 0')
+    return n_samples
+
+
+def _resolve_dt(state: AppState, file_id: str) -> float:
+    dt = float(state.file_registry.get_dt(file_id))
+    if not np.isfinite(dt) or dt <= 0.0:
+        raise ValueError('dt must be finite and greater than 0')
+    return dt
+
+
+def _resolve_input_artifacts(
+    state: AppState,
+    req: FirstBreakQcRequest,
+) -> tuple[Path, Path | None]:
+    solution_path = resolve_job_artifact_path(
+        state,
+        job_id=req.datum_solution.job_id,
+        name=req.datum_solution.name,
+        allowed_job_types={'statics'},
+        allowed_statics_kinds={'datum'},
+    )
+
+    pick_source = req.pick_source
+    if pick_source.kind == 'manual_memmap':
+        return solution_path, None
+    if pick_source.job_id is None or pick_source.name is None:
+        raise ValueError('pick_source artifact reference is incomplete')
+
+    if pick_source.kind == 'batch_job_artifact':
+        pick_path = resolve_job_artifact_path(
+            state,
+            job_id=pick_source.job_id,
+            name=pick_source.name,
+            allowed_job_types={'batch_apply'},
+        )
+        return solution_path, pick_path
+
+    if not pick_source.name.endswith('.npz'):
+        raise ValueError('manual_npz_artifact name must end with .npz')
+    pick_path = resolve_job_artifact_path(
+        state,
+        job_id=pick_source.job_id,
+        name=pick_source.name,
+        allowed_job_types={'statics', 'batch_apply', 'pipeline'},
+    )
+    return solution_path, pick_path
+
+
+def _load_pick_source(
+    *,
+    req: FirstBreakQcRequest,
+    reader: TraceStoreSectionReader,
+    pick_artifact_path: Path | None,
+    expected_dt: float,
+    expected_n_samples: int,
+    state: AppState,
+) -> LoadedPickSource:
+    pick_source = req.pick_source
+    if pick_source.kind == 'manual_memmap':
+        return load_manual_memmap_pick_source(
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            state=state,
+        )
+    if pick_artifact_path is None:
+        raise ValueError('pick source artifact path is required')
+    source_kind = 'batch_npz' if pick_source.kind == 'batch_job_artifact' else 'manual_npz'
+    return load_npz_pick_source(
+        pick_artifact_path,
+        reader=reader,
+        expected_dt=expected_dt,
+        expected_n_samples=expected_n_samples,
+        source_kind=source_kind,
+    )
+
+
+def _pick_source_artifact_name(req: FirstBreakQcRequest) -> str | None:
+    return None if req.pick_source.kind == 'manual_memmap' else req.pick_source.name
+
+
+def _run_first_break_qc_job_body(
+    job_id: str,
+    req: FirstBreakQcRequest,
+    state: AppState,
+    *,
+    lifecycle: _FirstBreakQcLifecycle,
+) -> JobCompletion | None:
+    job_dir = _resolve_job_dir(state, job_id)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    lifecycle.job_dir = job_dir
+    _write_job_meta(job_id=job_id, job_dir=job_dir, req=req)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.05,
+        message='resolving_source_trace_store',
+    )
+    reader = get_reader(req.file_id, req.key1_byte, req.key2_byte, state=state)
+    dt = _resolve_dt(state, req.file_id)
+    n_samples = _reader_n_samples(reader)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.10,
+        message='resolving_input_artifacts',
+    )
+    solution_path, pick_artifact_path = _resolve_input_artifacts(state, req)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.25,
+        message='loading_pick_source',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    pick_source = _load_pick_source(
+        req=req,
+        reader=reader,
+        pick_artifact_path=pick_artifact_path,
+        expected_dt=dt,
+        expected_n_samples=n_samples,
+        state=state,
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.40,
+        message='loading_datum_solution_and_offset',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    inputs = build_first_break_qc_inputs(
+        pick_source=pick_source,
+        solution_npz_path=solution_path,
+        reader=reader,
+        offset_byte=req.offset.offset_byte,
+        expected_dt=dt,
+        expected_n_samples=n_samples,
+        expected_key1_byte=req.key1_byte,
+        expected_key2_byte=req.key2_byte,
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.60,
+        message='computing_first_break_qc',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    metrics = compute_first_break_qc_metrics(
+        inputs,
+        require_linear_offset_model=req.qc.require_linear_offset_model,
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.85,
+        message='writing_first_break_qc_artifacts',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    write_first_break_qc_artifacts(
+        job_dir=job_dir,
+        inputs=inputs,
+        metrics=metrics,
+        solution_artifact_name=req.datum_solution.name,
+        pick_source_artifact_name=_pick_source_artifact_name(req),
+    )
+    _set_job_progress_message(state, job_id, progress=1.0, message='done')
+    return JobCompletion(finished_ts=time.time())
+
+
+def _handle_first_break_qc_job_error(
+    *,
+    lifecycle: _FirstBreakQcLifecycle,
+) -> JobFailure:
+    return JobFailure(finished_ts=time.time())
+
+
+def _handle_first_break_qc_job_cancel(
+    *,
+    lifecycle: _FirstBreakQcLifecycle,
+    exc: JobCancelledError,
+) -> JobCompletion:
+    finished_ts = float(exc.finished_ts) if exc.finished_ts is not None else time.time()
+    return JobCompletion(finished_ts=finished_ts)
+
+
+def run_first_break_qc_job(
+    job_id: str,
+    req: FirstBreakQcRequest,
+    state: AppState,
+) -> None:
+    """Run one first-break QC job and persist only QC artifacts."""
+    lifecycle = _FirstBreakQcLifecycle(created_ts=_resolve_created_ts(state, job_id))
+    run_job_with_lifecycle(
+        state=state,
+        job_id=job_id,
+        worker=lambda: _run_first_break_qc_job_body(
+            job_id,
+            req,
+            state,
+            lifecycle=lifecycle,
+        ),
+        progress_1_on_done=True,
+        start_progress=0.0,
+        clear_message_on_start=True,
+        on_error=lambda _exc: _handle_first_break_qc_job_error(
+            lifecycle=lifecycle,
+        ),
+        on_cancel=lambda exc: _handle_first_break_qc_job_cancel(
+            lifecycle=lifecycle,
+            exc=exc,
+        ),
+    )
+
+
+__all__ = ['run_first_break_qc_job']

--- a/app/services/job_artifact_refs.py
+++ b/app/services/job_artifact_refs.py
@@ -1,0 +1,68 @@
+"""Safe resolution of persisted background-job artifact files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core.state import AppState
+
+
+def _plain_artifact_name(name: str) -> str:
+    if not name or name in {'.', '..'} or Path(name).name != name:
+        raise ValueError('artifact name must be a plain file name')
+    return name
+
+
+def _job_type(job: dict[str, object]) -> str | None:
+    raw = job.get('job_type')
+    if isinstance(raw, str) and raw:
+        return raw
+    if 'pipeline_key' in job:
+        return 'pipeline'
+    return None
+
+
+def resolve_job_artifact_path(
+    state: AppState,
+    *,
+    job_id: str,
+    name: str,
+    allowed_job_types: set[str] | None = None,
+    allowed_statics_kinds: set[str] | None = None,
+) -> Path:
+    """Resolve a job artifact by job id and file name without accepting paths."""
+    artifact_name = _plain_artifact_name(name)
+    with state.lock:
+        raw_job = state.jobs.get(job_id)
+        job = dict(raw_job) if isinstance(raw_job, dict) else None
+    if job is None:
+        raise ValueError(f'job_id not found: {job_id}')
+
+    job_type = _job_type(job)
+    if allowed_job_types is not None and job_type not in allowed_job_types:
+        raise ValueError(f'job {job_id} has unsupported job_type: {job_type}')
+
+    if allowed_statics_kinds is not None:
+        if job_type != 'statics':
+            raise ValueError(f'job {job_id} is not a statics job')
+        statics_kind = job.get('statics_kind')
+        if statics_kind not in allowed_statics_kinds:
+            raise ValueError(
+                f'job {job_id} has unsupported statics_kind: {statics_kind}'
+            )
+
+    artifacts_dir_raw = job.get('artifacts_dir')
+    if not isinstance(artifacts_dir_raw, str) or not artifacts_dir_raw:
+        raise ValueError(f'job {job_id} has no artifacts_dir')
+
+    artifacts_dir = Path(artifacts_dir_raw)
+    if not artifacts_dir.is_dir():
+        raise ValueError(f'job artifacts_dir is not a directory: {artifacts_dir}')
+
+    artifact_path = artifacts_dir / artifact_name
+    if not artifact_path.is_file():
+        raise ValueError(f'job artifact not found: {artifact_name}')
+    return artifact_path
+
+
+__all__ = ['resolve_job_artifact_path']

--- a/app/tests/test_first_break_qc_job_api.py
+++ b/app/tests/test_first_break_qc_job_api.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.routers.statics as statics_router_module
+from app.main import app
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv('PIPELINE_JOBS_DIR', str(tmp_path / 'jobs'))
+    state = app.state.sv
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        'file_id': 'source-file-id',
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'datum_solution': {
+            'job_id': 'datum-static-job-id',
+            'name': 'datum_static_solution.npz',
+        },
+        'pick_source': {
+            'kind': 'batch_job_artifact',
+            'job_id': 'batch-apply-job-id',
+            'name': 'predicted_picks_time_s.npz',
+        },
+        'offset': {'offset_byte': 37},
+        'qc': {'require_linear_offset_model': False},
+    }
+
+
+def test_first_break_qc_endpoint_starts_static_job(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+
+    def _capture_start_job_thread(**kwargs: Any) -> object:
+        started.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        _capture_start_job_thread,
+    )
+
+    response = client.post('/statics/first-break/qc', json=_payload())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['state'] == 'queued'
+    assert isinstance(payload['job_id'], str)
+    assert len(started) == 1
+    assert started[0]['target'] is statics_router_module.run_first_break_qc_job
+
+    state = client.app.state.sv
+    with state.lock:
+        job = dict(state.jobs[payload['job_id']])
+
+    assert job['status'] == 'queued'
+    assert job['job_type'] == 'statics'
+    assert job['statics_kind'] == 'first_break_qc'
+    assert job['file_id'] == 'source-file-id'
+    assert job['key1_byte'] == 189
+    assert job['key2_byte'] == 193
+
+
+@pytest.mark.parametrize(
+    'mutator',
+    [
+        lambda payload: payload.update({'file_id': ''}),
+        lambda payload: payload.update({'key1_byte': 0}),
+        lambda payload: payload.update({'key2_byte': 0}),
+        lambda payload: payload['pick_source'].update({'kind': 'unknown'}),
+        lambda payload: payload['pick_source'].pop('job_id'),
+        lambda payload: payload['pick_source'].pop('name'),
+        lambda payload: payload.update(
+            {'pick_source': {'kind': 'manual_memmap', 'job_id': 'job-a'}}
+        ),
+        lambda payload: payload.update(
+            {'pick_source': {'kind': 'manual_memmap', 'name': 'manual.npz'}}
+        ),
+        lambda payload: payload['datum_solution'].update({'name': '../x.npz'}),
+        lambda payload: payload['datum_solution'].update({'name': 'nested/x.npz'}),
+        lambda payload: payload['datum_solution'].update({'name': '/tmp/x.npz'}),
+        lambda payload: payload['pick_source'].update({'name': '../x.npz'}),
+        lambda payload: payload['pick_source'].update({'name': 'nested/x.npz'}),
+        lambda payload: payload['pick_source'].update({'name': '/tmp/x.npz'}),
+        lambda payload: payload.update({'offset': {'offset_byte': 0}}),
+    ],
+)
+def test_first_break_qc_endpoint_rejects_invalid_request(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    mutator,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+    payload = _payload()
+    mutator(payload)
+
+    response = client.post('/statics/first-break/qc', json=payload)
+
+    assert response.status_code == 422
+    assert started == []
+
+
+def test_first_break_qc_job_files_and_download_use_static_lifecycle(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'first-break-qc-job'
+    job_dir.mkdir()
+    (job_dir / 'job_meta.json').write_text('{"job_id":"qc-job"}', encoding='utf-8')
+    (job_dir / 'first_break_qc.json').write_text('{"ok":true}', encoding='utf-8')
+    (job_dir / 'first_break_qc.csv').write_text('a,b\n', encoding='utf-8')
+    (job_dir / 'residual_by_key1.csv').write_text('key1\n', encoding='utf-8')
+    state = client.app.state.sv
+    with state.lock:
+        state.jobs.create_static_job(
+            'qc-job',
+            file_id='source-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='first_break_qc',
+            artifacts_dir=str(job_dir),
+        )
+        state.jobs.mark_done('qc-job')
+
+    files_response = client.get('/statics/job/qc-job/files')
+    download_response = client.get(
+        '/statics/job/qc-job/download',
+        params={'name': 'first_break_qc.json'},
+    )
+
+    assert files_response.status_code == 200
+    assert files_response.json() == {
+        'files': [
+            {'name': 'first_break_qc.csv', 'size_bytes': 4},
+            {'name': 'first_break_qc.json', 'size_bytes': 11},
+            {'name': 'job_meta.json', 'size_bytes': 19},
+            {'name': 'residual_by_key1.csv', 'size_bytes': 5},
+        ]
+    }
+    assert download_response.status_code == 200
+    assert download_response.text == '{"ok":true}'

--- a/app/tests/test_first_break_qc_service.py
+++ b/app/tests/test_first_break_qc_service.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+
+import app.services.first_break_qc_service as service
+from app.api.schemas import FirstBreakQcRequest
+from app.core.state import AppState, create_app_state
+
+
+class _Reader:
+    key1_byte = 189
+    key2_byte = 193
+
+    def __init__(self) -> None:
+        self.traces = np.zeros((4, 8), dtype=np.float32)
+
+    def get_n_samples(self) -> int:
+        return 8
+
+
+def _request(
+    *,
+    datum_job_id: str = 'datum-job',
+    pick_source: dict[str, object] | None = None,
+) -> FirstBreakQcRequest:
+    if pick_source is None:
+        pick_source = {
+            'kind': 'batch_job_artifact',
+            'job_id': 'batch-job',
+            'name': 'predicted_picks_time_s.npz',
+        }
+    return FirstBreakQcRequest(
+        file_id='source-file-id',
+        key1_byte=189,
+        key2_byte=193,
+        datum_solution={
+            'job_id': datum_job_id,
+            'name': 'datum_static_solution.npz',
+        },
+        pick_source=pick_source,
+        offset={'offset_byte': 37},
+        qc={'require_linear_offset_model': False},
+    )
+
+
+def _setup_state(tmp_path: Path) -> tuple[AppState, Path]:
+    state = create_app_state()
+    state.file_registry.set_record(
+        'source-file-id',
+        {
+            'path': str(tmp_path / 'line.sgy'),
+            'store_path': str(tmp_path / 'trace-store'),
+            'dt': 0.004,
+        },
+    )
+    job_dir = tmp_path / 'qc-job'
+    with state.lock:
+        state.jobs.create_static_job(
+            'qc-job',
+            file_id='source-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='first_break_qc',
+            artifacts_dir=str(job_dir),
+        )
+    return state, job_dir
+
+
+def _add_datum_job(state: AppState, tmp_path: Path, *, kind: str = 'datum') -> Path:
+    datum_dir = tmp_path / 'datum-job'
+    datum_dir.mkdir(parents=True, exist_ok=True)
+    solution = datum_dir / 'datum_static_solution.npz'
+    solution.write_bytes(b'solution')
+    with state.lock:
+        state.jobs.create_static_job(
+            'datum-job',
+            file_id='source-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind=kind,
+            artifacts_dir=str(datum_dir),
+        )
+    return solution
+
+
+def _add_batch_job(state: AppState, tmp_path: Path, *, write_artifact: bool = True) -> Path:
+    batch_dir = tmp_path / 'batch-job'
+    batch_dir.mkdir(parents=True, exist_ok=True)
+    artifact = batch_dir / 'predicted_picks_time_s.npz'
+    if write_artifact:
+        artifact.write_bytes(b'picks')
+    with state.lock:
+        state.jobs.create_batch_apply_job(
+            'batch-job',
+            file_id='source-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            artifacts_dir=str(batch_dir),
+        )
+    return artifact
+
+
+def _add_manual_npz_job(state: AppState, tmp_path: Path) -> Path:
+    manual_dir = tmp_path / 'manual-job'
+    manual_dir.mkdir(parents=True, exist_ok=True)
+    artifact = manual_dir / 'manual_picks.npz'
+    artifact.write_bytes(b'manual')
+    with state.lock:
+        state.jobs.create_static_job(
+            'manual-job',
+            file_id='source-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='first_break_qc',
+            artifacts_dir=str(manual_dir),
+        )
+    return artifact
+
+
+def _patch_success_path(monkeypatch, *, captured: dict[str, Any] | None = None) -> None:
+    if captured is None:
+        captured = {}
+    reader = _Reader()
+    pick_source = SimpleNamespace(name='pick-source')
+    inputs = SimpleNamespace(name='inputs')
+    metrics = SimpleNamespace(name='metrics')
+
+    monkeypatch.setattr(service, 'get_reader', lambda *args, **kwargs: reader)
+
+    def _load_npz(path: Path, **kwargs: Any) -> object:
+        captured['npz_path'] = Path(path)
+        captured['npz_kwargs'] = kwargs
+        return pick_source
+
+    def _load_memmap(**kwargs: Any) -> object:
+        captured['memmap_kwargs'] = kwargs
+        return pick_source
+
+    def _build_inputs(**kwargs: Any) -> object:
+        captured['build_kwargs'] = kwargs
+        return inputs
+
+    def _compute(actual_inputs: object, **kwargs: Any) -> object:
+        captured['compute_inputs'] = actual_inputs
+        captured['compute_kwargs'] = kwargs
+        return metrics
+
+    def _write_artifacts(**kwargs: Any) -> object:
+        captured['write_kwargs'] = kwargs
+        job_dir = Path(kwargs['job_dir'])
+        (job_dir / 'first_break_qc.json').write_text('{"ok":true}', encoding='utf-8')
+        (job_dir / 'first_break_qc.csv').write_text('a,b\n', encoding='utf-8')
+        (job_dir / 'residual_by_key1.csv').write_text('key1\n', encoding='utf-8')
+        return SimpleNamespace(
+            qc_json=job_dir / 'first_break_qc.json',
+            qc_csv=job_dir / 'first_break_qc.csv',
+            residual_by_key1_csv=job_dir / 'residual_by_key1.csv',
+        )
+
+    monkeypatch.setattr(service, 'load_npz_pick_source', _load_npz)
+    monkeypatch.setattr(service, 'load_manual_memmap_pick_source', _load_memmap)
+    monkeypatch.setattr(service, 'build_first_break_qc_inputs', _build_inputs)
+    monkeypatch.setattr(service, 'compute_first_break_qc_metrics', _compute)
+    monkeypatch.setattr(service, 'write_first_break_qc_artifacts', _write_artifacts)
+
+
+def test_first_break_qc_job_writes_job_meta_json(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    meta = json.loads((job_dir / 'job_meta.json').read_text(encoding='utf-8'))
+    assert meta['job_id'] == 'qc-job'
+    assert meta['job_type'] == 'statics'
+    assert meta['statics_kind'] == 'first_break_qc'
+    assert meta['source_file_id'] == 'source-file-id'
+    assert meta['inputs'] == {
+        'datum_solution': {
+            'job_id': 'datum-job',
+            'name': 'datum_static_solution.npz',
+        },
+        'pick_source': {
+            'kind': 'batch_job_artifact',
+            'job_id': 'batch-job',
+            'name': 'predicted_picks_time_s.npz',
+        },
+        'offset_byte': 37,
+    }
+    assert meta['artifacts'] == {
+        'qc_json': 'first_break_qc.json',
+        'qc_csv': 'first_break_qc.csv',
+        'residual_by_key1_csv': 'residual_by_key1.csv',
+    }
+
+
+def test_first_break_qc_job_uses_batch_predicted_picks_artifact(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    pick_path = _add_batch_job(state, tmp_path)
+    captured: dict[str, Any] = {}
+    _patch_success_path(monkeypatch, captured=captured)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    assert captured['npz_path'] == pick_path
+    assert captured['npz_kwargs']['source_kind'] == 'batch_npz'
+    assert captured['write_kwargs']['pick_source_artifact_name'] == (
+        'predicted_picks_time_s.npz'
+    )
+
+
+def test_first_break_qc_job_uses_manual_memmap_pick_source(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    captured: dict[str, Any] = {}
+    _patch_success_path(monkeypatch, captured=captured)
+    req = _request(pick_source={'kind': 'manual_memmap'})
+
+    service.run_first_break_qc_job('qc-job', req, state)
+
+    assert captured['memmap_kwargs']['file_id'] == 'source-file-id'
+    assert captured['write_kwargs']['pick_source_artifact_name'] is None
+    assert 'npz_path' not in captured
+
+
+def test_first_break_qc_job_uses_manual_npz_artifact(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    pick_path = _add_manual_npz_job(state, tmp_path)
+    captured: dict[str, Any] = {}
+    _patch_success_path(monkeypatch, captured=captured)
+    req = _request(
+        pick_source={
+            'kind': 'manual_npz_artifact',
+            'job_id': 'manual-job',
+            'name': 'manual_picks.npz',
+        }
+    )
+
+    service.run_first_break_qc_job('qc-job', req, state)
+
+    assert captured['npz_path'] == pick_path
+    assert captured['npz_kwargs']['source_kind'] == 'manual_npz'
+    assert captured['write_kwargs']['pick_source_artifact_name'] == 'manual_picks.npz'
+
+
+def test_first_break_qc_job_writes_expected_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    assert (job_dir / 'job_meta.json').is_file()
+    assert (job_dir / 'first_break_qc.json').is_file()
+    assert (job_dir / 'first_break_qc.csv').is_file()
+    assert (job_dir / 'residual_by_key1.csv').is_file()
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'done'
+    assert job['progress'] == 1.0
+
+
+def test_first_break_qc_job_errors_when_datum_job_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'job_id not found: datum-job' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_datum_job_is_not_datum_static(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path, kind='first_break_qc')
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'unsupported statics_kind' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_solution_artifact_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    solution = _add_datum_job(state, tmp_path)
+    solution.unlink()
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'job artifact not found: datum_static_solution.npz' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_pick_source_artifact_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path, write_artifact=False)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'job artifact not found: predicted_picks_time_s.npz' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_batch_pick_source_job_is_not_batch_apply(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    wrong_dir = tmp_path / 'batch-job'
+    wrong_dir.mkdir()
+    (wrong_dir / 'predicted_picks_time_s.npz').write_bytes(b'picks')
+    with state.lock:
+        state.jobs.create_static_job(
+            'batch-job',
+            file_id='source-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='datum',
+            artifacts_dir=str(wrong_dir),
+        )
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'unsupported job_type' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_input_shapes_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    def _fail_build(**_kwargs: Any) -> object:
+        raise ValueError('n_traces mismatch')
+
+    monkeypatch.setattr(service, 'build_first_break_qc_inputs', _fail_build)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert job['message'] == 'n_traces mismatch'
+
+
+def test_first_break_qc_job_cancel_before_artifact_write(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path)
+    captured: dict[str, Any] = {}
+    _patch_success_path(monkeypatch, captured=captured)
+
+    def _cancel_after_compute(actual_inputs: object, **kwargs: Any) -> object:
+        with state.lock:
+            state.jobs.request_cancel('qc-job')
+        return SimpleNamespace(name='metrics')
+
+    monkeypatch.setattr(service, 'compute_first_break_qc_metrics', _cancel_after_compute)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'cancelled'
+    assert 'write_kwargs' not in captured
+    assert not list(job_dir.glob('first_break_qc*.tmp'))
+    assert not list(job_dir.glob('residual_by_key1*.tmp'))
+
+
+def test_first_break_qc_job_does_not_register_corrected_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    assert set(state.file_registry.records) == {'source-file-id'}
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert 'corrected_file_id' not in job
+    assert 'corrected_store_path' not in job

--- a/app/tests/test_job_artifact_refs.py
+++ b/app/tests/test_job_artifact_refs.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.core.state import create_app_state
+from app.services.job_artifact_refs import resolve_job_artifact_path
+
+
+def test_resolve_job_artifact_path_returns_named_file(tmp_path: Path) -> None:
+    state = create_app_state()
+    job_dir = tmp_path / 'job'
+    job_dir.mkdir()
+    artifact = job_dir / 'datum_static_solution.npz'
+    artifact.write_bytes(b'data')
+    with state.lock:
+        state.jobs.create_static_job(
+            'datum-job',
+            file_id='file-a',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='datum',
+            artifacts_dir=str(job_dir),
+        )
+
+    resolved = resolve_job_artifact_path(
+        state,
+        job_id='datum-job',
+        name='datum_static_solution.npz',
+        allowed_job_types={'statics'},
+        allowed_statics_kinds={'datum'},
+    )
+
+    assert resolved == artifact
+
+
+@pytest.mark.parametrize('name', ['', '.', '..', '../x.npz', 'nested/x.npz', '/x.npz'])
+def test_resolve_job_artifact_path_rejects_path_names(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    state = create_app_state()
+    job_dir = tmp_path / 'job'
+    job_dir.mkdir()
+    with state.lock:
+        state.jobs.create_static_job(
+            'job-a',
+            file_id='file-a',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='datum',
+            artifacts_dir=str(job_dir),
+        )
+
+    with pytest.raises(ValueError, match='plain file name'):
+        resolve_job_artifact_path(state, job_id='job-a', name=name)
+
+
+def test_resolve_job_artifact_path_rejects_wrong_job_type(tmp_path: Path) -> None:
+    state = create_app_state()
+    job_dir = tmp_path / 'batch'
+    job_dir.mkdir()
+    (job_dir / 'artifact.npz').write_bytes(b'data')
+    with state.lock:
+        state.jobs.create_batch_apply_job(
+            'batch-job',
+            file_id='file-a',
+            key1_byte=189,
+            key2_byte=193,
+            artifacts_dir=str(job_dir),
+        )
+
+    with pytest.raises(ValueError, match='unsupported job_type'):
+        resolve_job_artifact_path(
+            state,
+            job_id='batch-job',
+            name='artifact.npz',
+            allowed_job_types={'statics'},
+        )
+
+
+def test_resolve_job_artifact_path_rejects_wrong_statics_kind(
+    tmp_path: Path,
+) -> None:
+    state = create_app_state()
+    job_dir = tmp_path / 'statics'
+    job_dir.mkdir()
+    (job_dir / 'artifact.npz').write_bytes(b'data')
+    with state.lock:
+        state.jobs.create_static_job(
+            'qc-job',
+            file_id='file-a',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='first_break_qc',
+            artifacts_dir=str(job_dir),
+        )
+
+    with pytest.raises(ValueError, match='unsupported statics_kind'):
+        resolve_job_artifact_path(
+            state,
+            job_id='qc-job',
+            name='artifact.npz',
+            allowed_statics_kinds={'datum'},
+        )


### PR DESCRIPTION
Closes #307

## Summary
- [PR3/api] /statics/first-break/qc job API を追加し、既存 statics job lifecycle に統合する

## Changed files
- `app/api/routers/statics.py`
- `app/api/schemas.py`
- `app/services/first_break_qc_service.py`
- `app/services/job_artifact_refs.py`
- `app/tests/test_first_break_qc_job_api.py`
- `app/tests/test_first_break_qc_service.py`
- `app/tests/test_job_artifact_refs.py`

## Checks
- `.work/codex/checks.log`: 743 passed in 44.95s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
