### PR TITLE
PR4-5 [statics residual] gauge fixing・damping・minimum data validation を solver に追加する

### DIFF
--- a/app/services/residual_static_sparse_solver.py
+++ b/app/services/residual_static_sparse_solver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 from scipy import sparse
@@ -13,11 +14,91 @@ from app.services.residual_static_design_matrix import (
     ResidualStaticModelEvaluation,
     ResidualStaticObservationMatrixTriplets,
     ResidualStaticParameterParts,
+    build_residual_static_column_layout,
     build_residual_static_observation_matrix_triplets,
     evaluate_residual_static_model,
     unpack_residual_static_parameters,
 )
 from app.services.residual_static_inputs import ResidualStaticSolverInputs
+
+ResidualStaticGauge = Literal['zero_mean_source_receiver']
+
+
+@dataclass(frozen=True)
+class ResidualStaticStabilizationOptions:
+    gauge: ResidualStaticGauge = 'zero_mean_source_receiver'
+    damping_lambda: float = 0.0
+    min_valid_picks: int = 10
+    min_picks_per_source: int = 1
+    min_picks_per_receiver: int = 1
+    max_abs_estimated_delay_ms: float = 250.0
+
+
+@dataclass(frozen=True)
+class ResidualStaticObservationGraphSummary:
+    n_components: int
+    source_component_index: np.ndarray
+    receiver_component_index: np.ndarray
+    component_observation_counts: np.ndarray
+    component_source_counts: np.ndarray
+    component_receiver_counts: np.ndarray
+
+
+@dataclass(frozen=True)
+class ResidualStaticMinimumDataSummary:
+    n_used_picks: int
+    n_sources: int
+    n_receivers: int
+    n_effective_parameters: int
+
+    source_used_pick_counts: np.ndarray
+    receiver_used_pick_counts: np.ndarray
+    underconstrained_source_ids: np.ndarray
+    underconstrained_receiver_ids: np.ndarray
+
+    graph: ResidualStaticObservationGraphSummary
+
+    abs_offset_min: float | None
+    abs_offset_max: float | None
+    abs_offset_span: float | None
+
+
+@dataclass(frozen=True)
+class ResidualStaticAugmentedSystem:
+    matrix: object
+    rhs_s: np.ndarray
+
+    n_observation_rows: int
+    n_gauge_rows: int
+    n_damping_rows: int
+    n_rows: int
+    n_cols: int
+
+    observation_row_to_sorted_trace_index: np.ndarray
+    used_mask_sorted: np.ndarray
+    minimum_data: ResidualStaticMinimumDataSummary
+
+
+@dataclass(frozen=True)
+class ResidualStaticStabilizedLeastSquaresResult:
+    parameter_vector: np.ndarray
+    parameter_parts: ResidualStaticParameterParts
+    model_evaluation: ResidualStaticModelEvaluation
+    diagnostics: ResidualStaticLsmrDiagnostics
+
+    layout: ResidualStaticColumnLayout
+    used_mask_sorted: np.ndarray
+    observation_row_to_sorted_trace_index: np.ndarray
+    minimum_data: ResidualStaticMinimumDataSummary
+    stabilization_options: ResidualStaticStabilizationOptions
+
+    n_observations: int
+    n_model_parameters: int
+    n_gauge_rows: int
+    n_damping_rows: int
+
+    max_abs_estimated_delay_s: float
+    rank_deficient_possible: bool
 
 
 @dataclass(frozen=True)
@@ -72,6 +153,503 @@ def validate_lsmr_options(
         btol=_coerce_nonnegative_finite_float(options.btol, name='btol'),
         conlim=_coerce_positive_finite_float(options.conlim, name='conlim'),
         maxiter=_coerce_optional_positive_int(options.maxiter, name='maxiter'),
+    )
+
+
+def validate_residual_static_stabilization_options(
+    options: ResidualStaticStabilizationOptions,
+) -> ResidualStaticStabilizationOptions:
+    """Validate and normalize residual-static stabilization options."""
+    if not isinstance(options, ResidualStaticStabilizationOptions):
+        raise ValueError(
+            'options must be a ResidualStaticStabilizationOptions instance'
+        )
+    if options.gauge != 'zero_mean_source_receiver':
+        raise ValueError('gauge must be zero_mean_source_receiver')
+    return ResidualStaticStabilizationOptions(
+        gauge='zero_mean_source_receiver',
+        damping_lambda=_coerce_nonnegative_finite_float(
+            options.damping_lambda,
+            name='damping_lambda',
+        ),
+        min_valid_picks=_coerce_positive_int(
+            options.min_valid_picks,
+            name='min_valid_picks',
+        ),
+        min_picks_per_source=_coerce_positive_int(
+            options.min_picks_per_source,
+            name='min_picks_per_source',
+        ),
+        min_picks_per_receiver=_coerce_positive_int(
+            options.min_picks_per_receiver,
+            name='min_picks_per_receiver',
+        ),
+        max_abs_estimated_delay_ms=_coerce_positive_finite_float(
+            options.max_abs_estimated_delay_ms,
+            name='max_abs_estimated_delay_ms',
+        ),
+    )
+
+
+def stabilization_options_from_request_solver(
+    solver: object,
+) -> ResidualStaticStabilizationOptions:
+    """Convert a request-like solver object into stabilization options."""
+    fields = (
+        'gauge',
+        'damping_lambda',
+        'min_valid_picks',
+        'min_picks_per_source',
+        'min_picks_per_receiver',
+        'max_abs_estimated_delay_ms',
+    )
+    try:
+        values = {field: getattr(solver, field) for field in fields}
+    except AttributeError as exc:
+        raise ValueError(f'solver missing stabilization field: {exc.name}') from exc
+    return validate_residual_static_stabilization_options(
+        ResidualStaticStabilizationOptions(**values)
+    )
+
+
+def validate_residual_static_used_mask(
+    inputs: ResidualStaticSolverInputs,
+    used_mask_sorted: np.ndarray | None,
+) -> np.ndarray:
+    """Validate the robust-solver used-pick mask against valid picks."""
+    n_traces = _input_n_traces(inputs)
+    valid_mask = _coerce_1d_bool_array(
+        inputs.valid_pick_mask_sorted,
+        name='valid_pick_mask_sorted',
+        expected_shape=(n_traces,),
+    )
+    if used_mask_sorted is None:
+        used_mask = np.ascontiguousarray(valid_mask, dtype=bool)
+    else:
+        used_mask = _coerce_1d_bool_array(
+            used_mask_sorted,
+            name='used_mask_sorted',
+            expected_shape=(n_traces,),
+        )
+    _validate_mask_subset(
+        used_mask,
+        valid_mask,
+        mask_name='used_mask_sorted',
+        base_name='valid_pick_mask_sorted',
+    )
+
+    pick_time_after_datum = _coerce_1d_real_numeric_float64(
+        inputs.pick_time_after_datum_s_sorted,
+        name='pick_time_after_datum_s_sorted',
+        expected_shape=(n_traces,),
+    )
+    if np.any(~np.isfinite(pick_time_after_datum[used_mask])):
+        raise ValueError('pick_time_after_datum_s_sorted must be finite for used picks')
+    return np.ascontiguousarray(used_mask, dtype=bool)
+
+
+def build_residual_static_observation_graph_summary(
+    inputs: ResidualStaticSolverInputs,
+    *,
+    used_mask_sorted: np.ndarray,
+) -> ResidualStaticObservationGraphSummary:
+    """Summarize source/receiver connectivity for used residual-static picks."""
+    used_mask = validate_residual_static_used_mask(inputs, used_mask_sorted)
+    layout = build_residual_static_column_layout(inputs)
+    n_traces = _input_n_traces(inputs)
+    source_index = _coerce_1d_integer_int64(
+        inputs.source_index_sorted,
+        name='source_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_index = _coerce_1d_integer_int64(
+        inputs.receiver_index_sorted,
+        name='receiver_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    _validate_index_range(
+        source_index,
+        n_unique=layout.n_sources,
+        name='source_index_sorted',
+    )
+    _validate_index_range(
+        receiver_index,
+        n_unique=layout.n_receivers,
+        name='receiver_index_sorted',
+    )
+
+    n_nodes = layout.n_sources + layout.n_receivers
+    parent = np.arange(n_nodes, dtype=np.int64)
+    rank = np.zeros(n_nodes, dtype=np.int8)
+
+    def find(node: int) -> int:
+        root = node
+        while int(parent[root]) != root:
+            root = int(parent[root])
+        while int(parent[node]) != node:
+            next_node = int(parent[node])
+            parent[node] = root
+            node = next_node
+        return root
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root == right_root:
+            return
+        if rank[left_root] < rank[right_root]:
+            parent[left_root] = right_root
+        elif rank[left_root] > rank[right_root]:
+            parent[right_root] = left_root
+        else:
+            parent[right_root] = left_root
+            rank[left_root] += 1
+
+    used_trace_indices = np.flatnonzero(used_mask)
+    for trace_index in used_trace_indices:
+        union(
+            int(source_index[trace_index]),
+            layout.n_sources + int(receiver_index[trace_index]),
+        )
+
+    component_by_root: dict[int, int] = {}
+    node_component = np.empty(n_nodes, dtype=np.int64)
+    for node in range(n_nodes):
+        root = find(node)
+        component = component_by_root.setdefault(root, len(component_by_root))
+        node_component[node] = component
+
+    n_components = int(len(component_by_root))
+    component_observation_counts = np.zeros(n_components, dtype=np.int64)
+    for trace_index in used_trace_indices:
+        component = node_component[int(source_index[trace_index])]
+        component_observation_counts[component] += 1
+
+    source_component_index = np.ascontiguousarray(
+        node_component[: layout.n_sources],
+        dtype=np.int64,
+    )
+    receiver_component_index = np.ascontiguousarray(
+        node_component[layout.n_sources :],
+        dtype=np.int64,
+    )
+    component_source_counts = np.bincount(
+        source_component_index,
+        minlength=n_components,
+    ).astype(np.int64, copy=False)
+    component_receiver_counts = np.bincount(
+        receiver_component_index,
+        minlength=n_components,
+    ).astype(np.int64, copy=False)
+
+    return ResidualStaticObservationGraphSummary(
+        n_components=n_components,
+        source_component_index=source_component_index,
+        receiver_component_index=receiver_component_index,
+        component_observation_counts=np.ascontiguousarray(
+            component_observation_counts,
+            dtype=np.int64,
+        ),
+        component_source_counts=np.ascontiguousarray(
+            component_source_counts,
+            dtype=np.int64,
+        ),
+        component_receiver_counts=np.ascontiguousarray(
+            component_receiver_counts,
+            dtype=np.int64,
+        ),
+    )
+
+
+def validate_minimum_residual_static_data(
+    inputs: ResidualStaticSolverInputs,
+    *,
+    used_mask_sorted: np.ndarray,
+    options: ResidualStaticStabilizationOptions,
+) -> ResidualStaticMinimumDataSummary:
+    """Validate that used picks can support a stabilized residual-static solve."""
+    validated_options = validate_residual_static_stabilization_options(options)
+    used_mask = validate_residual_static_used_mask(inputs, used_mask_sorted)
+    layout = build_residual_static_column_layout(inputs)
+    n_traces = _input_n_traces(inputs)
+    source_unique_ids = _coerce_1d_integer_preserve_dtype(
+        inputs.source_unique_ids,
+        name='source_unique_ids',
+        expected_shape=(layout.n_sources,),
+    )
+    receiver_unique_ids = _coerce_1d_integer_preserve_dtype(
+        inputs.receiver_unique_ids,
+        name='receiver_unique_ids',
+        expected_shape=(layout.n_receivers,),
+    )
+    source_index = _coerce_1d_integer_int64(
+        inputs.source_index_sorted,
+        name='source_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_index = _coerce_1d_integer_int64(
+        inputs.receiver_index_sorted,
+        name='receiver_index_sorted',
+        expected_shape=(n_traces,),
+    )
+    _validate_index_range(
+        source_index,
+        n_unique=layout.n_sources,
+        name='source_index_sorted',
+    )
+    _validate_index_range(
+        receiver_index,
+        n_unique=layout.n_receivers,
+        name='receiver_index_sorted',
+    )
+
+    used_trace_indices = np.flatnonzero(used_mask)
+    n_used_picks = int(used_trace_indices.shape[0])
+    n_effective_parameters = _effective_parameter_count(layout)
+    if n_used_picks < validated_options.min_valid_picks:
+        raise ValueError(
+            'n_used_picks must be greater than or equal to min_valid_picks'
+        )
+    if n_used_picks < n_effective_parameters:
+        raise ValueError(
+            'n_used_picks must be greater than or equal to n_effective_parameters'
+        )
+
+    source_used_pick_counts = np.bincount(
+        source_index[used_mask],
+        minlength=layout.n_sources,
+    ).astype(np.int64, copy=False)
+    receiver_used_pick_counts = np.bincount(
+        receiver_index[used_mask],
+        minlength=layout.n_receivers,
+    ).astype(np.int64, copy=False)
+    underconstrained_source_mask = (
+        source_used_pick_counts < validated_options.min_picks_per_source
+    )
+    underconstrained_receiver_mask = (
+        receiver_used_pick_counts < validated_options.min_picks_per_receiver
+    )
+    underconstrained_source_ids = np.ascontiguousarray(
+        source_unique_ids[underconstrained_source_mask],
+        dtype=source_unique_ids.dtype,
+    )
+    underconstrained_receiver_ids = np.ascontiguousarray(
+        receiver_unique_ids[underconstrained_receiver_mask],
+        dtype=receiver_unique_ids.dtype,
+    )
+    if underconstrained_source_ids.size > 0:
+        raise ValueError('used pick count is below min_picks_per_source')
+    if underconstrained_receiver_ids.size > 0:
+        raise ValueError('used pick count is below min_picks_per_receiver')
+
+    graph = build_residual_static_observation_graph_summary(
+        inputs,
+        used_mask_sorted=used_mask,
+    )
+    if graph.n_components != 1:
+        raise ValueError('source/receiver observation graph must be connected')
+
+    abs_offset_min: float | None
+    abs_offset_max: float | None
+    abs_offset_span: float | None
+    if layout.moveout_model == 'linear_abs_offset':
+        abs_offset = _required_abs_offset(inputs, expected_shape=(n_traces,))
+        used_abs_offset = abs_offset[used_mask]
+        if np.any(~np.isfinite(used_abs_offset)):
+            raise ValueError('abs_offset_sorted must be finite for used traces')
+        if np.any(used_abs_offset < 0.0):
+            raise ValueError('abs_offset_sorted must be non-negative for used traces')
+        abs_offset_min = float(np.min(used_abs_offset))
+        abs_offset_max = float(np.max(used_abs_offset))
+        abs_offset_span = float(abs_offset_max - abs_offset_min)
+        if abs_offset_span <= 0.0:
+            raise ValueError('abs_offset span must be greater than 0')
+    else:
+        abs_offset_min = None
+        abs_offset_max = None
+        abs_offset_span = None
+
+    return ResidualStaticMinimumDataSummary(
+        n_used_picks=n_used_picks,
+        n_sources=layout.n_sources,
+        n_receivers=layout.n_receivers,
+        n_effective_parameters=n_effective_parameters,
+        source_used_pick_counts=np.ascontiguousarray(
+            source_used_pick_counts,
+            dtype=np.int64,
+        ),
+        receiver_used_pick_counts=np.ascontiguousarray(
+            receiver_used_pick_counts,
+            dtype=np.int64,
+        ),
+        underconstrained_source_ids=underconstrained_source_ids,
+        underconstrained_receiver_ids=underconstrained_receiver_ids,
+        graph=graph,
+        abs_offset_min=abs_offset_min,
+        abs_offset_max=abs_offset_max,
+        abs_offset_span=abs_offset_span,
+    )
+
+
+def build_zero_mean_gauge_rows(
+    layout: ResidualStaticColumnLayout,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Build COO rows enforcing zero-mean source and receiver delays."""
+    _validate_layout_for_delay_regularization(layout)
+    source_cols = _coerce_1d_integer_int64(
+        layout.source_delay_cols,
+        name='layout.source_delay_cols',
+        expected_shape=(layout.n_sources,),
+    )
+    receiver_cols = _coerce_1d_integer_int64(
+        layout.receiver_delay_cols,
+        name='layout.receiver_delay_cols',
+        expected_shape=(layout.n_receivers,),
+    )
+    row_indices = np.concatenate(
+        [
+            np.zeros(layout.n_sources, dtype=np.int64),
+            np.ones(layout.n_receivers, dtype=np.int64),
+        ]
+    )
+    col_indices = np.concatenate([source_cols, receiver_cols]).astype(
+        np.int64,
+        copy=False,
+    )
+    data = np.concatenate(
+        [
+            np.full(layout.n_sources, 1.0 / layout.n_sources, dtype=np.float64),
+            np.full(
+                layout.n_receivers,
+                1.0 / layout.n_receivers,
+                dtype=np.float64,
+            ),
+        ]
+    )
+    rhs_s = np.zeros(2, dtype=np.float64)
+    return (
+        np.ascontiguousarray(row_indices, dtype=np.int64),
+        np.ascontiguousarray(col_indices, dtype=np.int64),
+        np.ascontiguousarray(data, dtype=np.float64),
+        np.ascontiguousarray(rhs_s, dtype=np.float64),
+    )
+
+
+def build_delay_damping_rows(
+    layout: ResidualStaticColumnLayout,
+    *,
+    damping_lambda: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Build COO rows for Tikhonov damping on source/receiver delays."""
+    _validate_layout_for_delay_regularization(layout)
+    damping = _coerce_nonnegative_finite_float(
+        damping_lambda,
+        name='damping_lambda',
+    )
+    if damping == 0.0:
+        return (
+            np.empty(0, dtype=np.int64),
+            np.empty(0, dtype=np.int64),
+            np.empty(0, dtype=np.float64),
+            np.empty(0, dtype=np.float64),
+        )
+
+    delay_cols = np.concatenate(
+        [
+            _coerce_1d_integer_int64(
+                layout.source_delay_cols,
+                name='layout.source_delay_cols',
+                expected_shape=(layout.n_sources,),
+            ),
+            _coerce_1d_integer_int64(
+                layout.receiver_delay_cols,
+                name='layout.receiver_delay_cols',
+                expected_shape=(layout.n_receivers,),
+            ),
+        ]
+    )
+    n_rows = int(delay_cols.shape[0])
+    row_indices = np.arange(n_rows, dtype=np.int64)
+    data = np.full(n_rows, damping, dtype=np.float64)
+    rhs_s = np.zeros(n_rows, dtype=np.float64)
+    return (
+        np.ascontiguousarray(row_indices, dtype=np.int64),
+        np.ascontiguousarray(delay_cols, dtype=np.int64),
+        np.ascontiguousarray(data, dtype=np.float64),
+        np.ascontiguousarray(rhs_s, dtype=np.float64),
+    )
+
+
+def build_stabilized_residual_static_augmented_system(
+    inputs: ResidualStaticSolverInputs,
+    *,
+    used_mask_sorted: np.ndarray | None = None,
+    options: ResidualStaticStabilizationOptions | None = None,
+) -> ResidualStaticAugmentedSystem:
+    """Build observation, gauge, and damping rows as one CSR system."""
+    validated_options = validate_residual_static_stabilization_options(
+        options or ResidualStaticStabilizationOptions()
+    )
+    used_mask = validate_residual_static_used_mask(inputs, used_mask_sorted)
+    minimum_data = validate_minimum_residual_static_data(
+        inputs,
+        used_mask_sorted=used_mask,
+        options=validated_options,
+    )
+    triplets = build_residual_static_observation_matrix_triplets(
+        inputs,
+        used_mask_sorted=used_mask,
+    )
+    observation_matrix = build_csr_matrix_from_residual_static_triplets(triplets)
+    n_cols = int(observation_matrix.shape[1])
+
+    gauge_rows, gauge_cols, gauge_data, gauge_rhs = build_zero_mean_gauge_rows(
+        triplets.layout
+    )
+    gauge_matrix = sparse.coo_matrix(
+        (gauge_data, (gauge_rows, gauge_cols)),
+        shape=(2, n_cols),
+        dtype=np.float64,
+    ).tocsr()
+
+    damping_rows, damping_cols, damping_data, damping_rhs = build_delay_damping_rows(
+        triplets.layout,
+        damping_lambda=validated_options.damping_lambda,
+    )
+    n_damping_rows = int(damping_rhs.shape[0])
+    damping_matrix = sparse.coo_matrix(
+        (damping_data, (damping_rows, damping_cols)),
+        shape=(n_damping_rows, n_cols),
+        dtype=np.float64,
+    ).tocsr()
+
+    matrix = sparse.vstack(
+        [observation_matrix, gauge_matrix, damping_matrix],
+        format='csr',
+        dtype=np.float64,
+    )
+    rhs_s = np.ascontiguousarray(
+        np.concatenate([triplets.rhs_s, gauge_rhs, damping_rhs]),
+        dtype=np.float64,
+    )
+    n_rows = int(matrix.shape[0])
+    if rhs_s.shape != (n_rows,):
+        raise ValueError('augmented rhs_s shape must match augmented matrix rows')
+
+    return ResidualStaticAugmentedSystem(
+        matrix=matrix,
+        rhs_s=rhs_s,
+        n_observation_rows=int(observation_matrix.shape[0]),
+        n_gauge_rows=2,
+        n_damping_rows=n_damping_rows,
+        n_rows=n_rows,
+        n_cols=n_cols,
+        observation_row_to_sorted_trace_index=np.ascontiguousarray(
+            triplets.row_to_sorted_trace_index,
+            dtype=np.int64,
+        ),
+        used_mask_sorted=np.ascontiguousarray(triplets.used_mask_sorted, dtype=bool),
+        minimum_data=minimum_data,
     )
 
 
@@ -226,6 +804,103 @@ def solve_residual_static_least_squares(
     )
 
 
+def solve_residual_static_stabilized_least_squares(
+    inputs: ResidualStaticSolverInputs,
+    *,
+    used_mask_sorted: np.ndarray | None = None,
+    stabilization_options: ResidualStaticStabilizationOptions | None = None,
+    lsmr_options: ResidualStaticLsmrOptions | None = None,
+) -> ResidualStaticStabilizedLeastSquaresResult:
+    """Solve zero-mean-gauged residual static delays with sparse LSMR."""
+    validated_options = validate_residual_static_stabilization_options(
+        stabilization_options or ResidualStaticStabilizationOptions()
+    )
+    augmented = build_stabilized_residual_static_augmented_system(
+        inputs,
+        used_mask_sorted=used_mask_sorted,
+        options=validated_options,
+    )
+    raw_result = run_sparse_lsmr(
+        augmented.matrix,
+        augmented.rhs_s,
+        options=lsmr_options,
+    )
+    matrix_csr = _coerce_sparse_matrix_float64_csr(augmented.matrix)
+    layout = build_residual_static_column_layout(inputs)
+    if layout.n_model_parameters != augmented.n_cols:
+        raise ValueError('layout.n_model_parameters must match augmented.n_cols')
+    parameter_parts = unpack_residual_static_parameters(
+        layout,
+        raw_result.parameter_vector,
+    )
+    model_evaluation = evaluate_residual_static_model(
+        inputs,
+        layout,
+        raw_result.parameter_vector,
+        residual_mask_sorted=augmented.used_mask_sorted,
+    )
+    _validate_domain_result(
+        parameter_vector=raw_result.parameter_vector,
+        parameter_parts=parameter_parts,
+        model_evaluation=model_evaluation,
+        layout=layout,
+    )
+    _validate_zero_mean_delay_gauge(parameter_parts)
+    max_abs_estimated_delay_s = validate_residual_static_estimated_delay_limit(
+        model_evaluation,
+        max_abs_estimated_delay_ms=validated_options.max_abs_estimated_delay_ms,
+    )
+
+    return ResidualStaticStabilizedLeastSquaresResult(
+        parameter_vector=raw_result.parameter_vector,
+        parameter_parts=parameter_parts,
+        model_evaluation=model_evaluation,
+        diagnostics=raw_result.diagnostics,
+        layout=layout,
+        used_mask_sorted=np.ascontiguousarray(augmented.used_mask_sorted, dtype=bool),
+        observation_row_to_sorted_trace_index=np.ascontiguousarray(
+            augmented.observation_row_to_sorted_trace_index,
+            dtype=np.int64,
+        ),
+        minimum_data=augmented.minimum_data,
+        stabilization_options=validated_options,
+        n_observations=augmented.n_observation_rows,
+        n_model_parameters=int(matrix_csr.shape[1]),
+        n_gauge_rows=augmented.n_gauge_rows,
+        n_damping_rows=augmented.n_damping_rows,
+        max_abs_estimated_delay_s=max_abs_estimated_delay_s,
+        rank_deficient_possible=False,
+    )
+
+
+def validate_residual_static_estimated_delay_limit(
+    evaluation: ResidualStaticModelEvaluation,
+    *,
+    max_abs_estimated_delay_ms: float,
+) -> float:
+    """Validate the estimated trace delay limit and return the max abs seconds."""
+    max_delay_ms = _coerce_positive_finite_float(
+        max_abs_estimated_delay_ms,
+        name='max_abs_estimated_delay_ms',
+    )
+    estimated_delay = _coerce_1d_real_numeric_float64(
+        evaluation.estimated_trace_delay_s_sorted,
+        name='estimated_trace_delay_s_sorted',
+    )
+    if estimated_delay.size == 0:
+        raise ValueError('estimated_trace_delay_s_sorted must be non-empty')
+    _validate_all_finite(
+        estimated_delay,
+        name='estimated_trace_delay_s_sorted',
+    )
+    max_abs_delay_s = float(np.max(np.abs(estimated_delay)))
+    if max_abs_delay_s > max_delay_ms / 1000.0:
+        raise ValueError(
+            'estimated_trace_delay_s_sorted exceeds max_abs_estimated_delay_ms'
+        )
+    return max_abs_delay_s
+
+
 def _validate_domain_result(
     *,
     parameter_vector: np.ndarray,
@@ -253,6 +928,85 @@ def _validate_domain_result(
     )
     if np.any(~np.isfinite(residual[residual_mask])):
         raise ValueError('residual_s_sorted must be finite for used traces')
+
+
+def _validate_zero_mean_delay_gauge(
+    parameter_parts: ResidualStaticParameterParts,
+) -> None:
+    source_mean = float(np.mean(parameter_parts.source_delay_s))
+    receiver_mean = float(np.mean(parameter_parts.receiver_delay_s))
+    if not np.isclose(source_mean, 0.0, atol=1.0e-8, rtol=0.0):
+        raise ValueError('source_delay_s must have zero mean')
+    if not np.isclose(receiver_mean, 0.0, atol=1.0e-8, rtol=0.0):
+        raise ValueError('receiver_delay_s must have zero mean')
+
+
+def _input_n_traces(inputs: ResidualStaticSolverInputs) -> int:
+    return _coerce_positive_int(inputs.n_traces, name='n_traces')
+
+
+def _effective_parameter_count(layout: ResidualStaticColumnLayout) -> int:
+    _validate_layout_for_delay_regularization(layout)
+    if layout.moveout_model == 'linear_abs_offset':
+        return 2 + layout.n_sources + layout.n_receivers - 2
+    if layout.moveout_model == 'none':
+        return 1 + layout.n_sources + layout.n_receivers - 2
+    raise ValueError(f'unsupported moveout_model: {layout.moveout_model!r}')
+
+
+def _required_abs_offset(
+    inputs: ResidualStaticSolverInputs,
+    *,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    if inputs.abs_offset_sorted is None:
+        raise ValueError('abs_offset_sorted is required for linear_abs_offset moveout')
+    return _coerce_1d_real_numeric_float64(
+        inputs.abs_offset_sorted,
+        name='abs_offset_sorted',
+        expected_shape=expected_shape,
+    )
+
+
+def _validate_mask_subset(
+    mask: np.ndarray,
+    base_mask: np.ndarray,
+    *,
+    mask_name: str,
+    base_name: str,
+) -> None:
+    if mask.shape != base_mask.shape:
+        raise ValueError(f'{mask_name} shape must match {base_name}')
+    if np.any(mask & ~base_mask):
+        raise ValueError(f'{mask_name} must be a subset of {base_name}')
+
+
+def _validate_layout_for_delay_regularization(
+    layout: ResidualStaticColumnLayout,
+) -> None:
+    _coerce_positive_int(layout.n_model_parameters, name='layout.n_model_parameters')
+    _coerce_positive_int(layout.n_sources, name='layout.n_sources')
+    _coerce_positive_int(layout.n_receivers, name='layout.n_receivers')
+    source_delay_cols = _coerce_1d_integer_int64(
+        layout.source_delay_cols,
+        name='layout.source_delay_cols',
+        expected_shape=(layout.n_sources,),
+    )
+    receiver_delay_cols = _coerce_1d_integer_int64(
+        layout.receiver_delay_cols,
+        name='layout.receiver_delay_cols',
+        expected_shape=(layout.n_receivers,),
+    )
+    _validate_index_range(
+        source_delay_cols,
+        n_unique=layout.n_model_parameters,
+        name='layout.source_delay_cols',
+    )
+    _validate_index_range(
+        receiver_delay_cols,
+        n_unique=layout.n_model_parameters,
+        name='layout.receiver_delay_cols',
+    )
 
 
 def _coerce_sparse_matrix_float64_csr(matrix):
@@ -295,10 +1049,14 @@ def _coerce_1d_bool_array(
     values: object,
     *,
     name: str,
+    expected_shape: tuple[int, ...] | None = None,
 ) -> np.ndarray:
     arr = np.asarray(values)
     if arr.ndim != 1:
         raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        raise ValueError(msg)
     if not np.issubdtype(arr.dtype, np.bool_):
         raise ValueError(f'{name} must have bool dtype')
     return np.ascontiguousarray(arr, dtype=bool)
@@ -319,6 +1077,25 @@ def _coerce_1d_real_numeric_float64(
     if not _is_real_numeric_dtype(arr.dtype):
         raise ValueError(f'{name} must have a numeric dtype')
     return np.ascontiguousarray(arr, dtype=np.float64)
+
+
+def _coerce_1d_integer_preserve_dtype(
+    values: object,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        raise ValueError(msg)
+    if np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must contain integer values')
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(f'{name} must contain integer values')
+    return np.ascontiguousarray(arr)
 
 
 def _coerce_positive_int(value: object, *, name: str) -> int:
@@ -389,12 +1166,28 @@ def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
 
 
 __all__ = [
+    'ResidualStaticAugmentedSystem',
+    'ResidualStaticGauge',
     'ResidualStaticLeastSquaresResult',
     'ResidualStaticLsmrDiagnostics',
     'ResidualStaticLsmrOptions',
+    'ResidualStaticMinimumDataSummary',
+    'ResidualStaticObservationGraphSummary',
     'ResidualStaticRawLsmrResult',
+    'ResidualStaticStabilizationOptions',
+    'ResidualStaticStabilizedLeastSquaresResult',
+    'build_delay_damping_rows',
     'build_csr_matrix_from_residual_static_triplets',
+    'build_residual_static_observation_graph_summary',
+    'build_stabilized_residual_static_augmented_system',
+    'build_zero_mean_gauge_rows',
     'run_sparse_lsmr',
     'solve_residual_static_least_squares',
+    'solve_residual_static_stabilized_least_squares',
+    'stabilization_options_from_request_solver',
+    'validate_minimum_residual_static_data',
     'validate_lsmr_options',
+    'validate_residual_static_estimated_delay_limit',
+    'validate_residual_static_stabilization_options',
+    'validate_residual_static_used_mask',
 ]

--- a/app/tests/test_residual_static_solver_stabilization.py
+++ b/app/tests/test_residual_static_solver_stabilization.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from app.services.residual_static_design_matrix import (
+    build_residual_static_column_layout,
+)
+from app.services.residual_static_inputs import ResidualStaticSolverInputs
+from app.services.residual_static_sparse_solver import (
+    ResidualStaticLsmrOptions,
+    ResidualStaticStabilizationOptions,
+    build_delay_damping_rows,
+    build_residual_static_observation_graph_summary,
+    build_stabilized_residual_static_augmented_system,
+    build_zero_mean_gauge_rows,
+    solve_residual_static_stabilized_least_squares,
+    stabilization_options_from_request_solver,
+    validate_minimum_residual_static_data,
+    validate_residual_static_stabilization_options,
+    validate_residual_static_used_mask,
+)
+
+SOURCE_DELAY_S = np.asarray([-0.012, 0.004, 0.008], dtype=np.float64)
+RECEIVER_DELAY_S = np.asarray([-0.006, -0.002, 0.003, 0.005], dtype=np.float64)
+INTERCEPT_S = 0.080
+SLOWNESS_S_PER_OFFSET_UNIT = 2.5e-5
+
+
+def _synthetic_inputs(
+    *,
+    moveout_model: str = 'linear_abs_offset',
+    **overrides: Any,
+) -> ResidualStaticSolverInputs:
+    source_unique_ids = np.asarray([101, 102, 103], dtype=np.int32)
+    receiver_unique_ids = np.asarray([201, 202, 203, 204], dtype=np.int32)
+    n_sources = int(source_unique_ids.shape[0])
+    n_receivers = int(receiver_unique_ids.shape[0])
+    source_index = np.repeat(np.arange(n_sources, dtype=np.int64), n_receivers)
+    receiver_index = np.tile(np.arange(n_receivers, dtype=np.int64), n_sources)
+    n_traces = int(source_index.shape[0])
+
+    abs_offset = np.asarray(
+        [
+            [100.0, 185.0, 260.0, 415.0],
+            [150.0, 245.0, 395.0, 525.0],
+            [230.0, 315.0, 475.0, 655.0],
+        ],
+        dtype=np.float64,
+    ).reshape(-1)
+    offset_sign = np.where(np.arange(n_traces) % 2 == 0, -1.0, 1.0)
+    offset = abs_offset * offset_sign
+
+    if moveout_model == 'linear_abs_offset':
+        moveout_s = INTERCEPT_S + SLOWNESS_S_PER_OFFSET_UNIT * abs_offset
+        offset_sorted = offset
+        abs_offset_sorted = abs_offset
+        offset_byte = 37
+    else:
+        moveout_s = np.full(n_traces, INTERCEPT_S, dtype=np.float64)
+        offset_sorted = None
+        abs_offset_sorted = None
+        offset_byte = None
+
+    pick_time_after_datum = (
+        moveout_s
+        + SOURCE_DELAY_S[source_index]
+        + RECEIVER_DELAY_S[receiver_index]
+    )
+    valid_pick_mask = np.ones(n_traces, dtype=bool)
+    payload: dict[str, Any] = {
+        'picks_time_s_sorted': pick_time_after_datum.copy(),
+        'valid_pick_mask_sorted': valid_pick_mask,
+        'pick_time_after_datum_s_sorted': pick_time_after_datum.copy(),
+        'datum_trace_shift_s_sorted': np.zeros(n_traces, dtype=np.float64),
+        'source_id_sorted': source_unique_ids[source_index],
+        'receiver_id_sorted': receiver_unique_ids[receiver_index],
+        'source_unique_ids': source_unique_ids,
+        'receiver_unique_ids': receiver_unique_ids,
+        'source_index_sorted': source_index,
+        'receiver_index_sorted': receiver_index,
+        'source_valid_pick_counts': np.bincount(
+            source_index,
+            minlength=n_sources,
+        ).astype(np.int64),
+        'receiver_valid_pick_counts': np.bincount(
+            receiver_index,
+            minlength=n_receivers,
+        ).astype(np.int64),
+        'offset_sorted': offset_sorted,
+        'abs_offset_sorted': abs_offset_sorted,
+        'key1_sorted': np.repeat([10, 20, 30], n_receivers).astype(np.int64),
+        'key2_sorted': np.tile([1, 2, 3, 4], n_sources).astype(np.int64),
+        'source_elevation_m_sorted': np.zeros(n_traces, dtype=np.float64),
+        'receiver_elevation_m_sorted': np.zeros(n_traces, dtype=np.float64),
+        'dt': 0.004,
+        'n_traces': n_traces,
+        'n_samples': 64,
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'source_id_byte': 17,
+        'receiver_id_byte': 13,
+        'offset_byte': offset_byte,
+        'moveout_model': moveout_model,
+        'input_file_id': 'corrected-file-id',
+        'datum_source_file_id': 'source-file-id',
+        'datum_job_id': 'datum-job',
+        'pick_source_kind': 'batch_npz',
+        'metadata': {'source': 'stabilization-test'},
+    }
+    payload.update(overrides)
+    return ResidualStaticSolverInputs(**payload)
+
+
+def _options(**overrides: Any) -> ResidualStaticStabilizationOptions:
+    payload: dict[str, Any] = {
+        'gauge': 'zero_mean_source_receiver',
+        'damping_lambda': 0.0,
+        'min_valid_picks': 10,
+        'min_picks_per_source': 1,
+        'min_picks_per_receiver': 1,
+        'max_abs_estimated_delay_ms': 250.0,
+    }
+    payload.update(overrides)
+    return ResidualStaticStabilizationOptions(**payload)
+
+
+def test_validate_stabilization_options_accepts_request_like_object() -> None:
+    class RequestSolver:
+        gauge = 'zero_mean_source_receiver'
+        damping_lambda = 0.25
+        min_valid_picks = 12
+        min_picks_per_source = 2
+        min_picks_per_receiver = 3
+        max_abs_estimated_delay_ms = 50.0
+
+    options = stabilization_options_from_request_solver(RequestSolver())
+
+    assert options == ResidualStaticStabilizationOptions(
+        gauge='zero_mean_source_receiver',
+        damping_lambda=0.25,
+        min_valid_picks=12,
+        min_picks_per_source=2,
+        min_picks_per_receiver=3,
+        max_abs_estimated_delay_ms=50.0,
+    )
+
+
+def test_validate_stabilization_options_rejects_bool_numeric_fields() -> None:
+    with pytest.raises(ValueError, match='min_valid_picks'):
+        validate_residual_static_stabilization_options(
+            _options(min_valid_picks=True)
+        )
+
+    with pytest.raises(ValueError, match='damping_lambda'):
+        validate_residual_static_stabilization_options(
+            _options(damping_lambda=False)
+        )
+
+
+def test_validate_stabilization_options_rejects_unsupported_gauge() -> None:
+    with pytest.raises(ValueError, match='gauge'):
+        validate_residual_static_stabilization_options(_options(gauge='free'))
+
+
+def test_validate_used_mask_defaults_to_valid_pick_mask_and_allows_nan_invalid() -> None:
+    valid_mask = np.ones(12, dtype=bool)
+    valid_mask[3] = False
+    pick_time = _synthetic_inputs().pick_time_after_datum_s_sorted.copy()
+    pick_time[3] = np.nan
+    inputs = _synthetic_inputs(
+        valid_pick_mask_sorted=valid_mask,
+        pick_time_after_datum_s_sorted=pick_time,
+    )
+
+    used_mask = validate_residual_static_used_mask(inputs, None)
+
+    np.testing.assert_array_equal(used_mask, valid_mask)
+
+
+def test_validate_used_mask_rejects_invalid_pick_subset_violation() -> None:
+    valid_mask = np.ones(12, dtype=bool)
+    valid_mask[3] = False
+    inputs = _synthetic_inputs(valid_pick_mask_sorted=valid_mask)
+    used_mask = np.ones(12, dtype=bool)
+
+    with pytest.raises(ValueError, match='subset'):
+        validate_residual_static_used_mask(inputs, used_mask)
+
+
+def test_validate_used_mask_rejects_nonfinite_used_pick_time() -> None:
+    pick_time = _synthetic_inputs().pick_time_after_datum_s_sorted.copy()
+    pick_time[0] = np.nan
+
+    with pytest.raises(ValueError, match='pick_time_after_datum'):
+        validate_residual_static_used_mask(
+            _synthetic_inputs(pick_time_after_datum_s_sorted=pick_time),
+            None,
+        )
+
+
+def test_observation_graph_summary_connected_complete_grid() -> None:
+    inputs = _synthetic_inputs()
+    graph = build_residual_static_observation_graph_summary(
+        inputs,
+        used_mask_sorted=np.ones(inputs.n_traces, dtype=bool),
+    )
+
+    assert graph.n_components == 1
+    np.testing.assert_array_equal(graph.source_component_index, [0, 0, 0])
+    np.testing.assert_array_equal(graph.receiver_component_index, [0, 0, 0, 0])
+    np.testing.assert_array_equal(graph.component_observation_counts, [12])
+    np.testing.assert_array_equal(graph.component_source_counts, [3])
+    np.testing.assert_array_equal(graph.component_receiver_counts, [4])
+
+
+def test_minimum_data_summary_counts_and_offset_span() -> None:
+    inputs = _synthetic_inputs()
+
+    summary = validate_minimum_residual_static_data(
+        inputs,
+        used_mask_sorted=np.ones(inputs.n_traces, dtype=bool),
+        options=_options(),
+    )
+
+    assert summary.n_used_picks == 12
+    assert summary.n_sources == 3
+    assert summary.n_receivers == 4
+    assert summary.n_effective_parameters == 7
+    np.testing.assert_array_equal(summary.source_used_pick_counts, [4, 4, 4])
+    np.testing.assert_array_equal(summary.receiver_used_pick_counts, [3, 3, 3, 3])
+    assert summary.underconstrained_source_ids.dtype == np.int32
+    assert summary.underconstrained_receiver_ids.dtype == np.int32
+    assert summary.abs_offset_min == 100.0
+    assert summary.abs_offset_max == 655.0
+    assert summary.abs_offset_span == 555.0
+
+
+def test_minimum_data_rejects_source_with_insufficient_used_picks() -> None:
+    inputs = _synthetic_inputs()
+    used_mask = inputs.source_index_sorted != 2
+
+    with pytest.raises(ValueError, match='min_picks_per_source'):
+        validate_minimum_residual_static_data(
+            inputs,
+            used_mask_sorted=used_mask,
+            options=_options(min_valid_picks=1),
+        )
+
+
+def test_minimum_data_rejects_disconnected_observation_graph() -> None:
+    inputs = _synthetic_inputs(moveout_model='none')
+    used_mask = np.asarray(
+        [
+            True,
+            True,
+            False,
+            False,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+            True,
+            True,
+        ],
+        dtype=bool,
+    )
+
+    with pytest.raises(ValueError, match='connected'):
+        validate_minimum_residual_static_data(
+            inputs,
+            used_mask_sorted=used_mask,
+            options=_options(min_valid_picks=1),
+        )
+
+
+def test_minimum_data_rejects_linear_abs_offset_without_offset_span() -> None:
+    inputs = _synthetic_inputs(
+        abs_offset_sorted=np.full(12, 100.0, dtype=np.float64),
+        offset_sorted=np.full(12, 100.0, dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match='span'):
+        validate_minimum_residual_static_data(
+            inputs,
+            used_mask_sorted=np.ones(inputs.n_traces, dtype=bool),
+            options=_options(),
+        )
+
+
+def test_gauge_and_damping_rows_target_only_delay_columns() -> None:
+    layout = build_residual_static_column_layout(_synthetic_inputs())
+
+    gauge_rows, gauge_cols, gauge_data, gauge_rhs = build_zero_mean_gauge_rows(
+        layout
+    )
+    gauge_matrix = sparse.coo_matrix(
+        (gauge_data, (gauge_rows, gauge_cols)),
+        shape=(2, layout.n_model_parameters),
+    ).toarray()
+
+    assert gauge_rhs.tolist() == [0.0, 0.0]
+    assert gauge_matrix[0, layout.intercept_col] == 0.0
+    assert layout.slowness_col is not None
+    assert gauge_matrix[0, layout.slowness_col] == 0.0
+    np.testing.assert_allclose(gauge_matrix[0, layout.source_delay_cols], 1.0 / 3.0)
+    np.testing.assert_allclose(gauge_matrix[1, layout.receiver_delay_cols], 1.0 / 4.0)
+
+    damping_rows, damping_cols, damping_data, damping_rhs = build_delay_damping_rows(
+        layout,
+        damping_lambda=0.2,
+    )
+
+    np.testing.assert_array_equal(damping_rows, np.arange(7, dtype=np.int64))
+    np.testing.assert_array_equal(
+        damping_cols,
+        np.concatenate([layout.source_delay_cols, layout.receiver_delay_cols]),
+    )
+    np.testing.assert_allclose(damping_data, np.full(7, 0.2, dtype=np.float64))
+    np.testing.assert_allclose(damping_rhs, np.zeros(7, dtype=np.float64))
+
+    empty_rows = build_delay_damping_rows(layout, damping_lambda=0.0)
+    assert all(part.size == 0 for part in empty_rows)
+
+
+def test_augmented_system_includes_observation_gauge_and_damping_rows() -> None:
+    inputs = _synthetic_inputs()
+
+    augmented = build_stabilized_residual_static_augmented_system(
+        inputs,
+        options=_options(damping_lambda=0.5),
+    )
+
+    assert sparse.isspmatrix_csr(augmented.matrix)
+    assert augmented.n_observation_rows == 12
+    assert augmented.n_gauge_rows == 2
+    assert augmented.n_damping_rows == 7
+    assert augmented.n_rows == 21
+    assert augmented.n_cols == 9
+    assert augmented.rhs_s.shape == (21,)
+    np.testing.assert_array_equal(
+        augmented.observation_row_to_sorted_trace_index,
+        np.arange(12, dtype=np.int64),
+    )
+
+
+def test_stabilized_solver_recovers_zero_mean_synthetic_delays() -> None:
+    inputs = _synthetic_inputs()
+
+    result = solve_residual_static_stabilized_least_squares(
+        inputs,
+        stabilization_options=_options(),
+        lsmr_options=ResidualStaticLsmrOptions(
+            atol=1.0e-12,
+            btol=1.0e-12,
+            conlim=1.0e12,
+            maxiter=10000,
+        ),
+    )
+
+    assert result.rank_deficient_possible is False
+    assert result.n_observations == 12
+    assert result.n_model_parameters == 9
+    assert result.n_gauge_rows == 2
+    assert result.n_damping_rows == 0
+    np.testing.assert_allclose(
+        result.parameter_parts.source_delay_s,
+        SOURCE_DELAY_S,
+        atol=1.0e-8,
+    )
+    np.testing.assert_allclose(
+        result.parameter_parts.receiver_delay_s,
+        RECEIVER_DELAY_S,
+        atol=1.0e-8,
+    )
+    np.testing.assert_allclose(
+        np.mean(result.parameter_parts.source_delay_s),
+        0.0,
+        atol=1.0e-10,
+    )
+    np.testing.assert_allclose(
+        np.mean(result.parameter_parts.receiver_delay_s),
+        0.0,
+        atol=1.0e-10,
+    )
+    assert result.parameter_parts.intercept_s == pytest.approx(INTERCEPT_S, abs=1e-8)
+    assert result.parameter_parts.slowness_s_per_offset_unit == pytest.approx(
+        SLOWNESS_S_PER_OFFSET_UNIT,
+        abs=1e-10,
+    )
+    np.testing.assert_allclose(
+        result.model_evaluation.residual_s_sorted[result.used_mask_sorted],
+        np.zeros(inputs.n_traces, dtype=np.float64),
+        atol=1.0e-8,
+    )
+    assert not hasattr(result, 'applied_residual_shift_s_sorted')
+
+
+def test_stabilized_solver_rejects_estimated_delay_limit_exceedance() -> None:
+    with pytest.raises(ValueError, match='max_abs_estimated_delay_ms'):
+        solve_residual_static_stabilized_least_squares(
+            _synthetic_inputs(),
+            stabilization_options=_options(max_abs_estimated_delay_ms=1.0),
+            lsmr_options=ResidualStaticLsmrOptions(
+                atol=1.0e-12,
+                btol=1.0e-12,
+                conlim=1.0e12,
+                maxiter=10000,
+            ),
+        )


### PR DESCRIPTION
Closes #318

## Summary
- PR4-5 [statics residual] gauge fixing・damping・minimum data validation を solver に追加する

## Changed files
- `app/services/residual_static_sparse_solver.py`
- `app/tests/test_residual_static_solver_stabilization.py`

## Checks
- `.work/codex/checks.log`: 878 passed in 45.06s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
