### PR TITLE
PR4-8 [statics residual] estimated delay を applied residual shift に変換して補正済み TraceStore を生成・登録する

### DIFF
--- a/app/services/corrected_trace_store.py
+++ b/app/services/corrected_trace_store.py
@@ -374,6 +374,7 @@ def _build_meta(
     shift_summary: dict[str, float],
     derived_metadata: Mapping[str, Any] | None,
     from_file_id: str | None,
+    original_segy_path: str | None,
 ) -> dict[str, Any]:
     derived_extra = dict(derived_metadata or {})
     reserved = sorted(_RESERVED_DERIVED_KEYS.intersection(derived_extra))
@@ -414,7 +415,7 @@ def _build_meta(
         },
         'sorted_by': ['key1', 'key2'],
         'dt': source_meta.dt,
-        'original_segy_path': None,
+        'original_segy_path': original_segy_path,
         'source_sha256': None,
         'derived': derived,
     }
@@ -492,6 +493,7 @@ def build_time_shifted_trace_store(
     output_dtype: str = 'float32',
     derived_metadata: Mapping[str, Any] | None = None,
     from_file_id: str | None = None,
+    original_segy_path: str | None = None,
     header_bytes_to_materialize: Iterable[int] = (),
     chunk_size: int = 512,
     progress_callback: Callable[[float, str], None] | None = None,
@@ -539,6 +541,7 @@ def build_time_shifted_trace_store(
         shift_summary=shift_summary,
         derived_metadata=derived_metadata,
         from_file_id=from_file_id,
+        original_segy_path=original_segy_path,
     )
     _raise_if_cancelled(cancel_check)
 

--- a/app/services/datum_static_service.py
+++ b/app/services/datum_static_service.py
@@ -438,6 +438,7 @@ def _run_datum_static_apply_job_body(
             fill_value=req.apply.fill_value,
             output_dtype=req.apply.output_dtype,
             from_file_id=req.file_id,
+            original_segy_path=_reader_original_segy_path(reader),
             header_bytes_to_materialize=header_bytes_to_materialize,
             derived_metadata={
                 'statics_kind': 'datum',

--- a/app/services/residual_static_corrected_store.py
+++ b/app/services/residual_static_corrected_store.py
@@ -1,0 +1,699 @@
+"""Apply residual static solution artifacts to datum-corrected TraceStores."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import shutil
+from typing import Any, Literal
+from uuid import uuid4
+
+import numpy as np
+
+from app.services.corrected_trace_store import build_time_shifted_trace_store
+from app.services.trace_store_registration import (
+    register_trace_store,
+    trace_store_cache_key,
+)
+
+SOLUTION_NPZ_NAME = 'residual_static_solution.npz'
+_CORRECTED_FILE_NAME = 'corrected_file.json'
+_SAFE_STORE_NAME_RE = re.compile(r'[^A-Za-z0-9_.-]+')
+_SIGN_CONVENTION = (
+    'estimated_trace_delay_s=source_delay_s+receiver_delay_s; '
+    'applied_residual_shift_s=-estimated_trace_delay_s; '
+    'corrected(t)=raw(t-shift_s)'
+)
+_BUILDER_SIGN_CONVENTION = (
+    'corrected(t)=raw(t-shift_s); positive_shift_delays_events'
+)
+_REQUIRED_SOLUTION_FIELDS = {
+    'applied_residual_shift_s_sorted',
+    'estimated_trace_delay_s_sorted',
+    'dt',
+    'n_traces',
+    'key1_byte',
+    'key2_byte',
+    'sign_convention',
+}
+
+
+@dataclass(frozen=True)
+class ResidualStaticTraceStoreApplyOptions:
+    interpolation: Literal['linear'] = 'linear'
+    fill_value: float = 0.0
+    max_abs_shift_ms: float = 250.0
+    output_dtype: Literal['float32'] = 'float32'
+    register_corrected_file: bool = True
+
+
+@dataclass(frozen=True)
+class ResidualStaticSolutionForApply:
+    applied_residual_shift_s_sorted: np.ndarray
+    estimated_trace_delay_s_sorted: np.ndarray
+    dt: float
+    n_traces: int
+    key1_byte: int
+    key2_byte: int
+    sign_convention: str
+
+
+@dataclass(frozen=True)
+class ResidualStaticCorrectedStoreResult:
+    file_id: str
+    store_path: Path
+    store_name: str
+    corrected_file_json_path: Path
+    derived_from_file_id: str
+    derived_from_store_path: Path
+    job_id: str
+    key1_byte: int
+    key2_byte: int
+    dt: float
+
+
+@dataclass(frozen=True)
+class _SourceTraceStoreMeta:
+    raw: dict[str, object]
+    n_traces: int
+    n_samples: int
+    dt: float
+    key1_byte: int
+    key2_byte: int
+    original_segy_path: str
+
+
+def load_residual_static_solution_for_apply(
+    solution_npz_path: Path,
+    *,
+    expected_n_traces: int,
+    expected_dt: float,
+    expected_key1_byte: int,
+    expected_key2_byte: int,
+) -> ResidualStaticSolutionForApply:
+    """Load the residual static solution fields needed for TraceStore apply."""
+    path = Path(solution_npz_path)
+    if not path.exists():
+        raise ValueError(f'residual_static_solution.npz does not exist: {path}')
+    if not path.is_file():
+        raise ValueError(f'residual_static_solution.npz is not a file: {path}')
+    expected_n = _coerce_positive_int(
+        expected_n_traces,
+        name='expected_n_traces',
+    )
+    expected_dt_value = _coerce_positive_finite_float(
+        expected_dt,
+        name='expected_dt',
+    )
+
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            missing = sorted(_REQUIRED_SOLUTION_FIELDS.difference(data.files))
+            if missing:
+                raise ValueError(
+                    'residual_static_solution.npz is missing required fields: '
+                    + ', '.join(missing)
+                )
+            applied = _require_1d_float64(
+                data['applied_residual_shift_s_sorted'],
+                name='applied_residual_shift_s_sorted',
+                expected_shape=(expected_n,),
+            )
+            estimated = _require_1d_float64(
+                data['estimated_trace_delay_s_sorted'],
+                name='estimated_trace_delay_s_sorted',
+                expected_shape=(expected_n,),
+            )
+            dt = _require_scalar_float(data['dt'], name='dt')
+            n_traces = _require_scalar_int(data['n_traces'], name='n_traces')
+            key1_byte = _require_scalar_int(data['key1_byte'], name='key1_byte')
+            key2_byte = _require_scalar_int(data['key2_byte'], name='key2_byte')
+            sign_convention = _require_scalar_str(
+                data['sign_convention'],
+                name='sign_convention',
+            )
+    except ValueError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(
+            f'residual_static_solution.npz could not be loaded: {path}'
+        ) from exc
+
+    if n_traces != expected_n:
+        raise ValueError(
+            'residual_static_solution.npz n_traces mismatch: '
+            f'expected {expected_n}, got {n_traces}'
+        )
+    if not np.isclose(dt, expected_dt_value, rtol=1.0e-9, atol=1.0e-12):
+        raise ValueError(
+            'residual_static_solution.npz dt mismatch: '
+            f'expected {expected_dt_value}, got {dt}'
+        )
+    if key1_byte != int(expected_key1_byte):
+        raise ValueError(
+            'residual_static_solution.npz key1_byte mismatch: '
+            f'expected {int(expected_key1_byte)}, got {key1_byte}'
+        )
+    if key2_byte != int(expected_key2_byte):
+        raise ValueError(
+            'residual_static_solution.npz key2_byte mismatch: '
+            f'expected {int(expected_key2_byte)}, got {key2_byte}'
+        )
+    if not sign_convention:
+        raise ValueError('residual_static_solution.npz sign_convention is empty')
+    _validate_applied_shift_sign(applied, estimated)
+
+    return ResidualStaticSolutionForApply(
+        applied_residual_shift_s_sorted=applied,
+        estimated_trace_delay_s_sorted=estimated,
+        dt=dt,
+        n_traces=n_traces,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        sign_convention=sign_convention,
+    )
+
+
+def validate_residual_static_shift_for_apply(
+    solution: ResidualStaticSolutionForApply,
+    *,
+    max_abs_shift_ms: float,
+) -> None:
+    """Validate service-level residual shift limits without clipping."""
+    max_abs_ms = _coerce_nonnegative_finite_float(
+        max_abs_shift_ms,
+        name='max_abs_shift_ms',
+    )
+    applied = _require_1d_float64(
+        solution.applied_residual_shift_s_sorted,
+        name='applied_residual_shift_s_sorted',
+        expected_shape=(solution.n_traces,),
+    )
+    estimated = _require_1d_float64(
+        solution.estimated_trace_delay_s_sorted,
+        name='estimated_trace_delay_s_sorted',
+        expected_shape=(solution.n_traces,),
+    )
+    _validate_applied_shift_sign(applied, estimated)
+    max_abs_shift_ms_actual = float(np.max(np.abs(applied)) * 1000.0)
+    if max_abs_shift_ms_actual > max_abs_ms:
+        raise ValueError(
+            'applied_residual_shift_s_sorted exceeds max_abs_shift_ms: '
+            f'{max_abs_shift_ms_actual:.6g} > {max_abs_ms:.6g}'
+        )
+
+
+def build_residual_static_derived_metadata(
+    *,
+    source_meta: dict[str, object],
+    source_file_id: str,
+    source_store_path: Path,
+    job_id: str,
+    residual_solution_artifact_name: str = SOLUTION_NPZ_NAME,
+) -> dict[str, object]:
+    """Build derived metadata extras for the residual corrected TraceStore."""
+    derived = _require_derived_dict(source_meta)
+    components = _component_dicts(derived)
+    if not _components_include(components, 'datum_static_correction'):
+        if not _has_legacy_datum_lineage(derived):
+            raise ValueError('source TraceStore is missing datum static lineage')
+        components.append(_datum_component_from_legacy_derived(derived))
+
+    components.append(
+        {
+            'name': 'residual_static_correction',
+            'job_id': str(job_id),
+            'solution_artifact': str(residual_solution_artifact_name),
+            'estimated_delay_field': 'estimated_trace_delay_s_sorted',
+            'shift_field': 'applied_residual_shift_s_sorted',
+            'value_kind': 'applied_event_time_shift_s',
+            'sign_convention': (
+                'applied_residual_shift_s=-estimated_trace_delay_s'
+            ),
+        }
+    )
+    return {
+        'applied_to': 'datum_corrected_trace_store',
+        'components': components,
+    }
+
+
+def apply_residual_static_correction_to_trace_store(
+    *,
+    source_file_id: str,
+    source_store_path: Path,
+    key1_byte: int,
+    key2_byte: int,
+    residual_solution_npz_path: Path,
+    artifacts_dir: Path,
+    job_id: str,
+    state: object,
+    options: ResidualStaticTraceStoreApplyOptions,
+    corrected_file_id: str | None = None,
+) -> ResidualStaticCorrectedStoreResult:
+    """Create, register, and describe a residual-corrected TraceStore."""
+    _validate_apply_options(options)
+    source_path = Path(source_store_path)
+    _validate_registry_source_path(
+        state=state,
+        source_file_id=source_file_id,
+        source_store_path=source_path,
+    )
+    source_meta = _load_and_validate_source_meta(
+        source_path,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+    )
+    solution = load_residual_static_solution_for_apply(
+        Path(residual_solution_npz_path),
+        expected_n_traces=source_meta.n_traces,
+        expected_dt=source_meta.dt,
+        expected_key1_byte=key1_byte,
+        expected_key2_byte=key2_byte,
+    )
+    validate_residual_static_shift_for_apply(
+        solution,
+        max_abs_shift_ms=options.max_abs_shift_ms,
+    )
+
+    resolved_file_id = str(corrected_file_id or uuid4())
+    output_store_path = _corrected_store_path(
+        source_store_path=source_path,
+        job_id=job_id,
+    )
+    derived_metadata = build_residual_static_derived_metadata(
+        source_meta=source_meta.raw,
+        source_file_id=source_file_id,
+        source_store_path=source_path,
+        job_id=job_id,
+        residual_solution_artifact_name=Path(residual_solution_npz_path).name,
+    )
+    corrected_file_json_path = Path(artifacts_dir) / _CORRECTED_FILE_NAME
+
+    build_result = None
+    try:
+        build_result = build_time_shifted_trace_store(
+            source_store_path=source_path,
+            output_store_path=output_store_path,
+            trace_shift_s_sorted=solution.applied_residual_shift_s_sorted,
+            fill_value=options.fill_value,
+            output_dtype=options.output_dtype,
+            derived_metadata=derived_metadata,
+            from_file_id=source_file_id,
+            original_segy_path=source_meta.original_segy_path,
+        )
+        register_trace_store(
+            state=state,
+            file_id=resolved_file_id,
+            store_dir=build_result.store_path,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
+            dt=build_result.dt,
+            update_registry=True,
+            touch_meta=True,
+        )
+        _write_json_atomic(
+            corrected_file_json_path,
+            _build_corrected_file_payload(
+                corrected_file_id=resolved_file_id,
+                store_path=build_result.store_path,
+                source_file_id=source_file_id,
+                source_store_path=source_path,
+                job_id=job_id,
+                key1_byte=key1_byte,
+                key2_byte=key2_byte,
+                dt=build_result.dt,
+            ),
+        )
+    except Exception:
+        _cleanup_registration(
+            state,
+            file_id=resolved_file_id,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
+        )
+        _cleanup_store(output_store_path)
+        raise
+
+    return ResidualStaticCorrectedStoreResult(
+        file_id=resolved_file_id,
+        store_path=build_result.store_path,
+        store_name=build_result.store_path.name,
+        corrected_file_json_path=corrected_file_json_path,
+        derived_from_file_id=source_file_id,
+        derived_from_store_path=source_path,
+        job_id=job_id,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        dt=build_result.dt,
+    )
+
+
+def _validate_apply_options(options: ResidualStaticTraceStoreApplyOptions) -> None:
+    if options.interpolation != 'linear':
+        raise ValueError('interpolation must be "linear"')
+    if options.output_dtype != 'float32':
+        raise ValueError('output_dtype must be "float32"')
+    if options.register_corrected_file is not True:
+        raise ValueError('register_corrected_file must be true')
+
+
+def _validate_registry_source_path(
+    *,
+    state: object,
+    source_file_id: str,
+    source_store_path: Path,
+) -> None:
+    if not source_store_path.exists():
+        raise ValueError(f'source_store_path does not exist: {source_store_path}')
+    if not source_store_path.is_dir():
+        raise ValueError(f'source_store_path must be a directory: {source_store_path}')
+    try:
+        registry_store_path = Path(state.file_registry.get_store_path(source_file_id))
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(
+            f'source_file_id is not registered with a TraceStore: {source_file_id}'
+        ) from exc
+    if registry_store_path.resolve() != source_store_path.resolve():
+        raise ValueError(
+            'source_store_path does not match file registry for source_file_id'
+        )
+
+
+def _load_and_validate_source_meta(
+    source_store_path: Path,
+    *,
+    key1_byte: int,
+    key2_byte: int,
+) -> _SourceTraceStoreMeta:
+    meta_path = source_store_path / 'meta.json'
+    if not meta_path.exists():
+        raise ValueError(f'source TraceStore meta.json is missing: {meta_path}')
+    try:
+        meta = json.loads(meta_path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f'source TraceStore meta.json is invalid: {meta_path}') from exc
+    if not isinstance(meta, dict):
+        raise ValueError('source TraceStore meta.json must be an object')
+
+    n_traces = _coerce_positive_int(meta.get('n_traces'), name='meta.n_traces')
+    n_samples = _coerce_positive_int(meta.get('n_samples'), name='meta.n_samples')
+    dt = _coerce_positive_finite_float(meta.get('dt'), name='meta.dt')
+    key_bytes = meta.get('key_bytes')
+    if not isinstance(key_bytes, dict):
+        raise ValueError('source TraceStore meta.key_bytes must be an object')
+    meta_key1 = _coerce_header_byte(key_bytes.get('key1'), name='meta.key_bytes.key1')
+    meta_key2 = _coerce_header_byte(key_bytes.get('key2'), name='meta.key_bytes.key2')
+    if meta_key1 != int(key1_byte):
+        raise ValueError(
+            f'source TraceStore key1_byte mismatch: expected {key1_byte}, got {meta_key1}'
+        )
+    if meta_key2 != int(key2_byte):
+        raise ValueError(
+            f'source TraceStore key2_byte mismatch: expected {key2_byte}, got {meta_key2}'
+        )
+
+    original_segy_path = meta.get('original_segy_path')
+    if not isinstance(original_segy_path, str) or not original_segy_path:
+        raise ValueError('source TraceStore original_segy_path must be a non-empty string')
+    _validate_source_lineage(meta)
+
+    return _SourceTraceStoreMeta(
+        raw=meta,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt=dt,
+        key1_byte=meta_key1,
+        key2_byte=meta_key2,
+        original_segy_path=original_segy_path,
+    )
+
+
+def _validate_source_lineage(source_meta: dict[str, object]) -> None:
+    derived = _require_derived_dict(source_meta)
+    components = _component_dicts(derived)
+    if _components_include(components, 'residual_static_correction'):
+        raise ValueError('source TraceStore already has residual_static_correction')
+    if _components_include(components, 'datum_static_correction'):
+        return
+    if _has_legacy_datum_lineage(derived):
+        return
+    raise ValueError('source TraceStore is missing datum static lineage')
+
+
+def _require_derived_dict(source_meta: dict[str, object]) -> dict[str, object]:
+    derived = source_meta.get('derived')
+    if not isinstance(derived, dict):
+        raise ValueError('source TraceStore is missing derived metadata')
+    return dict(derived)
+
+
+def _component_dicts(derived: dict[str, object]) -> list[dict[str, object]]:
+    components = derived.get('components')
+    if components is None:
+        return []
+    if not isinstance(components, list):
+        raise ValueError('source TraceStore derived.components must be a list')
+    output: list[dict[str, object]] = []
+    for index, component in enumerate(components):
+        if not isinstance(component, dict):
+            raise ValueError(
+                f'source TraceStore derived.components[{index}] must be an object'
+            )
+        output.append(dict(component))
+    return output
+
+
+def _components_include(components: list[dict[str, object]], name: str) -> bool:
+    return any(component.get('name') == name for component in components)
+
+
+def _has_legacy_datum_lineage(derived: dict[str, object]) -> bool:
+    return (
+        derived.get('statics_kind') == 'datum'
+        or derived.get('derived_by') == 'datum_static_correction'
+    )
+
+
+def _datum_component_from_legacy_derived(
+    derived: dict[str, object],
+) -> dict[str, object]:
+    component: dict[str, object] = {
+        'name': 'datum_static_correction',
+        'solution_artifact': str(
+            derived.get('solution_artifact') or 'datum_static_solution.npz'
+        ),
+        'shift_field': str(derived.get('shift_field') or 'trace_shift_s_sorted'),
+        'value_kind': str(
+            derived.get('value_kind') or 'applied_event_time_shift_s'
+        ),
+    }
+    job_id = derived.get('job_id')
+    if job_id is not None:
+        component['job_id'] = str(job_id)
+    return component
+
+
+def _corrected_store_path(*, source_store_path: Path, job_id: str) -> Path:
+    source_name = _safe_store_name_component(source_store_path.name)
+    job_prefix = _safe_store_name_component(str(job_id)[:8])
+    store_name = f'{source_name}.statics.residual.{job_prefix}'
+    output_path = source_store_path.parent / store_name
+    if output_path.exists() or output_path.is_symlink():
+        raise ValueError(f'corrected output path already exists: {output_path}')
+    return output_path
+
+
+def _safe_store_name_component(value: str) -> str:
+    safe = _SAFE_STORE_NAME_RE.sub('_', str(value))
+    if safe in {'', '.', '..'}:
+        raise ValueError('TraceStore name cannot be made filesystem-safe')
+    return safe
+
+
+def _build_corrected_file_payload(
+    *,
+    corrected_file_id: str,
+    store_path: Path,
+    source_file_id: str,
+    source_store_path: Path,
+    job_id: str,
+    key1_byte: int,
+    key2_byte: int,
+    dt: float,
+) -> dict[str, object]:
+    return {
+        'schema_version': 1,
+        'artifact_kind': 'corrected_file',
+        'file_id': corrected_file_id,
+        'store_path': str(store_path),
+        'store_name': store_path.name,
+        'derived_from_file_id': source_file_id,
+        'derived_from_store_path': str(source_store_path),
+        'derived_by': 'residual_static_correction',
+        'applied_to': 'datum_corrected_trace_store',
+        'job_id': job_id,
+        'key1_byte': int(key1_byte),
+        'key2_byte': int(key2_byte),
+        'dt': float(dt),
+        'solution_artifact': SOLUTION_NPZ_NAME,
+        'shift_field': 'applied_residual_shift_s_sorted',
+        'estimated_delay_field': 'estimated_trace_delay_s_sorted',
+        'sign_convention': _SIGN_CONVENTION,
+    }
+
+
+def _write_json_atomic(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.tmp')
+    try:
+        with tmp_path.open('w', encoding='utf-8') as handle:
+            json.dump(
+                payload,
+                handle,
+                allow_nan=False,
+                ensure_ascii=True,
+                sort_keys=True,
+            )
+        tmp_path.replace(path)
+    except Exception:
+        if tmp_path.is_file() or tmp_path.is_symlink():
+            tmp_path.unlink()
+        raise
+
+
+def _cleanup_registration(
+    state: object,
+    *,
+    file_id: str,
+    key1_byte: int,
+    key2_byte: int,
+) -> None:
+    lock = getattr(state, 'lock', None)
+    context = lock if lock is not None else nullcontext()
+    with context:
+        state.file_registry.pop(file_id, None)
+        state.cached_readers.pop(trace_store_cache_key(file_id, key1_byte, key2_byte), None)
+
+
+def _cleanup_store(output_path: Path) -> None:
+    for tmp_path in output_path.parent.glob(f'{output_path.name}.tmp-*'):
+        if tmp_path.is_dir():
+            shutil.rmtree(tmp_path, ignore_errors=True)
+    if output_path.exists():
+        shutil.rmtree(output_path, ignore_errors=True)
+
+
+def _validate_applied_shift_sign(applied: np.ndarray, estimated: np.ndarray) -> None:
+    if not np.allclose(applied, -estimated, rtol=1.0e-7, atol=1.0e-9):
+        raise ValueError(
+            'applied_residual_shift_s_sorted must equal '
+            '-estimated_trace_delay_s_sorted'
+        )
+
+
+def _require_1d_float64(
+    value: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be 1-dimensional')
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        )
+    if not np.issubdtype(arr.dtype, np.floating):
+        raise ValueError(f'{name} must be a float array')
+    out = np.asarray(arr, dtype=np.float64)
+    if not np.all(np.isfinite(out)):
+        raise ValueError(f'{name} must contain only finite values')
+    return np.ascontiguousarray(out, dtype=np.float64)
+
+
+def _require_scalar_int(value: np.ndarray, *, name: str) -> int:
+    arr = np.asarray(value)
+    if arr.shape != ():
+        raise ValueError(f'{name} must be a scalar')
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(f'{name} must be an integer scalar')
+    return _coerce_positive_int(arr.item(), name=name)
+
+
+def _require_scalar_float(value: np.ndarray, *, name: str) -> float:
+    arr = np.asarray(value)
+    if arr.shape != ():
+        raise ValueError(f'{name} must be a scalar')
+    if not np.issubdtype(arr.dtype, np.number):
+        raise ValueError(f'{name} must be a numeric scalar')
+    return _coerce_positive_finite_float(arr.item(), name=name)
+
+
+def _require_scalar_str(value: np.ndarray, *, name: str) -> str:
+    arr = np.asarray(value)
+    if arr.shape != ():
+        raise ValueError(f'{name} must be a scalar')
+    if arr.dtype.kind not in {'U', 'S'}:
+        raise ValueError(f'{name} must be a string scalar')
+    item = arr.item()
+    if isinstance(item, bytes):
+        return item.decode('utf-8')
+    return str(item)
+
+
+def _coerce_positive_int(value: Any, *, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be a positive integer')
+    if not isinstance(value, int | np.integer):
+        raise ValueError(f'{name} must be a positive integer')
+    out = int(value)
+    if out <= 0:
+        raise ValueError(f'{name} must be a positive integer')
+    return out
+
+
+def _coerce_header_byte(value: Any, *, name: str) -> int:
+    out = _coerce_positive_int(value, name=name)
+    if out > 240:
+        raise ValueError(f'{name} must be between 1 and 240')
+    return out
+
+
+def _coerce_positive_finite_float(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be finite and greater than 0')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite and greater than 0') from exc
+    if not np.isfinite(out) or out <= 0.0:
+        raise ValueError(f'{name} must be finite and greater than 0')
+    return out
+
+
+def _coerce_nonnegative_finite_float(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be finite and non-negative')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite and non-negative') from exc
+    if not np.isfinite(out) or out < 0.0:
+        raise ValueError(f'{name} must be finite and non-negative')
+    return out
+
+
+__all__ = [
+    'ResidualStaticCorrectedStoreResult',
+    'ResidualStaticSolutionForApply',
+    'ResidualStaticTraceStoreApplyOptions',
+    'apply_residual_static_correction_to_trace_store',
+    'build_residual_static_derived_metadata',
+    'load_residual_static_solution_for_apply',
+    'validate_residual_static_shift_for_apply',
+]

--- a/app/tests/test_residual_static_corrected_store.py
+++ b/app/tests/test_residual_static_corrected_store.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import app.services.residual_static_corrected_store as svc
+from app.core.state import AppState, create_app_state
+from app.services.residual_static_corrected_store import (
+    ResidualStaticTraceStoreApplyOptions,
+    apply_residual_static_correction_to_trace_store,
+    load_residual_static_solution_for_apply,
+    validate_residual_static_shift_for_apply,
+)
+from app.services.trace_store_registration import trace_store_cache_key
+
+KEY1 = 189
+KEY2 = 193
+SOURCE_FILE_ID = 'datum-corrected-file-id'
+CORRECTED_FILE_ID = 'residual-corrected-file-id'
+JOB_ID = 'bbbb2222-residual-job'
+DT = 0.004
+SIGN_CONVENTION = (
+    'estimated_trace_delay_s=source_delay_s+receiver_delay_s; '
+    'applied_residual_shift_s=-estimated_trace_delay_s; '
+    'corrected(t)=raw(t-shift_s)'
+)
+
+
+def _datum_component() -> dict[str, object]:
+    return {
+        'name': 'datum_static_correction',
+        'job_id': 'aaaa1111-datum-job',
+        'solution_artifact': 'datum_static_solution.npz',
+        'shift_field': 'trace_shift_s_sorted',
+        'value_kind': 'applied_event_time_shift_s',
+    }
+
+
+def _write_datum_store(
+    store: Path,
+    *,
+    traces: np.ndarray | None = None,
+    dt: float = DT,
+    derived: dict[str, object] | None = None,
+    original_segy_path: str = '/data/line001.sgy',
+    source_sha256: str | None = 'datum-source-sha',
+) -> np.ndarray:
+    store.mkdir(parents=True, exist_ok=True)
+    if traces is None:
+        traces = np.zeros((3, 120), dtype=np.float32)
+        traces[:, 100] = 1.0
+    traces = np.asarray(traces, dtype=np.float32)
+    n_traces, n_samples = traces.shape
+    np.save(store / 'traces.npy', traces)
+    np.savez(
+        store / 'index.npz',
+        key1_values=np.asarray([100], dtype=np.int64),
+        key1_offsets=np.asarray([0], dtype=np.int64),
+        key1_counts=np.asarray([n_traces], dtype=np.int64),
+        sorted_to_original=np.arange(n_traces, dtype=np.int64),
+    )
+    np.save(store / f'headers_byte_{KEY1}.npy', np.full(n_traces, 100, dtype=np.int32))
+    np.save(store / f'headers_byte_{KEY2}.npy', np.arange(n_traces, dtype=np.int32))
+
+    if derived is None:
+        derived = {
+            'kind': 'time_shifted_trace_store',
+            'from_file_id': 'raw-file-id',
+            'components': [_datum_component()],
+        }
+    meta = {
+        'schema_version': 1,
+        'dtype': 'float32',
+        'n_traces': int(n_traces),
+        'n_samples': int(n_samples),
+        'key_bytes': {'key1': KEY1, 'key2': KEY2},
+        'sorted_by': ['key1', 'key2'],
+        'dt': float(dt),
+        'original_segy_path': original_segy_path,
+        'source_sha256': source_sha256,
+        'derived': derived,
+    }
+    (store / 'meta.json').write_text(json.dumps(meta), encoding='utf-8')
+    return traces
+
+
+def _write_solution(
+    path: Path,
+    *,
+    n_traces: int,
+    applied: np.ndarray | None = None,
+    estimated: np.ndarray | None = None,
+    dt: float = DT,
+    key1_byte: int = KEY1,
+    key2_byte: int = KEY2,
+    include_shift: bool = True,
+) -> Path:
+    if estimated is None:
+        estimated = np.zeros(n_traces, dtype=np.float64)
+    if applied is None:
+        applied = -np.asarray(estimated, dtype=np.float64)
+    payload: dict[str, Any] = {
+        'estimated_trace_delay_s_sorted': np.asarray(estimated, dtype=np.float64),
+        'dt': np.asarray(dt, dtype=np.float64),
+        'n_traces': np.asarray(n_traces, dtype=np.int64),
+        'key1_byte': np.asarray(key1_byte, dtype=np.int64),
+        'key2_byte': np.asarray(key2_byte, dtype=np.int64),
+        'sign_convention': np.asarray(SIGN_CONVENTION, dtype=np.str_),
+    }
+    if include_shift:
+        payload['applied_residual_shift_s_sorted'] = np.asarray(
+            applied,
+            dtype=np.float64,
+        )
+    np.savez(path, **payload)
+    return path
+
+
+def _state_with_store(tmp_path: Path, **store_kwargs: Any) -> tuple[AppState, Path]:
+    state = create_app_state()
+    store = tmp_path / 'line001.sgy.statics.datum.aaaa1111'
+    _write_datum_store(store, **store_kwargs)
+    state.file_registry.update(SOURCE_FILE_ID, store_path=str(store), dt=DT)
+    return state, store
+
+
+def _apply(
+    tmp_path: Path,
+    state: AppState,
+    store: Path,
+    solution_path: Path,
+    *,
+    options: ResidualStaticTraceStoreApplyOptions | None = None,
+) -> svc.ResidualStaticCorrectedStoreResult:
+    return apply_residual_static_correction_to_trace_store(
+        source_file_id=SOURCE_FILE_ID,
+        source_store_path=store,
+        key1_byte=KEY1,
+        key2_byte=KEY2,
+        residual_solution_npz_path=solution_path,
+        artifacts_dir=tmp_path / 'job',
+        job_id=JOB_ID,
+        state=state,
+        options=options or ResidualStaticTraceStoreApplyOptions(),
+        corrected_file_id=CORRECTED_FILE_ID,
+    )
+
+
+def test_load_residual_solution_for_apply_validates_required_fields(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=2,
+        estimated=np.asarray([0.001, -0.002], dtype=np.float64),
+    )
+
+    solution = load_residual_static_solution_for_apply(
+        solution_path,
+        expected_n_traces=2,
+        expected_dt=DT,
+        expected_key1_byte=KEY1,
+        expected_key2_byte=KEY2,
+    )
+
+    np.testing.assert_allclose(
+        solution.applied_residual_shift_s_sorted,
+        np.asarray([-0.001, 0.002], dtype=np.float64),
+    )
+    np.testing.assert_allclose(
+        solution.estimated_trace_delay_s_sorted,
+        np.asarray([0.001, -0.002], dtype=np.float64),
+    )
+    assert solution.sign_convention == SIGN_CONVENTION
+
+
+def test_load_residual_solution_for_apply_rejects_missing_shift(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=2,
+        include_shift=False,
+    )
+
+    with pytest.raises(ValueError, match='applied_residual_shift_s_sorted'):
+        load_residual_static_solution_for_apply(
+            solution_path,
+            expected_n_traces=2,
+            expected_dt=DT,
+            expected_key1_byte=KEY1,
+            expected_key2_byte=KEY2,
+        )
+
+
+def test_load_residual_solution_for_apply_rejects_shape_mismatch(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+        estimated=np.asarray([0.0, 0.0, 0.0], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match='shape mismatch'):
+        load_residual_static_solution_for_apply(
+            solution_path,
+            expected_n_traces=2,
+            expected_dt=DT,
+            expected_key1_byte=KEY1,
+            expected_key2_byte=KEY2,
+        )
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf])
+def test_load_residual_solution_for_apply_rejects_nan_or_inf_shift(
+    tmp_path: Path,
+    bad_value: float,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=2,
+        applied=np.asarray([0.0, bad_value], dtype=np.float64),
+        estimated=np.asarray([0.0, 0.0], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match='finite'):
+        load_residual_static_solution_for_apply(
+            solution_path,
+            expected_n_traces=2,
+            expected_dt=DT,
+            expected_key1_byte=KEY1,
+            expected_key2_byte=KEY2,
+        )
+
+
+def test_load_residual_solution_for_apply_rejects_sign_mismatch(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=2,
+        applied=np.asarray([0.001, 0.0], dtype=np.float64),
+        estimated=np.asarray([0.001, 0.0], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match='must equal'):
+        load_residual_static_solution_for_apply(
+            solution_path,
+            expected_n_traces=2,
+            expected_dt=DT,
+            expected_key1_byte=KEY1,
+            expected_key2_byte=KEY2,
+        )
+
+
+def test_residual_shift_rejects_large_shift_without_clip(tmp_path: Path) -> None:
+    solution = load_residual_static_solution_for_apply(
+        _write_solution(
+            tmp_path / 'residual_static_solution.npz',
+            n_traces=2,
+            estimated=np.asarray([0.0, 0.251], dtype=np.float64),
+        ),
+        expected_n_traces=2,
+        expected_dt=DT,
+        expected_key1_byte=KEY1,
+        expected_key2_byte=KEY2,
+    )
+
+    with pytest.raises(ValueError, match='max_abs_shift_ms'):
+        validate_residual_static_shift_for_apply(solution, max_abs_shift_ms=250.0)
+
+    np.testing.assert_allclose(
+        solution.applied_residual_shift_s_sorted,
+        np.asarray([-0.0, -0.251], dtype=np.float64),
+    )
+
+
+def test_residual_corrected_store_applies_opposite_sign_shift_to_impulse(
+    tmp_path: Path,
+) -> None:
+    traces = np.zeros((1, 128), dtype=np.float32)
+    traces[0, 100] = 1.0
+    state, store = _state_with_store(tmp_path, traces=traces)
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=1,
+        estimated=np.asarray([0.008], dtype=np.float64),
+    )
+
+    result = _apply(tmp_path, state, store, solution_path)
+
+    corrected = np.load(result.store_path / 'traces.npy')
+    assert int(np.argmax(corrected[0])) == 98
+    assert corrected[0, 98] == pytest.approx(1.0)
+    assert corrected[0, 100] == pytest.approx(0.0)
+
+
+def test_residual_corrected_store_registers_new_file_id(tmp_path: Path) -> None:
+    state, store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+    )
+
+    result = _apply(tmp_path, state, store, solution_path)
+
+    assert result.file_id == CORRECTED_FILE_ID
+    assert result.store_name == (
+        'line001.sgy.statics.datum.aaaa1111.statics.residual.bbbb2222'
+    )
+    assert state.file_registry.get_store_path(CORRECTED_FILE_ID) == str(
+        result.store_path
+    )
+    assert state.file_registry.get_dt(CORRECTED_FILE_ID) == pytest.approx(DT)
+    with state.lock:
+        cache_key = trace_store_cache_key(CORRECTED_FILE_ID, KEY1, KEY2)
+        assert cache_key in state.cached_readers
+        reader = state.cached_readers[cache_key]
+    assert reader.get_section(100).arr.shape == (3, 120)
+
+
+def test_residual_corrected_store_writes_corrected_file_json(
+    tmp_path: Path,
+) -> None:
+    state, store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+    )
+
+    result = _apply(tmp_path, state, store, solution_path)
+    payload = json.loads(result.corrected_file_json_path.read_text(encoding='utf-8'))
+
+    json.dumps(payload, allow_nan=False)
+    assert payload['schema_version'] == 1
+    assert payload['artifact_kind'] == 'corrected_file'
+    assert payload['file_id'] == CORRECTED_FILE_ID
+    assert payload['store_path'] == str(result.store_path)
+    assert payload['derived_from_file_id'] == SOURCE_FILE_ID
+    assert payload['derived_by'] == 'residual_static_correction'
+    assert payload['applied_to'] == 'datum_corrected_trace_store'
+    assert payload['shift_field'] == 'applied_residual_shift_s_sorted'
+    assert payload['estimated_delay_field'] == 'estimated_trace_delay_s_sorted'
+    assert not (tmp_path / 'job' / 'corrected_file.json.tmp').exists()
+
+
+def test_residual_corrected_store_meta_appends_residual_component(
+    tmp_path: Path,
+) -> None:
+    state, store = _state_with_store(tmp_path, original_segy_path='/keep/source.sgy')
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+    )
+
+    result = _apply(tmp_path, state, store, solution_path)
+    meta = json.loads((result.store_path / 'meta.json').read_text(encoding='utf-8'))
+
+    assert meta['original_segy_path'] == '/keep/source.sgy'
+    assert meta['source_sha256'] is None
+    components = meta['derived']['components']
+    assert [component['name'] for component in components] == [
+        'datum_static_correction',
+        'residual_static_correction',
+    ]
+    assert components[-1]['job_id'] == JOB_ID
+    assert components[-1]['shift_field'] == 'applied_residual_shift_s_sorted'
+    assert meta['derived']['applied_to'] == 'datum_corrected_trace_store'
+
+
+def test_residual_corrected_store_rejects_non_datum_source_store(
+    tmp_path: Path,
+) -> None:
+    state, store = _state_with_store(tmp_path, derived={'kind': 'raw_trace_store'})
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+    )
+
+    with pytest.raises(ValueError, match='datum static lineage'):
+        _apply(tmp_path, state, store, solution_path)
+
+
+def test_residual_corrected_store_rejects_double_residual_application(
+    tmp_path: Path,
+) -> None:
+    derived = {
+        'kind': 'time_shifted_trace_store',
+        'components': [
+            _datum_component(),
+            {'name': 'residual_static_correction', 'job_id': 'old-job'},
+        ],
+    }
+    state, store = _state_with_store(tmp_path, derived=derived)
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+    )
+
+    with pytest.raises(ValueError, match='already has residual_static_correction'):
+        _apply(tmp_path, state, store, solution_path)
+
+
+def test_residual_corrected_store_rejects_output_dtype_other_than_float32(
+    tmp_path: Path,
+) -> None:
+    state, store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+    )
+
+    with pytest.raises(ValueError, match='output_dtype'):
+        _apply(
+            tmp_path,
+            state,
+            store,
+            solution_path,
+            options=ResidualStaticTraceStoreApplyOptions(output_dtype='float64'),
+        )
+
+
+def test_residual_corrected_store_rejects_register_false(tmp_path: Path) -> None:
+    state, store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+    )
+
+    with pytest.raises(ValueError, match='register_corrected_file'):
+        _apply(
+            tmp_path,
+            state,
+            store,
+            solution_path,
+            options=ResidualStaticTraceStoreApplyOptions(register_corrected_file=False),
+        )
+
+
+def test_residual_corrected_store_does_not_leave_partial_store_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'residual_static_solution.npz',
+        n_traces=3,
+    )
+
+    def _fail_register(**_kwargs: Any) -> None:
+        raise RuntimeError('registration failed')
+
+    monkeypatch.setattr(svc, 'register_trace_store', _fail_register)
+
+    with pytest.raises(RuntimeError, match='registration failed'):
+        _apply(tmp_path, state, store, solution_path)
+
+    output = tmp_path / (
+        'line001.sgy.statics.datum.aaaa1111.statics.residual.bbbb2222'
+    )
+    assert not output.exists()
+    assert list(tmp_path.glob(f'{output.name}.tmp-*')) == []
+    assert state.file_registry.get_record(CORRECTED_FILE_ID) is None
+    with state.lock:
+        assert trace_store_cache_key(CORRECTED_FILE_ID, KEY1, KEY2) not in (
+            state.cached_readers
+        )


### PR DESCRIPTION
Closes #326

## Summary
- PR4-8 [statics residual] estimated delay を applied residual shift に変換して補正済み TraceStore を生成・登録する

## Changed files
- `app/services/corrected_trace_store.py`
- `app/services/datum_static_service.py`
- `app/services/residual_static_corrected_store.py`
- `app/tests/test_residual_static_corrected_store.py`

## Checks
- `.work/codex/checks.log`: 970 passed in 45.64s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
