### PR TITLE
[statics linkage] Linkage request schemaとheader validationを追加する

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -418,6 +418,115 @@ def _require_positive_finite_float(value: object, name: str) -> float:
     return out
 
 
+class StaticLinkageGeometryRequest(BaseModel):
+    """Geometry header configuration for static linkage."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    source_x_byte: int = 73
+    source_y_byte: int = 77
+    receiver_x_byte: int = 81
+    receiver_y_byte: int = 85
+    coordinate_scalar_byte: int = 71
+
+    @field_validator(
+        'source_x_byte',
+        'source_y_byte',
+        'receiver_x_byte',
+        'receiver_y_byte',
+        'coordinate_scalar_byte',
+        mode='before',
+    )
+    @classmethod
+    def _check_header_byte(cls, value: object, info: Any) -> int:
+        return require_trace_header_byte(value, info.field_name)
+
+    @model_validator(mode='after')
+    def _check_unique_headers(self) -> 'StaticLinkageGeometryRequest':
+        header_bytes = (
+            self.source_x_byte,
+            self.source_y_byte,
+            self.receiver_x_byte,
+            self.receiver_y_byte,
+            self.coordinate_scalar_byte,
+        )
+        if len(set(header_bytes)) != len(header_bytes):
+            raise ValueError('geometry header bytes must be unique')
+        return self
+
+
+class StaticLinkageOptionsRequest(BaseModel):
+    """Linkage options for static linkage geometry building."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    mode: Literal['none', 'auto_threshold']
+    threshold_m: float | None = None
+    receiver_location_interval_m: float | None = None
+    prefer_receiver_anchor: bool = True
+
+    @field_validator('threshold_m', mode='before')
+    @classmethod
+    def _check_threshold_m(cls, value: object) -> float | None:
+        if value is None:
+            return None
+        return _require_positive_finite_float(value, 'linkage.threshold_m')
+
+    @field_validator('receiver_location_interval_m', mode='before')
+    @classmethod
+    def _check_receiver_location_interval_m(cls, value: object) -> float | None:
+        if value is None:
+            return None
+        return _require_positive_finite_float(
+            value,
+            'linkage.receiver_location_interval_m',
+        )
+
+    @field_validator('prefer_receiver_anchor', mode='before')
+    @classmethod
+    def _check_prefer_receiver_anchor(cls, value: object) -> bool:
+        return _require_bool(value, 'linkage.prefer_receiver_anchor')
+
+    @model_validator(mode='after')
+    def _check_mode_options(self) -> 'StaticLinkageOptionsRequest':
+        if self.mode == 'auto_threshold' and self.threshold_m is None:
+            raise ValueError('linkage.threshold_m is required for auto_threshold')
+        if self.mode == 'none':
+            if self.threshold_m is not None:
+                raise ValueError('linkage.threshold_m must be null for none mode')
+            if self.receiver_location_interval_m is not None:
+                raise ValueError(
+                    'linkage.receiver_location_interval_m must be null for none mode'
+                )
+        return self
+
+
+class StaticLinkageBuildRequest(BaseModel):
+    """Request model for future ``/statics/linkage/build`` jobs."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    file_id: str
+    key1_byte: int = 189
+    key2_byte: int = 193
+    geometry: StaticLinkageGeometryRequest = Field(
+        default_factory=StaticLinkageGeometryRequest,
+    )
+    linkage: StaticLinkageOptionsRequest
+
+    @field_validator('file_id', mode='before')
+    @classmethod
+    def _check_file_id(cls, value: object) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError('file_id must be a non-empty string')
+        return value
+
+    @field_validator('key1_byte', 'key2_byte', mode='before')
+    @classmethod
+    def _check_key_header_byte(cls, value: object, info: Any) -> int:
+        return require_trace_header_byte(value, info.field_name)
+
+
 class FirstBreakQcDatumSolutionRequest(BaseModel):
     """Datum static solution artifact reference for first-break QC."""
 

--- a/app/services/geometry_linkage_validation.py
+++ b/app/services/geometry_linkage_validation.py
@@ -1,0 +1,216 @@
+"""Validation helpers for static linkage TraceStore headers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from app.trace_store.reader import TraceStoreSectionReader
+
+
+@dataclass(frozen=True)
+class GeometryLinkageHeaderConfig:
+    source_x_byte: int = 73
+    source_y_byte: int = 77
+    receiver_x_byte: int = 81
+    receiver_y_byte: int = 85
+    coordinate_scalar_byte: int = 71
+
+    def __post_init__(self) -> None:
+        _validate_config(self)
+
+
+@dataclass(frozen=True)
+class GeometryLinkageHeaders:
+    source_x: np.ndarray
+    source_y: np.ndarray
+    receiver_x: np.ndarray
+    receiver_y: np.ndarray
+    coordinate_scalar: np.ndarray
+    checked_bytes: tuple[int, ...]
+
+
+def validate_geometry_linkage_headers(
+    *,
+    reader: TraceStoreSectionReader,
+    config: GeometryLinkageHeaderConfig,
+) -> GeometryLinkageHeaders:
+    """Materialize and validate static linkage headers in TraceStore order."""
+    n_traces = int(reader.traces.shape[0])
+    raw_headers: dict[str, np.ndarray] = {}
+    checked_bytes: list[int] = []
+
+    for name, byte in _required_headers(config):
+        values = _read_header(reader=reader, byte=byte)
+        raw_headers[name] = np.asarray(values)
+        checked_bytes.append(byte)
+
+    coordinate_scalar = _validate_coordinate_scalar_header(
+        raw_headers['coordinate_scalar'],
+        name='coordinate_scalar',
+        byte=config.coordinate_scalar_byte,
+        n_traces=n_traces,
+    )
+    source_x = _validate_coordinate_header(
+        raw_headers['source_x'],
+        name='source_x',
+        byte=config.source_x_byte,
+        n_traces=n_traces,
+    )
+    source_y = _validate_coordinate_header(
+        raw_headers['source_y'],
+        name='source_y',
+        byte=config.source_y_byte,
+        n_traces=n_traces,
+    )
+    receiver_x = _validate_coordinate_header(
+        raw_headers['receiver_x'],
+        name='receiver_x',
+        byte=config.receiver_x_byte,
+        n_traces=n_traces,
+    )
+    receiver_y = _validate_coordinate_header(
+        raw_headers['receiver_y'],
+        name='receiver_y',
+        byte=config.receiver_y_byte,
+        n_traces=n_traces,
+    )
+
+    return GeometryLinkageHeaders(
+        source_x=source_x,
+        source_y=source_y,
+        receiver_x=receiver_x,
+        receiver_y=receiver_y,
+        coordinate_scalar=coordinate_scalar,
+        checked_bytes=tuple(checked_bytes),
+    )
+
+
+def _required_headers(
+    config: GeometryLinkageHeaderConfig,
+) -> tuple[tuple[str, int], ...]:
+    return (
+        ('coordinate_scalar', config.coordinate_scalar_byte),
+        ('source_x', config.source_x_byte),
+        ('source_y', config.source_y_byte),
+        ('receiver_x', config.receiver_x_byte),
+        ('receiver_y', config.receiver_y_byte),
+    )
+
+
+def _validate_config(config: GeometryLinkageHeaderConfig) -> None:
+    header_bytes = [
+        _validate_header_byte(value, name=name)
+        for name, value in (
+            ('source_x_byte', config.source_x_byte),
+            ('source_y_byte', config.source_y_byte),
+            ('receiver_x_byte', config.receiver_x_byte),
+            ('receiver_y_byte', config.receiver_y_byte),
+            ('coordinate_scalar_byte', config.coordinate_scalar_byte),
+        )
+    ]
+    if len(set(header_bytes)) != len(header_bytes):
+        msg = 'geometry header bytes must be unique'
+        raise ValueError(msg)
+
+
+def _validate_header_byte(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f'{name} must be an integer SEG-Y trace header byte'
+        raise ValueError(msg)
+    if value < 1 or value > 240:
+        msg = f'{name} must be in the range 1..240'
+        raise ValueError(msg)
+    return value
+
+
+def _read_header(
+    *,
+    reader: TraceStoreSectionReader,
+    byte: int,
+) -> np.ndarray:
+    try:
+        return reader.ensure_header(byte)
+    except Exception as exc:
+        msg = f'failed to read geometry linkage header byte {byte}: {exc}'
+        raise ValueError(msg) from exc
+
+
+def _validate_coordinate_header(
+    values: np.ndarray,
+    *,
+    name: str,
+    byte: int,
+    n_traces: int,
+) -> np.ndarray:
+    arr = _validate_header_shape(values, name=name, byte=byte, n_traces=n_traces)
+    if not _is_real_numeric_dtype(arr.dtype):
+        msg = f'{name} header byte {byte} must have a real numeric dtype'
+        raise ValueError(msg)
+    if np.issubdtype(arr.dtype, np.floating) and not np.all(np.isfinite(arr)):
+        msg = f'{name} header byte {byte} must contain only finite values'
+        raise ValueError(msg)
+    return arr
+
+
+def _validate_coordinate_scalar_header(
+    values: np.ndarray,
+    *,
+    name: str,
+    byte: int,
+    n_traces: int,
+) -> np.ndarray:
+    arr = _validate_header_shape(values, name=name, byte=byte, n_traces=n_traces)
+    if np.issubdtype(arr.dtype, np.integer):
+        return arr
+    if not np.issubdtype(arr.dtype, np.floating):
+        msg = (
+            f'{name} header byte {byte} must have an integer dtype '
+            'or integer-valued float dtype'
+        )
+        raise ValueError(msg)
+
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(arr_f64)):
+        msg = f'{name} header byte {byte} must contain only finite values'
+        raise ValueError(msg)
+    if not np.all(arr_f64 == np.rint(arr_f64)):
+        msg = f'{name} header byte {byte} must contain only integer values'
+        raise ValueError(msg)
+    return arr
+
+
+def _validate_header_shape(
+    values: np.ndarray,
+    *,
+    name: str,
+    byte: int,
+    n_traces: int,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        msg = f'{name} header byte {byte} must be a 1D array'
+        raise ValueError(msg)
+    expected_shape = (n_traces,)
+    if arr.shape != expected_shape:
+        msg = (
+            f'{name} header byte {byte} shape mismatch: '
+            f'expected {expected_shape}, got {arr.shape}'
+        )
+        raise ValueError(msg)
+    return arr
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'GeometryLinkageHeaderConfig',
+    'GeometryLinkageHeaders',
+    'validate_geometry_linkage_headers',
+]

--- a/app/tests/test_geometry_linkage_schema.py
+++ b/app/tests/test_geometry_linkage_schema.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.schemas import StaticLinkageBuildRequest
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        'file_id': 'file-1',
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'linkage': {
+            'mode': 'auto_threshold',
+            'threshold_m': 25.0,
+        },
+    }
+
+
+def _validate(payload: dict[str, Any]) -> StaticLinkageBuildRequest:
+    return StaticLinkageBuildRequest.model_validate(deepcopy(payload))
+
+
+def test_static_linkage_request_accepts_auto_threshold_defaults() -> None:
+    req = _validate(_payload())
+
+    assert req.file_id == 'file-1'
+    assert req.key1_byte == 189
+    assert req.key2_byte == 193
+    assert req.geometry.source_x_byte == 73
+    assert req.geometry.source_y_byte == 77
+    assert req.geometry.receiver_x_byte == 81
+    assert req.geometry.receiver_y_byte == 85
+    assert req.geometry.coordinate_scalar_byte == 71
+    assert req.linkage.mode == 'auto_threshold'
+    assert req.linkage.threshold_m == 25.0
+    assert req.linkage.receiver_location_interval_m is None
+    assert req.linkage.prefer_receiver_anchor is True
+
+
+def test_static_linkage_request_accepts_none_mode() -> None:
+    payload = _payload()
+    payload['linkage'] = {
+        'mode': 'none',
+        'threshold_m': None,
+        'prefer_receiver_anchor': False,
+    }
+
+    req = _validate(payload)
+
+    assert req.linkage.mode == 'none'
+    assert req.linkage.threshold_m is None
+    assert req.linkage.prefer_receiver_anchor is False
+
+
+def test_static_linkage_request_rejects_extra_fields() -> None:
+    payload = _payload()
+    payload['unknown'] = True
+
+    with pytest.raises(ValidationError):
+        _validate(payload)
+
+
+def test_static_linkage_request_rejects_nested_extra_fields() -> None:
+    payload = _payload()
+    payload['geometry'] = {'source_x_byte': 73, 'unknown': True}
+
+    with pytest.raises(ValidationError):
+        _validate(payload)
+
+
+def test_static_linkage_request_rejects_bool_header_byte() -> None:
+    payload = _payload()
+    payload['geometry'] = {'source_x_byte': True}
+
+    with pytest.raises(ValidationError, match='integer SEG-Y trace header byte'):
+        _validate(payload)
+
+
+@pytest.mark.parametrize('bad_byte', [0, 241])
+def test_static_linkage_request_rejects_out_of_range_header_byte(
+    bad_byte: int,
+) -> None:
+    payload = _payload()
+    payload['key1_byte'] = bad_byte
+
+    with pytest.raises(ValidationError, match='range 1..240'):
+        _validate(payload)
+
+
+def test_static_linkage_request_rejects_duplicate_geometry_header_bytes() -> None:
+    payload = _payload()
+    payload['geometry'] = {
+        'source_x_byte': 73,
+        'source_y_byte': 73,
+        'receiver_x_byte': 81,
+        'receiver_y_byte': 85,
+        'coordinate_scalar_byte': 71,
+    }
+
+    with pytest.raises(ValidationError, match='geometry header bytes must be unique'):
+        _validate(payload)
+
+
+def test_static_linkage_request_rejects_auto_threshold_without_threshold() -> None:
+    payload = _payload()
+    payload['linkage'] = {
+        'mode': 'auto_threshold',
+        'threshold_m': None,
+    }
+
+    with pytest.raises(ValidationError, match='threshold_m is required'):
+        _validate(payload)
+
+
+def test_static_linkage_request_rejects_none_mode_with_threshold() -> None:
+    payload = _payload()
+    payload['linkage'] = {
+        'mode': 'none',
+        'threshold_m': 10.0,
+    }
+
+    with pytest.raises(ValidationError, match='threshold_m must be null'):
+        _validate(payload)
+
+
+@pytest.mark.parametrize('threshold_m', [0.0, -1.0])
+def test_static_linkage_request_rejects_non_positive_threshold(
+    threshold_m: float,
+) -> None:
+    payload = _payload()
+    payload['linkage']['threshold_m'] = threshold_m
+
+    with pytest.raises(ValidationError, match='threshold_m'):
+        _validate(payload)
+
+
+@pytest.mark.parametrize('threshold_m', [float('nan'), float('inf'), float('-inf')])
+def test_static_linkage_request_rejects_non_finite_threshold(
+    threshold_m: float,
+) -> None:
+    payload = _payload()
+    payload['linkage']['threshold_m'] = threshold_m
+
+    with pytest.raises(ValidationError, match='threshold_m'):
+        _validate(payload)
+
+
+@pytest.mark.parametrize(
+    'receiver_location_interval_m',
+    [0.0, -1.0, float('nan'), float('inf'), float('-inf')],
+)
+def test_static_linkage_request_rejects_invalid_receiver_location_interval(
+    receiver_location_interval_m: float,
+) -> None:
+    payload = _payload()
+    payload['linkage']['receiver_location_interval_m'] = (
+        receiver_location_interval_m
+    )
+
+    with pytest.raises(ValidationError, match='receiver_location_interval_m'):
+        _validate(payload)
+
+
+def test_static_linkage_request_rejects_none_mode_with_receiver_interval() -> None:
+    payload = _payload()
+    payload['linkage'] = {
+        'mode': 'none',
+        'threshold_m': None,
+        'receiver_location_interval_m': 10.0,
+    }
+
+    with pytest.raises(ValidationError, match='receiver_location_interval_m'):
+        _validate(payload)
+
+
+def test_static_linkage_request_rejects_non_bool_prefer_receiver_anchor() -> None:
+    payload = _payload()
+    payload['linkage']['prefer_receiver_anchor'] = 1
+
+    with pytest.raises(ValidationError, match='prefer_receiver_anchor'):
+        _validate(payload)
+
+
+def test_static_linkage_request_rejects_empty_file_id() -> None:
+    payload = _payload()
+    payload['file_id'] = ''
+
+    with pytest.raises(ValidationError, match='file_id'):
+        _validate(payload)

--- a/app/tests/test_geometry_linkage_validation.py
+++ b/app/tests/test_geometry_linkage_validation.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.geometry_linkage_validation import (
+    GeometryLinkageHeaderConfig,
+    validate_geometry_linkage_headers,
+)
+
+
+class FakeReader:
+    def __init__(self, headers: dict[int, np.ndarray], n_traces: int = 3) -> None:
+        self.headers = headers
+        self.traces = np.zeros((n_traces, 4), dtype=np.float32)
+        self.ensure_calls: list[int] = []
+
+    def ensure_header(self, byte: int) -> np.ndarray:
+        self.ensure_calls.append(byte)
+        if byte not in self.headers:
+            raise KeyError(byte)
+        return self.headers[byte]
+
+
+def _headers() -> dict[int, np.ndarray]:
+    return {
+        71: np.array([1, -10, 0], dtype=np.int16),
+        73: np.array([100.0, 110.0, 120.0], dtype=np.float32),
+        77: np.array([200.0, 210.0, 220.0], dtype=np.float32),
+        81: np.array([130.0, 140.0, 150.0], dtype=np.float32),
+        85: np.array([230.0, 240.0, 250.0], dtype=np.float32),
+    }
+
+
+def test_validate_geometry_linkage_headers_reads_required_headers() -> None:
+    reader = FakeReader(_headers())
+
+    result = validate_geometry_linkage_headers(
+        reader=reader,
+        config=GeometryLinkageHeaderConfig(),
+    )
+
+    assert reader.ensure_calls == [71, 73, 77, 81, 85]
+    assert result.checked_bytes == (71, 73, 77, 81, 85)
+    np.testing.assert_array_equal(result.coordinate_scalar, _headers()[71])
+    np.testing.assert_array_equal(result.source_x, _headers()[73])
+    np.testing.assert_array_equal(result.source_y, _headers()[77])
+    np.testing.assert_array_equal(result.receiver_x, _headers()[81])
+    np.testing.assert_array_equal(result.receiver_y, _headers()[85])
+
+
+def test_validate_geometry_linkage_headers_rejects_missing_header() -> None:
+    headers = _headers()
+    del headers[81]
+
+    with pytest.raises(ValueError, match='header byte 81'):
+        validate_geometry_linkage_headers(
+            reader=FakeReader(headers),
+            config=GeometryLinkageHeaderConfig(),
+        )
+
+
+def test_validate_geometry_linkage_headers_rejects_shape_mismatch() -> None:
+    headers = _headers()
+    headers[73] = np.array([100.0, 110.0], dtype=np.float32)
+
+    with pytest.raises(ValueError, match='shape mismatch'):
+        validate_geometry_linkage_headers(
+            reader=FakeReader(headers),
+            config=GeometryLinkageHeaderConfig(),
+        )
+
+
+def test_validate_geometry_linkage_headers_rejects_non_numeric_coordinate() -> None:
+    headers = _headers()
+    headers[73] = np.array(['100', '110', '120'])
+
+    with pytest.raises(ValueError, match='real numeric dtype'):
+        validate_geometry_linkage_headers(
+            reader=FakeReader(headers),
+            config=GeometryLinkageHeaderConfig(),
+        )
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf, -np.inf])
+def test_validate_geometry_linkage_headers_rejects_non_finite_coordinate(
+    bad_value: float,
+) -> None:
+    headers = _headers()
+    headers[77] = np.array([200.0, bad_value, 220.0], dtype=np.float64)
+
+    with pytest.raises(ValueError, match='finite values'):
+        validate_geometry_linkage_headers(
+            reader=FakeReader(headers),
+            config=GeometryLinkageHeaderConfig(),
+        )
+
+
+def test_validate_geometry_linkage_headers_rejects_non_integer_scalar() -> None:
+    headers = _headers()
+    headers[71] = np.array([1.0, 2.5, 3.0], dtype=np.float64)
+
+    with pytest.raises(ValueError, match='integer values'):
+        validate_geometry_linkage_headers(
+            reader=FakeReader(headers),
+            config=GeometryLinkageHeaderConfig(),
+        )
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf, -np.inf])
+def test_validate_geometry_linkage_headers_rejects_non_finite_scalar(
+    bad_value: float,
+) -> None:
+    headers = _headers()
+    headers[71] = np.array([1.0, bad_value, 3.0], dtype=np.float64)
+
+    with pytest.raises(ValueError, match='finite values'):
+        validate_geometry_linkage_headers(
+            reader=FakeReader(headers),
+            config=GeometryLinkageHeaderConfig(),
+        )
+
+
+def test_validate_geometry_linkage_headers_accepts_integer_valued_float_scalar() -> None:
+    headers = _headers()
+    headers[71] = np.array([1.0, -10.0, 0.0], dtype=np.float64)
+    reader = FakeReader(headers)
+
+    result = validate_geometry_linkage_headers(
+        reader=reader,
+        config=GeometryLinkageHeaderConfig(),
+    )
+
+    np.testing.assert_array_equal(result.coordinate_scalar, headers[71])


### PR DESCRIPTION
Closes #332

## Summary
- [statics linkage] Linkage request schemaとheader validationを追加する

## Changed files
- `app/api/schemas.py`
- `app/services/geometry_linkage_validation.py`
- `app/tests/test_geometry_linkage_schema.py`
- `app/tests/test_geometry_linkage_validation.py`

## Checks
- `.work/codex/checks.log`: 1014 passed in 45.89s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
