### PR TITLE
# PR4-9 [statics residual] /statics/residual/apply job endpoint と lifecycle/cancel/download を統合する

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -15,6 +15,8 @@ from app.api.schemas import (
     DatumStaticApplyResponse,
     FirstBreakQcJobResponse,
     FirstBreakQcRequest,
+    ResidualStaticApplyRequest,
+    ResidualStaticApplyResponse,
     StaticJobFilesResponse,
     StaticJobStatusResponse,
 )
@@ -25,6 +27,7 @@ from app.services.in_memory_cleanup import cleanup_in_memory_state
 from app.services.job_manager import JobManager
 from app.services.job_runner import request_job_cancel, start_job_thread
 from app.services.pipeline_artifacts import get_job_dir, maybe_cleanup_expired_jobs
+from app.services.residual_static_service import run_residual_static_apply_job
 
 router = APIRouter()
 
@@ -115,6 +118,39 @@ def first_break_qc(
     start_job_thread(
         thread_factory=threading.Thread,
         target=run_first_break_qc_job,
+        args=(job_id, req, state),
+    )
+
+    return {'job_id': job_id, 'state': status}
+
+
+@router.post(
+    '/statics/residual/apply',
+    response_model=ResidualStaticApplyResponse,
+)
+def residual_static_apply(
+    req: ResidualStaticApplyRequest,
+    request: Request,
+) -> ResidualStaticApplyResponse:
+    state = get_state(request.app)
+    cleanup_in_memory_state(state)
+    maybe_cleanup_expired_jobs()
+
+    job_id = str(uuid4())
+    with state.lock:
+        job_state = state.jobs.create_static_job(
+            job_id,
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            statics_kind='residual',
+            artifacts_dir=str(get_job_dir(job_id)),
+        )
+        status = job_state['status']
+
+    start_job_thread(
+        thread_factory=threading.Thread,
+        target=run_residual_static_apply_job,
         args=(job_id, req, state),
     )
 

--- a/app/services/residual_static_corrected_store.py
+++ b/app/services/residual_static_corrected_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextlib import nullcontext
 from dataclasses import dataclass
 import json
@@ -253,9 +254,13 @@ def apply_residual_static_correction_to_trace_store(
     state: object,
     options: ResidualStaticTraceStoreApplyOptions,
     corrected_file_id: str | None = None,
+    progress_callback: Callable[[float, str], None] | None = None,
+    cancel_check: Callable[[], bool] | None = None,
 ) -> ResidualStaticCorrectedStoreResult:
     """Create, register, and describe a residual-corrected TraceStore."""
     _validate_apply_options(options)
+    _notify_progress(progress_callback, 0.0, 'validating_residual_static_trace_shift')
+    _raise_if_cancelled(cancel_check)
     source_path = Path(source_store_path)
     _validate_registry_source_path(
         state=state,
@@ -278,6 +283,7 @@ def apply_residual_static_correction_to_trace_store(
         solution,
         max_abs_shift_ms=options.max_abs_shift_ms,
     )
+    _raise_if_cancelled(cancel_check)
 
     resolved_file_id = str(corrected_file_id or uuid4())
     output_store_path = _corrected_store_path(
@@ -293,8 +299,18 @@ def apply_residual_static_correction_to_trace_store(
     )
     corrected_file_json_path = Path(artifacts_dir) / _CORRECTED_FILE_NAME
 
+    def builder_progress_callback(progress: float, message: str) -> None:
+        mapped = 0.10 + (0.75 * max(0.0, min(1.0, float(progress))))
+        _notify_progress(progress_callback, mapped, message)
+
     build_result = None
     try:
+        _notify_progress(
+            progress_callback,
+            0.10,
+            'building_residual_corrected_trace_store',
+        )
+        _raise_if_cancelled(cancel_check)
         build_result = build_time_shifted_trace_store(
             source_store_path=source_path,
             output_store_path=output_store_path,
@@ -304,7 +320,20 @@ def apply_residual_static_correction_to_trace_store(
             derived_metadata=derived_metadata,
             from_file_id=source_file_id,
             original_segy_path=source_meta.original_segy_path,
+            progress_callback=(
+                builder_progress_callback
+                if progress_callback is not None
+                else None
+            ),
+            cancel_check=cancel_check,
         )
+        _raise_if_cancelled(cancel_check)
+        _notify_progress(
+            progress_callback,
+            0.90,
+            'registering_residual_corrected_trace_store',
+        )
+        _raise_if_cancelled(cancel_check)
         register_trace_store(
             state=state,
             file_id=resolved_file_id,
@@ -315,6 +344,8 @@ def apply_residual_static_correction_to_trace_store(
             update_registry=True,
             touch_meta=True,
         )
+        _raise_if_cancelled(cancel_check)
+        _notify_progress(progress_callback, 0.97, 'writing_corrected_file_manifest')
         _write_json_atomic(
             corrected_file_json_path,
             _build_corrected_file_payload(
@@ -350,6 +381,21 @@ def apply_residual_static_correction_to_trace_store(
         key2_byte=key2_byte,
         dt=build_result.dt,
     )
+
+
+def _notify_progress(
+    progress_callback: Callable[[float, str], None] | None,
+    progress: float,
+    message: str,
+) -> None:
+    if progress_callback is None:
+        return
+    progress_callback(float(progress), message)
+
+
+def _raise_if_cancelled(cancel_check: Callable[[], bool] | None) -> None:
+    if cancel_check is not None and cancel_check():
+        raise RuntimeError('residual static TraceStore apply cancelled')
 
 
 def _validate_apply_options(options: ResidualStaticTraceStoreApplyOptions) -> None:

--- a/app/services/residual_static_service.py
+++ b/app/services/residual_static_service.py
@@ -1,0 +1,393 @@
+"""Residual static correction background job service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import time
+from typing import Any
+from uuid import uuid4
+
+import numpy as np
+
+from app.api.schemas import ResidualStaticApplyRequest
+from app.core.state import AppState
+from app.services.job_runner import (
+    JobCancelledError,
+    JobCompletion,
+    JobFailure,
+    ensure_job_not_cancelled,
+    run_job_with_lifecycle,
+)
+from app.services.pipeline_artifacts import get_job_dir
+from app.services.reader import get_reader
+from app.services.residual_static_artifacts import (
+    QC_JSON_NAME,
+    SOLUTION_NPZ_NAME,
+    STATICS_CSV_NAME,
+    ResidualStaticArtifactMetadata,
+    write_residual_static_artifacts,
+)
+from app.services.residual_static_corrected_store import (
+    ResidualStaticTraceStoreApplyOptions,
+    apply_residual_static_correction_to_trace_store,
+)
+from app.services.residual_static_inputs import (
+    build_residual_static_solver_inputs,
+    load_residual_static_pick_source,
+    resolve_residual_static_input_artifacts,
+)
+from app.services.residual_static_robust_solver import (
+    robust_options_from_request_robust,
+    solve_residual_static_robust_least_squares,
+)
+from app.services.residual_static_sparse_solver import (
+    stabilization_options_from_request_solver,
+)
+
+_CORRECTED_FILE_NAME = 'corrected_file.json'
+
+
+@dataclass
+class _ResidualStaticLifecycle:
+    created_ts: float
+    job_dir: Path | None = None
+    corrected_file_id: str | None = None
+    corrected_store_path: Path | None = None
+
+
+def _resolve_created_ts(state: AppState, job_id: str) -> float:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        if job is None:
+            return time.time()
+        created_ts_obj = job.get('created_ts')
+    return (
+        float(created_ts_obj)
+        if isinstance(created_ts_obj, (int, float))
+        else time.time()
+    )
+
+
+def _resolve_job_dir(state: AppState, job_id: str) -> Path:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        artifacts_dir = job.get('artifacts_dir') if isinstance(job, dict) else None
+    if isinstance(artifacts_dir, str) and artifacts_dir:
+        return Path(artifacts_dir)
+    return get_job_dir(job_id)
+
+
+def _set_job_progress_message(
+    state: AppState,
+    job_id: str,
+    *,
+    progress: float,
+    message: str,
+) -> None:
+    with state.lock:
+        if state.jobs.get(job_id) is None:
+            return
+        state.jobs.set_progress(job_id, progress)
+        state.jobs.set_message(job_id, message)
+
+
+def _is_cancel_requested(state: AppState, job_id: str) -> bool:
+    with state.lock:
+        return state.jobs.is_cancel_requested(job_id)
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+    try:
+        tmp_path.write_text(
+            json.dumps(
+                payload,
+                allow_nan=False,
+                ensure_ascii=True,
+                sort_keys=True,
+            ),
+            encoding='utf-8',
+        )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _write_job_meta(
+    *,
+    job_id: str,
+    job_dir: Path,
+    req: ResidualStaticApplyRequest,
+) -> None:
+    _write_json_atomic(
+        job_dir / 'job_meta.json',
+        {
+            'job_id': job_id,
+            'job_type': 'statics',
+            'statics_kind': 'residual',
+            'source_file_id': req.file_id,
+            'key1_byte': req.key1_byte,
+            'key2_byte': req.key2_byte,
+            'request': req.model_dump(mode='json'),
+            'inputs': {
+                'datum_solution': req.datum_solution.model_dump(mode='json'),
+                'pick_source': req.pick_source.model_dump(
+                    mode='json',
+                    exclude_none=True,
+                ),
+                'geometry': req.geometry.model_dump(mode='json'),
+                'offset': req.offset.model_dump(mode='json'),
+                'moveout': req.moveout.model_dump(mode='json'),
+            },
+            'solver': req.solver.model_dump(mode='json'),
+            'robust': req.robust.model_dump(mode='json'),
+            'apply': req.apply.model_dump(mode='json'),
+            'artifacts': {
+                'solution_npz': SOLUTION_NPZ_NAME,
+                'qc_json': QC_JSON_NAME,
+                'statics_csv': STATICS_CSV_NAME,
+                'corrected_file_json': _CORRECTED_FILE_NAME,
+            },
+        },
+    )
+
+
+def _reader_n_samples(reader: object) -> int:
+    getter = getattr(reader, 'get_n_samples', None)
+    if callable(getter):
+        n_samples = int(getter())
+    else:
+        traces = getattr(reader, 'traces', None)
+        shape = getattr(traces, 'shape', ())
+        if len(shape) < 2:
+            raise ValueError('reader cannot provide number of samples')
+        n_samples = int(shape[-1])
+    if n_samples <= 0:
+        raise ValueError('reader n_samples must be greater than 0')
+    return n_samples
+
+
+def _resolve_dt(state: AppState, file_id: str) -> float:
+    dt = float(state.file_registry.get_dt(file_id))
+    if not np.isfinite(dt) or dt <= 0.0:
+        raise ValueError('dt must be finite and greater than 0')
+    return dt
+
+
+def _apply_options_from_request(
+    req: ResidualStaticApplyRequest,
+) -> ResidualStaticTraceStoreApplyOptions:
+    return ResidualStaticTraceStoreApplyOptions(
+        interpolation=req.apply.interpolation,
+        fill_value=req.apply.fill_value,
+        max_abs_shift_ms=req.apply.max_abs_shift_ms,
+        output_dtype=req.apply.output_dtype,
+        register_corrected_file=req.apply.register_corrected_file,
+    )
+
+
+def _run_residual_static_apply_job_body(
+    job_id: str,
+    req: ResidualStaticApplyRequest,
+    state: AppState,
+    *,
+    lifecycle: _ResidualStaticLifecycle,
+) -> JobCompletion | None:
+    job_dir = _resolve_job_dir(state, job_id)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    lifecycle.job_dir = job_dir
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.02,
+        message='preparing_residual_static_job',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    _write_job_meta(job_id=job_id, job_dir=job_dir, req=req)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.05,
+        message='resolving_residual_static_inputs',
+    )
+    reader = get_reader(req.file_id, req.key1_byte, req.key2_byte, state=state)
+    source_store_path = Path(state.file_registry.get_store_path(req.file_id))
+    dt = _resolve_dt(state, req.file_id)
+    n_samples = _reader_n_samples(reader)
+    artifacts = resolve_residual_static_input_artifacts(state, req)
+    ensure_job_not_cancelled(state, job_id)
+    pick_source = load_residual_static_pick_source(
+        req=req,
+        artifacts=artifacts,
+        reader=reader,
+        expected_dt=dt,
+        expected_n_samples=n_samples,
+        state=state,
+    )
+    ensure_job_not_cancelled(state, job_id)
+    inputs = build_residual_static_solver_inputs(
+        req=req,
+        artifacts=artifacts,
+        pick_source=pick_source,
+        reader=reader,
+        expected_dt=dt,
+        expected_n_samples=n_samples,
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.20,
+        message='solving_residual_static_delays',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    robust_result = solve_residual_static_robust_least_squares(
+        inputs,
+        stabilization_options=stabilization_options_from_request_solver(req.solver),
+        robust_options=robust_options_from_request_robust(req.robust),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.45,
+        message='writing_residual_static_artifacts',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    artifact_paths = write_residual_static_artifacts(
+        job_dir,
+        inputs,
+        robust_result,
+        metadata=ResidualStaticArtifactMetadata(
+            job_id=job_id,
+            input_file_id=req.file_id,
+            datum_source_file_id=artifacts.datum_source_file_id,
+            datum_job_id=artifacts.datum_job_id,
+            datum_solution_artifact=req.datum_solution.name,
+            pick_source_kind=inputs.pick_source_kind,
+            pick_source_artifact=artifacts.pick_source_artifact_name,
+        ),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    def progress_callback(apply_progress: float, message: str) -> None:
+        progress_value = max(0.0, min(1.0, float(apply_progress)))
+        if message == 'registering_residual_corrected_trace_store':
+            mapped_progress = 0.90
+            mapped_message = message
+        else:
+            mapped_progress = 0.60 + (0.30 * progress_value)
+            mapped_message = 'applying_residual_static_trace_shift'
+        _set_job_progress_message(
+            state,
+            job_id,
+            progress=mapped_progress,
+            message=mapped_message,
+        )
+
+    def cancel_check() -> bool:
+        return _is_cancel_requested(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.60,
+        message='applying_residual_static_trace_shift',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    try:
+        corrected_result = apply_residual_static_correction_to_trace_store(
+            source_file_id=req.file_id,
+            source_store_path=source_store_path,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            residual_solution_npz_path=artifact_paths.solution_npz_path,
+            artifacts_dir=job_dir,
+            job_id=job_id,
+            state=state,
+            options=_apply_options_from_request(req),
+            progress_callback=progress_callback,
+            cancel_check=cancel_check,
+        )
+    except RuntimeError as exc:
+        if 'cancelled' in str(exc).lower() and cancel_check():
+            raise JobCancelledError() from exc
+        raise
+
+    lifecycle.corrected_file_id = corrected_result.file_id
+    lifecycle.corrected_store_path = corrected_result.store_path
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.90,
+        message='registering_residual_corrected_trace_store',
+    )
+    with state.lock:
+        state.jobs.set_static_corrected_file(
+            job_id,
+            corrected_file_id=corrected_result.file_id,
+            corrected_store_path=str(corrected_result.store_path),
+        )
+    _set_job_progress_message(state, job_id, progress=1.0, message='done')
+    return JobCompletion(finished_ts=time.time())
+
+
+def _handle_residual_static_job_error(
+    *,
+    lifecycle: _ResidualStaticLifecycle,
+) -> JobFailure:
+    return JobFailure(finished_ts=time.time())
+
+
+def _handle_residual_static_job_cancel(
+    *,
+    lifecycle: _ResidualStaticLifecycle,
+    exc: JobCancelledError,
+) -> JobCompletion:
+    finished_ts = float(exc.finished_ts) if exc.finished_ts is not None else time.time()
+    return JobCompletion(finished_ts=finished_ts)
+
+
+def run_residual_static_apply_job(
+    job_id: str,
+    req: ResidualStaticApplyRequest,
+    state: AppState,
+) -> None:
+    """Run one residual static correction job and register the corrected TraceStore."""
+    lifecycle = _ResidualStaticLifecycle(created_ts=_resolve_created_ts(state, job_id))
+
+    def worker() -> JobCompletion | None:
+        return _run_residual_static_apply_job_body(
+            job_id=job_id,
+            req=req,
+            state=state,
+            lifecycle=lifecycle,
+        )
+
+    run_job_with_lifecycle(
+        state=state,
+        job_id=job_id,
+        worker=worker,
+        progress_1_on_done=True,
+        start_progress=0.0,
+        clear_message_on_start=True,
+        on_error=lambda _exc: _handle_residual_static_job_error(
+            lifecycle=lifecycle,
+        ),
+        on_cancel=lambda exc: _handle_residual_static_job_cancel(
+            lifecycle=lifecycle,
+            exc=exc,
+        ),
+    )
+
+
+__all__ = ['run_residual_static_apply_job']

--- a/app/tests/test_residual_static_job_api.py
+++ b/app/tests/test_residual_static_job_api.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.routers.statics as statics_router_module
+import app.services.residual_static_service as residual_service
+from app.api.schemas import ResidualStaticApplyRequest
+from app.main import app
+from app.services.residual_static_artifacts import ResidualStaticArtifactPaths
+from app.services.residual_static_corrected_store import (
+    ResidualStaticCorrectedStoreResult,
+)
+from app.services.residual_static_inputs import ResidualStaticResolvedArtifacts
+
+FILE_ID = 'datum-corrected-file-id'
+SOURCE_FILE_ID = 'raw-source-file-id'
+DATUM_JOB_ID = 'datum-static-job-id'
+PICK_JOB_ID = 'batch-pick-job-id'
+KEY1_BYTE = 189
+KEY2_BYTE = 193
+DT = 0.004
+
+
+class _Reader:
+    key1_byte = KEY1_BYTE
+    key2_byte = KEY2_BYTE
+
+    def __init__(self) -> None:
+        self.traces = np.zeros((4, 16), dtype=np.float32)
+        self.meta = {'dt': DT}
+
+    def get_n_samples(self) -> int:
+        return int(self.traces.shape[-1])
+
+
+class _Inputs:
+    pick_source_kind = 'batch_npz'
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv('PIPELINE_JOBS_DIR', str(tmp_path / 'jobs'))
+    state = app.state.sv
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        'file_id': FILE_ID,
+        'key1_byte': KEY1_BYTE,
+        'key2_byte': KEY2_BYTE,
+        'datum_solution': {
+            'job_id': DATUM_JOB_ID,
+            'name': 'datum_static_solution.npz',
+        },
+        'pick_source': {
+            'kind': 'batch_job_artifact',
+            'job_id': PICK_JOB_ID,
+            'name': 'predicted_picks_time_s.npz',
+        },
+        'geometry': {
+            'source_id_byte': 17,
+            'receiver_id_byte': 13,
+        },
+        'offset': {'offset_byte': 37},
+        'moveout': {'model': 'linear_abs_offset'},
+        'solver': {
+            'gauge': 'zero_mean_source_receiver',
+            'damping_lambda': 0.0,
+            'min_valid_picks': 10,
+            'min_picks_per_source': 1,
+            'min_picks_per_receiver': 1,
+            'max_abs_estimated_delay_ms': 250.0,
+        },
+        'robust': {
+            'enabled': True,
+            'method': 'mad',
+            'max_iterations': 3,
+            'threshold': 4.0,
+            'min_used_fraction': 0.5,
+        },
+        'apply': {
+            'interpolation': 'linear',
+            'fill_value': 0.0,
+            'max_abs_shift_ms': 250.0,
+            'output_dtype': 'float32',
+            'register_corrected_file': True,
+        },
+    }
+
+
+def _request(**overrides: Any) -> ResidualStaticApplyRequest:
+    payload = _payload()
+    payload.update(overrides)
+    return ResidualStaticApplyRequest.model_validate(payload)
+
+
+def _create_residual_job(client: TestClient, tmp_path: Path) -> tuple[str, Path, Path]:
+    job_id = 'residual-job-id'
+    job_dir = tmp_path / 'residual-job'
+    source_store = tmp_path / 'datum-corrected-store'
+    source_store.mkdir()
+    state = client.app.state.sv
+    state.file_registry.update(FILE_ID, store_path=source_store, dt=DT)
+    with state.lock:
+        state.jobs.create_static_job(
+            job_id,
+            file_id=FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='residual',
+            artifacts_dir=str(job_dir),
+        )
+    return job_id, job_dir, source_store
+
+
+def _install_success_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    calls: list[str],
+) -> None:
+    def _get_reader(*args: Any, **kwargs: Any) -> _Reader:
+        calls.append('get_reader')
+        return _Reader()
+
+    def _resolve_artifacts(*args: Any, **kwargs: Any) -> ResidualStaticResolvedArtifacts:
+        calls.append('resolve_artifacts')
+        datum_path = tmp_path / 'datum_static_solution.npz'
+        pick_path = tmp_path / 'predicted_picks_time_s.npz'
+        datum_path.write_bytes(b'datum')
+        pick_path.write_bytes(b'picks')
+        return ResidualStaticResolvedArtifacts(
+            datum_solution_path=datum_path,
+            pick_artifact_path=pick_path,
+            datum_job_id=DATUM_JOB_ID,
+            datum_source_file_id=SOURCE_FILE_ID,
+            datum_corrected_file_id=FILE_ID,
+            pick_source_artifact_name='predicted_picks_time_s.npz',
+        )
+
+    def _load_pick_source(*args: Any, **kwargs: Any) -> object:
+        calls.append('load_pick_source')
+        return object()
+
+    def _build_inputs(*args: Any, **kwargs: Any) -> _Inputs:
+        calls.append('build_inputs')
+        return _Inputs()
+
+    def _solve(*args: Any, **kwargs: Any) -> object:
+        calls.append('solve')
+        return object()
+
+    def _write_artifacts(
+        job_dir: Path,
+        *args: Any,
+        **kwargs: Any,
+    ) -> ResidualStaticArtifactPaths:
+        calls.append('write_artifacts')
+        solution = job_dir / 'residual_static_solution.npz'
+        qc = job_dir / 'residual_static_qc.json'
+        csv = job_dir / 'residual_statics.csv'
+        solution.write_bytes(b'solution')
+        qc.write_text('{"ok":true}', encoding='utf-8')
+        csv.write_text('trace,shift\n', encoding='utf-8')
+        return ResidualStaticArtifactPaths(
+            solution_npz_path=solution,
+            qc_json_path=qc,
+            statics_csv_path=csv,
+        )
+
+    def _apply_trace_store(**kwargs: Any) -> ResidualStaticCorrectedStoreResult:
+        calls.append('apply_trace_store')
+        progress_callback = kwargs.get('progress_callback')
+        if callable(progress_callback):
+            progress_callback(1.0, 'registering_residual_corrected_trace_store')
+        artifacts_dir = Path(kwargs['artifacts_dir'])
+        corrected_file = artifacts_dir / 'corrected_file.json'
+        corrected_store = tmp_path / 'residual-corrected-store'
+        corrected_store.mkdir(exist_ok=True)
+        corrected_file.write_text(
+            json.dumps({'file_id': 'residual-corrected-file-id'}),
+            encoding='utf-8',
+        )
+        return ResidualStaticCorrectedStoreResult(
+            file_id='residual-corrected-file-id',
+            store_path=corrected_store,
+            store_name=corrected_store.name,
+            corrected_file_json_path=corrected_file,
+            derived_from_file_id=FILE_ID,
+            derived_from_store_path=Path(kwargs['source_store_path']),
+            job_id=kwargs['job_id'],
+            key1_byte=kwargs['key1_byte'],
+            key2_byte=kwargs['key2_byte'],
+            dt=DT,
+        )
+
+    monkeypatch.setattr(residual_service, 'get_reader', _get_reader)
+    monkeypatch.setattr(
+        residual_service,
+        'resolve_residual_static_input_artifacts',
+        _resolve_artifacts,
+    )
+    monkeypatch.setattr(
+        residual_service,
+        'load_residual_static_pick_source',
+        _load_pick_source,
+    )
+    monkeypatch.setattr(
+        residual_service,
+        'build_residual_static_solver_inputs',
+        _build_inputs,
+    )
+    monkeypatch.setattr(
+        residual_service,
+        'solve_residual_static_robust_least_squares',
+        _solve,
+    )
+    monkeypatch.setattr(
+        residual_service,
+        'write_residual_static_artifacts',
+        _write_artifacts,
+    )
+    monkeypatch.setattr(
+        residual_service,
+        'apply_residual_static_correction_to_trace_store',
+        _apply_trace_store,
+    )
+
+
+def test_residual_static_apply_endpoint_creates_static_job(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+
+    def _capture_start_job_thread(**kwargs: Any) -> object:
+        started.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        _capture_start_job_thread,
+    )
+
+    response = client.post('/statics/residual/apply', json=_payload())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['state'] == 'queued'
+    assert isinstance(payload['job_id'], str)
+    assert len(started) == 1
+    assert started[0]['target'] is statics_router_module.run_residual_static_apply_job
+
+    state = client.app.state.sv
+    with state.lock:
+        job = dict(state.jobs[payload['job_id']])
+
+    assert job['status'] == 'queued'
+    assert job['job_type'] == 'statics'
+    assert job['statics_kind'] == 'residual'
+    assert job['file_id'] == FILE_ID
+    assert job['key1_byte'] == KEY1_BYTE
+    assert job['key2_byte'] == KEY2_BYTE
+
+
+def test_run_residual_static_apply_job_success_lifecycle(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, job_dir, _source_store = _create_residual_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+
+    residual_service.run_residual_static_apply_job(
+        job_id,
+        _request(),
+        client.app.state.sv,
+    )
+
+    assert calls == [
+        'get_reader',
+        'resolve_artifacts',
+        'load_pick_source',
+        'build_inputs',
+        'solve',
+        'write_artifacts',
+        'apply_trace_store',
+    ]
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'done'
+    assert job['progress'] == 1.0
+    assert job['corrected_file_id'] == 'residual-corrected-file-id'
+    assert Path(str(job['corrected_store_path'])).name == 'residual-corrected-store'
+
+    files_response = client.get(f'/statics/job/{job_id}/files')
+    assert files_response.status_code == 200
+    assert {item['name'] for item in files_response.json()['files']} == {
+        'job_meta.json',
+        'residual_static_solution.npz',
+        'residual_static_qc.json',
+        'residual_statics.csv',
+        'corrected_file.json',
+    }
+
+    meta = json.loads((job_dir / 'job_meta.json').read_text(encoding='utf-8'))
+    assert meta['job_type'] == 'statics'
+    assert meta['statics_kind'] == 'residual'
+    assert meta['source_file_id'] == FILE_ID
+    assert meta['inputs']['datum_solution']['job_id'] == DATUM_JOB_ID
+    assert meta['inputs']['geometry'] == {
+        'source_id_byte': 17,
+        'receiver_id_byte': 13,
+    }
+    assert meta['artifacts']['corrected_file_json'] == 'corrected_file.json'
+
+
+def test_run_residual_static_apply_job_cancel_before_solver(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir, _source_store = _create_residual_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+    with client.app.state.sv.lock:
+        client.app.state.sv.jobs[job_id]['cancel_requested'] = True
+
+    residual_service.run_residual_static_apply_job(
+        job_id,
+        _request(),
+        client.app.state.sv,
+    )
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'cancelled'
+    assert job['message'] == 'The job was cancelled by the user.'
+    assert calls == []
+
+
+def test_run_residual_static_apply_job_cancel_before_apply(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir, _source_store = _create_residual_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+
+    original_writer = residual_service.write_residual_static_artifacts
+
+    def _write_and_cancel(*args: Any, **kwargs: Any) -> ResidualStaticArtifactPaths:
+        paths = original_writer(*args, **kwargs)
+        with client.app.state.sv.lock:
+            client.app.state.sv.jobs.request_cancel(job_id)
+        return paths
+
+    monkeypatch.setattr(
+        residual_service,
+        'write_residual_static_artifacts',
+        _write_and_cancel,
+    )
+
+    residual_service.run_residual_static_apply_job(
+        job_id,
+        _request(),
+        client.app.state.sv,
+    )
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'cancelled'
+    assert 'apply_trace_store' not in calls
+
+
+def test_run_residual_static_apply_job_failure_sets_error_message(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir, _source_store = _create_residual_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+
+    def _raise_input_error(*args: Any, **kwargs: Any) -> object:
+        raise ValueError('residual input mismatch')
+
+    monkeypatch.setattr(
+        residual_service,
+        'build_residual_static_solver_inputs',
+        _raise_input_error,
+    )
+
+    residual_service.run_residual_static_apply_job(
+        job_id,
+        _request(),
+        client.app.state.sv,
+    )
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'error'
+    assert job['message'] == 'residual input mismatch'
+    assert 'solve' not in calls
+
+
+def test_residual_static_job_files_and_download_artifact(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_id, job_dir, _source_store = _create_residual_job(client, tmp_path)
+    job_dir.mkdir(parents=True)
+    (job_dir / 'job_meta.json').write_text('{"job_id":"residual"}', encoding='utf-8')
+    (job_dir / 'residual_static_solution.npz').write_bytes(b'npz')
+    (job_dir / 'residual_static_qc.json').write_text('{"ok":true}', encoding='utf-8')
+    (job_dir / 'residual_statics.csv').write_text('trace,shift\n', encoding='utf-8')
+    (job_dir / 'corrected_file.json').write_text(
+        '{"file_id":"residual"}',
+        encoding='utf-8',
+    )
+
+    files_response = client.get(f'/statics/job/{job_id}/files')
+    download_response = client.get(
+        f'/statics/job/{job_id}/download',
+        params={'name': 'residual_static_qc.json'},
+    )
+
+    assert files_response.status_code == 200
+    assert {item['name'] for item in files_response.json()['files']} == {
+        'job_meta.json',
+        'residual_static_solution.npz',
+        'residual_static_qc.json',
+        'residual_statics.csv',
+        'corrected_file.json',
+    }
+    assert download_response.status_code == 200
+    assert download_response.text == '{"ok":true}'
+
+
+def test_residual_static_job_download_rejects_path_traversal(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_id, job_dir, _source_store = _create_residual_job(client, tmp_path)
+    job_dir.mkdir(parents=True)
+
+    response = client.get(
+        f'/statics/job/{job_id}/download',
+        params={'name': '../residual_static_qc.json'},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {'detail': 'Invalid file name'}
+
+
+def test_residual_static_apply_endpoint_schema_validation_422(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+    payload = _payload()
+    payload['moveout'] = {'model': 'none'}
+
+    response = client.post('/statics/residual/apply', json=payload)
+
+    assert response.status_code == 422
+    assert started == []


### PR DESCRIPTION
Closes #328

## Summary
- # PR4-9 [statics residual] /statics/residual/apply job endpoint と lifecycle/cancel/download を統合する

## Changed files
- `app/api/routers/statics.py`
- `app/services/residual_static_corrected_store.py`
- `app/services/residual_static_service.py`
- `app/tests/test_residual_static_job_api.py`

## Checks
- `.work/codex/checks.log`: 978 passed in 45.45s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
