### PR TITLE
[statics linkage] source/receiver endpoint geometry table builderを追加する

### DIFF
--- a/app/services/geometry_linkage_tables.py
+++ b/app/services/geometry_linkage_tables.py
@@ -1,0 +1,204 @@
+"""Endpoint geometry table builder for static linkage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from app.services.geometry_linkage_validation import GeometryLinkageHeaders
+from app.utils.segy_scalars import apply_segy_scalar, count_zero_segy_scalars
+
+EndpointKind = Literal['source', 'receiver']
+
+
+@dataclass(frozen=True)
+class EndpointGeometryTable:
+    endpoint_kind: EndpointKind
+    endpoint_id: np.ndarray
+    x_m: np.ndarray
+    y_m: np.ndarray
+    first_sorted_trace_index: np.ndarray
+    trace_count: np.ndarray
+
+
+@dataclass(frozen=True)
+class EndpointGeometryTables:
+    n_traces: int
+    source_x_m_sorted: np.ndarray
+    source_y_m_sorted: np.ndarray
+    receiver_x_m_sorted: np.ndarray
+    receiver_y_m_sorted: np.ndarray
+    coordinate_scalar_sorted: np.ndarray
+    source_endpoint_id_sorted: np.ndarray
+    receiver_endpoint_id_sorted: np.ndarray
+    source_endpoints: EndpointGeometryTable
+    receiver_endpoints: EndpointGeometryTable
+    scalar_zero_count: int
+
+
+def build_endpoint_geometry_tables(
+    headers: GeometryLinkageHeaders,
+) -> EndpointGeometryTables:
+    """Build exact-coordinate source and receiver endpoint tables."""
+    source_x_raw = _coerce_1d_numeric(headers.source_x, name='source_x')
+    source_y_raw = _coerce_1d_numeric(headers.source_y, name='source_y')
+    receiver_x_raw = _coerce_1d_numeric(headers.receiver_x, name='receiver_x')
+    receiver_y_raw = _coerce_1d_numeric(headers.receiver_y, name='receiver_y')
+    scalars = _coerce_1d_integer_scalars(
+        headers.coordinate_scalar,
+        name='coordinate_scalar',
+    )
+
+    expected_shape = source_x_raw.shape
+    _validate_matching_shape(source_y_raw, name='source_y', expected_shape=expected_shape)
+    _validate_matching_shape(
+        receiver_x_raw,
+        name='receiver_x',
+        expected_shape=expected_shape,
+    )
+    _validate_matching_shape(
+        receiver_y_raw,
+        name='receiver_y',
+        expected_shape=expected_shape,
+    )
+    _validate_matching_shape(
+        scalars,
+        name='coordinate_scalar',
+        expected_shape=expected_shape,
+    )
+
+    n_traces = int(source_x_raw.shape[0])
+    if n_traces <= 0:
+        msg = 'geometry linkage headers must contain at least one trace'
+        raise ValueError(msg)
+
+    source_x_m = apply_segy_scalar(source_x_raw, scalars)
+    source_y_m = apply_segy_scalar(source_y_raw, scalars)
+    receiver_x_m = apply_segy_scalar(receiver_x_raw, scalars)
+    receiver_y_m = apply_segy_scalar(receiver_y_raw, scalars)
+
+    source_table, source_inverse = _build_unique_endpoint_table(
+        'source',
+        source_x_m,
+        source_y_m,
+    )
+    receiver_table, receiver_inverse = _build_unique_endpoint_table(
+        'receiver',
+        receiver_x_m,
+        receiver_y_m,
+    )
+
+    return EndpointGeometryTables(
+        n_traces=n_traces,
+        source_x_m_sorted=np.ascontiguousarray(source_x_m, dtype=np.float64),
+        source_y_m_sorted=np.ascontiguousarray(source_y_m, dtype=np.float64),
+        receiver_x_m_sorted=np.ascontiguousarray(receiver_x_m, dtype=np.float64),
+        receiver_y_m_sorted=np.ascontiguousarray(receiver_y_m, dtype=np.float64),
+        coordinate_scalar_sorted=np.ascontiguousarray(scalars, dtype=np.int64),
+        source_endpoint_id_sorted=np.ascontiguousarray(source_inverse, dtype=np.int64),
+        receiver_endpoint_id_sorted=np.ascontiguousarray(
+            receiver_inverse,
+            dtype=np.int64,
+        ),
+        source_endpoints=source_table,
+        receiver_endpoints=receiver_table,
+        scalar_zero_count=count_zero_segy_scalars(scalars),
+    )
+
+
+def _build_unique_endpoint_table(
+    endpoint_kind: EndpointKind,
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+) -> tuple[EndpointGeometryTable, np.ndarray]:
+    xy = np.column_stack((x_m, y_m))
+    unique_xy, first_index, inverse, counts = np.unique(
+        xy,
+        axis=0,
+        return_index=True,
+        return_inverse=True,
+        return_counts=True,
+    )
+    n_endpoints = int(unique_xy.shape[0])
+    endpoint_id = np.arange(n_endpoints, dtype=np.int64)
+    table = EndpointGeometryTable(
+        endpoint_kind=endpoint_kind,
+        endpoint_id=endpoint_id,
+        x_m=np.ascontiguousarray(unique_xy[:, 0], dtype=np.float64),
+        y_m=np.ascontiguousarray(unique_xy[:, 1], dtype=np.float64),
+        first_sorted_trace_index=np.ascontiguousarray(first_index, dtype=np.int64),
+        trace_count=np.ascontiguousarray(counts, dtype=np.int64),
+    )
+    return table, np.asarray(inverse, dtype=np.int64)
+
+
+def _coerce_1d_numeric(values: np.ndarray, *, name: str) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        msg = f'{name} must be a 1D array'
+        raise ValueError(msg)
+    if not _is_real_numeric_dtype(arr.dtype):
+        msg = f'{name} must have a real numeric dtype'
+        raise ValueError(msg)
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(arr_f64)):
+        msg = f'{name} must contain only finite values'
+        raise ValueError(msg)
+    return arr_f64
+
+
+def _coerce_1d_integer_scalars(values: np.ndarray, *, name: str) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        msg = f'{name} must be a 1D array'
+        raise ValueError(msg)
+    if np.issubdtype(arr.dtype, np.integer):
+        return np.asarray(arr, dtype=np.int64)
+    if not np.issubdtype(arr.dtype, np.floating):
+        msg = f'{name} must have an integer dtype or integer-valued float dtype'
+        raise ValueError(msg)
+
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(arr_f64)):
+        msg = f'{name} must contain only finite values'
+        raise ValueError(msg)
+    if not np.all(arr_f64 == np.rint(arr_f64)):
+        msg = f'{name} must contain only integer values'
+        raise ValueError(msg)
+
+    int64_info = np.iinfo(np.int64)
+    if arr_f64.size and (
+        float(arr_f64.min()) < int64_info.min
+        or float(arr_f64.max()) > int64_info.max
+    ):
+        msg = f'{name} values are outside the int64 range'
+        raise ValueError(msg)
+    return np.asarray(arr_f64, dtype=np.int64)
+
+
+def _validate_matching_shape(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> None:
+    if values.shape != expected_shape:
+        msg = f'{name} shape mismatch: expected {expected_shape}, got {values.shape}'
+        raise ValueError(msg)
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'EndpointGeometryTable',
+    'EndpointGeometryTables',
+    'EndpointKind',
+    'build_endpoint_geometry_tables',
+]

--- a/app/tests/test_geometry_linkage_tables.py
+++ b/app/tests/test_geometry_linkage_tables.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services.geometry_linkage_tables import build_endpoint_geometry_tables
+from app.services.geometry_linkage_validation import GeometryLinkageHeaders
+
+
+def _headers(
+    *,
+    source_x: np.ndarray | None = None,
+    source_y: np.ndarray | None = None,
+    receiver_x: np.ndarray | None = None,
+    receiver_y: np.ndarray | None = None,
+    coordinate_scalar: np.ndarray | None = None,
+) -> GeometryLinkageHeaders:
+    if source_x is None:
+        source_x = np.array([0.0, 10.0, 0.0], dtype=np.float64)
+    if source_y is None:
+        source_y = np.array([0.0, 0.0, 0.0], dtype=np.float64)
+    if receiver_x is None:
+        receiver_x = np.array([100.0, 110.0, 100.0], dtype=np.float64)
+    if receiver_y is None:
+        receiver_y = np.array([200.0, 210.0, 200.0], dtype=np.float64)
+    if coordinate_scalar is None:
+        coordinate_scalar = np.ones(np.asarray(source_x).shape, dtype=np.int16)
+    return GeometryLinkageHeaders(
+        source_x=source_x,
+        source_y=source_y,
+        receiver_x=receiver_x,
+        receiver_y=receiver_y,
+        coordinate_scalar=coordinate_scalar,
+        checked_bytes=(71, 73, 77, 81, 85),
+    )
+
+
+def test_build_endpoint_geometry_tables_applies_positive_scalar() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([10.0, 20.0], dtype=np.float32),
+            source_y=np.array([30.0, 40.0], dtype=np.float32),
+            receiver_x=np.array([50.0, 60.0], dtype=np.float32),
+            receiver_y=np.array([70.0, 80.0], dtype=np.float32),
+            coordinate_scalar=np.array([2, 3], dtype=np.int16),
+        )
+    )
+
+    np.testing.assert_allclose(tables.source_x_m_sorted, np.array([20.0, 60.0]))
+    np.testing.assert_allclose(tables.source_y_m_sorted, np.array([60.0, 120.0]))
+    np.testing.assert_allclose(tables.receiver_x_m_sorted, np.array([100.0, 180.0]))
+    np.testing.assert_allclose(tables.receiver_y_m_sorted, np.array([140.0, 240.0]))
+
+
+def test_build_endpoint_geometry_tables_applies_negative_scalar() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([10.0, 20.0], dtype=np.float64),
+            source_y=np.array([30.0, 40.0], dtype=np.float64),
+            receiver_x=np.array([50.0, 60.0], dtype=np.float64),
+            receiver_y=np.array([70.0, 80.0], dtype=np.float64),
+            coordinate_scalar=np.array([-2, -4], dtype=np.int16),
+        )
+    )
+
+    np.testing.assert_allclose(tables.source_x_m_sorted, np.array([5.0, 5.0]))
+    np.testing.assert_allclose(tables.source_y_m_sorted, np.array([15.0, 10.0]))
+    np.testing.assert_allclose(tables.receiver_x_m_sorted, np.array([25.0, 15.0]))
+    np.testing.assert_allclose(tables.receiver_y_m_sorted, np.array([35.0, 20.0]))
+
+
+def test_build_endpoint_geometry_tables_treats_zero_scalar_as_one() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([10.0], dtype=np.float64),
+            source_y=np.array([20.0], dtype=np.float64),
+            receiver_x=np.array([30.0], dtype=np.float64),
+            receiver_y=np.array([40.0], dtype=np.float64),
+            coordinate_scalar=np.array([0], dtype=np.int16),
+        )
+    )
+
+    np.testing.assert_allclose(tables.source_x_m_sorted, np.array([10.0]))
+    np.testing.assert_allclose(tables.source_y_m_sorted, np.array([20.0]))
+    np.testing.assert_allclose(tables.receiver_x_m_sorted, np.array([30.0]))
+    np.testing.assert_allclose(tables.receiver_y_m_sorted, np.array([40.0]))
+
+
+def test_build_endpoint_geometry_tables_counts_zero_scalars() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(coordinate_scalar=np.array([0, 1, 0], dtype=np.int16))
+    )
+
+    assert tables.scalar_zero_count == 2
+
+
+def test_build_endpoint_geometry_tables_builds_unique_source_endpoints() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([2.0, 1.0, 2.0, 1.0], dtype=np.float64),
+            source_y=np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64),
+            receiver_x=np.array([10.0, 11.0, 12.0, 13.0], dtype=np.float64),
+            receiver_y=np.array([20.0, 21.0, 22.0, 23.0], dtype=np.float64),
+            coordinate_scalar=np.ones(4, dtype=np.int16),
+        )
+    )
+
+    assert tables.source_endpoints.endpoint_kind == 'source'
+    np.testing.assert_array_equal(tables.source_endpoints.endpoint_id, [0, 1, 2])
+    np.testing.assert_allclose(tables.source_endpoints.x_m, [1.0, 1.0, 2.0])
+    np.testing.assert_allclose(tables.source_endpoints.y_m, [0.0, 1.0, 0.0])
+
+
+def test_build_endpoint_geometry_tables_builds_unique_receiver_endpoints() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([10.0, 11.0, 12.0, 13.0], dtype=np.float64),
+            source_y=np.array([20.0, 21.0, 22.0, 23.0], dtype=np.float64),
+            receiver_x=np.array([3.0, 3.0, 2.0, 2.0], dtype=np.float64),
+            receiver_y=np.array([5.0, 5.0, 4.0, 6.0], dtype=np.float64),
+            coordinate_scalar=np.ones(4, dtype=np.int16),
+        )
+    )
+
+    assert tables.receiver_endpoints.endpoint_kind == 'receiver'
+    np.testing.assert_array_equal(tables.receiver_endpoints.endpoint_id, [0, 1, 2])
+    np.testing.assert_allclose(tables.receiver_endpoints.x_m, [2.0, 2.0, 3.0])
+    np.testing.assert_allclose(tables.receiver_endpoints.y_m, [4.0, 6.0, 5.0])
+
+
+def test_build_endpoint_geometry_tables_keeps_source_receiver_tables_separate() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([10.0, 10.0], dtype=np.float64),
+            source_y=np.array([20.0, 20.0], dtype=np.float64),
+            receiver_x=np.array([10.0, 10.0], dtype=np.float64),
+            receiver_y=np.array([20.0, 20.0], dtype=np.float64),
+            coordinate_scalar=np.ones(2, dtype=np.int16),
+        )
+    )
+
+    np.testing.assert_array_equal(tables.source_endpoints.endpoint_id, [0])
+    np.testing.assert_array_equal(tables.receiver_endpoints.endpoint_id, [0])
+    assert tables.source_endpoints.endpoint_kind == 'source'
+    assert tables.receiver_endpoints.endpoint_kind == 'receiver'
+
+
+def test_build_endpoint_geometry_tables_returns_sorted_trace_mappings() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([2.0, 1.0, 2.0, 1.0], dtype=np.float64),
+            source_y=np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64),
+            receiver_x=np.array([3.0, 3.0, 2.0, 2.0], dtype=np.float64),
+            receiver_y=np.array([5.0, 5.0, 4.0, 6.0], dtype=np.float64),
+            coordinate_scalar=np.ones(4, dtype=np.int16),
+        )
+    )
+
+    assert tables.source_endpoint_id_sorted.shape == (4,)
+    assert tables.receiver_endpoint_id_sorted.shape == (4,)
+    np.testing.assert_array_equal(tables.source_endpoint_id_sorted, [2, 0, 2, 1])
+    np.testing.assert_array_equal(tables.receiver_endpoint_id_sorted, [2, 2, 0, 1])
+
+
+def test_build_endpoint_geometry_tables_endpoint_ids_are_xy_sorted() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([5.0, 1.0, 1.0, 3.0], dtype=np.float64),
+            source_y=np.array([0.0, 9.0, 2.0, 4.0], dtype=np.float64),
+            receiver_x=np.array([8.0, 7.0, 8.0, 6.0], dtype=np.float64),
+            receiver_y=np.array([1.0, 0.0, 0.0, 9.0], dtype=np.float64),
+            coordinate_scalar=np.ones(4, dtype=np.int16),
+        )
+    )
+
+    np.testing.assert_array_equal(tables.source_endpoints.endpoint_id, [0, 1, 2, 3])
+    np.testing.assert_allclose(tables.source_endpoints.x_m, [1.0, 1.0, 3.0, 5.0])
+    np.testing.assert_allclose(tables.source_endpoints.y_m, [2.0, 9.0, 4.0, 0.0])
+    np.testing.assert_array_equal(tables.receiver_endpoints.endpoint_id, [0, 1, 2, 3])
+    np.testing.assert_allclose(tables.receiver_endpoints.x_m, [6.0, 7.0, 8.0, 8.0])
+    np.testing.assert_allclose(tables.receiver_endpoints.y_m, [9.0, 0.0, 0.0, 1.0])
+
+
+def test_build_endpoint_geometry_tables_first_sorted_trace_index_and_count() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(
+            source_x=np.array([2.0, 1.0, 2.0, 1.0, 2.0], dtype=np.float64),
+            source_y=np.array([0.0, 0.0, 0.0, 1.0, 0.0], dtype=np.float64),
+            receiver_x=np.array([3.0, 3.0, 2.0, 2.0, 3.0], dtype=np.float64),
+            receiver_y=np.array([5.0, 5.0, 4.0, 6.0, 5.0], dtype=np.float64),
+            coordinate_scalar=np.ones(5, dtype=np.int16),
+        )
+    )
+
+    np.testing.assert_array_equal(
+        tables.source_endpoints.first_sorted_trace_index,
+        [1, 3, 0],
+    )
+    np.testing.assert_array_equal(tables.source_endpoints.trace_count, [1, 1, 3])
+    np.testing.assert_array_equal(
+        tables.receiver_endpoints.first_sorted_trace_index,
+        [2, 3, 0],
+    )
+    np.testing.assert_array_equal(tables.receiver_endpoints.trace_count, [1, 1, 3])
+
+
+def test_build_endpoint_geometry_tables_rejects_shape_mismatch() -> None:
+    with pytest.raises(ValueError, match='shape mismatch'):
+        build_endpoint_geometry_tables(
+            _headers(
+                source_x=np.array([1.0, 2.0], dtype=np.float64),
+                source_y=np.array([1.0], dtype=np.float64),
+                receiver_x=np.array([1.0, 2.0], dtype=np.float64),
+                receiver_y=np.array([1.0, 2.0], dtype=np.float64),
+                coordinate_scalar=np.ones(2, dtype=np.int16),
+            )
+        )
+
+
+def test_build_endpoint_geometry_tables_rejects_empty_input() -> None:
+    empty = np.array([], dtype=np.float64)
+
+    with pytest.raises(ValueError, match='at least one trace'):
+        build_endpoint_geometry_tables(
+            _headers(
+                source_x=empty,
+                source_y=empty,
+                receiver_x=empty,
+                receiver_y=empty,
+                coordinate_scalar=np.array([], dtype=np.int16),
+            )
+        )
+
+
+def test_build_endpoint_geometry_tables_rejects_non_finite_coordinate() -> None:
+    with pytest.raises(ValueError, match='source_x.*finite values'):
+        build_endpoint_geometry_tables(
+            _headers(source_x=np.array([1.0, np.nan, 3.0], dtype=np.float64))
+        )
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf, -np.inf])
+def test_build_endpoint_geometry_tables_rejects_non_finite_scalar(
+    bad_value: float,
+) -> None:
+    with pytest.raises(ValueError, match='coordinate_scalar.*finite values'):
+        build_endpoint_geometry_tables(
+            _headers(
+                coordinate_scalar=np.array([1.0, bad_value, 3.0], dtype=np.float64)
+            )
+        )
+
+
+def test_build_endpoint_geometry_tables_rejects_non_integer_scalar() -> None:
+    with pytest.raises(ValueError, match='integer values'):
+        build_endpoint_geometry_tables(
+            _headers(coordinate_scalar=np.array([1.0, 2.5, 3.0], dtype=np.float64))
+        )
+
+
+def test_build_endpoint_geometry_tables_accepts_integer_valued_float_scalar() -> None:
+    tables = build_endpoint_geometry_tables(
+        _headers(coordinate_scalar=np.array([1.0, -2.0, 0.0], dtype=np.float64))
+    )
+
+    np.testing.assert_array_equal(tables.coordinate_scalar_sorted, [1, -2, 0])
+    assert tables.coordinate_scalar_sorted.dtype == np.int64
+    np.testing.assert_allclose(tables.source_x_m_sorted, [0.0, 5.0, 0.0])


### PR DESCRIPTION
Closes #334

## Summary
- [statics linkage] source/receiver endpoint geometry table builderを追加する

## Changed files
- `app/services/geometry_linkage_tables.py`
- `app/tests/test_geometry_linkage_tables.py`

## Checks
- `.work/codex/checks.log`: 1032 passed in 45.46s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
