### PR TITLE
[PR3/fix] first-break QC job の NaN handling・datum solution 検証・artifact 参照整合性を修正する

### DIFF
--- a/app/services/first_break_qc_inputs.py
+++ b/app/services/first_break_qc_inputs.py
@@ -175,7 +175,10 @@ def load_datum_static_solution_npz(
             msg = f'n_traces mismatch: expected {n_traces}, got {solution_n_traces}'
             raise ValueError(msg)
 
-        solution_dt = _read_float_scalar(npz, 'dt')
+        solution_dt = _coerce_positive_finite_float(
+            _read_float_scalar(npz, 'dt'),
+            name='datum_static_solution.npz dt',
+        )
         if abs(solution_dt - dt) > _DT_TOLERANCE:
             msg = f'dt mismatch: expected {dt}, got {solution_dt}'
             raise ValueError(msg)

--- a/app/services/first_break_qc_math.py
+++ b/app/services/first_break_qc_math.py
@@ -418,13 +418,16 @@ def fit_linear_offset_model(
     intercept, slowness = np.linalg.lstsq(design, y, rcond=None)[0]
     model = np.asarray(intercept + slowness * np.abs(offset), dtype=np.float64)
     residual = np.full(picks.shape, np.nan, dtype=np.float64)
-    residual[valid_mask] = picks[valid_mask] - model[valid_mask]
     if (
         not np.isfinite(intercept)
         or not np.isfinite(slowness)
-        or not np.all(np.isfinite(model))
-        or not np.all(np.isfinite(residual[valid_mask]))
+        or not np.all(np.isfinite(model[valid_mask]))
     ):
+        msg = 'linear offset model produced NaN or Inf'
+        raise ValueError(msg)
+    model[~valid_mask] = np.nan
+    residual[valid_mask] = picks[valid_mask] - model[valid_mask]
+    if not np.all(np.isfinite(residual[valid_mask])):
         msg = 'linear offset model produced NaN or Inf'
         raise ValueError(msg)
 

--- a/app/services/first_break_qc_service.py
+++ b/app/services/first_break_qc_service.py
@@ -158,6 +158,10 @@ def _resolve_input_artifacts(
         name=req.datum_solution.name,
         allowed_job_types={'statics'},
         allowed_statics_kinds={'datum'},
+        expected_file_id=req.file_id,
+        expected_key1_byte=req.key1_byte,
+        expected_key2_byte=req.key2_byte,
+        reference_label='datum_solution',
     )
 
     pick_source = req.pick_source
@@ -172,6 +176,10 @@ def _resolve_input_artifacts(
             job_id=pick_source.job_id,
             name=pick_source.name,
             allowed_job_types={'batch_apply'},
+            expected_file_id=req.file_id,
+            expected_key1_byte=req.key1_byte,
+            expected_key2_byte=req.key2_byte,
+            reference_label='pick_source',
         )
         return solution_path, pick_path
 

--- a/app/services/job_artifact_refs.py
+++ b/app/services/job_artifact_refs.py
@@ -29,6 +29,10 @@ def resolve_job_artifact_path(
     name: str,
     allowed_job_types: set[str] | None = None,
     allowed_statics_kinds: set[str] | None = None,
+    expected_file_id: str | None = None,
+    expected_key1_byte: int | None = None,
+    expected_key2_byte: int | None = None,
+    reference_label: str = 'referenced',
 ) -> Path:
     """Resolve a job artifact by job id and file name without accepting paths."""
     artifact_name = _plain_artifact_name(name)
@@ -51,6 +55,15 @@ def resolve_job_artifact_path(
                 f'job {job_id} has unsupported statics_kind: {statics_kind}'
             )
 
+    _validate_expected_job_metadata(
+        job_id=job_id,
+        job=job,
+        reference_label=reference_label,
+        expected_file_id=expected_file_id,
+        expected_key1_byte=expected_key1_byte,
+        expected_key2_byte=expected_key2_byte,
+    )
+
     artifacts_dir_raw = job.get('artifacts_dir')
     if not isinstance(artifacts_dir_raw, str) or not artifacts_dir_raw:
         raise ValueError(f'job {job_id} has no artifacts_dir')
@@ -63,6 +76,58 @@ def resolve_job_artifact_path(
     if not artifact_path.is_file():
         raise ValueError(f'job artifact not found: {artifact_name}')
     return artifact_path
+
+
+def _validate_expected_job_metadata(
+    *,
+    job_id: str,
+    job: dict[str, object],
+    reference_label: str,
+    expected_file_id: str | None,
+    expected_key1_byte: int | None,
+    expected_key2_byte: int | None,
+) -> None:
+    _validate_expected_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label=reference_label,
+        field='file_id',
+        expected=expected_file_id,
+    )
+    _validate_expected_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label=reference_label,
+        field='key1_byte',
+        expected=expected_key1_byte,
+    )
+    _validate_expected_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label=reference_label,
+        field='key2_byte',
+        expected=expected_key2_byte,
+    )
+
+
+def _validate_expected_job_field(
+    *,
+    job_id: str,
+    job: dict[str, object],
+    reference_label: str,
+    field: str,
+    expected: object | None,
+) -> None:
+    if expected is None:
+        return
+    actual = job.get(field)
+    if actual == expected:
+        return
+    msg = (
+        f'{reference_label} job {job_id} metadata mismatch: '
+        f'{field} expected {expected!r}, got {actual!r}'
+    )
+    raise ValueError(msg)
 
 
 __all__ = ['resolve_job_artifact_path']

--- a/app/tests/test_first_break_qc_artifacts.py
+++ b/app/tests/test_first_break_qc_artifacts.py
@@ -100,10 +100,7 @@ def _base_inputs() -> FirstBreakQcInputs:
 
 def _metrics(inputs: FirstBreakQcInputs | None = None) -> FirstBreakQcMetrics:
     actual_inputs = _base_inputs() if inputs is None else inputs
-    metrics = compute_first_break_qc_metrics(actual_inputs)
-    linear_model = metrics.linear_moveout_model_s_sorted.copy()
-    linear_model[~metrics.residual_valid_mask_sorted] = np.nan
-    return replace(metrics, linear_moveout_model_s_sorted=linear_model)
+    return compute_first_break_qc_metrics(actual_inputs)
 
 
 def _write(
@@ -246,6 +243,25 @@ def test_write_first_break_qc_artifacts_writes_blank_for_invalid_pick_nan(
 
     invalid = rows[2]
     assert invalid['valid_pick'] == 'false'
+    assert invalid['pick_time_raw_s'] == ''
+    assert invalid['pick_time_after_datum_s'] == ''
+    assert invalid['linear_moveout_model_s'] == ''
+    assert invalid['residual_after_datum_s'] == ''
+
+
+def test_first_break_qc_compute_then_writer_allows_nan_pick(
+    tmp_path: Path,
+) -> None:
+    inputs = _base_inputs()
+    metrics = compute_first_break_qc_metrics(inputs)
+
+    paths = _write(tmp_path, inputs=inputs, metrics=metrics)
+    rows = _read_csv(paths.qc_csv)
+
+    assert paths.qc_json.is_file()
+    assert paths.qc_csv.is_file()
+    assert paths.residual_by_key1_csv.is_file()
+    invalid = rows[2]
     assert invalid['pick_time_raw_s'] == ''
     assert invalid['pick_time_after_datum_s'] == ''
     assert invalid['linear_moveout_model_s'] == ''

--- a/app/tests/test_first_break_qc_inputs.py
+++ b/app/tests/test_first_break_qc_inputs.py
@@ -185,6 +185,62 @@ def test_load_datum_static_solution_npz_rejects_dt_mismatch(
         _load_solution(path)
 
 
+def test_load_datum_static_solution_npz_rejects_nan_dt(tmp_path: Path) -> None:
+    path = _write_solution(tmp_path / 'datum_static_solution.npz', dt=np.float64(np.nan))
+
+    with pytest.raises(ValueError, match='datum_static_solution.npz dt'):
+        _load_solution(path)
+
+
+@pytest.mark.parametrize('bad_dt', [np.float64(np.inf), np.float64(-np.inf)])
+def test_load_datum_static_solution_npz_rejects_inf_dt(
+    tmp_path: Path,
+    bad_dt: np.float64,
+) -> None:
+    path = _write_solution(tmp_path / 'datum_static_solution.npz', dt=bad_dt)
+
+    with pytest.raises(ValueError, match='datum_static_solution.npz dt'):
+        _load_solution(path)
+
+
+@pytest.mark.parametrize('bad_dt', [np.float64(0.0), np.float64(-0.004)])
+def test_load_datum_static_solution_npz_rejects_non_positive_dt(
+    tmp_path: Path,
+    bad_dt: np.float64,
+) -> None:
+    path = _write_solution(tmp_path / 'datum_static_solution.npz', dt=bad_dt)
+
+    with pytest.raises(ValueError, match='datum_static_solution.npz dt'):
+        _load_solution(path)
+
+
+def test_load_datum_static_solution_npz_accepts_matching_positive_finite_dt(
+    tmp_path: Path,
+) -> None:
+    path = _write_solution(tmp_path / 'datum_static_solution.npz', dt=np.float64(DT))
+
+    solution = _load_solution(path)
+
+    assert solution.dt == pytest.approx(DT)
+
+
+@pytest.mark.parametrize('bad_dt', [np.nan, np.inf, -np.inf, 0.0, -0.004])
+def test_load_datum_static_solution_npz_rejects_invalid_expected_dt(
+    tmp_path: Path,
+    bad_dt: float,
+) -> None:
+    path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    with pytest.raises(ValueError, match='expected_dt'):
+        load_datum_static_solution_npz(
+            path,
+            expected_n_traces=4,
+            expected_dt=bad_dt,
+            expected_key1_byte=KEY1_BYTE,
+            expected_key2_byte=KEY2_BYTE,
+        )
+
+
 def test_load_datum_static_solution_npz_rejects_n_traces_mismatch(
     tmp_path: Path,
 ) -> None:

--- a/app/tests/test_first_break_qc_job_api.py
+++ b/app/tests/test_first_break_qc_job_api.py
@@ -1,13 +1,46 @@
 from __future__ import annotations
 
+import csv
+import json
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
 import app.api.routers.statics as statics_router_module
 from app.main import app
+
+KEY1_SORTED = np.asarray([10, 10, 20, 20], dtype=np.int64)
+KEY2_SORTED = np.asarray([1, 2, 1, 2], dtype=np.int64)
+OFFSET_SORTED = np.asarray([-1200.0, -400.0, 350.0, 1250.0], dtype=np.float64)
+PICKS_TIME_S = np.asarray([0.004, np.nan, 0.012, 0.020], dtype=np.float32)
+DT = 0.004
+N_SAMPLES = 8
+
+
+class _Reader:
+    key1_byte = 189
+    key2_byte = 193
+
+    def __init__(self) -> None:
+        self.traces = np.zeros((4, N_SAMPLES), dtype=np.float32)
+        self.meta = {'dt': DT}
+        self.headers = {
+            189: KEY1_SORTED,
+            193: KEY2_SORTED,
+            37: OFFSET_SORTED,
+        }
+
+    def get_n_samples(self) -> int:
+        return N_SAMPLES
+
+    def ensure_header(self, byte: int) -> np.ndarray:
+        return self.headers[int(byte)]
+
+    def get_sorted_to_original(self) -> np.ndarray:
+        return np.arange(4, dtype=np.int64)
 
 
 @pytest.fixture()
@@ -43,6 +76,91 @@ def _payload() -> dict[str, Any]:
         'offset': {'offset_byte': 37},
         'qc': {'require_linear_offset_model': False},
     }
+
+
+def _write_real_datum_solution(path: Path) -> Path:
+    source_shift = np.zeros(4, dtype=np.float64)
+    receiver_shift = np.zeros(4, dtype=np.float64)
+    np.savez(
+        path,
+        trace_shift_s_sorted=source_shift + receiver_shift,
+        source_shift_s_sorted=source_shift,
+        receiver_shift_s_sorted=receiver_shift,
+        source_elevation_m_sorted=np.asarray([100.0, 105.0, 110.0, 115.0]),
+        receiver_elevation_m_sorted=np.asarray([90.0, 95.0, 100.0, 105.0]),
+        key1_sorted=KEY1_SORTED,
+        key2_sorted=KEY2_SORTED,
+        datum_elevation_m=np.float64(500.0),
+        replacement_velocity_m_s=np.float64(2000.0),
+        dt=np.float64(DT),
+        n_traces=np.int64(4),
+        key1_byte=np.int64(189),
+        key2_byte=np.int64(193),
+        source_elevation_byte=np.int64(45),
+        receiver_elevation_byte=np.int64(41),
+    )
+    return path
+
+
+def _write_real_pick_npz(path: Path) -> Path:
+    np.savez(
+        path,
+        picks_time_s=PICKS_TIME_S,
+        n_traces=np.int64(4),
+        n_samples=np.int64(N_SAMPLES),
+        dt=np.float64(DT),
+        sorted_to_original=np.arange(4, dtype=np.int64),
+    )
+    return path
+
+
+def _setup_real_first_break_qc_inputs(client: TestClient, tmp_path: Path) -> None:
+    datum_dir = tmp_path / 'datum-job'
+    datum_dir.mkdir()
+    batch_dir = tmp_path / 'batch-job'
+    batch_dir.mkdir()
+    _write_real_datum_solution(datum_dir / 'datum_static_solution.npz')
+    _write_real_pick_npz(batch_dir / 'predicted_picks_time_s.npz')
+
+    state = client.app.state.sv
+    state.file_registry.set_record(
+        'source-file-id',
+        {
+            'path': str(tmp_path / 'line.sgy'),
+            'store_path': str(tmp_path / 'trace-store'),
+            'dt': DT,
+        },
+    )
+    with state.lock:
+        state.cached_readers['source-file-id_189_193'] = _Reader()
+        state.jobs.create_static_job(
+            'datum-static-job-id',
+            file_id='source-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='datum',
+            artifacts_dir=str(datum_dir),
+        )
+        state.jobs.create_batch_apply_job(
+            'batch-apply-job-id',
+            file_id='source-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            artifacts_dir=str(batch_dir),
+        )
+
+
+def _run_job_sync(**kwargs: Any) -> object:
+    target = kwargs['target']
+    args = kwargs.get('args', ())
+    extra_kwargs = kwargs.get('kwargs') or {}
+    target(*args, **extra_kwargs)
+    return object()
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))
 
 
 def test_first_break_qc_endpoint_starts_static_job(
@@ -165,3 +283,34 @@ def test_first_break_qc_job_files_and_download_use_static_lifecycle(
     }
     assert download_response.status_code == 200
     assert download_response.text == '{"ok":true}'
+
+
+def test_first_break_qc_job_real_path_allows_nan_pick(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _setup_real_first_break_qc_inputs(client, tmp_path)
+    monkeypatch.setattr(statics_router_module, 'start_job_thread', _run_job_sync)
+
+    response = client.post('/statics/first-break/qc', json=_payload())
+
+    assert response.status_code == 200
+    job_id = response.json()['job_id']
+    status_response = client.get(f'/statics/job/{job_id}/status')
+    assert status_response.status_code == 200
+    assert status_response.json()['state'] == 'done'
+
+    state = client.app.state.sv
+    with state.lock:
+        job = dict(state.jobs[job_id])
+    job_dir = Path(str(job['artifacts_dir']))
+    payload = json.loads((job_dir / 'first_break_qc.json').read_text(encoding='utf-8'))
+    json.dumps(payload, allow_nan=False)
+    rows = _read_csv(job_dir / 'first_break_qc.csv')
+    invalid = rows[1]
+    assert invalid['pick_time_raw_s'] == ''
+    assert invalid['pick_time_after_datum_s'] == ''
+    assert invalid['linear_moveout_model_s'] == ''
+    assert invalid['residual_after_datum_s'] == ''
+    assert (job_dir / 'residual_by_key1.csv').is_file()

--- a/app/tests/test_first_break_qc_math.py
+++ b/app/tests/test_first_break_qc_math.py
@@ -127,7 +127,22 @@ def test_first_break_qc_linear_offset_model_recovers_intercept_and_slowness() ->
     assert metrics.linear_offset_fit.slowness_s_per_offset_unit == pytest.approx(0.0001)
     assert metrics.linear_offset_fit.r2 == pytest.approx(1.0)
     expected_model = 0.100 + 0.0001 * np.abs(_base_inputs().offset_sorted)
-    np.testing.assert_allclose(metrics.linear_moveout_model_s_sorted, expected_model)
+    expected_model[~_base_inputs().valid_pick_mask_sorted] = np.nan
+    np.testing.assert_allclose(
+        metrics.linear_moveout_model_s_sorted,
+        expected_model,
+        equal_nan=True,
+    )
+
+
+def test_first_break_qc_metrics_linear_model_nan_for_invalid_pick() -> None:
+    metrics = compute_first_break_qc_metrics(_base_inputs())
+    invalid_mask = ~_base_inputs().valid_pick_mask_sorted
+
+    assert np.all(np.isnan(metrics.linear_moveout_model_s_sorted[invalid_mask]))
+    assert np.all(np.isnan(metrics.residual_after_datum_s_sorted[invalid_mask]))
+    assert np.all(np.isfinite(metrics.linear_moveout_model_s_sorted[~invalid_mask]))
+    assert np.all(np.isfinite(metrics.residual_after_datum_s_sorted[~invalid_mask]))
 
 
 def test_first_break_qc_linear_offset_model_uses_abs_offset() -> None:

--- a/app/tests/test_first_break_qc_service.py
+++ b/app/tests/test_first_break_qc_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,16 +12,35 @@ import app.services.first_break_qc_service as service
 from app.api.schemas import FirstBreakQcRequest
 from app.core.state import AppState, create_app_state
 
+KEY1_SORTED = np.asarray([10, 10, 20, 20], dtype=np.int64)
+KEY2_SORTED = np.asarray([1, 2, 1, 2], dtype=np.int64)
+OFFSET_SORTED = np.asarray([-1200.0, -400.0, 350.0, 1250.0], dtype=np.float64)
+PICKS_TIME_S = np.asarray([0.004, np.nan, 0.012, 0.020], dtype=np.float32)
+DT = 0.004
+N_SAMPLES = 8
+
 
 class _Reader:
     key1_byte = 189
     key2_byte = 193
 
     def __init__(self) -> None:
-        self.traces = np.zeros((4, 8), dtype=np.float32)
+        self.traces = np.zeros((4, N_SAMPLES), dtype=np.float32)
+        self.meta = {'dt': DT}
+        self.headers = {
+            189: KEY1_SORTED,
+            193: KEY2_SORTED,
+            37: OFFSET_SORTED,
+        }
 
     def get_n_samples(self) -> int:
-        return 8
+        return N_SAMPLES
+
+    def ensure_header(self, byte: int) -> np.ndarray:
+        return self.headers[int(byte)]
+
+    def get_sorted_to_original(self) -> np.ndarray:
+        return np.arange(4, dtype=np.int64)
 
 
 def _request(
@@ -71,7 +91,15 @@ def _setup_state(tmp_path: Path) -> tuple[AppState, Path]:
     return state, job_dir
 
 
-def _add_datum_job(state: AppState, tmp_path: Path, *, kind: str = 'datum') -> Path:
+def _add_datum_job(
+    state: AppState,
+    tmp_path: Path,
+    *,
+    kind: str = 'datum',
+    file_id: str = 'source-file-id',
+    key1_byte: int = 189,
+    key2_byte: int = 193,
+) -> Path:
     datum_dir = tmp_path / 'datum-job'
     datum_dir.mkdir(parents=True, exist_ok=True)
     solution = datum_dir / 'datum_static_solution.npz'
@@ -79,16 +107,24 @@ def _add_datum_job(state: AppState, tmp_path: Path, *, kind: str = 'datum') -> P
     with state.lock:
         state.jobs.create_static_job(
             'datum-job',
-            file_id='source-file-id',
-            key1_byte=189,
-            key2_byte=193,
+            file_id=file_id,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
             statics_kind=kind,
             artifacts_dir=str(datum_dir),
         )
     return solution
 
 
-def _add_batch_job(state: AppState, tmp_path: Path, *, write_artifact: bool = True) -> Path:
+def _add_batch_job(
+    state: AppState,
+    tmp_path: Path,
+    *,
+    write_artifact: bool = True,
+    file_id: str = 'source-file-id',
+    key1_byte: int = 189,
+    key2_byte: int = 193,
+) -> Path:
     batch_dir = tmp_path / 'batch-job'
     batch_dir.mkdir(parents=True, exist_ok=True)
     artifact = batch_dir / 'predicted_picks_time_s.npz'
@@ -97,12 +133,58 @@ def _add_batch_job(state: AppState, tmp_path: Path, *, write_artifact: bool = Tr
     with state.lock:
         state.jobs.create_batch_apply_job(
             'batch-job',
-            file_id='source-file-id',
-            key1_byte=189,
-            key2_byte=193,
+            file_id=file_id,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
             artifacts_dir=str(batch_dir),
         )
     return artifact
+
+
+def _write_real_datum_solution(path: Path) -> Path:
+    source_shift = np.zeros(4, dtype=np.float64)
+    receiver_shift = np.zeros(4, dtype=np.float64)
+    np.savez(
+        path,
+        trace_shift_s_sorted=source_shift + receiver_shift,
+        source_shift_s_sorted=source_shift,
+        receiver_shift_s_sorted=receiver_shift,
+        source_elevation_m_sorted=np.asarray([100.0, 105.0, 110.0, 115.0]),
+        receiver_elevation_m_sorted=np.asarray([90.0, 95.0, 100.0, 105.0]),
+        key1_sorted=KEY1_SORTED,
+        key2_sorted=KEY2_SORTED,
+        datum_elevation_m=np.float64(500.0),
+        replacement_velocity_m_s=np.float64(2000.0),
+        dt=np.float64(DT),
+        n_traces=np.int64(4),
+        key1_byte=np.int64(189),
+        key2_byte=np.int64(193),
+        source_elevation_byte=np.int64(45),
+        receiver_elevation_byte=np.int64(41),
+    )
+    return path
+
+
+def _write_real_pick_npz(path: Path) -> Path:
+    np.savez(
+        path,
+        picks_time_s=PICKS_TIME_S,
+        n_traces=np.int64(4),
+        n_samples=np.int64(N_SAMPLES),
+        dt=np.float64(DT),
+        sorted_to_original=np.arange(4, dtype=np.int64),
+    )
+    return path
+
+
+def _register_real_reader(state: AppState) -> None:
+    with state.lock:
+        state.cached_readers['source-file-id_189_193'] = _Reader()
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))
 
 
 def _add_manual_npz_job(state: AppState, tmp_path: Path) -> Path:
@@ -381,6 +463,124 @@ def test_first_break_qc_job_errors_when_batch_pick_source_job_is_not_batch_apply
     assert 'unsupported job_type' in str(job['message'])
 
 
+def test_first_break_qc_job_errors_when_datum_job_file_id_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path, file_id='other-file-id')
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'datum_solution job datum-job metadata mismatch: file_id' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_datum_job_key1_byte_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path, key1_byte=191)
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'datum_solution job datum-job metadata mismatch: key1_byte' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_datum_job_key2_byte_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path, key2_byte=195)
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'datum_solution job datum-job metadata mismatch: key2_byte' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_batch_pick_source_file_id_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path, file_id='other-file-id')
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'pick_source job batch-job metadata mismatch: file_id' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_batch_pick_source_key1_byte_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path, key1_byte=191)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'pick_source job batch-job metadata mismatch: key1_byte' in str(job['message'])
+
+
+def test_first_break_qc_job_errors_when_batch_pick_source_key2_byte_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path, key2_byte=195)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'error'
+    assert 'pick_source job batch-job metadata mismatch: key2_byte' in str(job['message'])
+
+
+def test_first_break_qc_job_accepts_matching_datum_and_batch_pick_jobs(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    state, _job_dir = _setup_state(tmp_path)
+    _add_datum_job(state, tmp_path)
+    _add_batch_job(state, tmp_path)
+    _patch_success_path(monkeypatch)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'done'
+
+
 def test_first_break_qc_job_errors_when_input_shapes_mismatch(
     tmp_path: Path,
     monkeypatch,
@@ -446,3 +646,29 @@ def test_first_break_qc_job_does_not_register_corrected_file(
         job = dict(state.jobs['qc-job'])
     assert 'corrected_file_id' not in job
     assert 'corrected_store_path' not in job
+
+
+def test_first_break_qc_service_real_compute_writer_allows_nan_pick(
+    tmp_path: Path,
+) -> None:
+    state, job_dir = _setup_state(tmp_path)
+    solution = _add_datum_job(state, tmp_path)
+    picks = _add_batch_job(state, tmp_path)
+    _write_real_datum_solution(solution)
+    _write_real_pick_npz(picks)
+    _register_real_reader(state)
+
+    service.run_first_break_qc_job('qc-job', _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs['qc-job'])
+    assert job['status'] == 'done'
+    payload = json.loads((job_dir / 'first_break_qc.json').read_text(encoding='utf-8'))
+    json.dumps(payload, allow_nan=False)
+    rows = _read_csv(job_dir / 'first_break_qc.csv')
+    invalid = rows[1]
+    assert invalid['pick_time_raw_s'] == ''
+    assert invalid['pick_time_after_datum_s'] == ''
+    assert invalid['linear_moveout_model_s'] == ''
+    assert invalid['residual_after_datum_s'] == ''
+    assert (job_dir / 'residual_by_key1.csv').is_file()


### PR DESCRIPTION
Closes #309

## Summary
- [PR3/fix] first-break QC job の NaN handling・datum solution 検証・artifact 参照整合性を修正する

## Changed files
- `app/services/first_break_qc_inputs.py`
- `app/services/first_break_qc_math.py`
- `app/services/first_break_qc_service.py`
- `app/services/job_artifact_refs.py`
- `app/tests/test_first_break_qc_artifacts.py`
- `app/tests/test_first_break_qc_inputs.py`
- `app/tests/test_first_break_qc_job_api.py`
- `app/tests/test_first_break_qc_math.py`
- `app/tests/test_first_break_qc_service.py`

## Checks
- `.work/codex/checks.log`: 765 passed in 44.61s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
