### PR TITLE
PR4-5.5 [statics residual] residual apply schema と solver type layering の取りこぼしを修正する

### DIFF
--- a/.devcontainer/requirements-dev.txt
+++ b/.devcontainer/requirements-dev.txt
@@ -6,6 +6,7 @@ tqdm
 segyio
 numba
 fastapi
+pydantic>=2,<3
 httpx
 uvicorn[standard]
 python-multipart

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *.ipynb_checkpoints
+.pytest_cache/
 
 # Jupyter ノートブックのチェックポイント
 .ipynb_checkpoints/

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -4,7 +4,7 @@ import math
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.utils.validation import require_non_negative_int, require_positive_int
 
@@ -366,6 +366,58 @@ def _validate_artifact_basename(name: str, field_name: str) -> str:
     return name
 
 
+def require_trace_header_byte(value: object, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be an integer SEG-Y trace header byte')
+    if not isinstance(value, int):
+        raise ValueError(f'{name} must be an integer SEG-Y trace header byte')
+    if value < 1 or value > 240:
+        raise ValueError(f'{name} must be in the range 1..240')
+    return value
+
+
+def _require_positive_int(value: object, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be a positive integer')
+    if not isinstance(value, int):
+        raise ValueError(f'{name} must be a positive integer')
+    if value <= 0:
+        raise ValueError(f'{name} must be a positive integer')
+    return value
+
+
+def _require_bool(value: object, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f'{name} must be a bool')
+    return value
+
+
+def _require_finite_float(value: object, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be finite')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite') from exc
+    if not math.isfinite(out):
+        raise ValueError(f'{name} must be finite')
+    return out
+
+
+def _require_nonnegative_finite_float(value: object, name: str) -> float:
+    out = _require_finite_float(value, name)
+    if out < 0.0:
+        raise ValueError(f'{name} must be finite and >= 0')
+    return out
+
+
+def _require_positive_finite_float(value: object, name: str) -> float:
+    out = _require_finite_float(value, name)
+    if out <= 0.0:
+        raise ValueError(f'{name} must be finite and > 0')
+    return out
+
+
 class FirstBreakQcDatumSolutionRequest(BaseModel):
     """Datum static solution artifact reference for first-break QC."""
 
@@ -446,47 +498,254 @@ class FirstBreakQcJobResponse(BaseModel):
     state: str
 
 
-class ResidualStaticDatumSolutionRequest(FirstBreakQcDatumSolutionRequest):
+class ResidualStaticDatumSolutionRequest(BaseModel):
     """Datum static solution artifact reference for residual statics."""
 
+    model_config = ConfigDict(extra='forbid')
 
-class ResidualStaticPickSourceRequest(FirstBreakQcPickSourceRequest):
+    job_id: str
+    name: str = 'datum_static_solution.npz'
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'ResidualStaticDatumSolutionRequest':
+        if not self.job_id:
+            raise ValueError('datum_solution.job_id must be a non-empty string')
+        _validate_artifact_basename(self.name, 'datum_solution.name')
+        return self
+
+
+class ResidualStaticPickSourceRequest(BaseModel):
     """First-break pick source reference for residual static estimation."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['batch_job_artifact', 'manual_npz_artifact', 'manual_memmap']
+    job_id: str | None = None
+    name: str | None = None
+
+    @model_validator(mode='after')
+    def _check_ref(self) -> 'ResidualStaticPickSourceRequest':
+        if self.kind in {'batch_job_artifact', 'manual_npz_artifact'}:
+            if not self.job_id:
+                raise ValueError('pick_source.job_id is required for artifact sources')
+            if not self.name:
+                raise ValueError('pick_source.name is required for artifact sources')
+            _validate_artifact_basename(self.name, 'pick_source.name')
+            return self
+
+        if self.job_id is not None or self.name is not None:
+            raise ValueError('pick_source.job_id/name must be omitted for manual_memmap')
+        return self
+
+
+class ResidualStaticGeometryRequest(BaseModel):
+    """Source and receiver header configuration for residual statics."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    source_id_byte: int
+    receiver_id_byte: int
+
+    @field_validator('source_id_byte', 'receiver_id_byte', mode='before')
+    @classmethod
+    def _check_header_byte(cls, value: object, info: Any) -> int:
+        return require_trace_header_byte(value, info.field_name)
+
+    @model_validator(mode='after')
+    def _check_distinct_headers(self) -> 'ResidualStaticGeometryRequest':
+        if self.source_id_byte == self.receiver_id_byte:
+            raise ValueError('source_id_byte and receiver_id_byte must differ')
+        return self
+
+
+class ResidualStaticOffsetRequest(BaseModel):
+    """Offset header configuration for residual statics."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    offset_byte: int | None = 37
+
+    @field_validator('offset_byte', mode='before')
+    @classmethod
+    def _check_offset_byte(cls, value: object) -> int | None:
+        if value is None:
+            return None
+        return require_trace_header_byte(value, 'offset.offset_byte')
 
 
 class ResidualStaticMoveoutRequest(BaseModel):
     """Moveout model configuration for residual static estimation."""
 
+    model_config = ConfigDict(extra='forbid')
+
     model: Literal['linear_abs_offset', 'none'] = 'linear_abs_offset'
+
+
+class ResidualStaticSolverRequest(BaseModel):
+    """Sparse solver stabilization options for residual statics."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    gauge: Literal['zero_mean_source_receiver'] = 'zero_mean_source_receiver'
+    damping_lambda: float = 0.0
+    min_valid_picks: int = 10
+    min_picks_per_source: int = 1
+    min_picks_per_receiver: int = 1
+    max_abs_estimated_delay_ms: float = 250.0
+
+    @field_validator('damping_lambda', mode='before')
+    @classmethod
+    def _check_damping_lambda(cls, value: object) -> float:
+        return _require_nonnegative_finite_float(value, 'solver.damping_lambda')
+
+    @field_validator(
+        'min_valid_picks',
+        'min_picks_per_source',
+        'min_picks_per_receiver',
+        mode='before',
+    )
+    @classmethod
+    def _check_positive_int(cls, value: object, info: Any) -> int:
+        return _require_positive_int(value, f'solver.{info.field_name}')
+
+    @field_validator('max_abs_estimated_delay_ms', mode='before')
+    @classmethod
+    def _check_max_abs_estimated_delay_ms(cls, value: object) -> float:
+        return _require_positive_finite_float(
+            value,
+            'solver.max_abs_estimated_delay_ms',
+        )
+
+
+class ResidualStaticRobustRequest(BaseModel):
+    """Robust outlier-rejection options for residual statics."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    enabled: bool = True
+    method: Literal['mad', 'sigma'] = 'mad'
+    max_iterations: int = 3
+    threshold: float = 4.0
+    min_used_fraction: float = 0.5
+
+    @field_validator('enabled', mode='before')
+    @classmethod
+    def _check_enabled(cls, value: object) -> bool:
+        return _require_bool(value, 'robust.enabled')
+
+    @field_validator('max_iterations', mode='before')
+    @classmethod
+    def _check_max_iterations(cls, value: object) -> int:
+        return _require_positive_int(value, 'robust.max_iterations')
+
+    @field_validator('threshold', mode='before')
+    @classmethod
+    def _check_threshold(cls, value: object) -> float:
+        return _require_positive_finite_float(value, 'robust.threshold')
+
+    @field_validator('min_used_fraction', mode='before')
+    @classmethod
+    def _check_min_used_fraction(cls, value: object) -> float:
+        fraction = _require_positive_finite_float(value, 'robust.min_used_fraction')
+        if fraction > 1.0:
+            raise ValueError('robust.min_used_fraction must be <= 1')
+        return fraction
+
+
+class ResidualStaticApplyOptions(BaseModel):
+    """Options for applying residual statics to a corrected TraceStore."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    interpolation: Literal['linear'] = 'linear'
+    fill_value: float = 0.0
+    max_abs_shift_ms: float = 250.0
+    output_dtype: Literal['float32'] = 'float32'
+    register_corrected_file: bool = True
+
+    @field_validator('fill_value', mode='before')
+    @classmethod
+    def _check_fill_value(cls, value: object) -> float:
+        return _require_finite_float(value, 'apply.fill_value')
+
+    @field_validator('max_abs_shift_ms', mode='before')
+    @classmethod
+    def _check_max_abs_shift_ms(cls, value: object) -> float:
+        return _require_positive_finite_float(value, 'apply.max_abs_shift_ms')
+
+    @field_validator('register_corrected_file', mode='before')
+    @classmethod
+    def _check_register_corrected_file_bool(cls, value: object) -> bool:
+        return _require_bool(value, 'apply.register_corrected_file')
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'ResidualStaticApplyOptions':
+        if self.register_corrected_file is not True:
+            raise ValueError('apply.register_corrected_file must be true')
+        return self
 
 
 class ResidualStaticApplyRequest(BaseModel):
     """Request model for future ``/statics/residual/apply`` jobs."""
+
+    model_config = ConfigDict(extra='forbid')
 
     file_id: str
     key1_byte: int = 189
     key2_byte: int = 193
     datum_solution: ResidualStaticDatumSolutionRequest
     pick_source: ResidualStaticPickSourceRequest
-    source_id_byte: int
-    receiver_id_byte: int
-    offset_byte: int | None = 37
+    geometry: ResidualStaticGeometryRequest
+    offset: ResidualStaticOffsetRequest = Field(
+        default_factory=ResidualStaticOffsetRequest,
+    )
     moveout: ResidualStaticMoveoutRequest = Field(
         default_factory=ResidualStaticMoveoutRequest,
     )
+    solver: ResidualStaticSolverRequest = Field(
+        default_factory=ResidualStaticSolverRequest,
+    )
+    robust: ResidualStaticRobustRequest = Field(
+        default_factory=ResidualStaticRobustRequest,
+    )
+    apply: ResidualStaticApplyOptions = Field(
+        default_factory=ResidualStaticApplyOptions,
+    )
+
+    @field_validator('key1_byte', 'key2_byte', mode='before')
+    @classmethod
+    def _check_key_header_byte(cls, value: object, info: Any) -> int:
+        return require_trace_header_byte(value, info.field_name)
 
     @model_validator(mode='after')
     def _check_values(self) -> 'ResidualStaticApplyRequest':
         if not self.file_id:
             raise ValueError('file_id must be a non-empty string')
-        require_positive_int(self.key1_byte, 'key1_byte')
-        require_positive_int(self.key2_byte, 'key2_byte')
-        require_positive_int(self.source_id_byte, 'source_id_byte')
-        require_positive_int(self.receiver_id_byte, 'receiver_id_byte')
-        if self.source_id_byte == self.receiver_id_byte:
-            raise ValueError('source_id_byte and receiver_id_byte must differ')
-        if self.offset_byte is not None:
-            require_positive_int(self.offset_byte, 'offset_byte')
-        if self.moveout.model == 'linear_abs_offset' and self.offset_byte is None:
-            raise ValueError('offset_byte is required for linear_abs_offset moveout')
+        if self.moveout.model == 'linear_abs_offset' and self.offset.offset_byte is None:
+            raise ValueError(
+                'offset.offset_byte is required for linear_abs_offset moveout'
+            )
+        if self.moveout.model == 'none' and self.offset.offset_byte is not None:
+            raise ValueError('offset.offset_byte must be null for none moveout')
         return self
+
+    @property
+    def source_id_byte(self) -> int:
+        return self.geometry.source_id_byte
+
+    @property
+    def receiver_id_byte(self) -> int:
+        return self.geometry.receiver_id_byte
+
+    @property
+    def offset_byte(self) -> int | None:
+        return self.offset.offset_byte
+
+
+class ResidualStaticApplyResponse(BaseModel):
+    """Response model for creating a residual static apply job."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    job_id: str
+    state: str

--- a/app/services/residual_static_design_matrix.py
+++ b/app/services/residual_static_design_matrix.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
 
 import numpy as np
 
-from app.services.residual_static_inputs import ResidualStaticSolverInputs
-
-MoveoutModel = Literal['linear_abs_offset', 'none']
+from app.services.residual_static_types import MoveoutModel, ResidualStaticSolverInputs
 
 
 @dataclass(frozen=True)

--- a/app/services/residual_static_inputs.py
+++ b/app/services/residual_static_inputs.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 import json
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 
@@ -22,9 +22,11 @@ from app.services.pick_source_loader import (
     load_manual_memmap_pick_source,
     load_npz_pick_source,
 )
+from app.services.residual_static_types import (
+    MoveoutModel,
+    ResidualStaticSolverInputs,
+)
 from app.trace_store.reader import TraceStoreSectionReader
-
-MoveoutModel = Literal['linear_abs_offset', 'none']
 
 _DT_TOLERANCE = 1e-9
 _CORRECTED_FILE_MANIFEST = 'corrected_file.json'
@@ -38,47 +40,6 @@ class ResidualStaticResolvedArtifacts:
     datum_source_file_id: str
     datum_corrected_file_id: str
     pick_source_artifact_name: str | None
-
-
-@dataclass(frozen=True)
-class ResidualStaticSolverInputs:
-    picks_time_s_sorted: np.ndarray
-    valid_pick_mask_sorted: np.ndarray
-    pick_time_after_datum_s_sorted: np.ndarray
-    datum_trace_shift_s_sorted: np.ndarray
-
-    source_id_sorted: np.ndarray
-    receiver_id_sorted: np.ndarray
-    source_unique_ids: np.ndarray
-    receiver_unique_ids: np.ndarray
-    source_index_sorted: np.ndarray
-    receiver_index_sorted: np.ndarray
-    source_valid_pick_counts: np.ndarray
-    receiver_valid_pick_counts: np.ndarray
-
-    offset_sorted: np.ndarray | None
-    abs_offset_sorted: np.ndarray | None
-
-    key1_sorted: np.ndarray
-    key2_sorted: np.ndarray
-    source_elevation_m_sorted: np.ndarray
-    receiver_elevation_m_sorted: np.ndarray
-
-    dt: float
-    n_traces: int
-    n_samples: int
-    key1_byte: int
-    key2_byte: int
-    source_id_byte: int
-    receiver_id_byte: int
-    offset_byte: int | None
-    moveout_model: MoveoutModel
-
-    input_file_id: str
-    datum_source_file_id: str
-    datum_job_id: str
-    pick_source_kind: str
-    metadata: dict[str, Any]
 
 
 def resolve_residual_static_input_artifacts(
@@ -649,6 +610,8 @@ def _request_offset_byte(
         if moveout_model == 'linear_abs_offset':
             raise ValueError('offset_byte is required for linear_abs_offset moveout')
         return None
+    if moveout_model == 'none':
+        raise ValueError('offset_byte must be None for none moveout')
     return _validate_header_byte(raw_offset_byte, name='offset_byte')
 
 

--- a/app/services/residual_static_sparse_solver.py
+++ b/app/services/residual_static_sparse_solver.py
@@ -19,7 +19,7 @@ from app.services.residual_static_design_matrix import (
     evaluate_residual_static_model,
     unpack_residual_static_parameters,
 )
-from app.services.residual_static_inputs import ResidualStaticSolverInputs
+from app.services.residual_static_types import ResidualStaticSolverInputs
 
 ResidualStaticGauge = Literal['zero_mean_source_receiver']
 

--- a/app/services/residual_static_types.py
+++ b/app/services/residual_static_types.py
@@ -1,0 +1,54 @@
+"""Lightweight shared types for residual static solver stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import numpy as np
+
+MoveoutModel = Literal['linear_abs_offset', 'none']
+
+
+@dataclass(frozen=True)
+class ResidualStaticSolverInputs:
+    picks_time_s_sorted: np.ndarray
+    valid_pick_mask_sorted: np.ndarray
+    pick_time_after_datum_s_sorted: np.ndarray
+    datum_trace_shift_s_sorted: np.ndarray
+
+    source_id_sorted: np.ndarray
+    receiver_id_sorted: np.ndarray
+    source_unique_ids: np.ndarray
+    receiver_unique_ids: np.ndarray
+    source_index_sorted: np.ndarray
+    receiver_index_sorted: np.ndarray
+    source_valid_pick_counts: np.ndarray
+    receiver_valid_pick_counts: np.ndarray
+
+    offset_sorted: np.ndarray | None
+    abs_offset_sorted: np.ndarray | None
+
+    key1_sorted: np.ndarray
+    key2_sorted: np.ndarray
+    source_elevation_m_sorted: np.ndarray
+    receiver_elevation_m_sorted: np.ndarray
+
+    dt: float
+    n_traces: int
+    n_samples: int
+    key1_byte: int
+    key2_byte: int
+    source_id_byte: int
+    receiver_id_byte: int
+    offset_byte: int | None
+    moveout_model: MoveoutModel
+
+    input_file_id: str
+    datum_source_file_id: str
+    datum_job_id: str
+    pick_source_kind: str
+    metadata: dict[str, Any]
+
+
+__all__ = ['MoveoutModel', 'ResidualStaticSolverInputs']

--- a/app/tests/test_residual_static_design_matrix.py
+++ b/app/tests/test_residual_static_design_matrix.py
@@ -14,7 +14,7 @@ from app.services.residual_static_design_matrix import (
     pack_residual_static_parameters,
     unpack_residual_static_parameters,
 )
-from app.services.residual_static_inputs import ResidualStaticSolverInputs
+from app.services.residual_static_types import ResidualStaticSolverInputs
 
 PICK_TIME_AFTER_DATUM = np.asarray([0.100, 0.110, 0.120, 0.130])
 VALID_PICK_MASK = np.asarray([True, True, True, True])

--- a/app/tests/test_residual_static_import_layering.py
+++ b/app/tests/test_residual_static_import_layering.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import app.services.residual_static_design_matrix as design_matrix
+import app.services.residual_static_sparse_solver as sparse_solver
+import app.services.residual_static_types as residual_static_types
+
+
+def _module_source(module: ModuleType) -> str:
+    path = Path(module.__file__ or '')
+    return path.read_text(encoding='utf-8')
+
+
+def test_residual_static_lightweight_modules_import() -> None:
+    assert residual_static_types.MoveoutModel is not None
+    assert design_matrix.ResidualStaticColumnLayout is not None
+    assert sparse_solver.ResidualStaticLsmrOptions is not None
+
+
+def test_residual_static_design_matrix_has_no_api_reader_or_input_dependency() -> None:
+    source = _module_source(design_matrix)
+
+    assert 'app.api.schemas' not in source
+    assert 'app.trace_store.reader' not in source
+    assert 'segyio' not in source
+    assert 'residual_static_inputs' not in source
+
+
+def test_residual_static_sparse_solver_has_no_api_reader_or_input_dependency() -> None:
+    source = _module_source(sparse_solver)
+
+    assert 'app.api.schemas' not in source
+    assert 'app.trace_store.reader' not in source
+    assert 'segyio' not in source
+    assert 'residual_static_inputs' not in source

--- a/app/tests/test_residual_static_inputs.py
+++ b/app/tests/test_residual_static_inputs.py
@@ -81,6 +81,10 @@ class _Reader:
 
 
 def _request(**overrides: Any) -> ResidualStaticApplyRequest:
+    overrides = dict(overrides)
+    source_id_byte = overrides.pop('source_id_byte', SOURCE_ID_BYTE)
+    receiver_id_byte = overrides.pop('receiver_id_byte', RECEIVER_ID_BYTE)
+    offset_byte = overrides.pop('offset_byte', OFFSET_BYTE)
     payload: dict[str, Any] = {
         'file_id': CORRECTED_FILE_ID,
         'key1_byte': KEY1_BYTE,
@@ -94,9 +98,11 @@ def _request(**overrides: Any) -> ResidualStaticApplyRequest:
             'job_id': 'pick-job',
             'name': 'predicted_picks_time_s.npz',
         },
-        'source_id_byte': SOURCE_ID_BYTE,
-        'receiver_id_byte': RECEIVER_ID_BYTE,
-        'offset_byte': OFFSET_BYTE,
+        'geometry': {
+            'source_id_byte': source_id_byte,
+            'receiver_id_byte': receiver_id_byte,
+        },
+        'offset': {'offset_byte': offset_byte},
         'moveout': {'model': 'linear_abs_offset'},
     }
     payload.update(overrides)

--- a/app/tests/test_residual_static_schema.py
+++ b/app/tests/test_residual_static_schema.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
-from app.api.schemas import ResidualStaticApplyRequest
+from app.api.schemas import ResidualStaticApplyRequest, ResidualStaticApplyResponse
 
 
 def _payload() -> dict[str, Any]:
@@ -22,55 +23,240 @@ def _payload() -> dict[str, Any]:
             'job_id': 'pick-job',
             'name': 'predicted_picks_time_s.npz',
         },
-        'source_id_byte': 17,
-        'receiver_id_byte': 13,
-        'offset_byte': 37,
+        'geometry': {
+            'source_id_byte': 17,
+            'receiver_id_byte': 13,
+        },
+        'offset': {'offset_byte': 37},
         'moveout': {'model': 'linear_abs_offset'},
+        'solver': {
+            'gauge': 'zero_mean_source_receiver',
+            'damping_lambda': 0.0,
+            'min_valid_picks': 10,
+            'min_picks_per_source': 1,
+            'min_picks_per_receiver': 1,
+            'max_abs_estimated_delay_ms': 250.0,
+        },
+        'robust': {
+            'enabled': True,
+            'method': 'mad',
+            'max_iterations': 3,
+            'threshold': 4.0,
+            'min_used_fraction': 0.5,
+        },
+        'apply': {
+            'interpolation': 'linear',
+            'fill_value': 0.0,
+            'max_abs_shift_ms': 250.0,
+            'output_dtype': 'float32',
+            'register_corrected_file': True,
+        },
     }
 
 
-def test_residual_static_apply_request_accepts_linear_abs_offset() -> None:
-    req = ResidualStaticApplyRequest.model_validate(_payload())
+def _validate(payload: dict[str, Any]) -> ResidualStaticApplyRequest:
+    return ResidualStaticApplyRequest.model_validate(deepcopy(payload))
+
+
+def test_residual_static_apply_request_accepts_nested_linear_abs_offset() -> None:
+    req = _validate(_payload())
 
     assert req.file_id == 'datum-corrected-file-id'
     assert req.datum_solution.name == 'datum_static_solution.npz'
     assert req.pick_source.kind == 'batch_job_artifact'
+    assert req.geometry.source_id_byte == 17
+    assert req.geometry.receiver_id_byte == 13
+    assert req.offset.offset_byte == 37
     assert req.source_id_byte == 17
     assert req.receiver_id_byte == 13
     assert req.offset_byte == 37
     assert req.moveout.model == 'linear_abs_offset'
+    assert req.solver.min_valid_picks == 10
+    assert req.robust.enabled is True
+    assert req.apply.output_dtype == 'float32'
 
 
-def test_residual_static_apply_request_accepts_moveout_none_without_offset() -> None:
+def test_residual_static_apply_request_accepts_moveout_none_with_null_offset() -> None:
     payload = _payload()
     payload['moveout'] = {'model': 'none'}
-    payload['offset_byte'] = None
+    payload['offset'] = {'offset_byte': None}
+    payload['pick_source'] = {'kind': 'manual_memmap'}
 
-    req = ResidualStaticApplyRequest.model_validate(payload)
+    req = _validate(payload)
 
     assert req.moveout.model == 'none'
     assert req.offset_byte is None
 
 
-def test_residual_static_apply_request_rejects_same_source_receiver_id_byte() -> None:
+def test_residual_static_apply_request_rejects_flattened_source_receiver_fields() -> None:
     payload = _payload()
-    payload['receiver_id_byte'] = payload['source_id_byte']
+    payload['source_id_byte'] = 17
+    payload['receiver_id_byte'] = 13
+    payload['offset_byte'] = 37
 
-    with pytest.raises(ValidationError, match='source_id_byte and receiver_id_byte'):
-        ResidualStaticApplyRequest.model_validate(payload)
+    with pytest.raises(ValidationError):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_moveout_none_with_offset_byte() -> None:
+    payload = _payload()
+    payload['moveout'] = {'model': 'none'}
+
+    with pytest.raises(ValidationError, match='offset.offset_byte must be null'):
+        _validate(payload)
 
 
 def test_residual_static_apply_request_rejects_linear_abs_offset_without_offset() -> None:
     payload = _payload()
-    payload['offset_byte'] = None
+    payload['offset'] = {'offset_byte': None}
 
-    with pytest.raises(ValidationError, match='offset_byte is required'):
-        ResidualStaticApplyRequest.model_validate(payload)
+    with pytest.raises(ValidationError, match='offset.offset_byte is required'):
+        _validate(payload)
 
 
-def test_residual_static_apply_request_rejects_path_artifact_names() -> None:
+def test_residual_static_apply_request_rejects_header_byte_zero() -> None:
     payload = _payload()
-    payload['datum_solution']['name'] = '../datum_static_solution.npz'
+    payload['key1_byte'] = 0
 
-    with pytest.raises(ValidationError, match='plain file name'):
-        ResidualStaticApplyRequest.model_validate(payload)
+    with pytest.raises(ValidationError, match='range 1..240'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_header_byte_241() -> None:
+    payload = _payload()
+    payload['geometry']['source_id_byte'] = 241
+
+    with pytest.raises(ValidationError, match='range 1..240'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_bool_header_byte() -> None:
+    payload = _payload()
+    payload['offset'] = {'offset_byte': True}
+
+    with pytest.raises(ValidationError, match='integer SEG-Y trace header byte'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_same_source_receiver_id_byte() -> None:
+    payload = _payload()
+    payload['geometry']['receiver_id_byte'] = payload['geometry']['source_id_byte']
+
+    with pytest.raises(ValidationError, match='source_id_byte and receiver_id_byte'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_negative_damping_lambda() -> None:
+    payload = _payload()
+    payload['solver']['damping_lambda'] = -1.0
+
+    with pytest.raises(ValidationError, match='damping_lambda'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_non_finite_damping_lambda() -> None:
+    payload = _payload()
+    payload['solver']['damping_lambda'] = float('inf')
+
+    with pytest.raises(ValidationError, match='damping_lambda'):
+        _validate(payload)
+
+
+@pytest.mark.parametrize(
+    'field',
+    ['min_valid_picks', 'min_picks_per_source', 'min_picks_per_receiver'],
+)
+def test_residual_static_apply_request_rejects_non_positive_solver_ints(
+    field: str,
+) -> None:
+    payload = _payload()
+    payload['solver'][field] = 0
+
+    with pytest.raises(ValidationError, match=field):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_bool_positive_int() -> None:
+    payload = _payload()
+    payload['solver']['min_valid_picks'] = True
+
+    with pytest.raises(ValidationError, match='min_valid_picks'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_non_positive_max_abs_delay() -> None:
+    payload = _payload()
+    payload['solver']['max_abs_estimated_delay_ms'] = 0.0
+
+    with pytest.raises(ValidationError, match='max_abs_estimated_delay_ms'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_invalid_robust_threshold() -> None:
+    payload = _payload()
+    payload['robust']['threshold'] = 0.0
+
+    with pytest.raises(ValidationError, match='robust.threshold'):
+        _validate(payload)
+
+
+@pytest.mark.parametrize('min_used_fraction', [0.0, 1.1])
+def test_residual_static_apply_request_rejects_invalid_min_used_fraction(
+    min_used_fraction: float,
+) -> None:
+    payload = _payload()
+    payload['robust']['min_used_fraction'] = min_used_fraction
+
+    with pytest.raises(ValidationError, match='min_used_fraction'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_register_corrected_file_false() -> None:
+    payload = _payload()
+    payload['apply']['register_corrected_file'] = False
+
+    with pytest.raises(ValidationError, match='register_corrected_file'):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_non_finite_fill_value() -> None:
+    payload = _payload()
+    payload['apply']['fill_value'] = float('nan')
+
+    with pytest.raises(ValidationError, match='apply.fill_value'):
+        _validate(payload)
+
+
+@pytest.mark.parametrize(
+    'name',
+    ['', '.', '..', '/tmp/datum_static_solution.npz', '../x.npz', 'nested/x.npz'],
+)
+def test_residual_static_apply_request_rejects_path_artifact_names(
+    name: str,
+) -> None:
+    payload = _payload()
+    payload['datum_solution']['name'] = name
+
+    with pytest.raises(ValidationError):
+        _validate(payload)
+
+
+def test_residual_static_apply_request_rejects_manual_memmap_artifact_ref() -> None:
+    payload = _payload()
+    payload['pick_source'] = {
+        'kind': 'manual_memmap',
+        'job_id': 'pick-job',
+        'name': 'manual_picks.npz',
+    }
+
+    with pytest.raises(ValidationError, match='manual_memmap'):
+        _validate(payload)
+
+
+def test_residual_static_apply_response_accepts_job_id_and_state() -> None:
+    response = ResidualStaticApplyResponse.model_validate(
+        {'job_id': 'residual-job', 'state': 'queued'}
+    )
+
+    assert response.job_id == 'residual-job'
+    assert response.state == 'queued'

--- a/app/tests/test_residual_static_solver_stabilization.py
+++ b/app/tests/test_residual_static_solver_stabilization.py
@@ -9,7 +9,6 @@ from scipy import sparse
 from app.services.residual_static_design_matrix import (
     build_residual_static_column_layout,
 )
-from app.services.residual_static_inputs import ResidualStaticSolverInputs
 from app.services.residual_static_sparse_solver import (
     ResidualStaticLsmrOptions,
     ResidualStaticStabilizationOptions,
@@ -23,6 +22,7 @@ from app.services.residual_static_sparse_solver import (
     validate_residual_static_stabilization_options,
     validate_residual_static_used_mask,
 )
+from app.services.residual_static_types import ResidualStaticSolverInputs
 
 SOURCE_DELAY_S = np.asarray([-0.012, 0.004, 0.008], dtype=np.float64)
 RECEIVER_DELAY_S = np.asarray([-0.006, -0.002, 0.003, 0.005], dtype=np.float64)

--- a/app/tests/test_residual_static_sparse_solver.py
+++ b/app/tests/test_residual_static_sparse_solver.py
@@ -13,7 +13,6 @@ from app.services.residual_static_design_matrix import (
     ResidualStaticModelEvaluation,
     build_residual_static_observation_matrix_triplets,
 )
-from app.services.residual_static_inputs import ResidualStaticSolverInputs
 from app.services.residual_static_sparse_solver import (
     ResidualStaticLsmrDiagnostics,
     ResidualStaticLsmrOptions,
@@ -22,6 +21,7 @@ from app.services.residual_static_sparse_solver import (
     solve_residual_static_least_squares,
     validate_lsmr_options,
 )
+from app.services.residual_static_types import ResidualStaticSolverInputs
 
 PICK_TIME_AFTER_DATUM = np.asarray([0.100, 0.110, 0.120, 0.130])
 VALID_PICK_MASK = np.asarray([True, True, True, True])


### PR DESCRIPTION
Closes #320

## Summary
- PR4-5.5 [statics residual] residual apply schema と solver type layering の取りこぼしを修正する

## Changed files
- `.devcontainer/requirements-dev.txt`
- `.gitignore`
- `app/api/schemas.py`
- `app/services/residual_static_design_matrix.py`
- `app/services/residual_static_inputs.py`
- `app/services/residual_static_sparse_solver.py`
- `app/services/residual_static_types.py`
- `app/tests/test_residual_static_design_matrix.py`
- `app/tests/test_residual_static_import_layering.py`
- `app/tests/test_residual_static_inputs.py`
- `app/tests/test_residual_static_schema.py`
- `app/tests/test_residual_static_solver_stabilization.py`
- `app/tests/test_residual_static_sparse_solver.py`

## Checks
- `.work/codex/checks.log`: 905 passed in 45.10s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
