### PR TITLE
[statics linkage] geometry_linkage artifact loaderとsorted trace node mapping検証を追加する

### DIFF
--- a/app/services/geometry_linkage_loader.py
+++ b/app/services/geometry_linkage_loader.py
@@ -1,0 +1,1264 @@
+"""Strict loader for static geometry linkage NPZ artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+
+from app.services.geometry_linkage_artifacts import (
+    GEOMETRY_LINKAGE_NPZ_NAME,
+    ORDER,
+    SCHEMA_VERSION,
+    SOLUTION_ARTIFACT_KIND,
+)
+
+LinkageMode = Literal['none', 'auto_threshold']
+
+_KNOWN_MODES = {'none', 'auto_threshold'}
+_KNOWN_RECORD_LINKED_TO_KINDS = {'', 'source', 'receiver'}
+_KNOWN_RECORD_METHODS = {
+    'none_mode_receiver_independent',
+    'none_mode_source_independent',
+    'receiver_seed',
+    'receiver_anchor',
+    'source_fallback',
+    'source_independent',
+}
+
+_SCALAR_FIELDS = (
+    'schema_version',
+    'artifact_kind',
+    'order',
+    'mode',
+    'threshold_m',
+    'receiver_location_interval_m',
+    'prefer_receiver_anchor',
+    'n_traces',
+    'n_source_endpoints',
+    'n_receiver_endpoints',
+    'n_nodes',
+    'n_receiver_anchor_links',
+    'n_source_fallback_links',
+    'n_independent_source_nodes',
+    'coordinate_scalar_zero_count',
+    'job_id',
+    'input_file_id',
+    'key1_byte',
+    'key2_byte',
+    'source_x_byte',
+    'source_y_byte',
+    'receiver_x_byte',
+    'receiver_y_byte',
+    'coordinate_scalar_byte',
+    'header_source_segy_path',
+)
+_TRACE_LEVEL_FIELDS = (
+    'source_x_m_sorted',
+    'source_y_m_sorted',
+    'receiver_x_m_sorted',
+    'receiver_y_m_sorted',
+    'coordinate_scalar_sorted',
+    'source_endpoint_id_sorted',
+    'receiver_endpoint_id_sorted',
+    'source_node_id_sorted',
+    'receiver_node_id_sorted',
+)
+_SOURCE_ENDPOINT_FIELDS = (
+    'source_endpoint_id',
+    'source_endpoint_x_m',
+    'source_endpoint_y_m',
+    'source_endpoint_first_sorted_trace_index',
+    'source_endpoint_trace_count',
+    'source_node_id_by_endpoint',
+)
+_RECEIVER_ENDPOINT_FIELDS = (
+    'receiver_endpoint_id',
+    'receiver_endpoint_x_m',
+    'receiver_endpoint_y_m',
+    'receiver_endpoint_first_sorted_trace_index',
+    'receiver_endpoint_trace_count',
+    'receiver_node_id_by_endpoint',
+)
+_RECORD_FIELDS = (
+    'record_endpoint_kind',
+    'record_endpoint_id',
+    'record_x_m',
+    'record_y_m',
+    'record_node_id',
+    'record_linked_to_kind',
+    'record_linked_to_id',
+    'record_distance_m',
+    'record_method',
+)
+_REQUIRED_FIELDS = (
+    *_SCALAR_FIELDS,
+    *_TRACE_LEVEL_FIELDS,
+    *_SOURCE_ENDPOINT_FIELDS,
+    *_RECEIVER_ENDPOINT_FIELDS,
+    *_RECORD_FIELDS,
+)
+
+
+@dataclass(frozen=True)
+class GeometryLinkageLoadedMetadata:
+    job_id: str | None
+    input_file_id: str | None
+    key1_byte: int | None
+    key2_byte: int | None
+    source_x_byte: int | None
+    source_y_byte: int | None
+    receiver_x_byte: int | None
+    receiver_y_byte: int | None
+    coordinate_scalar_byte: int | None
+    header_source_segy_path: str | None
+
+
+@dataclass(frozen=True)
+class GeometryLinkageTraceNodeMapping:
+    n_traces: int
+    n_nodes: int
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+
+
+@dataclass(frozen=True)
+class LoadedGeometryLinkageArtifact:
+    path: Path
+    schema_version: int
+    artifact_kind: str
+    order: str
+    mode: LinkageMode
+    threshold_m: float | None
+    receiver_location_interval_m: float | None
+    prefer_receiver_anchor: bool
+    n_traces: int
+    n_source_endpoints: int
+    n_receiver_endpoints: int
+    n_nodes: int
+    n_receiver_anchor_links: int
+    n_source_fallback_links: int
+    n_independent_source_nodes: int
+    coordinate_scalar_zero_count: int
+    metadata: GeometryLinkageLoadedMetadata
+
+    source_x_m_sorted: np.ndarray
+    source_y_m_sorted: np.ndarray
+    receiver_x_m_sorted: np.ndarray
+    receiver_y_m_sorted: np.ndarray
+    coordinate_scalar_sorted: np.ndarray
+    source_endpoint_id_sorted: np.ndarray
+    receiver_endpoint_id_sorted: np.ndarray
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+
+    source_endpoint_id: np.ndarray
+    source_endpoint_x_m: np.ndarray
+    source_endpoint_y_m: np.ndarray
+    source_endpoint_first_sorted_trace_index: np.ndarray
+    source_endpoint_trace_count: np.ndarray
+    source_node_id_by_endpoint: np.ndarray
+
+    receiver_endpoint_id: np.ndarray
+    receiver_endpoint_x_m: np.ndarray
+    receiver_endpoint_y_m: np.ndarray
+    receiver_endpoint_first_sorted_trace_index: np.ndarray
+    receiver_endpoint_trace_count: np.ndarray
+    receiver_node_id_by_endpoint: np.ndarray
+
+    record_endpoint_kind: np.ndarray
+    record_endpoint_id: np.ndarray
+    record_x_m: np.ndarray
+    record_y_m: np.ndarray
+    record_node_id: np.ndarray
+    record_linked_to_kind: np.ndarray
+    record_linked_to_id: np.ndarray
+    record_distance_m: np.ndarray
+    record_method: np.ndarray
+
+    def trace_node_mapping(self) -> GeometryLinkageTraceNodeMapping:
+        return GeometryLinkageTraceNodeMapping(
+            n_traces=self.n_traces,
+            n_nodes=self.n_nodes,
+            source_node_id_sorted=self.source_node_id_sorted,
+            receiver_node_id_sorted=self.receiver_node_id_sorted,
+        )
+
+
+def load_geometry_linkage_artifact(
+    npz_path: Path,
+    *,
+    expected_n_traces: int | None = None,
+    expected_key1_byte: int | None = None,
+    expected_key2_byte: int | None = None,
+) -> LoadedGeometryLinkageArtifact:
+    """Load and validate a geometry linkage solution artifact."""
+    path = Path(npz_path)
+    arrays = _read_required_arrays(path)
+
+    schema_version = _read_integer_scalar(
+        arrays['schema_version'],
+        name='schema_version',
+    )
+    artifact_kind = _read_string_scalar(
+        arrays['artifact_kind'],
+        name='artifact_kind',
+    )
+    order = _read_string_scalar(arrays['order'], name='order')
+    mode_value = _read_string_scalar(arrays['mode'], name='mode')
+    if schema_version != SCHEMA_VERSION:
+        raise ValueError(f'schema_version must be {SCHEMA_VERSION}')
+    if artifact_kind != SOLUTION_ARTIFACT_KIND:
+        raise ValueError(
+            f'geometry_linkage artifact kind must be {SOLUTION_ARTIFACT_KIND}'
+        )
+    if order != ORDER:
+        raise ValueError(f'geometry_linkage artifact order must be {ORDER}')
+    if mode_value not in _KNOWN_MODES:
+        raise ValueError(f'mode contains unsupported value: {mode_value!r}')
+    mode: LinkageMode = 'none' if mode_value == 'none' else 'auto_threshold'
+
+    threshold_m = _read_optional_float_scalar(
+        arrays['threshold_m'],
+        name='threshold_m',
+    )
+    receiver_location_interval_m = _read_optional_float_scalar(
+        arrays['receiver_location_interval_m'],
+        name='receiver_location_interval_m',
+    )
+    prefer_receiver_anchor = _read_bool_scalar(
+        arrays['prefer_receiver_anchor'],
+        name='prefer_receiver_anchor',
+    )
+    n_traces = _read_positive_integer_scalar(arrays['n_traces'], name='n_traces')
+    n_source_endpoints = _read_positive_integer_scalar(
+        arrays['n_source_endpoints'],
+        name='n_source_endpoints',
+    )
+    n_receiver_endpoints = _read_positive_integer_scalar(
+        arrays['n_receiver_endpoints'],
+        name='n_receiver_endpoints',
+    )
+    n_nodes = _read_positive_integer_scalar(arrays['n_nodes'], name='n_nodes')
+    n_receiver_anchor_links = _read_nonnegative_integer_scalar(
+        arrays['n_receiver_anchor_links'],
+        name='n_receiver_anchor_links',
+    )
+    n_source_fallback_links = _read_nonnegative_integer_scalar(
+        arrays['n_source_fallback_links'],
+        name='n_source_fallback_links',
+    )
+    n_independent_source_nodes = _read_nonnegative_integer_scalar(
+        arrays['n_independent_source_nodes'],
+        name='n_independent_source_nodes',
+    )
+    coordinate_scalar_zero_count = _read_nonnegative_integer_scalar(
+        arrays['coordinate_scalar_zero_count'],
+        name='coordinate_scalar_zero_count',
+    )
+    _validate_expected_n_traces(n_traces, expected_n_traces)
+
+    metadata = GeometryLinkageLoadedMetadata(
+        job_id=_read_optional_string_scalar(arrays['job_id'], name='job_id'),
+        input_file_id=_read_optional_string_scalar(
+            arrays['input_file_id'],
+            name='input_file_id',
+        ),
+        key1_byte=_read_optional_integer_scalar(
+            arrays['key1_byte'],
+            name='key1_byte',
+        ),
+        key2_byte=_read_optional_integer_scalar(
+            arrays['key2_byte'],
+            name='key2_byte',
+        ),
+        source_x_byte=_read_optional_integer_scalar(
+            arrays['source_x_byte'],
+            name='source_x_byte',
+        ),
+        source_y_byte=_read_optional_integer_scalar(
+            arrays['source_y_byte'],
+            name='source_y_byte',
+        ),
+        receiver_x_byte=_read_optional_integer_scalar(
+            arrays['receiver_x_byte'],
+            name='receiver_x_byte',
+        ),
+        receiver_y_byte=_read_optional_integer_scalar(
+            arrays['receiver_y_byte'],
+            name='receiver_y_byte',
+        ),
+        coordinate_scalar_byte=_read_optional_integer_scalar(
+            arrays['coordinate_scalar_byte'],
+            name='coordinate_scalar_byte',
+        ),
+        header_source_segy_path=_read_optional_string_scalar(
+            arrays['header_source_segy_path'],
+            name='header_source_segy_path',
+        ),
+    )
+    _validate_expected_key_byte(
+        metadata.key1_byte,
+        expected_key1_byte,
+        name='key1_byte',
+        expected_name='expected_key1_byte',
+    )
+    _validate_expected_key_byte(
+        metadata.key2_byte,
+        expected_key2_byte,
+        name='key2_byte',
+        expected_name='expected_key2_byte',
+    )
+
+    if receiver_location_interval_m is not None and receiver_location_interval_m <= 0.0:
+        raise ValueError('receiver_location_interval_m must be finite and greater than 0')
+
+    source_x_m_sorted = _read_finite_float_1d(
+        arrays['source_x_m_sorted'],
+        name='source_x_m_sorted',
+        expected_shape=(n_traces,),
+    )
+    source_y_m_sorted = _read_finite_float_1d(
+        arrays['source_y_m_sorted'],
+        name='source_y_m_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_x_m_sorted = _read_finite_float_1d(
+        arrays['receiver_x_m_sorted'],
+        name='receiver_x_m_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_y_m_sorted = _read_finite_float_1d(
+        arrays['receiver_y_m_sorted'],
+        name='receiver_y_m_sorted',
+        expected_shape=(n_traces,),
+    )
+    coordinate_scalar_sorted = _read_integer_1d(
+        arrays['coordinate_scalar_sorted'],
+        name='coordinate_scalar_sorted',
+        expected_shape=(n_traces,),
+    )
+    source_endpoint_id_sorted = _read_integer_1d(
+        arrays['source_endpoint_id_sorted'],
+        name='source_endpoint_id_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_endpoint_id_sorted = _read_integer_1d(
+        arrays['receiver_endpoint_id_sorted'],
+        name='receiver_endpoint_id_sorted',
+        expected_shape=(n_traces,),
+    )
+    source_node_id_sorted = _read_integer_1d(
+        arrays['source_node_id_sorted'],
+        name='source_node_id_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_node_id_sorted = _read_integer_1d(
+        arrays['receiver_node_id_sorted'],
+        name='receiver_node_id_sorted',
+        expected_shape=(n_traces,),
+    )
+
+    source_endpoint_id = _read_integer_1d(
+        arrays['source_endpoint_id'],
+        name='source_endpoint_id',
+        expected_shape=(n_source_endpoints,),
+    )
+    source_endpoint_x_m = _read_finite_float_1d(
+        arrays['source_endpoint_x_m'],
+        name='source_endpoint_x_m',
+        expected_shape=(n_source_endpoints,),
+    )
+    source_endpoint_y_m = _read_finite_float_1d(
+        arrays['source_endpoint_y_m'],
+        name='source_endpoint_y_m',
+        expected_shape=(n_source_endpoints,),
+    )
+    source_endpoint_first_sorted_trace_index = _read_integer_1d(
+        arrays['source_endpoint_first_sorted_trace_index'],
+        name='source_endpoint_first_sorted_trace_index',
+        expected_shape=(n_source_endpoints,),
+    )
+    source_endpoint_trace_count = _read_integer_1d(
+        arrays['source_endpoint_trace_count'],
+        name='source_endpoint_trace_count',
+        expected_shape=(n_source_endpoints,),
+    )
+    source_node_id_by_endpoint = _read_integer_1d(
+        arrays['source_node_id_by_endpoint'],
+        name='source_node_id_by_endpoint',
+        expected_shape=(n_source_endpoints,),
+    )
+
+    receiver_endpoint_id = _read_integer_1d(
+        arrays['receiver_endpoint_id'],
+        name='receiver_endpoint_id',
+        expected_shape=(n_receiver_endpoints,),
+    )
+    receiver_endpoint_x_m = _read_finite_float_1d(
+        arrays['receiver_endpoint_x_m'],
+        name='receiver_endpoint_x_m',
+        expected_shape=(n_receiver_endpoints,),
+    )
+    receiver_endpoint_y_m = _read_finite_float_1d(
+        arrays['receiver_endpoint_y_m'],
+        name='receiver_endpoint_y_m',
+        expected_shape=(n_receiver_endpoints,),
+    )
+    receiver_endpoint_first_sorted_trace_index = _read_integer_1d(
+        arrays['receiver_endpoint_first_sorted_trace_index'],
+        name='receiver_endpoint_first_sorted_trace_index',
+        expected_shape=(n_receiver_endpoints,),
+    )
+    receiver_endpoint_trace_count = _read_integer_1d(
+        arrays['receiver_endpoint_trace_count'],
+        name='receiver_endpoint_trace_count',
+        expected_shape=(n_receiver_endpoints,),
+    )
+    receiver_node_id_by_endpoint = _read_integer_1d(
+        arrays['receiver_node_id_by_endpoint'],
+        name='receiver_node_id_by_endpoint',
+        expected_shape=(n_receiver_endpoints,),
+    )
+
+    n_records = n_receiver_endpoints + n_source_endpoints
+    record_endpoint_kind = _read_string_1d(
+        arrays['record_endpoint_kind'],
+        name='record_endpoint_kind',
+        expected_shape=(n_records,),
+    )
+    record_endpoint_id = _read_integer_1d(
+        arrays['record_endpoint_id'],
+        name='record_endpoint_id',
+        expected_shape=(n_records,),
+    )
+    record_x_m = _read_finite_float_1d(
+        arrays['record_x_m'],
+        name='record_x_m',
+        expected_shape=(n_records,),
+    )
+    record_y_m = _read_finite_float_1d(
+        arrays['record_y_m'],
+        name='record_y_m',
+        expected_shape=(n_records,),
+    )
+    record_node_id = _read_integer_1d(
+        arrays['record_node_id'],
+        name='record_node_id',
+        expected_shape=(n_records,),
+    )
+    record_linked_to_kind = _read_string_1d(
+        arrays['record_linked_to_kind'],
+        name='record_linked_to_kind',
+        expected_shape=(n_records,),
+    )
+    record_linked_to_id = _read_integer_1d(
+        arrays['record_linked_to_id'],
+        name='record_linked_to_id',
+        expected_shape=(n_records,),
+    )
+    record_distance_m = _read_record_distance_1d(
+        arrays['record_distance_m'],
+        name='record_distance_m',
+        expected_shape=(n_records,),
+    )
+    record_method = _read_string_1d(
+        arrays['record_method'],
+        name='record_method',
+        expected_shape=(n_records,),
+    )
+
+    _validate_mode_scalars(
+        mode=mode,
+        threshold_m=threshold_m,
+        prefer_receiver_anchor=prefer_receiver_anchor,
+        n_receiver_anchor_links=n_receiver_anchor_links,
+        n_source_fallback_links=n_source_fallback_links,
+        n_independent_source_nodes=n_independent_source_nodes,
+        n_source_endpoints=n_source_endpoints,
+        n_receiver_endpoints=n_receiver_endpoints,
+        n_nodes=n_nodes,
+    )
+    _validate_endpoint_ids(
+        source_endpoint_id=source_endpoint_id,
+        receiver_endpoint_id=receiver_endpoint_id,
+    )
+    _validate_sorted_endpoint_ids(
+        source_endpoint_id_sorted,
+        name='source_endpoint_id_sorted',
+        n_endpoints=n_source_endpoints,
+    )
+    _validate_sorted_endpoint_ids(
+        receiver_endpoint_id_sorted,
+        name='receiver_endpoint_id_sorted',
+        n_endpoints=n_receiver_endpoints,
+    )
+    _validate_endpoint_trace_metadata(
+        endpoint_id_sorted=source_endpoint_id_sorted,
+        first_sorted_trace_index=source_endpoint_first_sorted_trace_index,
+        trace_count=source_endpoint_trace_count,
+        n_endpoints=n_source_endpoints,
+        kind='source',
+    )
+    _validate_endpoint_trace_metadata(
+        endpoint_id_sorted=receiver_endpoint_id_sorted,
+        first_sorted_trace_index=receiver_endpoint_first_sorted_trace_index,
+        trace_count=receiver_endpoint_trace_count,
+        n_endpoints=n_receiver_endpoints,
+        kind='receiver',
+    )
+    _validate_node_ids(
+        source_node_id_by_endpoint=source_node_id_by_endpoint,
+        receiver_node_id_by_endpoint=receiver_node_id_by_endpoint,
+        n_nodes=n_nodes,
+    )
+    _validate_trace_node_mapping(
+        source_endpoint_id_sorted=source_endpoint_id_sorted,
+        receiver_endpoint_id_sorted=receiver_endpoint_id_sorted,
+        source_node_id_by_endpoint=source_node_id_by_endpoint,
+        receiver_node_id_by_endpoint=receiver_node_id_by_endpoint,
+        source_node_id_sorted=source_node_id_sorted,
+        receiver_node_id_sorted=receiver_node_id_sorted,
+    )
+    _validate_trace_coordinate_mapping(
+        source_endpoint_id_sorted=source_endpoint_id_sorted,
+        receiver_endpoint_id_sorted=receiver_endpoint_id_sorted,
+        source_x_m_sorted=source_x_m_sorted,
+        source_y_m_sorted=source_y_m_sorted,
+        receiver_x_m_sorted=receiver_x_m_sorted,
+        receiver_y_m_sorted=receiver_y_m_sorted,
+        source_endpoint_x_m=source_endpoint_x_m,
+        source_endpoint_y_m=source_endpoint_y_m,
+        receiver_endpoint_x_m=receiver_endpoint_x_m,
+        receiver_endpoint_y_m=receiver_endpoint_y_m,
+    )
+    _validate_records(
+        mode=mode,
+        n_source_endpoints=n_source_endpoints,
+        n_receiver_endpoints=n_receiver_endpoints,
+        n_receiver_anchor_links=n_receiver_anchor_links,
+        n_source_fallback_links=n_source_fallback_links,
+        n_independent_source_nodes=n_independent_source_nodes,
+        source_endpoint_x_m=source_endpoint_x_m,
+        source_endpoint_y_m=source_endpoint_y_m,
+        source_node_id_by_endpoint=source_node_id_by_endpoint,
+        receiver_endpoint_x_m=receiver_endpoint_x_m,
+        receiver_endpoint_y_m=receiver_endpoint_y_m,
+        receiver_node_id_by_endpoint=receiver_node_id_by_endpoint,
+        record_endpoint_kind=record_endpoint_kind,
+        record_endpoint_id=record_endpoint_id,
+        record_x_m=record_x_m,
+        record_y_m=record_y_m,
+        record_node_id=record_node_id,
+        record_linked_to_kind=record_linked_to_kind,
+        record_linked_to_id=record_linked_to_id,
+        record_distance_m=record_distance_m,
+        record_method=record_method,
+    )
+
+    return LoadedGeometryLinkageArtifact(
+        path=path,
+        schema_version=schema_version,
+        artifact_kind=artifact_kind,
+        order=order,
+        mode=mode,
+        threshold_m=threshold_m,
+        receiver_location_interval_m=receiver_location_interval_m,
+        prefer_receiver_anchor=prefer_receiver_anchor,
+        n_traces=n_traces,
+        n_source_endpoints=n_source_endpoints,
+        n_receiver_endpoints=n_receiver_endpoints,
+        n_nodes=n_nodes,
+        n_receiver_anchor_links=n_receiver_anchor_links,
+        n_source_fallback_links=n_source_fallback_links,
+        n_independent_source_nodes=n_independent_source_nodes,
+        coordinate_scalar_zero_count=coordinate_scalar_zero_count,
+        metadata=metadata,
+        source_x_m_sorted=source_x_m_sorted,
+        source_y_m_sorted=source_y_m_sorted,
+        receiver_x_m_sorted=receiver_x_m_sorted,
+        receiver_y_m_sorted=receiver_y_m_sorted,
+        coordinate_scalar_sorted=coordinate_scalar_sorted,
+        source_endpoint_id_sorted=source_endpoint_id_sorted,
+        receiver_endpoint_id_sorted=receiver_endpoint_id_sorted,
+        source_node_id_sorted=source_node_id_sorted,
+        receiver_node_id_sorted=receiver_node_id_sorted,
+        source_endpoint_id=source_endpoint_id,
+        source_endpoint_x_m=source_endpoint_x_m,
+        source_endpoint_y_m=source_endpoint_y_m,
+        source_endpoint_first_sorted_trace_index=source_endpoint_first_sorted_trace_index,
+        source_endpoint_trace_count=source_endpoint_trace_count,
+        source_node_id_by_endpoint=source_node_id_by_endpoint,
+        receiver_endpoint_id=receiver_endpoint_id,
+        receiver_endpoint_x_m=receiver_endpoint_x_m,
+        receiver_endpoint_y_m=receiver_endpoint_y_m,
+        receiver_endpoint_first_sorted_trace_index=receiver_endpoint_first_sorted_trace_index,
+        receiver_endpoint_trace_count=receiver_endpoint_trace_count,
+        receiver_node_id_by_endpoint=receiver_node_id_by_endpoint,
+        record_endpoint_kind=record_endpoint_kind,
+        record_endpoint_id=record_endpoint_id,
+        record_x_m=record_x_m,
+        record_y_m=record_y_m,
+        record_node_id=record_node_id,
+        record_linked_to_kind=record_linked_to_kind,
+        record_linked_to_id=record_linked_to_id,
+        record_distance_m=record_distance_m,
+        record_method=record_method,
+    )
+
+
+def load_geometry_linkage_from_job_dir(
+    job_dir: Path,
+    *,
+    expected_n_traces: int | None = None,
+    expected_key1_byte: int | None = None,
+    expected_key2_byte: int | None = None,
+) -> LoadedGeometryLinkageArtifact:
+    """Load the standard geometry linkage NPZ artifact from a job directory."""
+    return load_geometry_linkage_artifact(
+        Path(job_dir) / GEOMETRY_LINKAGE_NPZ_NAME,
+        expected_n_traces=expected_n_traces,
+        expected_key1_byte=expected_key1_byte,
+        expected_key2_byte=expected_key2_byte,
+    )
+
+
+def load_geometry_linkage_trace_node_mapping(
+    npz_path: Path,
+    *,
+    expected_n_traces: int | None = None,
+) -> GeometryLinkageTraceNodeMapping:
+    """Load only the sorted trace node mapping after full artifact validation."""
+    loaded = load_geometry_linkage_artifact(
+        npz_path,
+        expected_n_traces=expected_n_traces,
+    )
+    return loaded.trace_node_mapping()
+
+
+def _read_required_arrays(npz_path: Path) -> dict[str, np.ndarray]:
+    with np.load(npz_path, allow_pickle=False) as npz:
+        available_fields = set(npz.files)
+        for field in _REQUIRED_FIELDS:
+            if field not in available_fields:
+                raise ValueError(f'missing required field: {field}')
+        arrays: dict[str, np.ndarray] = {}
+        for field in npz.files:
+            arrays[field] = _copy_npz_array(npz, field)
+        return {field: arrays[field] for field in _REQUIRED_FIELDS}
+
+
+def _copy_npz_array(npz: np.lib.npyio.NpzFile, name: str) -> np.ndarray:
+    try:
+        arr = np.array(npz[name], copy=True)
+    except ValueError as exc:
+        if 'Object arrays cannot be loaded' in str(exc):
+            raise ValueError(f'{name} has object dtype') from exc
+        raise
+    _reject_object_dtype(arr, name=name)
+    return arr
+
+
+def _reject_object_dtype(arr: np.ndarray, *, name: str) -> None:
+    if arr.dtype == object:
+        raise ValueError(f'{name} has object dtype')
+
+
+def _require_scalar(arr: np.ndarray, *, name: str) -> None:
+    _reject_object_dtype(arr, name=name)
+    if arr.ndim != 0:
+        raise ValueError(f'{name} must be a scalar')
+
+
+def _read_integer_scalar(arr: np.ndarray, *, name: str) -> int:
+    _require_scalar(arr, name=name)
+    if np.issubdtype(arr.dtype, np.bool_) or not np.issubdtype(
+        arr.dtype,
+        np.integer,
+    ):
+        raise ValueError(f'{name} must be an integer scalar')
+    return int(arr.item())
+
+
+def _read_positive_integer_scalar(arr: np.ndarray, *, name: str) -> int:
+    value = _read_integer_scalar(arr, name=name)
+    if value <= 0:
+        raise ValueError(f'{name} must be greater than 0')
+    return value
+
+
+def _read_nonnegative_integer_scalar(arr: np.ndarray, *, name: str) -> int:
+    value = _read_integer_scalar(arr, name=name)
+    if value < 0:
+        raise ValueError(f'{name} must be nonnegative')
+    return value
+
+
+def _read_optional_integer_scalar(arr: np.ndarray, *, name: str) -> int | None:
+    _require_scalar(arr, name=name)
+    if np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must be an integer scalar or NaN')
+    if np.issubdtype(arr.dtype, np.integer):
+        return int(arr.item())
+    if not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must be an integer scalar or NaN')
+    value = float(arr.item())
+    if np.isnan(value):
+        return None
+    if not np.isfinite(value) or value != round(value):
+        raise ValueError(f'{name} must be an integer scalar or NaN')
+    return int(value)
+
+
+def _read_optional_float_scalar(arr: np.ndarray, *, name: str) -> float | None:
+    _require_scalar(arr, name=name)
+    if np.issubdtype(arr.dtype, np.bool_) or not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must be a numeric scalar')
+    value = float(arr.item())
+    if np.isnan(value):
+        return None
+    if not np.isfinite(value):
+        raise ValueError(f'{name} must be finite or NaN')
+    return value
+
+
+def _read_bool_scalar(arr: np.ndarray, *, name: str) -> bool:
+    _require_scalar(arr, name=name)
+    if np.issubdtype(arr.dtype, np.bool_):
+        return bool(arr.item())
+    if np.issubdtype(arr.dtype, np.integer):
+        value = int(arr.item())
+        if value in {0, 1}:
+            return bool(value)
+    raise ValueError(f'{name} must be a bool scalar')
+
+
+def _read_string_scalar(arr: np.ndarray, *, name: str) -> str:
+    _require_scalar(arr, name=name)
+    if not _is_string_dtype(arr.dtype):
+        raise ValueError(f'{name} must be a string scalar')
+    return _scalar_string_value(arr.item())
+
+
+def _read_optional_string_scalar(arr: np.ndarray, *, name: str) -> str | None:
+    value = _read_string_scalar(arr, name=name)
+    return None if value == '' else value
+
+
+def _scalar_string_value(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    return str(value)
+
+
+def _read_integer_1d(
+    arr: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    _validate_1d_shape(arr, name=name, expected_shape=expected_shape)
+    if np.issubdtype(arr.dtype, np.bool_) or not np.issubdtype(
+        arr.dtype,
+        np.integer,
+    ):
+        raise ValueError(f'{name} must have an integer dtype')
+    return _readonly(np.array(arr, dtype=np.int64, copy=True, order='C'))
+
+
+def _read_finite_float_1d(
+    arr: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    _validate_1d_shape(arr, name=name, expected_shape=expected_shape)
+    if np.issubdtype(arr.dtype, np.bool_) or not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a real numeric dtype')
+    out = np.array(arr, dtype=np.float64, copy=True, order='C')
+    if not np.all(np.isfinite(out)):
+        raise ValueError(f'{name} must contain only finite values')
+    return _readonly(out)
+
+
+def _read_record_distance_1d(
+    arr: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    _validate_1d_shape(arr, name=name, expected_shape=expected_shape)
+    if np.issubdtype(arr.dtype, np.bool_) or not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a real numeric dtype')
+    out = np.array(arr, dtype=np.float64, copy=True, order='C')
+    if np.any(np.isinf(out)):
+        raise ValueError(f'{name} must not contain Inf')
+    finite = out[np.isfinite(out)]
+    if np.any(finite < 0.0):
+        raise ValueError(f'{name} finite values must be greater than or equal to 0')
+    return _readonly(out)
+
+
+def _read_string_1d(
+    arr: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    _validate_1d_shape(arr, name=name, expected_shape=expected_shape)
+    if not _is_string_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a string dtype')
+    return _readonly(np.array(arr, dtype=np.str_, copy=True, order='C'))
+
+
+def _validate_1d_shape(
+    arr: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> None:
+    _reject_object_dtype(arr, name=name)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        )
+
+
+def _readonly(arr: np.ndarray) -> np.ndarray:
+    arr.setflags(write=False)
+    return arr
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+def _is_string_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.str_) or np.issubdtype(dtype, np.bytes_)
+
+
+def _validate_expected_n_traces(
+    n_traces: int,
+    expected_n_traces: int | None,
+) -> None:
+    if expected_n_traces is None:
+        return
+    if isinstance(expected_n_traces, bool) or not isinstance(
+        expected_n_traces,
+        int,
+    ):
+        raise ValueError('expected_n_traces must be an integer')
+    if n_traces != expected_n_traces:
+        raise ValueError(
+            f'n_traces mismatch: expected {expected_n_traces}, got {n_traces}'
+        )
+
+
+def _validate_expected_key_byte(
+    actual: int | None,
+    expected: int | None,
+    *,
+    name: str,
+    expected_name: str,
+) -> None:
+    if expected is None:
+        return
+    if isinstance(expected, bool) or not isinstance(expected, int):
+        raise ValueError(f'{expected_name} must be an integer')
+    if actual != expected:
+        raise ValueError(f'{name} mismatch: expected {expected}, got {actual}')
+
+
+def _validate_mode_scalars(
+    *,
+    mode: LinkageMode,
+    threshold_m: float | None,
+    prefer_receiver_anchor: bool,
+    n_receiver_anchor_links: int,
+    n_source_fallback_links: int,
+    n_independent_source_nodes: int,
+    n_source_endpoints: int,
+    n_receiver_endpoints: int,
+    n_nodes: int,
+) -> None:
+    if mode == 'none':
+        if threshold_m is not None:
+            raise ValueError('threshold_m must be None when mode is none')
+        if n_receiver_anchor_links != 0:
+            raise ValueError('n_receiver_anchor_links must be 0 when mode is none')
+        if n_source_fallback_links != 0:
+            raise ValueError('n_source_fallback_links must be 0 when mode is none')
+        if n_independent_source_nodes != n_source_endpoints:
+            raise ValueError(
+                'n_independent_source_nodes must equal n_source_endpoints when mode is none'
+            )
+        if n_nodes != n_receiver_endpoints + n_source_endpoints:
+            raise ValueError(
+                'n_nodes must equal n_receiver_endpoints + n_source_endpoints when mode is none'
+            )
+        return
+
+    if threshold_m is None or threshold_m <= 0.0:
+        raise ValueError('threshold_m must be finite and greater than 0')
+    if not prefer_receiver_anchor:
+        raise ValueError('prefer_receiver_anchor must be True when mode is auto_threshold')
+    if n_receiver_anchor_links > n_source_endpoints:
+        raise ValueError('n_receiver_anchor_links must be <= n_source_endpoints')
+    if n_source_fallback_links > n_source_endpoints:
+        raise ValueError('n_source_fallback_links must be <= n_source_endpoints')
+    if n_independent_source_nodes > n_source_endpoints:
+        raise ValueError('n_independent_source_nodes must be <= n_source_endpoints')
+
+
+def _validate_endpoint_ids(
+    *,
+    source_endpoint_id: np.ndarray,
+    receiver_endpoint_id: np.ndarray,
+) -> None:
+    expected_source = np.arange(source_endpoint_id.shape[0], dtype=np.int64)
+    if not np.array_equal(source_endpoint_id, expected_source):
+        raise ValueError('source_endpoint_id must be 0-based contiguous')
+    expected_receiver = np.arange(receiver_endpoint_id.shape[0], dtype=np.int64)
+    if not np.array_equal(receiver_endpoint_id, expected_receiver):
+        raise ValueError('receiver_endpoint_id must be 0-based contiguous')
+
+
+def _validate_sorted_endpoint_ids(
+    values: np.ndarray,
+    *,
+    name: str,
+    n_endpoints: int,
+) -> None:
+    if values.size and (int(values.min()) < 0 or int(values.max()) >= n_endpoints):
+        raise ValueError(f'{name} values must be in range 0..{n_endpoints - 1}')
+
+
+def _validate_endpoint_trace_metadata(
+    *,
+    endpoint_id_sorted: np.ndarray,
+    first_sorted_trace_index: np.ndarray,
+    trace_count: np.ndarray,
+    n_endpoints: int,
+    kind: str,
+) -> None:
+    if np.any(trace_count <= 0):
+        raise ValueError(f'{kind}_endpoint_trace_count values must be greater than 0')
+    expected_trace_count = np.bincount(
+        endpoint_id_sorted,
+        minlength=n_endpoints,
+    ).astype(np.int64)
+    if not np.array_equal(trace_count, expected_trace_count):
+        raise ValueError(
+            f'{kind}_endpoint_trace_count does not match {kind}_endpoint_id_sorted'
+        )
+
+    expected_first = np.full(n_endpoints, -1, dtype=np.int64)
+    for trace_index, endpoint_id in enumerate(endpoint_id_sorted):
+        endpoint_index = int(endpoint_id)
+        if expected_first[endpoint_index] < 0:
+            expected_first[endpoint_index] = trace_index
+    if not np.array_equal(first_sorted_trace_index, expected_first):
+        raise ValueError(
+            f'{kind}_endpoint_first_sorted_trace_index does not match {kind}_endpoint_id_sorted'
+        )
+
+
+def _validate_node_ids(
+    *,
+    source_node_id_by_endpoint: np.ndarray,
+    receiver_node_id_by_endpoint: np.ndarray,
+    n_nodes: int,
+) -> None:
+    all_endpoint_nodes = np.concatenate(
+        (source_node_id_by_endpoint, receiver_node_id_by_endpoint)
+    )
+    if all_endpoint_nodes.size == 0:
+        raise ValueError('node ids must be non-empty')
+    if int(all_endpoint_nodes.min()) != 0:
+        raise ValueError('node id values must start at 0')
+    if int(all_endpoint_nodes.max()) != n_nodes - 1:
+        raise ValueError('node id values must end at n_nodes - 1')
+    if not np.array_equal(np.unique(all_endpoint_nodes), np.arange(n_nodes)):
+        raise ValueError('node id values must be 0-based contiguous')
+
+
+def _validate_trace_node_mapping(
+    *,
+    source_endpoint_id_sorted: np.ndarray,
+    receiver_endpoint_id_sorted: np.ndarray,
+    source_node_id_by_endpoint: np.ndarray,
+    receiver_node_id_by_endpoint: np.ndarray,
+    source_node_id_sorted: np.ndarray,
+    receiver_node_id_sorted: np.ndarray,
+) -> None:
+    expected_source = source_node_id_by_endpoint[source_endpoint_id_sorted]
+    if not np.array_equal(source_node_id_sorted, expected_source):
+        raise ValueError(
+            'source_node_id_sorted does not match source_node_id_by_endpoint[source_endpoint_id_sorted]'
+        )
+    expected_receiver = receiver_node_id_by_endpoint[receiver_endpoint_id_sorted]
+    if not np.array_equal(receiver_node_id_sorted, expected_receiver):
+        raise ValueError(
+            'receiver_node_id_sorted does not match receiver_node_id_by_endpoint[receiver_endpoint_id_sorted]'
+        )
+
+
+def _validate_trace_coordinate_mapping(
+    *,
+    source_endpoint_id_sorted: np.ndarray,
+    receiver_endpoint_id_sorted: np.ndarray,
+    source_x_m_sorted: np.ndarray,
+    source_y_m_sorted: np.ndarray,
+    receiver_x_m_sorted: np.ndarray,
+    receiver_y_m_sorted: np.ndarray,
+    source_endpoint_x_m: np.ndarray,
+    source_endpoint_y_m: np.ndarray,
+    receiver_endpoint_x_m: np.ndarray,
+    receiver_endpoint_y_m: np.ndarray,
+) -> None:
+    if not np.allclose(
+        source_x_m_sorted,
+        source_endpoint_x_m[source_endpoint_id_sorted],
+    ):
+        raise ValueError(
+            'source_x_m_sorted does not match source_endpoint_x_m[source_endpoint_id_sorted]'
+        )
+    if not np.allclose(
+        source_y_m_sorted,
+        source_endpoint_y_m[source_endpoint_id_sorted],
+    ):
+        raise ValueError(
+            'source_y_m_sorted does not match source_endpoint_y_m[source_endpoint_id_sorted]'
+        )
+    if not np.allclose(
+        receiver_x_m_sorted,
+        receiver_endpoint_x_m[receiver_endpoint_id_sorted],
+    ):
+        raise ValueError(
+            'receiver_x_m_sorted does not match receiver_endpoint_x_m[receiver_endpoint_id_sorted]'
+        )
+    if not np.allclose(
+        receiver_y_m_sorted,
+        receiver_endpoint_y_m[receiver_endpoint_id_sorted],
+    ):
+        raise ValueError(
+            'receiver_y_m_sorted does not match receiver_endpoint_y_m[receiver_endpoint_id_sorted]'
+        )
+
+
+def _validate_records(
+    *,
+    mode: LinkageMode,
+    n_source_endpoints: int,
+    n_receiver_endpoints: int,
+    n_receiver_anchor_links: int,
+    n_source_fallback_links: int,
+    n_independent_source_nodes: int,
+    source_endpoint_x_m: np.ndarray,
+    source_endpoint_y_m: np.ndarray,
+    source_node_id_by_endpoint: np.ndarray,
+    receiver_endpoint_x_m: np.ndarray,
+    receiver_endpoint_y_m: np.ndarray,
+    receiver_node_id_by_endpoint: np.ndarray,
+    record_endpoint_kind: np.ndarray,
+    record_endpoint_id: np.ndarray,
+    record_x_m: np.ndarray,
+    record_y_m: np.ndarray,
+    record_node_id: np.ndarray,
+    record_linked_to_kind: np.ndarray,
+    record_linked_to_id: np.ndarray,
+    record_distance_m: np.ndarray,
+    record_method: np.ndarray,
+) -> None:
+    expected_kind = np.asarray(
+        ['receiver'] * n_receiver_endpoints + ['source'] * n_source_endpoints,
+        dtype=np.str_,
+    )
+    expected_id = np.concatenate(
+        (
+            np.arange(n_receiver_endpoints, dtype=np.int64),
+            np.arange(n_source_endpoints, dtype=np.int64),
+        )
+    )
+    if not np.array_equal(record_endpoint_kind, expected_kind) or not np.array_equal(
+        record_endpoint_id,
+        expected_id,
+    ):
+        raise ValueError(
+            'record arrays must be ordered by receiver endpoint id, then source endpoint id'
+        )
+    if not np.allclose(record_x_m[:n_receiver_endpoints], receiver_endpoint_x_m):
+        raise ValueError('record_x_m receiver rows must match receiver_endpoint_x_m')
+    if not np.allclose(record_y_m[:n_receiver_endpoints], receiver_endpoint_y_m):
+        raise ValueError('record_y_m receiver rows must match receiver_endpoint_y_m')
+    if not np.array_equal(
+        record_node_id[:n_receiver_endpoints],
+        receiver_node_id_by_endpoint,
+    ):
+        raise ValueError(
+            'record_node_id receiver rows must match receiver_node_id_by_endpoint'
+        )
+
+    source_slice = slice(n_receiver_endpoints, None)
+    if not np.allclose(record_x_m[source_slice], source_endpoint_x_m):
+        raise ValueError('record_x_m source rows must match source_endpoint_x_m')
+    if not np.allclose(record_y_m[source_slice], source_endpoint_y_m):
+        raise ValueError('record_y_m source rows must match source_endpoint_y_m')
+    if not np.array_equal(record_node_id[source_slice], source_node_id_by_endpoint):
+        raise ValueError('record_node_id source rows must match source_node_id_by_endpoint')
+
+    _validate_record_values(
+        n_source_endpoints=n_source_endpoints,
+        n_receiver_endpoints=n_receiver_endpoints,
+        record_linked_to_kind=record_linked_to_kind,
+        record_linked_to_id=record_linked_to_id,
+        record_distance_m=record_distance_m,
+        record_method=record_method,
+    )
+    _validate_record_methods_for_mode(
+        mode=mode,
+        n_receiver_endpoints=n_receiver_endpoints,
+        record_method=record_method,
+    )
+    _validate_summary_counts(
+        mode=mode,
+        n_receiver_endpoints=n_receiver_endpoints,
+        n_receiver_anchor_links=n_receiver_anchor_links,
+        n_source_fallback_links=n_source_fallback_links,
+        n_independent_source_nodes=n_independent_source_nodes,
+        record_method=record_method,
+    )
+
+
+def _validate_record_values(
+    *,
+    n_source_endpoints: int,
+    n_receiver_endpoints: int,
+    record_linked_to_kind: np.ndarray,
+    record_linked_to_id: np.ndarray,
+    record_distance_m: np.ndarray,
+    record_method: np.ndarray,
+) -> None:
+    unsupported_link_kinds = sorted(
+        set(record_linked_to_kind.tolist()) - _KNOWN_RECORD_LINKED_TO_KINDS
+    )
+    if unsupported_link_kinds:
+        raise ValueError(
+            f'record_linked_to_kind contains unsupported value: {unsupported_link_kinds[0]!r}'
+        )
+    unsupported_methods = sorted(set(record_method.tolist()) - _KNOWN_RECORD_METHODS)
+    if unsupported_methods:
+        raise ValueError(
+            f'record_method contains unsupported value: {unsupported_methods[0]!r}'
+        )
+
+    for index, linked_to_kind in enumerate(record_linked_to_kind):
+        linked_to_id = int(record_linked_to_id[index])
+        distance_m = float(record_distance_m[index])
+        if linked_to_kind == '':
+            if linked_to_id != -1:
+                raise ValueError(
+                    f'record_linked_to_id[{index}] must be -1 when record_linked_to_kind is empty'
+                )
+            if not np.isnan(distance_m):
+                raise ValueError(
+                    f'record_distance_m[{index}] must be NaN when record_linked_to_kind is empty'
+                )
+            continue
+
+        endpoint_count = (
+            n_source_endpoints
+            if linked_to_kind == 'source'
+            else n_receiver_endpoints
+        )
+        if linked_to_id < 0 or linked_to_id >= endpoint_count:
+            raise ValueError(
+                f'record_linked_to_id[{index}] is out of range for {linked_to_kind}'
+            )
+        if not np.isfinite(distance_m) or distance_m < 0.0:
+            raise ValueError(
+                f'record_distance_m[{index}] must be finite and greater than or equal to 0'
+            )
+
+
+def _validate_record_methods_for_mode(
+    *,
+    mode: LinkageMode,
+    n_receiver_endpoints: int,
+    record_method: np.ndarray,
+) -> None:
+    receiver_methods = record_method[:n_receiver_endpoints]
+    source_methods = record_method[n_receiver_endpoints:]
+    if mode == 'none':
+        if not np.all(receiver_methods == 'none_mode_receiver_independent'):
+            raise ValueError(
+                'record_method receiver rows must be none_mode_receiver_independent when mode is none'
+            )
+        if not np.all(source_methods == 'none_mode_source_independent'):
+            raise ValueError(
+                'record_method source rows must be none_mode_source_independent when mode is none'
+            )
+        return
+
+    if not np.all(receiver_methods == 'receiver_seed'):
+        raise ValueError(
+            'record_method receiver rows must be receiver_seed when mode is auto_threshold'
+        )
+    allowed_source_methods = {
+        'receiver_anchor',
+        'source_fallback',
+        'source_independent',
+    }
+    bad_source_methods = sorted(set(source_methods.tolist()) - allowed_source_methods)
+    if bad_source_methods:
+        raise ValueError(
+            f'record_method source rows contain unsupported auto_threshold value: {bad_source_methods[0]!r}'
+        )
+
+
+def _validate_summary_counts(
+    *,
+    mode: LinkageMode,
+    n_receiver_endpoints: int,
+    n_receiver_anchor_links: int,
+    n_source_fallback_links: int,
+    n_independent_source_nodes: int,
+    record_method: np.ndarray,
+) -> None:
+    source_methods = record_method[n_receiver_endpoints:]
+    receiver_anchor_count = int(np.count_nonzero(source_methods == 'receiver_anchor'))
+    source_fallback_count = int(np.count_nonzero(source_methods == 'source_fallback'))
+    independent_method = (
+        'none_mode_source_independent' if mode == 'none' else 'source_independent'
+    )
+    independent_count = int(np.count_nonzero(source_methods == independent_method))
+    if n_receiver_anchor_links != receiver_anchor_count:
+        raise ValueError(
+            'n_receiver_anchor_links does not match record_method receiver_anchor count'
+        )
+    if n_source_fallback_links != source_fallback_count:
+        raise ValueError(
+            'n_source_fallback_links does not match record_method source_fallback count'
+        )
+    if n_independent_source_nodes != independent_count:
+        raise ValueError(
+            'n_independent_source_nodes does not match record_method independent source count'
+        )
+
+
+__all__ = [
+    'GeometryLinkageLoadedMetadata',
+    'GeometryLinkageTraceNodeMapping',
+    'LinkageMode',
+    'LoadedGeometryLinkageArtifact',
+    'load_geometry_linkage_artifact',
+    'load_geometry_linkage_from_job_dir',
+    'load_geometry_linkage_trace_node_mapping',
+]

--- a/app/tests/test_geometry_linkage_loader.py
+++ b/app/tests/test_geometry_linkage_loader.py
@@ -1,0 +1,483 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import app.services.geometry_linkage_loader as loader
+from app.services.geometry_linkage_artifacts import (
+    GEOMETRY_LINKAGE_NPZ_NAME,
+    GeometryLinkageArtifactMetadata,
+    build_geometry_linkage_solution_arrays,
+)
+from app.services.geometry_linkage_linker import (
+    GeometryLinkageOptions,
+    build_geometry_linkage,
+)
+from app.services.geometry_linkage_tables import build_endpoint_geometry_tables
+from app.services.geometry_linkage_validation import GeometryLinkageHeaders
+from app.services.geometry_linkage_loader import (
+    load_geometry_linkage_artifact,
+    load_geometry_linkage_from_job_dir,
+    load_geometry_linkage_trace_node_mapping,
+)
+
+
+def test_load_geometry_linkage_artifact_reads_npz_with_allow_pickle_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_payload(tmp_path, _payload())
+    original_load = loader.np.load
+    allow_pickle_values: list[object] = []
+
+    def spy_load(*args: object, **kwargs: object) -> object:
+        allow_pickle_values.append(kwargs.get('allow_pickle'))
+        return original_load(*args, **kwargs)
+
+    monkeypatch.setattr(loader.np, 'load', spy_load)
+
+    load_geometry_linkage_artifact(path)
+
+    assert allow_pickle_values == [False]
+
+
+def test_load_geometry_linkage_artifact_returns_copied_arrays_after_npz_close(
+    tmp_path: Path,
+) -> None:
+    path = _write_payload(tmp_path, _payload())
+
+    loaded = load_geometry_linkage_artifact(path)
+
+    np.testing.assert_array_equal(
+        loaded.source_node_id_sorted,
+        loaded.source_node_id_by_endpoint[loaded.source_endpoint_id_sorted],
+    )
+    assert loaded.source_node_id_sorted.flags.writeable is False
+    assert loaded.record_method.flags.writeable is False
+
+
+def test_load_geometry_linkage_artifact_returns_metadata_and_counts(
+    tmp_path: Path,
+) -> None:
+    path = _write_payload(tmp_path, _payload(metadata=_metadata()))
+
+    loaded = load_geometry_linkage_artifact(
+        path,
+        expected_n_traces=5,
+        expected_key1_byte=189,
+        expected_key2_byte=193,
+    )
+
+    assert loaded.schema_version == 1
+    assert loaded.artifact_kind == 'geometry_linkage'
+    assert loaded.order == 'trace_store_sorted'
+    assert loaded.mode == 'auto_threshold'
+    assert loaded.threshold_m == pytest.approx(1.1)
+    assert loaded.receiver_location_interval_m == pytest.approx(25.0)
+    assert loaded.metadata.job_id == 'linkage-job'
+    assert loaded.metadata.key1_byte == 189
+    assert loaded.n_traces == 5
+    assert loaded.n_source_endpoints == 4
+    assert loaded.n_receiver_endpoints == 2
+    assert loaded.n_receiver_anchor_links == 1
+    assert loaded.n_source_fallback_links == 2
+    assert loaded.n_independent_source_nodes == 1
+
+
+def test_load_geometry_linkage_artifact_parses_none_scalars(
+    tmp_path: Path,
+) -> None:
+    path = _write_payload(tmp_path, _payload(mode='none'))
+
+    loaded = load_geometry_linkage_artifact(path)
+
+    assert loaded.threshold_m is None
+    assert loaded.receiver_location_interval_m is None
+    assert loaded.metadata.job_id is None
+    assert loaded.metadata.input_file_id is None
+    assert loaded.metadata.key1_byte is None
+    assert loaded.metadata.header_source_segy_path is None
+
+
+def test_load_geometry_linkage_artifact_rejects_missing_required_field(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload.pop('source_node_id_sorted')
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='missing required field: source_node_id_sorted'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_object_dtype(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['record_method'] = np.asarray(payload['record_method'], dtype=object)
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='record_method.*object dtype'):
+        load_geometry_linkage_artifact(path)
+
+
+@pytest.mark.parametrize(
+    ('field', 'value', 'match'),
+    [
+        ('schema_version', np.asarray(2, dtype=np.int64), 'schema_version'),
+        ('artifact_kind', np.asarray('wrong'), 'artifact kind'),
+        ('order', np.asarray('original_trace_order'), 'order'),
+        ('mode', np.asarray('manual'), 'mode'),
+    ],
+)
+def test_load_geometry_linkage_artifact_rejects_invalid_scalar_contract(
+    tmp_path: Path,
+    field: str,
+    value: np.ndarray,
+    match: str,
+) -> None:
+    payload = _payload()
+    payload[field] = value
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=match):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_trace_shape_mismatch(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['source_node_id_sorted'] = payload['source_node_id_sorted'][:-1]
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='source_node_id_sorted shape mismatch'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_expected_n_traces_mismatch(
+    tmp_path: Path,
+) -> None:
+    path = _write_payload(tmp_path, _payload())
+
+    with pytest.raises(ValueError, match='n_traces mismatch'):
+        load_geometry_linkage_artifact(path, expected_n_traces=6)
+
+
+def test_load_geometry_linkage_artifact_rejects_expected_key_bytes_mismatch(
+    tmp_path: Path,
+) -> None:
+    path = _write_payload(tmp_path, _payload(metadata=_metadata()))
+
+    with pytest.raises(ValueError, match='key1_byte mismatch'):
+        load_geometry_linkage_artifact(path, expected_key1_byte=188)
+
+
+def test_load_geometry_linkage_artifact_rejects_float_id_dtype(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['source_endpoint_id_sorted'] = payload[
+        'source_endpoint_id_sorted'
+    ].astype(np.float64)
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='source_endpoint_id_sorted.*integer dtype'):
+        load_geometry_linkage_artifact(path)
+
+
+@pytest.mark.parametrize(
+    ('field', 'match'),
+    [
+        ('source_endpoint_id', 'source_endpoint_id must be 0-based contiguous'),
+        ('receiver_endpoint_id', 'receiver_endpoint_id must be 0-based contiguous'),
+    ],
+)
+def test_load_geometry_linkage_artifact_rejects_non_contiguous_endpoint_ids(
+    tmp_path: Path,
+    field: str,
+    match: str,
+) -> None:
+    payload = _payload()
+    payload[field] = payload[field].copy()
+    payload[field][-1] += 1
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=match):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_endpoint_id_sorted_out_of_range(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['receiver_endpoint_id_sorted'] = payload[
+        'receiver_endpoint_id_sorted'
+    ].copy()
+    payload['receiver_endpoint_id_sorted'][0] = payload['n_receiver_endpoints'].item()
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='receiver_endpoint_id_sorted values'):
+        load_geometry_linkage_artifact(path)
+
+
+@pytest.mark.parametrize(
+    ('field', 'match'),
+    [
+        ('source_endpoint_trace_count', 'source_endpoint_trace_count'),
+        (
+            'receiver_endpoint_first_sorted_trace_index',
+            'receiver_endpoint_first_sorted_trace_index',
+        ),
+    ],
+)
+def test_load_geometry_linkage_artifact_validates_endpoint_trace_metadata(
+    tmp_path: Path,
+    field: str,
+    match: str,
+) -> None:
+    payload = _payload()
+    payload[field] = payload[field].copy()
+    payload[field][0] += 1
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=match):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_non_contiguous_node_ids(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    source_nodes = payload['source_node_id_by_endpoint'].copy()
+    source_nodes[-1] = 5
+    payload['source_node_id_by_endpoint'] = source_nodes
+    payload['source_node_id_sorted'] = source_nodes[payload['source_endpoint_id_sorted']]
+    payload['n_nodes'] = np.asarray(6, dtype=np.int64)
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='0-based contiguous|end at n_nodes'):
+        load_geometry_linkage_artifact(path)
+
+
+@pytest.mark.parametrize(
+    ('field', 'match'),
+    [
+        (
+            'source_node_id_sorted',
+            'source_node_id_sorted does not match source_node_id_by_endpoint',
+        ),
+        (
+            'receiver_node_id_sorted',
+            'receiver_node_id_sorted does not match receiver_node_id_by_endpoint',
+        ),
+    ],
+)
+def test_load_geometry_linkage_artifact_rejects_sorted_node_mapping_mismatch(
+    tmp_path: Path,
+    field: str,
+    match: str,
+) -> None:
+    payload = _payload()
+    payload[field] = payload[field].copy()
+    payload[field][0] += 1
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=match):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_trace_coordinate_mapping_mismatch(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['source_x_m_sorted'] = payload['source_x_m_sorted'].copy()
+    payload['source_x_m_sorted'][0] += 10.0
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='source_x_m_sorted does not match'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_non_finite_coordinate(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['receiver_endpoint_y_m'] = payload['receiver_endpoint_y_m'].copy()
+    payload['receiver_endpoint_y_m'][0] = np.nan
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='receiver_endpoint_y_m.*finite'):
+        load_geometry_linkage_artifact(path)
+
+
+@pytest.mark.parametrize(
+    ('value', 'match'),
+    [(np.inf, 'Inf'), (-1.0, 'greater than or equal to 0')],
+)
+def test_load_geometry_linkage_artifact_rejects_invalid_record_distance(
+    tmp_path: Path,
+    value: float,
+    match: str,
+) -> None:
+    payload = _payload()
+    linked = int(np.flatnonzero(~np.isnan(payload['record_distance_m']))[0])
+    payload['record_distance_m'] = payload['record_distance_m'].copy()
+    payload['record_distance_m'][linked] = value
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=match):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_validates_record_order(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['record_endpoint_id'] = payload['record_endpoint_id'].copy()
+    payload['record_endpoint_id'][0], payload['record_endpoint_id'][1] = 1, 0
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='ordered by receiver endpoint id'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_validates_record_node_ids(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['record_node_id'] = payload['record_node_id'].copy()
+    payload['record_node_id'][0] += 1
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='record_node_id receiver rows'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_unknown_record_method(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['record_method'] = payload['record_method'].copy()
+    payload['record_method'][0] = 'unknown'
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="record_method contains unsupported value: 'unknown'"):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_validates_none_mode_methods(
+    tmp_path: Path,
+) -> None:
+    payload = _payload(mode='none')
+    payload['record_method'] = payload['record_method'].copy()
+    payload['record_method'][0] = 'receiver_seed'
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='none_mode_receiver_independent'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_validates_auto_threshold_methods(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['record_method'] = payload['record_method'].astype('<U64')
+    payload['record_method'][0] = 'none_mode_receiver_independent'
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='receiver_seed'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_validates_summary_counts_against_records(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    payload['n_receiver_anchor_links'] = np.asarray(0, dtype=np.int64)
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='n_receiver_anchor_links does not match'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_from_job_dir_uses_standard_filename(
+    tmp_path: Path,
+) -> None:
+    _write_payload(tmp_path, _payload())
+
+    loaded = load_geometry_linkage_from_job_dir(tmp_path)
+
+    assert loaded.path == tmp_path / GEOMETRY_LINKAGE_NPZ_NAME
+
+
+def test_load_geometry_linkage_trace_node_mapping_returns_minimal_mapping(
+    tmp_path: Path,
+) -> None:
+    path = _write_payload(tmp_path, _payload())
+
+    mapping = load_geometry_linkage_trace_node_mapping(path, expected_n_traces=5)
+
+    assert mapping.n_traces == 5
+    assert mapping.n_nodes == 4
+    np.testing.assert_array_equal(mapping.source_node_id_sorted, [0, 2, 2, 3, 0])
+    np.testing.assert_array_equal(mapping.receiver_node_id_sorted, [0, 1, 1, 0, 1])
+
+
+def _payload(
+    *,
+    mode: str = 'auto_threshold',
+    metadata: GeometryLinkageArtifactMetadata | None = None,
+) -> dict[str, np.ndarray]:
+    tables = _tables()
+    options = (
+        GeometryLinkageOptions(
+            mode='auto_threshold',
+            threshold_m=1.1,
+            receiver_location_interval_m=25.0,
+        )
+        if mode == 'auto_threshold'
+        else GeometryLinkageOptions(mode='none')
+    )
+    linkage = build_geometry_linkage(tables, options)
+    return build_geometry_linkage_solution_arrays(
+        tables,
+        linkage,
+        metadata=metadata,
+    )
+
+
+def _tables():
+    headers = GeometryLinkageHeaders(
+        source_x=np.asarray([0.0, 10.0, 11.0, 30.0, 0.0], dtype=np.float64),
+        source_y=np.asarray([0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        receiver_x=np.asarray([0.0, 100.0, 100.0, 0.0, 100.0], dtype=np.float64),
+        receiver_y=np.asarray([0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        coordinate_scalar=np.ones(5, dtype=np.int64),
+        checked_bytes=(71, 73, 77, 81, 85),
+    )
+    return build_endpoint_geometry_tables(headers)
+
+
+def _metadata() -> GeometryLinkageArtifactMetadata:
+    return GeometryLinkageArtifactMetadata(
+        job_id='linkage-job',
+        input_file_id='file-id',
+        key1_byte=189,
+        key2_byte=193,
+        source_x_byte=73,
+        source_y_byte=77,
+        receiver_x_byte=81,
+        receiver_y_byte=85,
+        coordinate_scalar_byte=71,
+        header_source_segy_path='/data/input.sgy',
+    )
+
+
+def _write_payload(tmp_path: Path, payload: dict[str, np.ndarray]) -> Path:
+    path = tmp_path / GEOMETRY_LINKAGE_NPZ_NAME
+    with path.open('wb') as handle:
+        np.savez(handle, **payload)
+    return path


### PR DESCRIPTION
Closes #340

## Summary
- [statics linkage] geometry_linkage artifact loaderとsorted trace node mapping検証を追加する

## Changed files
- `app/services/geometry_linkage_loader.py`
- `app/tests/test_geometry_linkage_loader.py`

## Checks
- `.work/codex/checks.log`: 1116 passed in 45.87s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
