### PR TITLE
PR4-2 [statics residual] datum solution・pick source・offset・source/receiver ID header から solver 入力を構築する

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -444,3 +444,49 @@ class FirstBreakQcJobResponse(BaseModel):
 
     job_id: str
     state: str
+
+
+class ResidualStaticDatumSolutionRequest(FirstBreakQcDatumSolutionRequest):
+    """Datum static solution artifact reference for residual statics."""
+
+
+class ResidualStaticPickSourceRequest(FirstBreakQcPickSourceRequest):
+    """First-break pick source reference for residual static estimation."""
+
+
+class ResidualStaticMoveoutRequest(BaseModel):
+    """Moveout model configuration for residual static estimation."""
+
+    model: Literal['linear_abs_offset', 'none'] = 'linear_abs_offset'
+
+
+class ResidualStaticApplyRequest(BaseModel):
+    """Request model for future ``/statics/residual/apply`` jobs."""
+
+    file_id: str
+    key1_byte: int = 189
+    key2_byte: int = 193
+    datum_solution: ResidualStaticDatumSolutionRequest
+    pick_source: ResidualStaticPickSourceRequest
+    source_id_byte: int
+    receiver_id_byte: int
+    offset_byte: int | None = 37
+    moveout: ResidualStaticMoveoutRequest = Field(
+        default_factory=ResidualStaticMoveoutRequest,
+    )
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'ResidualStaticApplyRequest':
+        if not self.file_id:
+            raise ValueError('file_id must be a non-empty string')
+        require_positive_int(self.key1_byte, 'key1_byte')
+        require_positive_int(self.key2_byte, 'key2_byte')
+        require_positive_int(self.source_id_byte, 'source_id_byte')
+        require_positive_int(self.receiver_id_byte, 'receiver_id_byte')
+        if self.source_id_byte == self.receiver_id_byte:
+            raise ValueError('source_id_byte and receiver_id_byte must differ')
+        if self.offset_byte is not None:
+            require_positive_int(self.offset_byte, 'offset_byte')
+        if self.moveout.model == 'linear_abs_offset' and self.offset_byte is None:
+            raise ValueError('offset_byte is required for linear_abs_offset moveout')
+        return self

--- a/app/services/residual_static_inputs.py
+++ b/app/services/residual_static_inputs.py
@@ -1,0 +1,950 @@
+"""Validated sorted-order inputs for residual static estimation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+
+from app.api.schemas import ResidualStaticApplyRequest
+from app.core.state import AppState
+from app.services.first_break_qc_inputs import (
+    load_datum_static_solution_npz,
+    load_offset_header_sorted,
+)
+from app.services.job_artifact_refs import resolve_job_artifact_path
+from app.services.pick_source_loader import (
+    LoadedPickSource,
+    load_manual_memmap_pick_source,
+    load_npz_pick_source,
+)
+from app.trace_store.reader import TraceStoreSectionReader
+
+MoveoutModel = Literal['linear_abs_offset', 'none']
+
+_DT_TOLERANCE = 1e-9
+_CORRECTED_FILE_MANIFEST = 'corrected_file.json'
+
+
+@dataclass(frozen=True)
+class ResidualStaticResolvedArtifacts:
+    datum_solution_path: Path
+    pick_artifact_path: Path | None
+    datum_job_id: str
+    datum_source_file_id: str
+    datum_corrected_file_id: str
+    pick_source_artifact_name: str | None
+
+
+@dataclass(frozen=True)
+class ResidualStaticSolverInputs:
+    picks_time_s_sorted: np.ndarray
+    valid_pick_mask_sorted: np.ndarray
+    pick_time_after_datum_s_sorted: np.ndarray
+    datum_trace_shift_s_sorted: np.ndarray
+
+    source_id_sorted: np.ndarray
+    receiver_id_sorted: np.ndarray
+    source_unique_ids: np.ndarray
+    receiver_unique_ids: np.ndarray
+    source_index_sorted: np.ndarray
+    receiver_index_sorted: np.ndarray
+    source_valid_pick_counts: np.ndarray
+    receiver_valid_pick_counts: np.ndarray
+
+    offset_sorted: np.ndarray | None
+    abs_offset_sorted: np.ndarray | None
+
+    key1_sorted: np.ndarray
+    key2_sorted: np.ndarray
+    source_elevation_m_sorted: np.ndarray
+    receiver_elevation_m_sorted: np.ndarray
+
+    dt: float
+    n_traces: int
+    n_samples: int
+    key1_byte: int
+    key2_byte: int
+    source_id_byte: int
+    receiver_id_byte: int
+    offset_byte: int | None
+    moveout_model: MoveoutModel
+
+    input_file_id: str
+    datum_source_file_id: str
+    datum_job_id: str
+    pick_source_kind: str
+    metadata: dict[str, Any]
+
+
+def resolve_residual_static_input_artifacts(
+    state: AppState,
+    req: ResidualStaticApplyRequest,
+) -> ResidualStaticResolvedArtifacts:
+    """Resolve datum and pick artifacts for residual statics."""
+    datum_job_id = _non_empty_str(
+        getattr(req.datum_solution, 'job_id', None),
+        name='datum_solution.job_id',
+    )
+    datum_artifact_name = _plain_artifact_name(
+        _non_empty_str(
+            getattr(req.datum_solution, 'name', None),
+            name='datum_solution.name',
+        )
+    )
+    req_file_id = _non_empty_str(getattr(req, 'file_id', None), name='file_id')
+    key1_byte = _validate_header_byte(req.key1_byte, name='key1_byte')
+    key2_byte = _validate_header_byte(req.key2_byte, name='key2_byte')
+
+    datum_job = _get_job_snapshot(state, datum_job_id)
+    if datum_job is None:
+        raise ValueError(f'job_id not found: {datum_job_id}')
+    _validate_datum_job(
+        job_id=datum_job_id,
+        job=datum_job,
+        req_file_id=req_file_id,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+    )
+    datum_source_file_id = _non_empty_str(
+        datum_job.get('file_id'),
+        name=f'datum job {datum_job_id} file_id',
+    )
+    datum_corrected_file_id = _non_empty_str(
+        datum_job.get('corrected_file_id'),
+        name=f'datum job {datum_job_id} corrected_file_id',
+    )
+
+    datum_solution_path = resolve_job_artifact_path(
+        state,
+        job_id=datum_job_id,
+        name=datum_artifact_name,
+        allowed_job_types={'statics'},
+        allowed_statics_kinds={'datum'},
+        expected_key1_byte=key1_byte,
+        expected_key2_byte=key2_byte,
+        reference_label='datum_solution',
+    )
+    _validate_corrected_file_manifest_if_present(
+        datum_solution_path.parent / _CORRECTED_FILE_MANIFEST,
+        datum_source_file_id=datum_source_file_id,
+        datum_corrected_file_id=datum_corrected_file_id,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+    )
+
+    pick_path, pick_name = _resolve_pick_source_artifact(
+        state,
+        req=req,
+        datum_source_file_id=datum_source_file_id,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+    )
+    return ResidualStaticResolvedArtifacts(
+        datum_solution_path=datum_solution_path,
+        pick_artifact_path=pick_path,
+        datum_job_id=datum_job_id,
+        datum_source_file_id=datum_source_file_id,
+        datum_corrected_file_id=datum_corrected_file_id,
+        pick_source_artifact_name=pick_name,
+    )
+
+
+def load_residual_static_pick_source(
+    *,
+    req: ResidualStaticApplyRequest,
+    artifacts: ResidualStaticResolvedArtifacts,
+    reader: TraceStoreSectionReader,
+    expected_dt: float,
+    expected_n_samples: int,
+    state: AppState,
+) -> LoadedPickSource:
+    """Load the residual-static pick source in TraceStore sorted order."""
+    pick_source = req.pick_source
+    if pick_source.kind == 'manual_memmap':
+        return load_manual_memmap_pick_source(
+            file_id=artifacts.datum_source_file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            state=state,
+        )
+
+    if artifacts.pick_artifact_path is None:
+        raise ValueError('pick source artifact path is required')
+    source_kind = 'batch_npz' if pick_source.kind == 'batch_job_artifact' else 'manual_npz'
+    return load_npz_pick_source(
+        artifacts.pick_artifact_path,
+        reader=reader,
+        expected_dt=expected_dt,
+        expected_n_samples=expected_n_samples,
+        source_kind=source_kind,
+    )
+
+
+def load_source_receiver_id_headers_sorted(
+    reader: TraceStoreSectionReader,
+    *,
+    source_id_byte: int,
+    receiver_id_byte: int,
+    expected_n_traces: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Read source and receiver ID headers in TraceStore sorted order."""
+    source_byte = _validate_header_byte(source_id_byte, name='source_id_byte')
+    receiver_byte = _validate_header_byte(receiver_id_byte, name='receiver_id_byte')
+    if source_byte == receiver_byte:
+        raise ValueError('source_id_byte and receiver_id_byte must differ')
+    n_traces = _coerce_positive_int(expected_n_traces, name='expected_n_traces')
+    source_id = _coerce_1d_integer_int64(
+        _read_reader_header(reader, byte=source_byte, role='source_id'),
+        name=f'source_id header byte {source_byte}',
+        expected_shape=(n_traces,),
+    )
+    receiver_id = _coerce_1d_integer_int64(
+        _read_reader_header(reader, byte=receiver_byte, role='receiver_id'),
+        name=f'receiver_id header byte {receiver_byte}',
+        expected_shape=(n_traces,),
+    )
+    return source_id, receiver_id
+
+
+def build_residual_static_solver_inputs(
+    *,
+    req: ResidualStaticApplyRequest,
+    artifacts: ResidualStaticResolvedArtifacts,
+    pick_source: LoadedPickSource,
+    reader: TraceStoreSectionReader,
+    expected_dt: float,
+    expected_n_samples: int,
+) -> ResidualStaticSolverInputs:
+    """Build the sorted-order input object consumed by later PR4 solver stages."""
+    dt = _coerce_positive_finite_float(expected_dt, name='expected_dt')
+    n_samples = _coerce_positive_int(
+        expected_n_samples,
+        name='expected_n_samples',
+    )
+    key1_byte = _validate_header_byte(req.key1_byte, name='key1_byte')
+    key2_byte = _validate_header_byte(req.key2_byte, name='key2_byte')
+    source_id_byte = _validate_header_byte(
+        req.source_id_byte,
+        name='source_id_byte',
+    )
+    receiver_id_byte = _validate_header_byte(
+        req.receiver_id_byte,
+        name='receiver_id_byte',
+    )
+    if source_id_byte == receiver_id_byte:
+        raise ValueError('source_id_byte and receiver_id_byte must differ')
+
+    moveout_model = _moveout_model(req)
+    offset_byte = _request_offset_byte(req, moveout_model=moveout_model)
+    _validate_reader_key_bytes(
+        reader,
+        expected_key1_byte=key1_byte,
+        expected_key2_byte=key2_byte,
+    )
+    _validate_reader_dt(reader, expected_dt=dt)
+
+    n_traces = _reader_n_traces(reader)
+    reader_n_samples = _reader_n_samples(reader)
+    if reader_n_samples != n_samples:
+        msg = f'n_samples mismatch: expected {n_samples}, reader has {reader_n_samples}'
+        raise ValueError(msg)
+
+    solution = load_datum_static_solution_npz(
+        artifacts.datum_solution_path,
+        expected_n_traces=n_traces,
+        expected_dt=dt,
+        expected_key1_byte=key1_byte,
+        expected_key2_byte=key2_byte,
+    )
+    _validate_pick_source(
+        pick_source,
+        expected_n_traces=n_traces,
+        expected_n_samples=n_samples,
+        expected_dt=dt,
+    )
+    picks = _coerce_1d_pick_times(
+        pick_source.picks_time_s_sorted,
+        valid_mask=pick_source.valid_mask_sorted,
+        expected_shape=(n_traces,),
+    )
+    valid_mask = _coerce_1d_bool_array(
+        pick_source.valid_mask_sorted,
+        name='valid_mask_sorted',
+        expected_shape=(n_traces,),
+    )
+    pick_time_after_datum = np.ascontiguousarray(
+        picks + solution.trace_shift_s_sorted,
+        dtype=np.float64,
+    )
+    pick_time_after_datum[~valid_mask] = np.nan
+    if np.any(~np.isfinite(pick_time_after_datum[valid_mask])):
+        raise ValueError('pick_time_after_datum_s_sorted must be finite for valid picks')
+    if np.any(~np.isnan(pick_time_after_datum[~valid_mask])):
+        raise ValueError('pick_time_after_datum_s_sorted must be NaN for invalid picks')
+
+    key1_header = _coerce_1d_integer_int64(
+        _read_reader_header(reader, byte=key1_byte, role='key1'),
+        name=f'reader header byte {key1_byte}',
+        expected_shape=(n_traces,),
+    )
+    key2_header = _coerce_1d_integer_int64(
+        _read_reader_header(reader, byte=key2_byte, role='key2'),
+        name=f'reader header byte {key2_byte}',
+        expected_shape=(n_traces,),
+    )
+    if not np.array_equal(solution.key1_sorted, key1_header):
+        raise ValueError(
+            f'solution key1_sorted does not match reader header byte {key1_byte}'
+        )
+    if not np.array_equal(solution.key2_sorted, key2_header):
+        raise ValueError(
+            f'solution key2_sorted does not match reader header byte {key2_byte}'
+        )
+
+    source_id, receiver_id = load_source_receiver_id_headers_sorted(
+        reader,
+        source_id_byte=source_id_byte,
+        receiver_id_byte=receiver_id_byte,
+        expected_n_traces=n_traces,
+    )
+    source_unique_ids, source_inverse = np.unique(source_id, return_inverse=True)
+    receiver_unique_ids, receiver_inverse = np.unique(receiver_id, return_inverse=True)
+    source_index = np.ascontiguousarray(source_inverse, dtype=np.int64)
+    receiver_index = np.ascontiguousarray(receiver_inverse, dtype=np.int64)
+    source_counts = _valid_pick_counts(
+        source_index,
+        valid_mask=valid_mask,
+        n_unique=int(source_unique_ids.shape[0]),
+        name='source_index_sorted',
+    )
+    receiver_counts = _valid_pick_counts(
+        receiver_index,
+        valid_mask=valid_mask,
+        n_unique=int(receiver_unique_ids.shape[0]),
+        name='receiver_index_sorted',
+    )
+
+    if moveout_model == 'linear_abs_offset':
+        if offset_byte is None:
+            raise ValueError('offset_byte is required for linear_abs_offset moveout')
+        offset = load_offset_header_sorted(
+            reader,
+            offset_byte=offset_byte,
+            expected_n_traces=n_traces,
+        )
+        abs_offset = np.ascontiguousarray(np.abs(offset), dtype=np.float64)
+    else:
+        offset = None
+        abs_offset = None
+
+    pick_source_kind = _pick_source_kind(pick_source)
+    metadata: dict[str, Any] = {
+        'order': 'trace_store_sorted',
+        'sign_convention': (
+            'pick_time_after_datum_s = pick_time_raw_s + datum_trace_shift_s; '
+            'estimated_trace_delay_s is solved later; '
+            'applied_residual_shift_s = -estimated_trace_delay_s'
+        ),
+        'input_file_role': 'datum_corrected_trace_store',
+        'input_file_id': req.file_id,
+        'datum_source_file_id': artifacts.datum_source_file_id,
+        'datum_corrected_file_id': artifacts.datum_corrected_file_id,
+        'datum_job_id': artifacts.datum_job_id,
+        'datum_solution_artifact': artifacts.datum_solution_path.name,
+        'datum_solution_npz_path': str(artifacts.datum_solution_path),
+        'pick_source_kind': pick_source_kind,
+        'pick_source_artifact': artifacts.pick_source_artifact_name,
+        'pick_source_metadata': _pick_source_metadata(pick_source),
+        'key1_byte': key1_byte,
+        'key2_byte': key2_byte,
+        'source_id_byte': source_id_byte,
+        'receiver_id_byte': receiver_id_byte,
+        'offset_byte': offset_byte,
+        'moveout_model': moveout_model,
+        'n_valid_picks': int(np.count_nonzero(valid_mask)),
+        'n_sources': int(source_unique_ids.shape[0]),
+        'n_receivers': int(receiver_unique_ids.shape[0]),
+        'datum_static_solution_metadata': solution.metadata,
+    }
+
+    return ResidualStaticSolverInputs(
+        picks_time_s_sorted=picks,
+        valid_pick_mask_sorted=valid_mask,
+        pick_time_after_datum_s_sorted=pick_time_after_datum,
+        datum_trace_shift_s_sorted=solution.trace_shift_s_sorted,
+        source_id_sorted=source_id,
+        receiver_id_sorted=receiver_id,
+        source_unique_ids=np.ascontiguousarray(source_unique_ids, dtype=np.int64),
+        receiver_unique_ids=np.ascontiguousarray(receiver_unique_ids, dtype=np.int64),
+        source_index_sorted=source_index,
+        receiver_index_sorted=receiver_index,
+        source_valid_pick_counts=source_counts,
+        receiver_valid_pick_counts=receiver_counts,
+        offset_sorted=offset,
+        abs_offset_sorted=abs_offset,
+        key1_sorted=solution.key1_sorted,
+        key2_sorted=solution.key2_sorted,
+        source_elevation_m_sorted=solution.source_elevation_m_sorted,
+        receiver_elevation_m_sorted=solution.receiver_elevation_m_sorted,
+        dt=dt,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        source_id_byte=source_id_byte,
+        receiver_id_byte=receiver_id_byte,
+        offset_byte=offset_byte,
+        moveout_model=moveout_model,
+        input_file_id=req.file_id,
+        datum_source_file_id=artifacts.datum_source_file_id,
+        datum_job_id=artifacts.datum_job_id,
+        pick_source_kind=pick_source_kind,
+        metadata=metadata,
+    )
+
+
+def _resolve_pick_source_artifact(
+    state: AppState,
+    *,
+    req: ResidualStaticApplyRequest,
+    datum_source_file_id: str,
+    key1_byte: int,
+    key2_byte: int,
+) -> tuple[Path | None, str | None]:
+    pick_source = req.pick_source
+    if pick_source.kind == 'manual_memmap':
+        return None, None
+    job_id = _non_empty_str(pick_source.job_id, name='pick_source.job_id')
+    name = _plain_artifact_name(
+        _non_empty_str(pick_source.name, name='pick_source.name')
+    )
+    if pick_source.kind == 'batch_job_artifact':
+        return (
+            resolve_job_artifact_path(
+                state,
+                job_id=job_id,
+                name=name,
+                allowed_job_types={'batch_apply'},
+                expected_file_id=datum_source_file_id,
+                expected_key1_byte=key1_byte,
+                expected_key2_byte=key2_byte,
+                reference_label='pick_source',
+            ),
+            name,
+        )
+    if pick_source.kind != 'manual_npz_artifact':
+        raise ValueError(f'unsupported pick_source.kind: {pick_source.kind}')
+    if not name.endswith('.npz'):
+        raise ValueError('manual_npz_artifact name must end with .npz')
+    path = resolve_job_artifact_path(
+        state,
+        job_id=job_id,
+        name=name,
+        allowed_job_types={'statics', 'batch_apply', 'pipeline'},
+    )
+    job = _get_job_snapshot(state, job_id)
+    if job is None:
+        raise ValueError(f'job_id not found: {job_id}')
+    _validate_optional_pick_job_metadata(
+        job_id=job_id,
+        job=job,
+        expected_file_id=datum_source_file_id,
+        expected_key1_byte=key1_byte,
+        expected_key2_byte=key2_byte,
+    )
+    return path, name
+
+
+def _validate_datum_job(
+    *,
+    job_id: str,
+    job: Mapping[str, object],
+    req_file_id: str,
+    key1_byte: int,
+    key2_byte: int,
+) -> None:
+    job_type = job.get('job_type')
+    if job_type != 'statics':
+        raise ValueError(f'job {job_id} has unsupported job_type: {job_type}')
+    statics_kind = job.get('statics_kind')
+    if statics_kind != 'datum':
+        raise ValueError(f'job {job_id} has unsupported statics_kind: {statics_kind}')
+    _validate_required_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label='datum_solution',
+        field='key1_byte',
+        expected=key1_byte,
+    )
+    _validate_required_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label='datum_solution',
+        field='key2_byte',
+        expected=key2_byte,
+    )
+    corrected_file_id = job.get('corrected_file_id')
+    if not isinstance(corrected_file_id, str) or not corrected_file_id:
+        raise ValueError(f'datum job {job_id} has no corrected_file_id')
+    if corrected_file_id != req_file_id:
+        msg = (
+            f'datum job {job_id} corrected_file_id mismatch: '
+            f'expected {req_file_id!r}, got {corrected_file_id!r}'
+        )
+        raise ValueError(msg)
+
+
+def _validate_corrected_file_manifest_if_present(
+    path: Path,
+    *,
+    datum_source_file_id: str,
+    datum_corrected_file_id: str,
+    key1_byte: int,
+    key2_byte: int,
+) -> None:
+    if not path.exists():
+        return
+    if not path.is_file():
+        raise ValueError(f'corrected_file.json is not a file: {path}')
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f'Could not read corrected_file.json: {path}') from exc
+    if not isinstance(payload, dict):
+        raise ValueError('corrected_file.json must contain an object')
+    _validate_manifest_field(
+        payload,
+        field='file_id',
+        expected=datum_corrected_file_id,
+        label='corrected_file.json',
+    )
+    _validate_manifest_field(
+        payload,
+        field='derived_from_file_id',
+        expected=datum_source_file_id,
+        label='corrected_file.json',
+    )
+    _validate_manifest_field(
+        payload,
+        field='key1_byte',
+        expected=key1_byte,
+        label='corrected_file.json',
+    )
+    _validate_manifest_field(
+        payload,
+        field='key2_byte',
+        expected=key2_byte,
+        label='corrected_file.json',
+    )
+
+
+def _validate_optional_pick_job_metadata(
+    *,
+    job_id: str,
+    job: Mapping[str, object],
+    expected_file_id: str,
+    expected_key1_byte: int,
+    expected_key2_byte: int,
+) -> None:
+    _validate_optional_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label='pick_source',
+        field='file_id',
+        expected=expected_file_id,
+    )
+    _validate_optional_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label='pick_source',
+        field='key1_byte',
+        expected=expected_key1_byte,
+    )
+    _validate_optional_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label='pick_source',
+        field='key2_byte',
+        expected=expected_key2_byte,
+    )
+
+
+def _validate_required_job_field(
+    *,
+    job_id: str,
+    job: Mapping[str, object],
+    reference_label: str,
+    field: str,
+    expected: object,
+) -> None:
+    if job.get(field) == expected:
+        return
+    msg = (
+        f'{reference_label} job {job_id} metadata mismatch: '
+        f'{field} expected {expected!r}, got {job.get(field)!r}'
+    )
+    raise ValueError(msg)
+
+
+def _validate_optional_job_field(
+    *,
+    job_id: str,
+    job: Mapping[str, object],
+    reference_label: str,
+    field: str,
+    expected: object,
+) -> None:
+    if field not in job or job.get(field) is None:
+        return
+    _validate_required_job_field(
+        job_id=job_id,
+        job=job,
+        reference_label=reference_label,
+        field=field,
+        expected=expected,
+    )
+
+
+def _validate_manifest_field(
+    payload: Mapping[str, object],
+    *,
+    field: str,
+    expected: object,
+    label: str,
+) -> None:
+    actual = payload.get(field)
+    if actual == expected:
+        return
+    msg = f'{label} mismatch: {field} expected {expected!r}, got {actual!r}'
+    raise ValueError(msg)
+
+
+def _get_job_snapshot(state: AppState, job_id: str) -> dict[str, object] | None:
+    with state.lock:
+        raw_job = state.jobs.get(job_id)
+        return dict(raw_job) if isinstance(raw_job, dict) else None
+
+
+def _moveout_model(req: ResidualStaticApplyRequest) -> MoveoutModel:
+    model = getattr(getattr(req, 'moveout', None), 'model', None)
+    if model == 'linear_abs_offset':
+        return 'linear_abs_offset'
+    if model == 'none':
+        return 'none'
+    raise ValueError(f'unsupported moveout.model: {model}')
+
+
+def _request_offset_byte(
+    req: ResidualStaticApplyRequest,
+    *,
+    moveout_model: MoveoutModel,
+) -> int | None:
+    raw_offset_byte = getattr(req, 'offset_byte', None)
+    if raw_offset_byte is None:
+        if moveout_model == 'linear_abs_offset':
+            raise ValueError('offset_byte is required for linear_abs_offset moveout')
+        return None
+    return _validate_header_byte(raw_offset_byte, name='offset_byte')
+
+
+def _validate_pick_source(
+    pick_source: LoadedPickSource,
+    *,
+    expected_n_traces: int,
+    expected_n_samples: int,
+    expected_dt: float,
+) -> None:
+    pick_n_traces = _coerce_nonnegative_int(
+        getattr(pick_source, 'n_traces', None),
+        name='pick source n_traces',
+    )
+    if pick_n_traces != expected_n_traces:
+        msg = f'pick source n_traces mismatch: expected {expected_n_traces}, got {pick_n_traces}'
+        raise ValueError(msg)
+    pick_n_samples = _coerce_positive_int(
+        getattr(pick_source, 'n_samples', None),
+        name='pick source n_samples',
+    )
+    if pick_n_samples != expected_n_samples:
+        msg = f'pick source n_samples mismatch: expected {expected_n_samples}, got {pick_n_samples}'
+        raise ValueError(msg)
+    pick_dt = _coerce_positive_finite_float(
+        getattr(pick_source, 'dt', None),
+        name='pick source dt',
+    )
+    if abs(pick_dt - expected_dt) > _DT_TOLERANCE:
+        msg = f'pick source dt mismatch: expected {expected_dt}, got {pick_dt}'
+        raise ValueError(msg)
+    _pick_source_kind(pick_source)
+    _pick_source_metadata(pick_source)
+
+
+def _coerce_1d_pick_times(
+    values: np.ndarray,
+    *,
+    valid_mask: np.ndarray,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    picks = _coerce_1d_real_numeric_float64(
+        values,
+        name='picks_time_s_sorted',
+        expected_shape=expected_shape,
+    )
+    mask = _coerce_1d_bool_array(
+        valid_mask,
+        name='valid_mask_sorted',
+        expected_shape=expected_shape,
+    )
+    if np.any(np.isinf(picks)):
+        raise ValueError('picks_time_s_sorted contains inf')
+    if np.any(~np.isfinite(picks[mask])):
+        raise ValueError('valid picks must be finite')
+    if np.any(~np.isnan(picks[~mask])):
+        raise ValueError('invalid picks must be NaN')
+    return picks
+
+
+def _valid_pick_counts(
+    indices: np.ndarray,
+    *,
+    valid_mask: np.ndarray,
+    n_unique: int,
+    name: str,
+) -> np.ndarray:
+    if indices.shape != valid_mask.shape:
+        raise ValueError(f'{name} shape mismatch')
+    counts = np.bincount(indices[valid_mask], minlength=n_unique)
+    return np.ascontiguousarray(counts, dtype=np.int64)
+
+
+def _read_reader_header(
+    reader: TraceStoreSectionReader,
+    *,
+    byte: int,
+    role: str,
+) -> np.ndarray:
+    reader_header = getattr(reader, 'ensure_header', None)
+    if not callable(reader_header):
+        raise ValueError(f'reader cannot read {role} header byte {byte}')
+    try:
+        return reader_header(byte)
+    except Exception as exc:  # noqa: BLE001
+        msg = f'failed to read {role} header byte {byte}: {exc}'
+        raise ValueError(msg) from exc
+
+
+def _validate_reader_key_bytes(
+    reader: TraceStoreSectionReader,
+    *,
+    expected_key1_byte: int,
+    expected_key2_byte: int,
+) -> None:
+    if not hasattr(reader, 'key1_byte'):
+        raise ValueError('reader key1_byte is required')
+    if not hasattr(reader, 'key2_byte'):
+        raise ValueError('reader key2_byte is required')
+    reader_key1 = _validate_header_byte(reader.key1_byte, name='reader key1_byte')
+    reader_key2 = _validate_header_byte(reader.key2_byte, name='reader key2_byte')
+    if reader_key1 != expected_key1_byte:
+        msg = (
+            f'reader key1_byte mismatch: expected {expected_key1_byte}, '
+            f'got {reader_key1}'
+        )
+        raise ValueError(msg)
+    if reader_key2 != expected_key2_byte:
+        msg = (
+            f'reader key2_byte mismatch: expected {expected_key2_byte}, '
+            f'got {reader_key2}'
+        )
+        raise ValueError(msg)
+
+
+def _validate_reader_dt(
+    reader: TraceStoreSectionReader,
+    *,
+    expected_dt: float,
+) -> None:
+    meta = getattr(reader, 'meta', None)
+    if not isinstance(meta, Mapping):
+        raise ValueError('reader meta must be a mapping containing dt')
+    if 'dt' not in meta:
+        raise ValueError('reader meta missing dt')
+    reader_dt = _coerce_positive_finite_float(meta['dt'], name='reader dt')
+    if abs(reader_dt - expected_dt) > _DT_TOLERANCE:
+        msg = f'reader dt mismatch: expected {expected_dt}, got {reader_dt}'
+        raise ValueError(msg)
+
+
+def _reader_n_traces(reader: TraceStoreSectionReader) -> int:
+    if hasattr(reader, 'traces'):
+        shape = getattr(reader.traces, 'shape', ())
+        if shape:
+            return _coerce_positive_int(shape[0], name='reader n_traces')
+    meta = getattr(reader, 'meta', None)
+    if isinstance(meta, Mapping) and 'n_traces' in meta:
+        return _coerce_positive_int(meta['n_traces'], name='reader n_traces')
+    raise ValueError('reader cannot provide number of traces')
+
+
+def _reader_n_samples(reader: TraceStoreSectionReader) -> int:
+    getter = getattr(reader, 'get_n_samples', None)
+    if callable(getter):
+        return _coerce_positive_int(getter(), name='reader n_samples')
+    if hasattr(reader, 'traces'):
+        shape = getattr(reader.traces, 'shape', ())
+        if len(shape) >= 2:
+            return _coerce_positive_int(shape[-1], name='reader n_samples')
+    raise ValueError('reader cannot provide number of samples')
+
+
+def _coerce_1d_integer_int64(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if arr.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        raise ValueError(msg)
+    if np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must contain integer values')
+    if np.issubdtype(arr.dtype, np.integer):
+        return np.ascontiguousarray(arr, dtype=np.int64)
+    if not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must contain integer values')
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(arr_f64)):
+        raise ValueError(f'{name} must contain only finite values')
+    if not np.all(arr_f64 == np.rint(arr_f64)):
+        raise ValueError(f'{name} must contain integer values')
+    return np.ascontiguousarray(arr_f64, dtype=np.int64)
+
+
+def _coerce_1d_bool_array(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if arr.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        raise ValueError(msg)
+    if not np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must have bool dtype')
+    return np.ascontiguousarray(arr, dtype=bool)
+
+
+def _coerce_1d_real_numeric_float64(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if arr.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        raise ValueError(msg)
+    if not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a numeric dtype')
+    return np.ascontiguousarray(arr, dtype=np.float64)
+
+
+def _validate_header_byte(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer SEG-Y trace header byte')
+    byte = int(value)
+    if byte < 1 or byte > 240:
+        raise ValueError(f'{name} must be between 1 and 240')
+    return byte
+
+
+def _coerce_nonnegative_int(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer')
+    out = int(value)
+    if out < 0:
+        raise ValueError(f'{name} must be greater than or equal to 0')
+    return out
+
+
+def _coerce_positive_int(value: object, *, name: str) -> int:
+    out = _coerce_nonnegative_int(value, name=name)
+    if out <= 0:
+        raise ValueError(f'{name} must be greater than 0')
+    return out
+
+
+def _coerce_finite_float(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f'{name} must be finite')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite') from exc
+    if not np.isfinite(out):
+        raise ValueError(f'{name} must be finite')
+    return out
+
+
+def _coerce_positive_finite_float(value: object, *, name: str) -> float:
+    out = _coerce_finite_float(value, name=name)
+    if out <= 0.0:
+        raise ValueError(f'{name} must be finite and greater than 0')
+    return out
+
+
+def _pick_source_kind(pick_source: LoadedPickSource) -> str:
+    source_kind = getattr(pick_source, 'source_kind', None)
+    if not isinstance(source_kind, str) or not source_kind:
+        raise ValueError('pick source source_kind must be a non-empty string')
+    return source_kind
+
+
+def _pick_source_metadata(pick_source: LoadedPickSource) -> dict[str, object]:
+    metadata = getattr(pick_source, 'metadata', None)
+    if not isinstance(metadata, Mapping):
+        raise ValueError('pick source metadata must be a mapping')
+    return dict(metadata)
+
+
+def _plain_artifact_name(name: str) -> str:
+    if not name or name in {'.', '..'} or Path(name).name != name:
+        raise ValueError('artifact name must be a plain file name')
+    return name
+
+
+def _non_empty_str(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f'{name} must be a non-empty string')
+    return value
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'MoveoutModel',
+    'ResidualStaticResolvedArtifacts',
+    'ResidualStaticSolverInputs',
+    'build_residual_static_solver_inputs',
+    'load_residual_static_pick_source',
+    'load_source_receiver_id_headers_sorted',
+    'resolve_residual_static_input_artifacts',
+]

--- a/app/tests/test_residual_static_inputs.py
+++ b/app/tests/test_residual_static_inputs.py
@@ -1,0 +1,741 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from app.api.schemas import ResidualStaticApplyRequest
+from app.core.state import create_app_state
+from app.services.pick_source_loader import LoadedPickSource
+from app.services.residual_static_inputs import (
+    ResidualStaticResolvedArtifacts,
+    build_residual_static_solver_inputs,
+    load_residual_static_pick_source,
+    load_source_receiver_id_headers_sorted,
+    resolve_residual_static_input_artifacts,
+)
+
+KEY1_BYTE = 189
+KEY2_BYTE = 193
+SOURCE_ID_BYTE = 17
+RECEIVER_ID_BYTE = 13
+OFFSET_BYTE = 37
+SOURCE_ELEVATION_BYTE = 45
+RECEIVER_ELEVATION_BYTE = 41
+DT = 0.004
+N_SAMPLES = 64
+SOURCE_FILE_ID = 'source-file-id'
+CORRECTED_FILE_ID = 'corrected-file-id'
+DATUM_JOB_ID = 'datum-job'
+KEY1_SORTED = np.asarray([100, 100, 100, 200, 200, 200], dtype=np.int64)
+KEY2_SORTED = np.asarray([1, 2, 3, 1, 2, 3], dtype=np.int64)
+SOURCE_ID_SORTED = np.asarray([10, 10, 20, 20, 30, 30], dtype=np.int64)
+RECEIVER_ID_SORTED = np.asarray([1, 2, 1, 2, 1, 2], dtype=np.int64)
+SOURCE_SHIFT = np.asarray([-0.004, -0.004, -0.004, -0.008, -0.008, -0.008])
+RECEIVER_SHIFT = np.asarray([-0.006, -0.006, -0.006, -0.012, -0.012, -0.012])
+TRACE_SHIFT = SOURCE_SHIFT + RECEIVER_SHIFT
+SOURCE_ELEVATION = np.asarray([100.0, 101.0, 102.0, 103.0, 104.0, 105.0])
+RECEIVER_ELEVATION = np.asarray([90.0, 91.0, 92.0, 93.0, 94.0, 95.0])
+OFFSET_SORTED = np.asarray([-1200.0, -800.0, -400.0, 400.0, 800.0, 1200.0])
+PICKS_SORTED = np.asarray([0.100, 0.110, np.nan, 0.130, 0.140, 0.150])
+VALID_PICK_MASK = np.asarray([True, True, False, True, True, True])
+
+
+class _Reader:
+    def __init__(
+        self,
+        *,
+        key1_sorted: np.ndarray = KEY1_SORTED,
+        key2_sorted: np.ndarray = KEY2_SORTED,
+        source_id_sorted: np.ndarray = SOURCE_ID_SORTED,
+        receiver_id_sorted: np.ndarray = RECEIVER_ID_SORTED,
+        offset_sorted: np.ndarray = OFFSET_SORTED,
+        n_samples: int = N_SAMPLES,
+        dt: float = DT,
+        fail_offset_read: bool = False,
+    ) -> None:
+        self.key1_byte = KEY1_BYTE
+        self.key2_byte = KEY2_BYTE
+        self.traces = np.zeros((int(np.asarray(key1_sorted).shape[0]), n_samples))
+        self.meta = {'dt': dt}
+        self.fail_offset_read = fail_offset_read
+        self.headers = {
+            KEY1_BYTE: np.asarray(key1_sorted),
+            KEY2_BYTE: np.asarray(key2_sorted),
+            SOURCE_ID_BYTE: np.asarray(source_id_sorted),
+            RECEIVER_ID_BYTE: np.asarray(receiver_id_sorted),
+            OFFSET_BYTE: np.asarray(offset_sorted),
+        }
+
+    def ensure_header(self, byte: int) -> np.ndarray:
+        if self.fail_offset_read and int(byte) == OFFSET_BYTE:
+            raise AssertionError('offset header should not be read')
+        return self.headers[int(byte)]
+
+    def get_n_samples(self) -> int:
+        return int(self.traces.shape[-1])
+
+
+def _request(**overrides: Any) -> ResidualStaticApplyRequest:
+    payload: dict[str, Any] = {
+        'file_id': CORRECTED_FILE_ID,
+        'key1_byte': KEY1_BYTE,
+        'key2_byte': KEY2_BYTE,
+        'datum_solution': {
+            'job_id': DATUM_JOB_ID,
+            'name': 'datum_static_solution.npz',
+        },
+        'pick_source': {
+            'kind': 'batch_job_artifact',
+            'job_id': 'pick-job',
+            'name': 'predicted_picks_time_s.npz',
+        },
+        'source_id_byte': SOURCE_ID_BYTE,
+        'receiver_id_byte': RECEIVER_ID_BYTE,
+        'offset_byte': OFFSET_BYTE,
+        'moveout': {'model': 'linear_abs_offset'},
+    }
+    payload.update(overrides)
+    return ResidualStaticApplyRequest.model_validate(payload)
+
+
+def _state_with_datum_job(tmp_path: Path):
+    state = create_app_state()
+    job_dir = tmp_path / 'datum-job'
+    job_dir.mkdir()
+    (job_dir / 'datum_static_solution.npz').write_bytes(b'data')
+    corrected_store = tmp_path / 'corrected-store'
+    with state.lock:
+        state.jobs.create_static_job(
+            DATUM_JOB_ID,
+            file_id=SOURCE_FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='datum',
+            artifacts_dir=str(job_dir),
+        )
+        state.jobs.set_static_corrected_file(
+            DATUM_JOB_ID,
+            corrected_file_id=CORRECTED_FILE_ID,
+            corrected_store_path=str(corrected_store),
+        )
+    return state, job_dir, corrected_store
+
+
+def _write_corrected_manifest(
+    job_dir: Path,
+    *,
+    corrected_store: Path,
+    overrides: dict[str, Any] | None = None,
+) -> None:
+    payload = {
+        'file_id': CORRECTED_FILE_ID,
+        'store_path': str(corrected_store),
+        'derived_from_file_id': SOURCE_FILE_ID,
+        'job_id': DATUM_JOB_ID,
+        'key1_byte': KEY1_BYTE,
+        'key2_byte': KEY2_BYTE,
+    }
+    if overrides:
+        payload.update(overrides)
+    (job_dir / 'corrected_file.json').write_text(
+        json.dumps(payload),
+        encoding='utf-8',
+    )
+
+
+def _add_batch_pick_job(
+    state,
+    tmp_path: Path,
+    *,
+    job_id: str = 'pick-job',
+    file_id: str = SOURCE_FILE_ID,
+    key1_byte: int = KEY1_BYTE,
+    key2_byte: int = KEY2_BYTE,
+) -> Path:
+    job_dir = tmp_path / job_id
+    job_dir.mkdir()
+    artifact = job_dir / 'predicted_picks_time_s.npz'
+    artifact.write_bytes(b'data')
+    with state.lock:
+        state.jobs.create_batch_apply_job(
+            job_id,
+            file_id=file_id,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
+            artifacts_dir=str(job_dir),
+        )
+    return artifact
+
+
+def _add_manual_npz_job(
+    state,
+    tmp_path: Path,
+    *,
+    job_id: str = 'manual-job',
+    file_id: str = SOURCE_FILE_ID,
+) -> Path:
+    job_dir = tmp_path / job_id
+    job_dir.mkdir()
+    artifact = job_dir / 'manual_picks.npz'
+    artifact.write_bytes(b'data')
+    with state.lock:
+        state.jobs.create_static_job(
+            job_id,
+            file_id=file_id,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='first_break_qc',
+            artifacts_dir=str(job_dir),
+        )
+    return artifact
+
+
+def _base_solution_payload() -> dict[str, Any]:
+    return {
+        'trace_shift_s_sorted': TRACE_SHIFT,
+        'source_shift_s_sorted': SOURCE_SHIFT,
+        'receiver_shift_s_sorted': RECEIVER_SHIFT,
+        'source_elevation_m_sorted': SOURCE_ELEVATION,
+        'receiver_elevation_m_sorted': RECEIVER_ELEVATION,
+        'key1_sorted': KEY1_SORTED,
+        'key2_sorted': KEY2_SORTED,
+        'datum_elevation_m': np.float64(500.0),
+        'replacement_velocity_m_s': np.float64(2000.0),
+        'dt': np.float64(DT),
+        'n_traces': np.int64(KEY1_SORTED.shape[0]),
+        'key1_byte': np.int64(KEY1_BYTE),
+        'key2_byte': np.int64(KEY2_BYTE),
+        'source_elevation_byte': np.int64(SOURCE_ELEVATION_BYTE),
+        'receiver_elevation_byte': np.int64(RECEIVER_ELEVATION_BYTE),
+    }
+
+
+def _write_solution(path: Path, **overrides: Any) -> Path:
+    payload = _base_solution_payload()
+    payload.update(overrides)
+    np.savez(path, **payload)
+    return path
+
+
+def _artifacts(solution_path: Path) -> ResidualStaticResolvedArtifacts:
+    return ResidualStaticResolvedArtifacts(
+        datum_solution_path=solution_path,
+        pick_artifact_path=None,
+        datum_job_id=DATUM_JOB_ID,
+        datum_source_file_id=SOURCE_FILE_ID,
+        datum_corrected_file_id=CORRECTED_FILE_ID,
+        pick_source_artifact_name=None,
+    )
+
+
+def _pick_source(**overrides: Any) -> LoadedPickSource:
+    source = LoadedPickSource(
+        picks_time_s_sorted=PICKS_SORTED,
+        valid_mask_sorted=VALID_PICK_MASK,
+        source_kind='batch_npz',
+        n_traces=int(KEY1_SORTED.shape[0]),
+        n_samples=N_SAMPLES,
+        dt=DT,
+        n_valid=5,
+        n_nan=1,
+        metadata={'source': 'test'},
+    )
+    return source if not overrides else replace(source, **overrides)
+
+
+def test_resolve_residual_static_artifacts_accepts_datum_job_corrected_file_id(
+    tmp_path: Path,
+) -> None:
+    state, job_dir, corrected_store = _state_with_datum_job(tmp_path)
+    _write_corrected_manifest(job_dir, corrected_store=corrected_store)
+    pick_artifact = _add_batch_pick_job(state, tmp_path)
+
+    artifacts = resolve_residual_static_input_artifacts(state, _request())
+
+    assert artifacts.datum_solution_path == job_dir / 'datum_static_solution.npz'
+    assert artifacts.pick_artifact_path == pick_artifact
+    assert artifacts.datum_source_file_id == SOURCE_FILE_ID
+    assert artifacts.datum_corrected_file_id == CORRECTED_FILE_ID
+    assert artifacts.pick_source_artifact_name == 'predicted_picks_time_s.npz'
+
+
+def test_resolve_residual_static_artifacts_rejects_missing_datum_job() -> None:
+    state = create_app_state()
+
+    with pytest.raises(ValueError, match='job_id not found'):
+        resolve_residual_static_input_artifacts(state, _request())
+
+
+def test_resolve_residual_static_artifacts_rejects_non_datum_job(
+    tmp_path: Path,
+) -> None:
+    state = create_app_state()
+    job_dir = tmp_path / 'qc-job'
+    job_dir.mkdir()
+    (job_dir / 'datum_static_solution.npz').write_bytes(b'data')
+    with state.lock:
+        state.jobs.create_static_job(
+            DATUM_JOB_ID,
+            file_id=SOURCE_FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='first_break_qc',
+            artifacts_dir=str(job_dir),
+        )
+
+    with pytest.raises(ValueError, match='unsupported statics_kind'):
+        resolve_residual_static_input_artifacts(state, _request())
+
+
+def test_resolve_residual_static_artifacts_rejects_missing_corrected_file_id(
+    tmp_path: Path,
+) -> None:
+    state = create_app_state()
+    job_dir = tmp_path / 'datum-job'
+    job_dir.mkdir()
+    (job_dir / 'datum_static_solution.npz').write_bytes(b'data')
+    with state.lock:
+        state.jobs.create_static_job(
+            DATUM_JOB_ID,
+            file_id=SOURCE_FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='datum',
+            artifacts_dir=str(job_dir),
+        )
+
+    with pytest.raises(ValueError, match='corrected_file_id'):
+        resolve_residual_static_input_artifacts(state, _request())
+
+
+def test_resolve_residual_static_artifacts_rejects_corrected_file_id_mismatch(
+    tmp_path: Path,
+) -> None:
+    state, _job_dir, _corrected_store = _state_with_datum_job(tmp_path)
+    _add_batch_pick_job(state, tmp_path)
+
+    with pytest.raises(ValueError, match='corrected_file_id mismatch'):
+        resolve_residual_static_input_artifacts(
+            state,
+            _request(file_id='other-corrected-file-id'),
+        )
+
+
+def test_resolve_residual_static_artifacts_validates_corrected_file_manifest_when_present(
+    tmp_path: Path,
+) -> None:
+    state, job_dir, corrected_store = _state_with_datum_job(tmp_path)
+    _add_batch_pick_job(state, tmp_path)
+    _write_corrected_manifest(
+        job_dir,
+        corrected_store=corrected_store,
+        overrides={'derived_from_file_id': 'wrong-source'},
+    )
+
+    with pytest.raises(ValueError, match='derived_from_file_id'):
+        resolve_residual_static_input_artifacts(state, _request())
+
+
+def test_resolve_residual_static_artifacts_accepts_batch_pick_job_on_datum_source_file_id(
+    tmp_path: Path,
+) -> None:
+    state, _job_dir, _corrected_store = _state_with_datum_job(tmp_path)
+    pick_artifact = _add_batch_pick_job(state, tmp_path)
+
+    artifacts = resolve_residual_static_input_artifacts(state, _request())
+
+    assert artifacts.pick_artifact_path == pick_artifact
+
+
+def test_resolve_residual_static_artifacts_rejects_batch_pick_job_on_wrong_file_id(
+    tmp_path: Path,
+) -> None:
+    state, _job_dir, _corrected_store = _state_with_datum_job(tmp_path)
+    _add_batch_pick_job(state, tmp_path, file_id='wrong-source')
+
+    with pytest.raises(ValueError, match='file_id expected'):
+        resolve_residual_static_input_artifacts(state, _request())
+
+
+def test_resolve_residual_static_artifacts_accepts_manual_npz_artifact(
+    tmp_path: Path,
+) -> None:
+    state, _job_dir, _corrected_store = _state_with_datum_job(tmp_path)
+    manual_artifact = _add_manual_npz_job(state, tmp_path)
+    req = _request(
+        pick_source={
+            'kind': 'manual_npz_artifact',
+            'job_id': 'manual-job',
+            'name': 'manual_picks.npz',
+        },
+    )
+
+    artifacts = resolve_residual_static_input_artifacts(state, req)
+
+    assert artifacts.pick_artifact_path == manual_artifact
+    assert artifacts.pick_source_artifact_name == 'manual_picks.npz'
+
+
+def test_resolve_residual_static_artifacts_rejects_manual_npz_without_npz_suffix(
+    tmp_path: Path,
+) -> None:
+    state, _job_dir, _corrected_store = _state_with_datum_job(tmp_path)
+    job_dir = tmp_path / 'manual-job'
+    job_dir.mkdir()
+    (job_dir / 'manual_picks.txt').write_bytes(b'data')
+    with state.lock:
+        state.jobs.create_static_job(
+            'manual-job',
+            file_id=SOURCE_FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='first_break_qc',
+            artifacts_dir=str(job_dir),
+        )
+    req = _request(
+        pick_source={
+            'kind': 'manual_npz_artifact',
+            'job_id': 'manual-job',
+            'name': 'manual_picks.txt',
+        },
+    )
+
+    with pytest.raises(ValueError, match='must end with .npz'):
+        resolve_residual_static_input_artifacts(state, req)
+
+
+def test_resolve_residual_static_artifacts_returns_none_for_manual_memmap_artifact_path(
+    tmp_path: Path,
+) -> None:
+    state, _job_dir, _corrected_store = _state_with_datum_job(tmp_path)
+    req = _request(pick_source={'kind': 'manual_memmap'})
+
+    artifacts = resolve_residual_static_input_artifacts(state, req)
+
+    assert artifacts.pick_artifact_path is None
+    assert artifacts.pick_source_artifact_name is None
+
+
+def test_load_source_receiver_id_headers_sorted_success() -> None:
+    source_id, receiver_id = load_source_receiver_id_headers_sorted(
+        _Reader(),
+        source_id_byte=SOURCE_ID_BYTE,
+        receiver_id_byte=RECEIVER_ID_BYTE,
+        expected_n_traces=6,
+    )
+
+    np.testing.assert_array_equal(source_id, SOURCE_ID_SORTED)
+    np.testing.assert_array_equal(receiver_id, RECEIVER_ID_SORTED)
+
+
+def test_load_source_receiver_id_headers_sorted_accepts_zero_and_negative_ids() -> None:
+    source_ids = np.asarray([0, -1, -1, 2, 2, 0], dtype=np.int64)
+    receiver_ids = np.asarray([-10, -10, 0, 0, 5, 5], dtype=np.float64)
+    reader = _Reader(source_id_sorted=source_ids, receiver_id_sorted=receiver_ids)
+
+    source_id, receiver_id = load_source_receiver_id_headers_sorted(
+        reader,
+        source_id_byte=SOURCE_ID_BYTE,
+        receiver_id_byte=RECEIVER_ID_BYTE,
+        expected_n_traces=6,
+    )
+
+    np.testing.assert_array_equal(source_id, source_ids)
+    np.testing.assert_array_equal(receiver_id, receiver_ids.astype(np.int64))
+
+
+def test_load_source_receiver_id_headers_sorted_rejects_shape_mismatch() -> None:
+    reader = _Reader(source_id_sorted=SOURCE_ID_SORTED[:5])
+
+    with pytest.raises(ValueError, match='shape mismatch'):
+        load_source_receiver_id_headers_sorted(
+            reader,
+            source_id_byte=SOURCE_ID_BYTE,
+            receiver_id_byte=RECEIVER_ID_BYTE,
+            expected_n_traces=6,
+        )
+
+
+def test_load_source_receiver_id_headers_sorted_rejects_non_integer_values() -> None:
+    source_ids = SOURCE_ID_SORTED.astype(np.float64)
+    source_ids[0] = 10.5
+    reader = _Reader(source_id_sorted=source_ids)
+
+    with pytest.raises(ValueError, match='integer values'):
+        load_source_receiver_id_headers_sorted(
+            reader,
+            source_id_byte=SOURCE_ID_BYTE,
+            receiver_id_byte=RECEIVER_ID_BYTE,
+            expected_n_traces=6,
+        )
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf, -np.inf])
+def test_load_source_receiver_id_headers_sorted_rejects_nan_inf(
+    bad_value: float,
+) -> None:
+    source_ids = SOURCE_ID_SORTED.astype(np.float64)
+    source_ids[0] = bad_value
+    reader = _Reader(source_id_sorted=source_ids)
+
+    with pytest.raises(ValueError, match='finite values'):
+        load_source_receiver_id_headers_sorted(
+            reader,
+            source_id_byte=SOURCE_ID_BYTE,
+            receiver_id_byte=RECEIVER_ID_BYTE,
+            expected_n_traces=6,
+        )
+
+
+def test_build_residual_static_solver_inputs_success_linear_abs_offset(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    inputs = build_residual_static_solver_inputs(
+        req=_request(),
+        artifacts=_artifacts(solution_path),
+        pick_source=_pick_source(),
+        reader=_Reader(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+    )
+
+    np.testing.assert_allclose(inputs.picks_time_s_sorted, PICKS_SORTED, equal_nan=True)
+    np.testing.assert_array_equal(inputs.valid_pick_mask_sorted, VALID_PICK_MASK)
+    np.testing.assert_allclose(inputs.datum_trace_shift_s_sorted, TRACE_SHIFT)
+    np.testing.assert_allclose(inputs.offset_sorted, OFFSET_SORTED)
+    np.testing.assert_allclose(inputs.abs_offset_sorted, np.abs(OFFSET_SORTED))
+    assert inputs.moveout_model == 'linear_abs_offset'
+    assert inputs.input_file_id == CORRECTED_FILE_ID
+    assert inputs.datum_source_file_id == SOURCE_FILE_ID
+    assert inputs.metadata['input_file_role'] == 'datum_corrected_trace_store'
+
+
+def test_build_residual_static_solver_inputs_success_moveout_none(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    inputs = build_residual_static_solver_inputs(
+        req=_request(moveout={'model': 'none'}, offset_byte=None),
+        artifacts=_artifacts(solution_path),
+        pick_source=_pick_source(),
+        reader=_Reader(fail_offset_read=True),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+    )
+
+    assert inputs.offset_sorted is None
+    assert inputs.abs_offset_sorted is None
+    assert inputs.offset_byte is None
+    assert inputs.moveout_model == 'none'
+
+
+def test_build_residual_static_solver_inputs_computes_pick_time_after_datum(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    inputs = build_residual_static_solver_inputs(
+        req=_request(),
+        artifacts=_artifacts(solution_path),
+        pick_source=_pick_source(),
+        reader=_Reader(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+    )
+
+    expected = np.asarray([0.090, 0.100, np.nan, 0.110, 0.120, 0.130])
+    np.testing.assert_allclose(
+        inputs.pick_time_after_datum_s_sorted,
+        expected,
+        equal_nan=True,
+    )
+
+
+def test_build_residual_static_solver_inputs_keeps_nan_for_invalid_picks(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    inputs = build_residual_static_solver_inputs(
+        req=_request(),
+        artifacts=_artifacts(solution_path),
+        pick_source=_pick_source(),
+        reader=_Reader(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+    )
+
+    assert np.isnan(inputs.pick_time_after_datum_s_sorted[2])
+
+
+def test_build_residual_static_solver_inputs_builds_unique_ids_and_inverse_indices(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    inputs = build_residual_static_solver_inputs(
+        req=_request(),
+        artifacts=_artifacts(solution_path),
+        pick_source=_pick_source(),
+        reader=_Reader(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+    )
+
+    np.testing.assert_array_equal(inputs.source_unique_ids, [10, 20, 30])
+    np.testing.assert_array_equal(inputs.source_index_sorted, [0, 0, 1, 1, 2, 2])
+    np.testing.assert_array_equal(inputs.receiver_unique_ids, [1, 2])
+    np.testing.assert_array_equal(inputs.receiver_index_sorted, [0, 1, 0, 1, 0, 1])
+
+
+def test_build_residual_static_solver_inputs_computes_valid_pick_counts(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    inputs = build_residual_static_solver_inputs(
+        req=_request(),
+        artifacts=_artifacts(solution_path),
+        pick_source=_pick_source(),
+        reader=_Reader(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+    )
+
+    np.testing.assert_array_equal(inputs.source_valid_pick_counts, [2, 1, 2])
+    np.testing.assert_array_equal(inputs.receiver_valid_pick_counts, [2, 3])
+    assert inputs.metadata['n_valid_picks'] == 5
+    assert inputs.metadata['n_sources'] == 3
+    assert inputs.metadata['n_receivers'] == 2
+
+
+def test_build_residual_static_solver_inputs_rejects_key1_key2_mismatch(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+    key1 = KEY1_SORTED.copy()
+    key1[0] = 999
+
+    with pytest.raises(ValueError, match='key1_sorted does not match'):
+        build_residual_static_solver_inputs(
+            req=_request(),
+            artifacts=_artifacts(solution_path),
+            pick_source=_pick_source(),
+            reader=_Reader(key1_sorted=key1),
+            expected_dt=DT,
+            expected_n_samples=N_SAMPLES,
+        )
+
+
+def test_build_residual_static_solver_inputs_rejects_pick_source_dt_mismatch(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    with pytest.raises(ValueError, match='pick source dt mismatch'):
+        build_residual_static_solver_inputs(
+            req=_request(),
+            artifacts=_artifacts(solution_path),
+            pick_source=_pick_source(dt=0.002),
+            reader=_Reader(),
+            expected_dt=DT,
+            expected_n_samples=N_SAMPLES,
+        )
+
+
+def test_build_residual_static_solver_inputs_rejects_pick_source_n_samples_mismatch(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    with pytest.raises(ValueError, match='pick source n_samples mismatch'):
+        build_residual_static_solver_inputs(
+            req=_request(),
+            artifacts=_artifacts(solution_path),
+            pick_source=_pick_source(n_samples=N_SAMPLES + 1),
+            reader=_Reader(),
+            expected_dt=DT,
+            expected_n_samples=N_SAMPLES,
+        )
+
+
+def test_build_residual_static_solver_inputs_rejects_nonfinite_offset_for_linear_abs_offset(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+    offset = OFFSET_SORTED.copy()
+    offset[0] = np.inf
+
+    with pytest.raises(ValueError, match='offset header'):
+        build_residual_static_solver_inputs(
+            req=_request(),
+            artifacts=_artifacts(solution_path),
+            pick_source=_pick_source(),
+            reader=_Reader(offset_sorted=offset),
+            expected_dt=DT,
+            expected_n_samples=N_SAMPLES,
+        )
+
+
+def test_build_residual_static_solver_inputs_does_not_read_offset_for_moveout_none(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(tmp_path / 'datum_static_solution.npz')
+
+    inputs = build_residual_static_solver_inputs(
+        req=_request(moveout={'model': 'none'}, offset_byte=None),
+        artifacts=_artifacts(solution_path),
+        pick_source=_pick_source(),
+        reader=_Reader(fail_offset_read=True),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+    )
+
+    assert inputs.offset_sorted is None
+
+
+def test_load_residual_static_pick_source_manual_memmap_uses_datum_source_file_id(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state = create_app_state()
+    req = _request(pick_source={'kind': 'manual_memmap'})
+    artifacts = _artifacts(tmp_path / 'datum_static_solution.npz')
+    calls: list[dict[str, Any]] = []
+    loaded = _pick_source(source_kind='manual_memmap')
+
+    def _fake_loader(**kwargs: Any) -> LoadedPickSource:
+        calls.append(kwargs)
+        return loaded
+
+    monkeypatch.setattr(
+        'app.services.residual_static_inputs.load_manual_memmap_pick_source',
+        _fake_loader,
+    )
+
+    result = load_residual_static_pick_source(
+        req=req,
+        artifacts=artifacts,
+        reader=_Reader(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+        state=state,
+    )
+
+    assert result is loaded
+    assert calls == [
+        {
+            'file_id': SOURCE_FILE_ID,
+            'key1_byte': KEY1_BYTE,
+            'key2_byte': KEY2_BYTE,
+            'state': state,
+        }
+    ]

--- a/app/tests/test_residual_static_schema.py
+++ b/app/tests/test_residual_static_schema.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.schemas import ResidualStaticApplyRequest
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        'file_id': 'datum-corrected-file-id',
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'datum_solution': {
+            'job_id': 'datum-job',
+            'name': 'datum_static_solution.npz',
+        },
+        'pick_source': {
+            'kind': 'batch_job_artifact',
+            'job_id': 'pick-job',
+            'name': 'predicted_picks_time_s.npz',
+        },
+        'source_id_byte': 17,
+        'receiver_id_byte': 13,
+        'offset_byte': 37,
+        'moveout': {'model': 'linear_abs_offset'},
+    }
+
+
+def test_residual_static_apply_request_accepts_linear_abs_offset() -> None:
+    req = ResidualStaticApplyRequest.model_validate(_payload())
+
+    assert req.file_id == 'datum-corrected-file-id'
+    assert req.datum_solution.name == 'datum_static_solution.npz'
+    assert req.pick_source.kind == 'batch_job_artifact'
+    assert req.source_id_byte == 17
+    assert req.receiver_id_byte == 13
+    assert req.offset_byte == 37
+    assert req.moveout.model == 'linear_abs_offset'
+
+
+def test_residual_static_apply_request_accepts_moveout_none_without_offset() -> None:
+    payload = _payload()
+    payload['moveout'] = {'model': 'none'}
+    payload['offset_byte'] = None
+
+    req = ResidualStaticApplyRequest.model_validate(payload)
+
+    assert req.moveout.model == 'none'
+    assert req.offset_byte is None
+
+
+def test_residual_static_apply_request_rejects_same_source_receiver_id_byte() -> None:
+    payload = _payload()
+    payload['receiver_id_byte'] = payload['source_id_byte']
+
+    with pytest.raises(ValidationError, match='source_id_byte and receiver_id_byte'):
+        ResidualStaticApplyRequest.model_validate(payload)
+
+
+def test_residual_static_apply_request_rejects_linear_abs_offset_without_offset() -> None:
+    payload = _payload()
+    payload['offset_byte'] = None
+
+    with pytest.raises(ValidationError, match='offset_byte is required'):
+        ResidualStaticApplyRequest.model_validate(payload)
+
+
+def test_residual_static_apply_request_rejects_path_artifact_names() -> None:
+    payload = _payload()
+    payload['datum_solution']['name'] = '../datum_static_solution.npz'
+
+    with pytest.raises(ValidationError, match='plain file name'):
+        ResidualStaticApplyRequest.model_validate(payload)


### PR DESCRIPTION
Closes #311

## Summary
- PR4-2 [statics residual] datum solution・pick source・offset・source/receiver ID header から solver 入力を構築する

## Changed files
- `app/api/schemas.py`
- `app/services/residual_static_inputs.py`
- `app/tests/test_residual_static_inputs.py`
- `app/tests/test_residual_static_schema.py`

## Checks
- `.work/codex/checks.log`: 800 passed in 44.99s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
