### PR TITLE
PR4-3 [statics residual] linear abs-offset moveout と surface-consistent design matrix builder を追加する

### DIFF
--- a/app/services/residual_static_design_matrix.py
+++ b/app/services/residual_static_design_matrix.py
@@ -1,0 +1,732 @@
+"""Design-matrix helpers for residual static estimation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from app.services.residual_static_inputs import ResidualStaticSolverInputs
+
+MoveoutModel = Literal['linear_abs_offset', 'none']
+
+
+@dataclass(frozen=True)
+class ResidualStaticColumnLayout:
+    moveout_model: MoveoutModel
+    n_model_parameters: int
+
+    intercept_col: int
+    slowness_col: int | None
+
+    source_delay_start_col: int
+    receiver_delay_start_col: int
+
+    n_sources: int
+    n_receivers: int
+    source_delay_cols: np.ndarray
+    receiver_delay_cols: np.ndarray
+
+
+@dataclass(frozen=True)
+class ResidualStaticObservationMatrixTriplets:
+    row_indices: np.ndarray
+    col_indices: np.ndarray
+    data: np.ndarray
+    rhs_s: np.ndarray
+
+    row_to_sorted_trace_index: np.ndarray
+    used_mask_sorted: np.ndarray
+
+    n_rows: int
+    n_cols: int
+    layout: ResidualStaticColumnLayout
+
+
+@dataclass(frozen=True)
+class ResidualStaticParameterParts:
+    intercept_s: float
+    slowness_s_per_offset_unit: float | None
+    source_delay_s: np.ndarray
+    receiver_delay_s: np.ndarray
+
+
+@dataclass(frozen=True)
+class ResidualStaticModelEvaluation:
+    moveout_model_time_s_sorted: np.ndarray
+    estimated_trace_delay_s_sorted: np.ndarray
+    modeled_pick_time_s_sorted: np.ndarray
+    residual_s_sorted: np.ndarray
+    residual_valid_mask_sorted: np.ndarray
+
+
+def build_residual_static_column_layout(
+    inputs: ResidualStaticSolverInputs,
+) -> ResidualStaticColumnLayout:
+    """Build the deterministic parameter-column layout for residual statics."""
+    moveout_model = _validate_moveout_model(inputs.moveout_model)
+    n_traces = _input_n_traces(inputs)
+    source_unique_ids = _coerce_1d_integer_int64(
+        inputs.source_unique_ids,
+        name='source_unique_ids',
+    )
+    receiver_unique_ids = _coerce_1d_integer_int64(
+        inputs.receiver_unique_ids,
+        name='receiver_unique_ids',
+    )
+    n_sources = _non_empty_array_size(source_unique_ids, name='source_unique_ids')
+    n_receivers = _non_empty_array_size(
+        receiver_unique_ids,
+        name='receiver_unique_ids',
+    )
+
+    source_index = _coerce_1d_integer_int64(
+        inputs.source_index_sorted,
+        name='source_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_index = _coerce_1d_integer_int64(
+        inputs.receiver_index_sorted,
+        name='receiver_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    _validate_index_range(source_index, n_unique=n_sources, name='source_index_sorted')
+    _validate_index_range(
+        receiver_index,
+        n_unique=n_receivers,
+        name='receiver_index_sorted',
+    )
+
+    intercept_col = 0
+    if moveout_model == 'linear_abs_offset':
+        slowness_col: int | None = 1
+        source_delay_start_col = 2
+    else:
+        slowness_col = None
+        source_delay_start_col = 1
+    receiver_delay_start_col = source_delay_start_col + n_sources
+    n_model_parameters = receiver_delay_start_col + n_receivers
+
+    source_delay_cols = np.arange(
+        source_delay_start_col,
+        source_delay_start_col + n_sources,
+        dtype=np.int64,
+    )
+    receiver_delay_cols = np.arange(
+        receiver_delay_start_col,
+        receiver_delay_start_col + n_receivers,
+        dtype=np.int64,
+    )
+    return ResidualStaticColumnLayout(
+        moveout_model=moveout_model,
+        n_model_parameters=n_model_parameters,
+        intercept_col=intercept_col,
+        slowness_col=slowness_col,
+        source_delay_start_col=source_delay_start_col,
+        receiver_delay_start_col=receiver_delay_start_col,
+        n_sources=n_sources,
+        n_receivers=n_receivers,
+        source_delay_cols=source_delay_cols,
+        receiver_delay_cols=receiver_delay_cols,
+    )
+
+
+def build_residual_static_observation_matrix_triplets(
+    inputs: ResidualStaticSolverInputs,
+    *,
+    used_mask_sorted: np.ndarray | None = None,
+) -> ResidualStaticObservationMatrixTriplets:
+    """Build deterministic COO triplets for the residual static observations."""
+    layout = build_residual_static_column_layout(inputs)
+    n_traces = _input_n_traces(inputs)
+    source_index = _coerce_1d_integer_int64(
+        inputs.source_index_sorted,
+        name='source_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_index = _coerce_1d_integer_int64(
+        inputs.receiver_index_sorted,
+        name='receiver_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    valid_mask = _coerce_1d_bool_array(
+        inputs.valid_pick_mask_sorted,
+        name='valid_pick_mask_sorted',
+        expected_shape=(n_traces,),
+    )
+    used_mask = _used_mask_or_default(
+        valid_mask,
+        used_mask_sorted=used_mask_sorted,
+        n_traces=n_traces,
+    )
+    _validate_mask_subset(
+        used_mask,
+        valid_mask,
+        mask_name='used_mask_sorted',
+        base_name='valid_pick_mask_sorted',
+    )
+    row_to_sorted_trace_index = np.ascontiguousarray(
+        np.flatnonzero(used_mask),
+        dtype=np.int64,
+    )
+    n_rows = int(row_to_sorted_trace_index.shape[0])
+    if n_rows == 0:
+        raise ValueError('at least one used residual static pick is required')
+
+    pick_time_after_datum = _coerce_1d_real_numeric_float64(
+        inputs.pick_time_after_datum_s_sorted,
+        name='pick_time_after_datum_s_sorted',
+        expected_shape=(n_traces,),
+    )
+    _validate_no_inf(
+        pick_time_after_datum,
+        name='pick_time_after_datum_s_sorted',
+    )
+    _validate_finite_at_mask(
+        pick_time_after_datum,
+        mask=used_mask,
+        name='pick_time_after_datum_s_sorted',
+        mask_name='used picks',
+    )
+
+    if layout.moveout_model == 'linear_abs_offset':
+        abs_offset = _required_abs_offset(inputs, expected_shape=(n_traces,))
+        _validate_finite_nonnegative_at_mask(
+            abs_offset,
+            mask=used_mask,
+            name='abs_offset_sorted',
+            mask_name='used traces',
+        )
+        entries_per_row = 4
+    else:
+        abs_offset = None
+        entries_per_row = 3
+
+    row_indices = np.repeat(
+        np.arange(n_rows, dtype=np.int64),
+        entries_per_row,
+    )
+    col_indices = np.empty(n_rows * entries_per_row, dtype=np.int64)
+    data = np.empty(n_rows * entries_per_row, dtype=np.float64)
+
+    if layout.moveout_model == 'linear_abs_offset':
+        if layout.slowness_col is None:
+            raise ValueError('linear_abs_offset layout requires a slowness column')
+        col_indices[0::4] = layout.intercept_col
+        col_indices[1::4] = layout.slowness_col
+        col_indices[2::4] = layout.source_delay_cols[
+            source_index[row_to_sorted_trace_index]
+        ]
+        col_indices[3::4] = layout.receiver_delay_cols[
+            receiver_index[row_to_sorted_trace_index]
+        ]
+        data[0::4] = 1.0
+        data[1::4] = abs_offset[row_to_sorted_trace_index]
+        data[2::4] = 1.0
+        data[3::4] = 1.0
+    else:
+        col_indices[0::3] = layout.intercept_col
+        col_indices[1::3] = layout.source_delay_cols[
+            source_index[row_to_sorted_trace_index]
+        ]
+        col_indices[2::3] = layout.receiver_delay_cols[
+            receiver_index[row_to_sorted_trace_index]
+        ]
+        data[0::3] = 1.0
+        data[1::3] = 1.0
+        data[2::3] = 1.0
+
+    rhs_s = np.ascontiguousarray(
+        pick_time_after_datum[row_to_sorted_trace_index],
+        dtype=np.float64,
+    )
+    return ResidualStaticObservationMatrixTriplets(
+        row_indices=row_indices,
+        col_indices=col_indices,
+        data=data,
+        rhs_s=rhs_s,
+        row_to_sorted_trace_index=row_to_sorted_trace_index,
+        used_mask_sorted=np.ascontiguousarray(used_mask, dtype=bool),
+        n_rows=n_rows,
+        n_cols=layout.n_model_parameters,
+        layout=layout,
+    )
+
+
+def compute_linear_abs_offset_moveout_s(
+    abs_offset_sorted: np.ndarray,
+    *,
+    intercept_s: float,
+    slowness_s_per_offset_unit: float,
+) -> np.ndarray:
+    """Evaluate ``intercept + slowness * abs(offset)`` in seconds."""
+    abs_offset = _coerce_1d_real_numeric_float64(
+        abs_offset_sorted,
+        name='abs_offset_sorted',
+    )
+    _validate_finite_nonnegative(abs_offset, name='abs_offset_sorted')
+    intercept = _coerce_finite_float(intercept_s, name='intercept_s')
+    slowness = _coerce_finite_float(
+        slowness_s_per_offset_unit,
+        name='slowness_s_per_offset_unit',
+    )
+    with np.errstate(over='ignore', invalid='ignore'):
+        moveout_s = intercept + slowness * abs_offset
+    moveout_s = np.ascontiguousarray(moveout_s, dtype=np.float64)
+    _validate_all_finite(moveout_s, name='moveout_s')
+    return moveout_s
+
+
+def pack_residual_static_parameters(
+    *,
+    layout: ResidualStaticColumnLayout,
+    intercept_s: float,
+    slowness_s_per_offset_unit: float | None,
+    source_delay_s: np.ndarray,
+    receiver_delay_s: np.ndarray,
+) -> np.ndarray:
+    """Pack parameter parts according to a residual static column layout."""
+    moveout_model = _validate_moveout_model(layout.moveout_model)
+    _validate_layout_sizes(layout)
+    intercept = _coerce_finite_float(intercept_s, name='intercept_s')
+    source_delay = _coerce_1d_real_numeric_float64(
+        source_delay_s,
+        name='source_delay_s',
+        expected_shape=(layout.n_sources,),
+    )
+    receiver_delay = _coerce_1d_real_numeric_float64(
+        receiver_delay_s,
+        name='receiver_delay_s',
+        expected_shape=(layout.n_receivers,),
+    )
+    _validate_all_finite(source_delay, name='source_delay_s')
+    _validate_all_finite(receiver_delay, name='receiver_delay_s')
+
+    parameter_vector = np.zeros(layout.n_model_parameters, dtype=np.float64)
+    parameter_vector[layout.intercept_col] = intercept
+    if moveout_model == 'linear_abs_offset':
+        if layout.slowness_col is None:
+            raise ValueError('linear_abs_offset layout requires a slowness column')
+        if slowness_s_per_offset_unit is None:
+            raise ValueError(
+                'slowness_s_per_offset_unit is required for linear_abs_offset'
+            )
+        parameter_vector[layout.slowness_col] = _coerce_finite_float(
+            slowness_s_per_offset_unit,
+            name='slowness_s_per_offset_unit',
+        )
+    elif slowness_s_per_offset_unit is not None:
+        raise ValueError('slowness_s_per_offset_unit must be None for none moveout')
+
+    parameter_vector[layout.source_delay_cols] = source_delay
+    parameter_vector[layout.receiver_delay_cols] = receiver_delay
+    return np.ascontiguousarray(parameter_vector, dtype=np.float64)
+
+
+def unpack_residual_static_parameters(
+    layout: ResidualStaticColumnLayout,
+    parameter_vector: np.ndarray,
+) -> ResidualStaticParameterParts:
+    """Unpack a residual static parameter vector according to its layout."""
+    moveout_model = _validate_moveout_model(layout.moveout_model)
+    _validate_layout_sizes(layout)
+    vector = _coerce_1d_real_numeric_float64(
+        parameter_vector,
+        name='parameter_vector',
+        expected_shape=(layout.n_model_parameters,),
+    )
+    _validate_all_finite(vector, name='parameter_vector')
+    intercept_s = float(vector[layout.intercept_col])
+    if moveout_model == 'linear_abs_offset':
+        if layout.slowness_col is None:
+            raise ValueError('linear_abs_offset layout requires a slowness column')
+        slowness_s_per_offset_unit = float(vector[layout.slowness_col])
+    else:
+        slowness_s_per_offset_unit = None
+
+    return ResidualStaticParameterParts(
+        intercept_s=intercept_s,
+        slowness_s_per_offset_unit=slowness_s_per_offset_unit,
+        source_delay_s=np.ascontiguousarray(
+            vector[layout.source_delay_cols],
+            dtype=np.float64,
+        ),
+        receiver_delay_s=np.ascontiguousarray(
+            vector[layout.receiver_delay_cols],
+            dtype=np.float64,
+        ),
+    )
+
+
+def evaluate_residual_static_model(
+    inputs: ResidualStaticSolverInputs,
+    layout: ResidualStaticColumnLayout,
+    parameter_vector: np.ndarray,
+    *,
+    residual_mask_sorted: np.ndarray | None = None,
+) -> ResidualStaticModelEvaluation:
+    """Evaluate moveout, estimated delays, modeled picks, and residuals."""
+    input_moveout_model = _validate_moveout_model(inputs.moveout_model)
+    layout_moveout_model = _validate_moveout_model(layout.moveout_model)
+    if layout_moveout_model != input_moveout_model:
+        raise ValueError('layout moveout_model does not match inputs.moveout_model')
+    parts = unpack_residual_static_parameters(layout, parameter_vector)
+
+    n_traces = _input_n_traces(inputs)
+    source_index = _coerce_1d_integer_int64(
+        inputs.source_index_sorted,
+        name='source_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_index = _coerce_1d_integer_int64(
+        inputs.receiver_index_sorted,
+        name='receiver_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    _validate_index_range(
+        source_index,
+        n_unique=layout.n_sources,
+        name='source_index_sorted',
+    )
+    _validate_index_range(
+        receiver_index,
+        n_unique=layout.n_receivers,
+        name='receiver_index_sorted',
+    )
+
+    valid_mask = _coerce_1d_bool_array(
+        inputs.valid_pick_mask_sorted,
+        name='valid_pick_mask_sorted',
+        expected_shape=(n_traces,),
+    )
+    residual_mask = _residual_mask_or_default(
+        valid_mask,
+        residual_mask_sorted=residual_mask_sorted,
+        n_traces=n_traces,
+    )
+    _validate_mask_subset(
+        residual_mask,
+        valid_mask,
+        mask_name='residual_mask_sorted',
+        base_name='valid_pick_mask_sorted',
+    )
+    pick_time_after_datum = _coerce_1d_real_numeric_float64(
+        inputs.pick_time_after_datum_s_sorted,
+        name='pick_time_after_datum_s_sorted',
+        expected_shape=(n_traces,),
+    )
+    _validate_no_inf(
+        pick_time_after_datum,
+        name='pick_time_after_datum_s_sorted',
+    )
+    _validate_finite_at_mask(
+        pick_time_after_datum,
+        mask=residual_mask,
+        name='pick_time_after_datum_s_sorted',
+        mask_name='residual-valid traces',
+    )
+
+    if layout_moveout_model == 'linear_abs_offset':
+        if parts.slowness_s_per_offset_unit is None:
+            raise ValueError('linear_abs_offset parameters require slowness')
+        abs_offset = _required_abs_offset(inputs, expected_shape=(n_traces,))
+        _validate_finite_nonnegative(abs_offset, name='abs_offset_sorted')
+        moveout_model_time_s = compute_linear_abs_offset_moveout_s(
+            abs_offset,
+            intercept_s=parts.intercept_s,
+            slowness_s_per_offset_unit=parts.slowness_s_per_offset_unit,
+        )
+    else:
+        moveout_model_time_s = np.full(
+            n_traces,
+            parts.intercept_s,
+            dtype=np.float64,
+        )
+
+    estimated_trace_delay_s = np.ascontiguousarray(
+        parts.source_delay_s[source_index] + parts.receiver_delay_s[receiver_index],
+        dtype=np.float64,
+    )
+    modeled_pick_time_s = np.ascontiguousarray(
+        moveout_model_time_s + estimated_trace_delay_s,
+        dtype=np.float64,
+    )
+    residual_s = np.ascontiguousarray(
+        pick_time_after_datum - modeled_pick_time_s,
+        dtype=np.float64,
+    )
+    residual_s[~residual_mask] = np.nan
+    _validate_finite_at_mask(
+        residual_s,
+        mask=residual_mask,
+        name='residual_s_sorted',
+        mask_name='residual-valid traces',
+    )
+
+    return ResidualStaticModelEvaluation(
+        moveout_model_time_s_sorted=np.ascontiguousarray(
+            moveout_model_time_s,
+            dtype=np.float64,
+        ),
+        estimated_trace_delay_s_sorted=estimated_trace_delay_s,
+        modeled_pick_time_s_sorted=modeled_pick_time_s,
+        residual_s_sorted=residual_s,
+        residual_valid_mask_sorted=np.ascontiguousarray(residual_mask, dtype=bool),
+    )
+
+
+def _validate_moveout_model(value: object) -> MoveoutModel:
+    if value == 'linear_abs_offset':
+        return 'linear_abs_offset'
+    if value == 'none':
+        return 'none'
+    raise ValueError(f'unsupported moveout_model: {value!r}')
+
+
+def _input_n_traces(inputs: ResidualStaticSolverInputs) -> int:
+    return _coerce_positive_int(inputs.n_traces, name='n_traces')
+
+
+def _validate_layout_sizes(layout: ResidualStaticColumnLayout) -> None:
+    _coerce_positive_int(layout.n_model_parameters, name='layout.n_model_parameters')
+    _coerce_positive_int(layout.n_sources, name='layout.n_sources')
+    _coerce_positive_int(layout.n_receivers, name='layout.n_receivers')
+    _coerce_positive_int(layout.intercept_col + 1, name='layout.intercept_col')
+    _coerce_positive_int(
+        layout.source_delay_start_col + 1,
+        name='layout.source_delay_start_col',
+    )
+    _coerce_positive_int(
+        layout.receiver_delay_start_col + 1,
+        name='layout.receiver_delay_start_col',
+    )
+    source_delay_cols = _coerce_1d_integer_int64(
+        layout.source_delay_cols,
+        name='layout.source_delay_cols',
+        expected_shape=(layout.n_sources,),
+    )
+    receiver_delay_cols = _coerce_1d_integer_int64(
+        layout.receiver_delay_cols,
+        name='layout.receiver_delay_cols',
+        expected_shape=(layout.n_receivers,),
+    )
+    _validate_index_range(
+        source_delay_cols,
+        n_unique=layout.n_model_parameters,
+        name='layout.source_delay_cols',
+    )
+    _validate_index_range(
+        receiver_delay_cols,
+        n_unique=layout.n_model_parameters,
+        name='layout.receiver_delay_cols',
+    )
+
+
+def _used_mask_or_default(
+    valid_mask: np.ndarray,
+    *,
+    used_mask_sorted: np.ndarray | None,
+    n_traces: int,
+) -> np.ndarray:
+    if used_mask_sorted is None:
+        return np.ascontiguousarray(valid_mask, dtype=bool)
+    return _coerce_1d_bool_array(
+        used_mask_sorted,
+        name='used_mask_sorted',
+        expected_shape=(n_traces,),
+    )
+
+
+def _residual_mask_or_default(
+    valid_mask: np.ndarray,
+    *,
+    residual_mask_sorted: np.ndarray | None,
+    n_traces: int,
+) -> np.ndarray:
+    if residual_mask_sorted is None:
+        return np.ascontiguousarray(valid_mask, dtype=bool)
+    return _coerce_1d_bool_array(
+        residual_mask_sorted,
+        name='residual_mask_sorted',
+        expected_shape=(n_traces,),
+    )
+
+
+def _validate_mask_subset(
+    mask: np.ndarray,
+    base_mask: np.ndarray,
+    *,
+    mask_name: str,
+    base_name: str,
+) -> None:
+    if np.any(mask & ~base_mask):
+        raise ValueError(f'{mask_name} must be a subset of {base_name}')
+
+
+def _required_abs_offset(
+    inputs: ResidualStaticSolverInputs,
+    *,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    if inputs.abs_offset_sorted is None:
+        raise ValueError('abs_offset_sorted is required for linear_abs_offset moveout')
+    return _coerce_1d_real_numeric_float64(
+        inputs.abs_offset_sorted,
+        name='abs_offset_sorted',
+        expected_shape=expected_shape,
+    )
+
+
+def _non_empty_array_size(values: np.ndarray, *, name: str) -> int:
+    size = int(values.shape[0])
+    if size <= 0:
+        raise ValueError(f'{name} must be non-empty')
+    return size
+
+
+def _validate_index_range(
+    indices: np.ndarray,
+    *,
+    n_unique: int,
+    name: str,
+) -> None:
+    if np.any(indices < 0):
+        raise ValueError(f'{name} must be greater than or equal to 0')
+    if np.any(indices >= n_unique):
+        raise ValueError(f'{name} contains values outside 0..{n_unique - 1}')
+
+
+def _validate_no_inf(values: np.ndarray, *, name: str) -> None:
+    if np.any(np.isinf(values)):
+        raise ValueError(f'{name} contains inf')
+
+
+def _validate_finite_at_mask(
+    values: np.ndarray,
+    *,
+    mask: np.ndarray,
+    name: str,
+    mask_name: str,
+) -> None:
+    if np.any(~np.isfinite(values[mask])):
+        raise ValueError(f'{name} must be finite for {mask_name}')
+
+
+def _validate_finite_nonnegative_at_mask(
+    values: np.ndarray,
+    *,
+    mask: np.ndarray,
+    name: str,
+    mask_name: str,
+) -> None:
+    _validate_finite_at_mask(values, mask=mask, name=name, mask_name=mask_name)
+    if np.any(values[mask] < 0.0):
+        raise ValueError(f'{name} must be non-negative for {mask_name}')
+
+
+def _validate_finite_nonnegative(values: np.ndarray, *, name: str) -> None:
+    _validate_all_finite(values, name=name)
+    if np.any(values < 0.0):
+        raise ValueError(f'{name} must be non-negative')
+
+
+def _validate_all_finite(values: np.ndarray, *, name: str) -> None:
+    if np.any(~np.isfinite(values)):
+        raise ValueError(f'{name} must contain only finite values')
+
+
+def _coerce_1d_integer_int64(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        raise ValueError(msg)
+    if np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must contain integer values')
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(f'{name} must contain integer values')
+    return np.ascontiguousarray(arr, dtype=np.int64)
+
+
+def _coerce_1d_bool_array(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if arr.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        raise ValueError(msg)
+    if not np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must have bool dtype')
+    return np.ascontiguousarray(arr, dtype=bool)
+
+
+def _coerce_1d_real_numeric_float64(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        raise ValueError(msg)
+    if not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a numeric dtype')
+    return np.ascontiguousarray(arr, dtype=np.float64)
+
+
+def _coerce_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer')
+    out = int(value)
+    if out <= 0:
+        raise ValueError(f'{name} must be greater than 0')
+    return out
+
+
+def _coerce_finite_float(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f'{name} must be finite')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite') from exc
+    if not np.isfinite(out):
+        raise ValueError(f'{name} must be finite')
+    return out
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'MoveoutModel',
+    'ResidualStaticColumnLayout',
+    'ResidualStaticModelEvaluation',
+    'ResidualStaticObservationMatrixTriplets',
+    'ResidualStaticParameterParts',
+    'build_residual_static_column_layout',
+    'build_residual_static_observation_matrix_triplets',
+    'compute_linear_abs_offset_moveout_s',
+    'evaluate_residual_static_model',
+    'pack_residual_static_parameters',
+    'unpack_residual_static_parameters',
+]

--- a/app/tests/test_residual_static_design_matrix.py
+++ b/app/tests/test_residual_static_design_matrix.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import app.services.residual_static_design_matrix as design_matrix
+from app.services.residual_static_design_matrix import (
+    build_residual_static_column_layout,
+    build_residual_static_observation_matrix_triplets,
+    compute_linear_abs_offset_moveout_s,
+    evaluate_residual_static_model,
+    pack_residual_static_parameters,
+    unpack_residual_static_parameters,
+)
+from app.services.residual_static_inputs import ResidualStaticSolverInputs
+
+PICK_TIME_AFTER_DATUM = np.asarray([0.100, 0.110, 0.120, 0.130])
+VALID_PICK_MASK = np.asarray([True, True, True, True])
+SOURCE_UNIQUE_IDS = np.asarray([10, 20], dtype=np.int64)
+RECEIVER_UNIQUE_IDS = np.asarray([1, 2], dtype=np.int64)
+SOURCE_INDEX = np.asarray([0, 0, 1, 1], dtype=np.int64)
+RECEIVER_INDEX = np.asarray([0, 1, 0, 1], dtype=np.int64)
+ABS_OFFSET = np.asarray([100.0, 200.0, 100.0, 200.0])
+OFFSET = np.asarray([-100.0, 200.0, -100.0, 200.0])
+N_TRACES = 4
+
+
+def _inputs(**overrides: Any) -> ResidualStaticSolverInputs:
+    payload: dict[str, Any] = {
+        'picks_time_s_sorted': PICK_TIME_AFTER_DATUM.copy(),
+        'valid_pick_mask_sorted': VALID_PICK_MASK.copy(),
+        'pick_time_after_datum_s_sorted': PICK_TIME_AFTER_DATUM.copy(),
+        'datum_trace_shift_s_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'source_id_sorted': np.asarray([10, 10, 20, 20], dtype=np.int64),
+        'receiver_id_sorted': np.asarray([1, 2, 1, 2], dtype=np.int64),
+        'source_unique_ids': SOURCE_UNIQUE_IDS.copy(),
+        'receiver_unique_ids': RECEIVER_UNIQUE_IDS.copy(),
+        'source_index_sorted': SOURCE_INDEX.copy(),
+        'receiver_index_sorted': RECEIVER_INDEX.copy(),
+        'source_valid_pick_counts': np.asarray([2, 2], dtype=np.int64),
+        'receiver_valid_pick_counts': np.asarray([2, 2], dtype=np.int64),
+        'offset_sorted': OFFSET.copy(),
+        'abs_offset_sorted': ABS_OFFSET.copy(),
+        'key1_sorted': np.asarray([100, 100, 200, 200], dtype=np.int64),
+        'key2_sorted': np.asarray([1, 2, 1, 2], dtype=np.int64),
+        'source_elevation_m_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'receiver_elevation_m_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'dt': 0.004,
+        'n_traces': N_TRACES,
+        'n_samples': 64,
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'source_id_byte': 17,
+        'receiver_id_byte': 13,
+        'offset_byte': 37,
+        'moveout_model': 'linear_abs_offset',
+        'input_file_id': 'corrected-file-id',
+        'datum_source_file_id': 'source-file-id',
+        'datum_job_id': 'datum-job',
+        'pick_source_kind': 'batch_npz',
+        'metadata': {'source': 'test'},
+    }
+    payload.update(overrides)
+    return ResidualStaticSolverInputs(**payload)
+
+
+def _moveout_none_inputs(**overrides: Any) -> ResidualStaticSolverInputs:
+    payload: dict[str, Any] = {
+        'moveout_model': 'none',
+        'offset_byte': None,
+        'offset_sorted': None,
+        'abs_offset_sorted': None,
+    }
+    payload.update(overrides)
+    return _inputs(**payload)
+
+
+def _linear_layout():
+    return build_residual_static_column_layout(_inputs())
+
+
+def _linear_parameter_vector() -> np.ndarray:
+    return pack_residual_static_parameters(
+        layout=_linear_layout(),
+        intercept_s=0.050,
+        slowness_s_per_offset_unit=0.0001,
+        source_delay_s=np.asarray([0.001, -0.001]),
+        receiver_delay_s=np.asarray([0.002, -0.002]),
+    )
+
+
+def test_build_column_layout_linear_abs_offset() -> None:
+    layout = build_residual_static_column_layout(_inputs())
+
+    assert layout.moveout_model == 'linear_abs_offset'
+    assert layout.intercept_col == 0
+    assert layout.slowness_col == 1
+    assert layout.source_delay_start_col == 2
+    assert layout.receiver_delay_start_col == 4
+    assert layout.n_sources == 2
+    assert layout.n_receivers == 2
+    assert layout.n_model_parameters == 6
+    np.testing.assert_array_equal(layout.source_delay_cols, [2, 3])
+    np.testing.assert_array_equal(layout.receiver_delay_cols, [4, 5])
+    assert layout.source_delay_cols.dtype == np.int64
+    assert layout.receiver_delay_cols.dtype == np.int64
+
+
+def test_build_column_layout_moveout_none_omits_slowness_column() -> None:
+    layout = build_residual_static_column_layout(_moveout_none_inputs())
+
+    assert layout.moveout_model == 'none'
+    assert layout.intercept_col == 0
+    assert layout.slowness_col is None
+    assert layout.source_delay_start_col == 1
+    assert layout.receiver_delay_start_col == 3
+    assert layout.n_model_parameters == 5
+    np.testing.assert_array_equal(layout.source_delay_cols, [1, 2])
+    np.testing.assert_array_equal(layout.receiver_delay_cols, [3, 4])
+
+
+def test_build_column_layout_rejects_empty_sources() -> None:
+    with pytest.raises(ValueError, match='source_unique_ids'):
+        build_residual_static_column_layout(
+            _inputs(source_unique_ids=np.asarray([], dtype=np.int64))
+        )
+
+
+def test_build_column_layout_rejects_empty_receivers() -> None:
+    with pytest.raises(ValueError, match='receiver_unique_ids'):
+        build_residual_static_column_layout(
+            _inputs(receiver_unique_ids=np.asarray([], dtype=np.int64))
+        )
+
+
+def test_build_column_layout_rejects_source_index_out_of_range() -> None:
+    with pytest.raises(ValueError, match='source_index_sorted'):
+        build_residual_static_column_layout(
+            _inputs(source_index_sorted=np.asarray([0, 0, 1, 2], dtype=np.int64))
+        )
+
+
+def test_build_column_layout_rejects_receiver_index_out_of_range() -> None:
+    with pytest.raises(ValueError, match='receiver_index_sorted'):
+        build_residual_static_column_layout(
+            _inputs(receiver_index_sorted=np.asarray([0, 1, 0, 2], dtype=np.int64))
+        )
+
+
+def test_build_column_layout_rejects_bool_indices() -> None:
+    with pytest.raises(ValueError, match='source_index_sorted'):
+        build_residual_static_column_layout(
+            _inputs(source_index_sorted=np.asarray([True, False, True, False]))
+        )
+
+
+def test_build_observation_triplets_linear_abs_offset() -> None:
+    triplets = build_residual_static_observation_matrix_triplets(_inputs())
+
+    np.testing.assert_array_equal(
+        triplets.row_indices,
+        np.repeat(np.arange(4, dtype=np.int64), 4),
+    )
+    np.testing.assert_array_equal(
+        triplets.col_indices,
+        [0, 1, 2, 4, 0, 1, 2, 5, 0, 1, 3, 4, 0, 1, 3, 5],
+    )
+    np.testing.assert_allclose(
+        triplets.data,
+        [1.0, 100.0, 1.0, 1.0, 1.0, 200.0, 1.0, 1.0,
+         1.0, 100.0, 1.0, 1.0, 1.0, 200.0, 1.0, 1.0],
+    )
+    np.testing.assert_allclose(triplets.rhs_s, PICK_TIME_AFTER_DATUM)
+    np.testing.assert_array_equal(triplets.row_to_sorted_trace_index, [0, 1, 2, 3])
+    np.testing.assert_array_equal(triplets.used_mask_sorted, VALID_PICK_MASK)
+    assert triplets.n_rows == 4
+    assert triplets.n_cols == 6
+    assert triplets.row_indices.dtype == np.int64
+    assert triplets.col_indices.dtype == np.int64
+    assert triplets.data.dtype == np.float64
+    assert triplets.rhs_s.dtype == np.float64
+    assert triplets.used_mask_sorted.dtype == bool
+
+
+def test_build_observation_triplets_moveout_none() -> None:
+    triplets = build_residual_static_observation_matrix_triplets(
+        _moveout_none_inputs()
+    )
+
+    np.testing.assert_array_equal(
+        triplets.col_indices,
+        [0, 1, 3, 0, 1, 4, 0, 2, 3, 0, 2, 4],
+    )
+    np.testing.assert_allclose(triplets.data, np.ones(12, dtype=np.float64))
+    np.testing.assert_allclose(triplets.rhs_s, PICK_TIME_AFTER_DATUM)
+    assert triplets.n_rows == 4
+    assert triplets.n_cols == 5
+    assert triplets.layout.slowness_col is None
+
+
+def test_build_observation_triplets_uses_valid_pick_mask_by_default() -> None:
+    valid_mask = np.asarray([True, False, True, False])
+    pick_time = np.asarray([0.100, np.nan, 0.120, np.nan])
+
+    triplets = build_residual_static_observation_matrix_triplets(
+        _inputs(
+            valid_pick_mask_sorted=valid_mask,
+            pick_time_after_datum_s_sorted=pick_time,
+        )
+    )
+
+    np.testing.assert_array_equal(triplets.row_to_sorted_trace_index, [0, 2])
+    np.testing.assert_array_equal(triplets.used_mask_sorted, valid_mask)
+    np.testing.assert_allclose(triplets.rhs_s, [0.100, 0.120])
+
+
+def test_build_observation_triplets_accepts_used_mask_subset() -> None:
+    used_mask = np.asarray([True, False, True, False])
+
+    triplets = build_residual_static_observation_matrix_triplets(
+        _inputs(),
+        used_mask_sorted=used_mask,
+    )
+
+    np.testing.assert_array_equal(triplets.row_to_sorted_trace_index, [0, 2])
+    np.testing.assert_array_equal(triplets.used_mask_sorted, used_mask)
+    np.testing.assert_allclose(triplets.rhs_s, [0.100, 0.120])
+
+
+def test_build_observation_triplets_rejects_used_mask_that_includes_invalid_pick() -> None:
+    valid_mask = np.asarray([True, False, True, True])
+    used_mask = np.asarray([True, True, False, False])
+
+    with pytest.raises(ValueError, match='subset'):
+        build_residual_static_observation_matrix_triplets(
+            _inputs(
+                valid_pick_mask_sorted=valid_mask,
+                pick_time_after_datum_s_sorted=np.asarray(
+                    [0.100, np.nan, 0.120, 0.130]
+                ),
+            ),
+            used_mask_sorted=used_mask,
+        )
+
+
+def test_build_observation_triplets_rejects_zero_used_rows() -> None:
+    with pytest.raises(ValueError, match='at least one'):
+        build_residual_static_observation_matrix_triplets(
+            _inputs(),
+            used_mask_sorted=np.asarray([False, False, False, False]),
+        )
+
+
+def test_build_observation_triplets_rejects_nonfinite_pick_for_used_trace() -> None:
+    with pytest.raises(ValueError, match='pick_time_after_datum_s_sorted'):
+        build_residual_static_observation_matrix_triplets(
+            _inputs(
+                pick_time_after_datum_s_sorted=np.asarray(
+                    [0.100, np.nan, 0.120, 0.130]
+                )
+            )
+        )
+
+
+def test_build_observation_triplets_rejects_missing_abs_offset_for_linear_abs_offset() -> None:
+    with pytest.raises(ValueError, match='abs_offset_sorted'):
+        build_residual_static_observation_matrix_triplets(
+            _inputs(abs_offset_sorted=None)
+        )
+
+
+def test_build_observation_triplets_rejects_negative_abs_offset_for_linear_abs_offset() -> None:
+    with pytest.raises(ValueError, match='abs_offset_sorted'):
+        build_residual_static_observation_matrix_triplets(
+            _inputs(abs_offset_sorted=np.asarray([100.0, -1.0, 100.0, 200.0]))
+        )
+
+
+def test_build_observation_triplets_does_not_require_offset_for_moveout_none() -> None:
+    triplets = build_residual_static_observation_matrix_triplets(
+        _moveout_none_inputs(offset_sorted=None, abs_offset_sorted=None)
+    )
+
+    assert triplets.n_rows == 4
+    assert triplets.layout.slowness_col is None
+
+
+def test_build_observation_triplets_has_deterministic_entry_order() -> None:
+    triplets = build_residual_static_observation_matrix_triplets(
+        _inputs(),
+        used_mask_sorted=np.asarray([False, True, False, False]),
+    )
+
+    np.testing.assert_array_equal(triplets.row_indices, [0, 0, 0, 0])
+    np.testing.assert_array_equal(triplets.col_indices, [0, 1, 2, 5])
+    np.testing.assert_allclose(triplets.data, [1.0, 200.0, 1.0, 1.0])
+
+
+def test_compute_linear_abs_offset_moveout_s() -> None:
+    moveout = compute_linear_abs_offset_moveout_s(
+        ABS_OFFSET,
+        intercept_s=0.050,
+        slowness_s_per_offset_unit=0.0001,
+    )
+
+    np.testing.assert_allclose(moveout, [0.060, 0.070, 0.060, 0.070])
+    assert moveout.dtype == np.float64
+
+
+def test_compute_linear_abs_offset_moveout_rejects_nonfinite_inputs() -> None:
+    with pytest.raises(ValueError, match='abs_offset_sorted'):
+        compute_linear_abs_offset_moveout_s(
+            np.asarray([100.0, np.nan]),
+            intercept_s=0.050,
+            slowness_s_per_offset_unit=0.0001,
+        )
+    with pytest.raises(ValueError, match='intercept_s'):
+        compute_linear_abs_offset_moveout_s(
+            ABS_OFFSET,
+            intercept_s=np.nan,
+            slowness_s_per_offset_unit=0.0001,
+        )
+    with pytest.raises(ValueError, match='slowness_s_per_offset_unit'):
+        compute_linear_abs_offset_moveout_s(
+            ABS_OFFSET,
+            intercept_s=0.050,
+            slowness_s_per_offset_unit=np.inf,
+        )
+
+
+def test_pack_unpack_residual_static_parameters_linear_abs_offset() -> None:
+    layout = _linear_layout()
+    vector = pack_residual_static_parameters(
+        layout=layout,
+        intercept_s=0.050,
+        slowness_s_per_offset_unit=0.0001,
+        source_delay_s=np.asarray([0.001, -0.001]),
+        receiver_delay_s=np.asarray([0.002, -0.002]),
+    )
+
+    np.testing.assert_allclose(
+        vector,
+        [0.050, 0.0001, 0.001, -0.001, 0.002, -0.002],
+    )
+    parts = unpack_residual_static_parameters(layout, vector)
+    assert parts.intercept_s == pytest.approx(0.050)
+    assert parts.slowness_s_per_offset_unit == pytest.approx(0.0001)
+    np.testing.assert_allclose(parts.source_delay_s, [0.001, -0.001])
+    np.testing.assert_allclose(parts.receiver_delay_s, [0.002, -0.002])
+    assert vector.dtype == np.float64
+
+
+def test_pack_unpack_residual_static_parameters_moveout_none() -> None:
+    layout = build_residual_static_column_layout(_moveout_none_inputs())
+    vector = pack_residual_static_parameters(
+        layout=layout,
+        intercept_s=0.050,
+        slowness_s_per_offset_unit=None,
+        source_delay_s=np.asarray([0.001, -0.001]),
+        receiver_delay_s=np.asarray([0.002, -0.002]),
+    )
+
+    np.testing.assert_allclose(vector, [0.050, 0.001, -0.001, 0.002, -0.002])
+    parts = unpack_residual_static_parameters(layout, vector)
+    assert parts.intercept_s == pytest.approx(0.050)
+    assert parts.slowness_s_per_offset_unit is None
+    np.testing.assert_allclose(parts.source_delay_s, [0.001, -0.001])
+    np.testing.assert_allclose(parts.receiver_delay_s, [0.002, -0.002])
+
+
+def test_pack_parameters_rejects_wrong_source_delay_shape() -> None:
+    with pytest.raises(ValueError, match='source_delay_s'):
+        pack_residual_static_parameters(
+            layout=_linear_layout(),
+            intercept_s=0.050,
+            slowness_s_per_offset_unit=0.0001,
+            source_delay_s=np.asarray([0.001]),
+            receiver_delay_s=np.asarray([0.002, -0.002]),
+        )
+
+
+def test_unpack_parameters_rejects_wrong_vector_length() -> None:
+    with pytest.raises(ValueError, match='parameter_vector'):
+        unpack_residual_static_parameters(
+            _linear_layout(),
+            np.asarray([0.050, 0.0001]),
+        )
+
+
+def test_evaluate_residual_static_model_linear_abs_offset() -> None:
+    evaluation = evaluate_residual_static_model(
+        _inputs(),
+        _linear_layout(),
+        _linear_parameter_vector(),
+    )
+
+    np.testing.assert_allclose(
+        evaluation.moveout_model_time_s_sorted,
+        [0.060, 0.070, 0.060, 0.070],
+    )
+    np.testing.assert_allclose(
+        evaluation.estimated_trace_delay_s_sorted,
+        [0.003, -0.001, 0.001, -0.003],
+    )
+    np.testing.assert_allclose(
+        evaluation.modeled_pick_time_s_sorted,
+        [0.063, 0.069, 0.061, 0.067],
+    )
+    np.testing.assert_allclose(
+        evaluation.residual_s_sorted,
+        [0.037, 0.041, 0.059, 0.063],
+    )
+    np.testing.assert_array_equal(
+        evaluation.residual_valid_mask_sorted,
+        VALID_PICK_MASK,
+    )
+    assert evaluation.residual_s_sorted.dtype == np.float64
+
+
+def test_evaluate_residual_static_model_moveout_none() -> None:
+    inputs = _moveout_none_inputs()
+    layout = build_residual_static_column_layout(inputs)
+    vector = pack_residual_static_parameters(
+        layout=layout,
+        intercept_s=0.050,
+        slowness_s_per_offset_unit=None,
+        source_delay_s=np.asarray([0.001, -0.001]),
+        receiver_delay_s=np.asarray([0.002, -0.002]),
+    )
+
+    evaluation = evaluate_residual_static_model(inputs, layout, vector)
+
+    np.testing.assert_allclose(
+        evaluation.moveout_model_time_s_sorted,
+        [0.050, 0.050, 0.050, 0.050],
+    )
+    np.testing.assert_allclose(
+        evaluation.estimated_trace_delay_s_sorted,
+        [0.003, -0.001, 0.001, -0.003],
+    )
+    np.testing.assert_allclose(
+        evaluation.modeled_pick_time_s_sorted,
+        [0.053, 0.049, 0.051, 0.047],
+    )
+    np.testing.assert_allclose(
+        evaluation.residual_s_sorted,
+        [0.047, 0.061, 0.069, 0.083],
+    )
+
+
+def test_evaluate_residual_static_model_keeps_nan_for_invalid_pick() -> None:
+    inputs = _inputs(
+        valid_pick_mask_sorted=np.asarray([True, False, True, True]),
+        pick_time_after_datum_s_sorted=np.asarray([0.100, np.nan, 0.120, 0.130]),
+    )
+
+    evaluation = evaluate_residual_static_model(
+        inputs,
+        build_residual_static_column_layout(inputs),
+        _linear_parameter_vector(),
+    )
+
+    assert np.isnan(evaluation.residual_s_sorted[1])
+    np.testing.assert_array_equal(
+        evaluation.residual_valid_mask_sorted,
+        [True, False, True, True],
+    )
+
+
+def test_evaluate_residual_static_model_accepts_residual_mask_subset() -> None:
+    residual_mask = np.asarray([True, False, True, False])
+
+    evaluation = evaluate_residual_static_model(
+        _inputs(),
+        _linear_layout(),
+        _linear_parameter_vector(),
+        residual_mask_sorted=residual_mask,
+    )
+
+    np.testing.assert_array_equal(evaluation.residual_valid_mask_sorted, residual_mask)
+    assert np.isnan(evaluation.residual_s_sorted[1])
+    assert np.isnan(evaluation.residual_s_sorted[3])
+    np.testing.assert_allclose(evaluation.residual_s_sorted[[0, 2]], [0.037, 0.059])
+
+
+def test_evaluate_residual_static_model_rejects_residual_mask_that_includes_invalid_pick() -> None:
+    inputs = _inputs(
+        valid_pick_mask_sorted=np.asarray([True, False, True, True]),
+        pick_time_after_datum_s_sorted=np.asarray([0.100, np.nan, 0.120, 0.130]),
+    )
+
+    with pytest.raises(ValueError, match='subset'):
+        evaluate_residual_static_model(
+            inputs,
+            build_residual_static_column_layout(inputs),
+            _linear_parameter_vector(),
+            residual_mask_sorted=np.asarray([True, True, False, False]),
+        )
+
+
+def test_residual_static_design_matrix_module_does_not_import_scipy() -> None:
+    assert 'scipy' not in design_matrix.__dict__
+    assert 'scipy' not in design_matrix.__loader__.get_source(  # type: ignore[union-attr]
+        design_matrix.__name__
+    )


### PR DESCRIPTION
Closes #314

## Summary
- PR4-3 [statics residual] linear abs-offset moveout と surface-consistent design matrix builder を追加する

## Changed files
- `app/services/residual_static_design_matrix.py`
- `app/tests/test_residual_static_design_matrix.py`

## Checks
- `.work/codex/checks.log`: 830 passed in 45.10s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
