### PR TITLE
[statics api] /statics/linkage/build job APIを追加する

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -17,12 +17,15 @@ from app.api.schemas import (
     FirstBreakQcRequest,
     ResidualStaticApplyRequest,
     ResidualStaticApplyResponse,
+    StaticLinkageBuildRequest,
+    StaticLinkageBuildResponse,
     StaticJobFilesResponse,
     StaticJobStatusResponse,
 )
 from app.core.state import AppState
 from app.services.datum_static_service import run_datum_static_apply_job
 from app.services.first_break_qc_service import run_first_break_qc_job
+from app.services.geometry_linkage_service import run_geometry_linkage_build_job
 from app.services.in_memory_cleanup import cleanup_in_memory_state
 from app.services.job_manager import JobManager
 from app.services.job_runner import request_job_cancel, start_job_thread
@@ -118,6 +121,39 @@ def first_break_qc(
     start_job_thread(
         thread_factory=threading.Thread,
         target=run_first_break_qc_job,
+        args=(job_id, req, state),
+    )
+
+    return {'job_id': job_id, 'state': status}
+
+
+@router.post(
+    '/statics/linkage/build',
+    response_model=StaticLinkageBuildResponse,
+)
+def static_linkage_build(
+    req: StaticLinkageBuildRequest,
+    request: Request,
+) -> StaticLinkageBuildResponse:
+    state = get_state(request.app)
+    cleanup_in_memory_state(state)
+    maybe_cleanup_expired_jobs()
+
+    job_id = str(uuid4())
+    with state.lock:
+        job_state = state.jobs.create_static_job(
+            job_id,
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            statics_kind='geometry_linkage',
+            artifacts_dir=str(get_job_dir(job_id)),
+        )
+        status = job_state['status']
+
+    start_job_thread(
+        thread_factory=threading.Thread,
+        target=run_geometry_linkage_build_job,
         args=(job_id, req, state),
     )
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -527,6 +527,15 @@ class StaticLinkageBuildRequest(BaseModel):
         return require_trace_header_byte(value, info.field_name)
 
 
+class StaticLinkageBuildResponse(BaseModel):
+    """Response model for creating a static linkage build job."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    job_id: str
+    state: str
+
+
 class FirstBreakQcDatumSolutionRequest(BaseModel):
     """Datum static solution artifact reference for first-break QC."""
 

--- a/app/services/geometry_linkage_service.py
+++ b/app/services/geometry_linkage_service.py
@@ -1,0 +1,306 @@
+"""Static geometry linkage background job service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import time
+from typing import Any
+from uuid import uuid4
+
+from app.api.schemas import StaticLinkageBuildRequest
+from app.core.state import AppState
+from app.services.geometry_linkage_artifacts import (
+    GEOMETRY_LINKAGE_CSV_NAME,
+    GEOMETRY_LINKAGE_NPZ_NAME,
+    GEOMETRY_LINKAGE_QC_JSON_NAME,
+    GeometryLinkageArtifactMetadata,
+    write_geometry_linkage_artifacts,
+)
+from app.services.geometry_linkage_linker import (
+    GeometryLinkageOptions,
+    build_geometry_linkage,
+)
+from app.services.geometry_linkage_loader import load_geometry_linkage_from_job_dir
+from app.services.geometry_linkage_tables import build_endpoint_geometry_tables
+from app.services.geometry_linkage_validation import (
+    GeometryLinkageHeaderConfig,
+    validate_geometry_linkage_headers,
+)
+from app.services.job_runner import (
+    JobCancelledError,
+    JobCompletion,
+    JobFailure,
+    ensure_job_not_cancelled,
+    run_job_with_lifecycle,
+)
+from app.services.pipeline_artifacts import get_job_dir
+from app.services.reader import get_reader
+
+
+@dataclass
+class _GeometryLinkageLifecycle:
+    created_ts: float
+    job_dir: Path | None = None
+
+
+def _resolve_created_ts(state: AppState, job_id: str) -> float:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        if job is None:
+            return time.time()
+        created_ts_obj = job.get('created_ts')
+    return (
+        float(created_ts_obj)
+        if isinstance(created_ts_obj, (int, float))
+        else time.time()
+    )
+
+
+def _resolve_job_dir(state: AppState, job_id: str) -> Path:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        artifacts_dir = job.get('artifacts_dir') if isinstance(job, dict) else None
+    if isinstance(artifacts_dir, str) and artifacts_dir:
+        return Path(artifacts_dir)
+    return get_job_dir(job_id)
+
+
+def _set_job_progress_message(
+    state: AppState,
+    job_id: str,
+    *,
+    progress: float,
+    message: str,
+) -> None:
+    with state.lock:
+        if state.jobs.get(job_id) is None:
+            return
+        state.jobs.set_progress(job_id, progress)
+        state.jobs.set_message(job_id, message)
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+    try:
+        tmp_path.write_text(
+            json.dumps(
+                payload,
+                allow_nan=False,
+                ensure_ascii=True,
+                sort_keys=True,
+            ),
+            encoding='utf-8',
+        )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _write_job_meta(
+    *,
+    job_id: str,
+    job_dir: Path,
+    req: StaticLinkageBuildRequest,
+) -> None:
+    _write_json_atomic(
+        job_dir / 'job_meta.json',
+        {
+            'job_id': job_id,
+            'job_type': 'statics',
+            'statics_kind': 'geometry_linkage',
+            'source_file_id': req.file_id,
+            'key1_byte': req.key1_byte,
+            'key2_byte': req.key2_byte,
+            'request': req.model_dump(mode='json'),
+            'inputs': {
+                'geometry': req.geometry.model_dump(mode='json'),
+                'linkage': req.linkage.model_dump(mode='json'),
+            },
+            'artifacts': {
+                'linkage_npz': GEOMETRY_LINKAGE_NPZ_NAME,
+                'linkage_csv': GEOMETRY_LINKAGE_CSV_NAME,
+                'qc_json': GEOMETRY_LINKAGE_QC_JSON_NAME,
+            },
+        },
+    )
+
+
+def _reader_header_source_segy_path(reader: object) -> str | None:
+    meta = getattr(reader, 'meta', None)
+    if not isinstance(meta, dict):
+        return None
+    original = meta.get('original_segy_path')
+    return original if isinstance(original, str) else None
+
+
+def _run_geometry_linkage_build_job_body(
+    job_id: str,
+    req: StaticLinkageBuildRequest,
+    state: AppState,
+    *,
+    lifecycle: _GeometryLinkageLifecycle,
+) -> JobCompletion | None:
+    job_dir = _resolve_job_dir(state, job_id)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    lifecycle.job_dir = job_dir
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.02,
+        message='preparing_geometry_linkage_job',
+    )
+    _write_job_meta(job_id=job_id, job_dir=job_dir, req=req)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.05,
+        message='resolving_trace_store_reader',
+    )
+    reader = get_reader(req.file_id, req.key1_byte, req.key2_byte, state=state)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.15,
+        message='validating_geometry_linkage_headers',
+    )
+    headers = validate_geometry_linkage_headers(
+        reader=reader,
+        config=GeometryLinkageHeaderConfig(
+            source_x_byte=req.geometry.source_x_byte,
+            source_y_byte=req.geometry.source_y_byte,
+            receiver_x_byte=req.geometry.receiver_x_byte,
+            receiver_y_byte=req.geometry.receiver_y_byte,
+            coordinate_scalar_byte=req.geometry.coordinate_scalar_byte,
+        ),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.30,
+        message='building_endpoint_geometry_tables',
+    )
+    tables = build_endpoint_geometry_tables(headers)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.50,
+        message='building_geometry_linkage',
+    )
+    linkage = build_geometry_linkage(
+        tables,
+        options=GeometryLinkageOptions(
+            mode=req.linkage.mode,
+            threshold_m=req.linkage.threshold_m,
+            receiver_location_interval_m=req.linkage.receiver_location_interval_m,
+            prefer_receiver_anchor=req.linkage.prefer_receiver_anchor,
+        ),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.75,
+        message='writing_geometry_linkage_artifacts',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    write_geometry_linkage_artifacts(
+        job_dir=job_dir,
+        tables=tables,
+        linkage=linkage,
+        metadata=GeometryLinkageArtifactMetadata(
+            job_id=job_id,
+            input_file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            source_x_byte=req.geometry.source_x_byte,
+            source_y_byte=req.geometry.source_y_byte,
+            receiver_x_byte=req.geometry.receiver_x_byte,
+            receiver_y_byte=req.geometry.receiver_y_byte,
+            coordinate_scalar_byte=req.geometry.coordinate_scalar_byte,
+            header_source_segy_path=_reader_header_source_segy_path(reader),
+        ),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.90,
+        message='validating_geometry_linkage_artifacts',
+    )
+    load_geometry_linkage_from_job_dir(
+        job_dir,
+        expected_n_traces=tables.n_traces,
+        expected_key1_byte=req.key1_byte,
+        expected_key2_byte=req.key2_byte,
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(state, job_id, progress=1.0, message='done')
+    return JobCompletion(finished_ts=time.time())
+
+
+def _handle_geometry_linkage_job_error(
+    *,
+    lifecycle: _GeometryLinkageLifecycle,
+) -> JobFailure:
+    return JobFailure(finished_ts=time.time())
+
+
+def _handle_geometry_linkage_job_cancel(
+    *,
+    lifecycle: _GeometryLinkageLifecycle,
+    exc: JobCancelledError,
+) -> JobCompletion:
+    finished_ts = float(exc.finished_ts) if exc.finished_ts is not None else time.time()
+    return JobCompletion(finished_ts=finished_ts)
+
+
+def run_geometry_linkage_build_job(
+    job_id: str,
+    req: StaticLinkageBuildRequest,
+    state: AppState,
+) -> None:
+    """Build geometry linkage artifacts for a statics job."""
+    lifecycle = _GeometryLinkageLifecycle(created_ts=_resolve_created_ts(state, job_id))
+
+    def worker() -> JobCompletion | None:
+        return _run_geometry_linkage_build_job_body(
+            job_id=job_id,
+            req=req,
+            state=state,
+            lifecycle=lifecycle,
+        )
+
+    run_job_with_lifecycle(
+        state=state,
+        job_id=job_id,
+        worker=worker,
+        progress_1_on_done=True,
+        start_progress=0.0,
+        clear_message_on_start=True,
+        on_error=lambda _exc: _handle_geometry_linkage_job_error(
+            lifecycle=lifecycle,
+        ),
+        on_cancel=lambda exc: _handle_geometry_linkage_job_cancel(
+            lifecycle=lifecycle,
+            exc=exc,
+        ),
+    )
+
+
+__all__ = ['run_geometry_linkage_build_job']

--- a/app/tests/test_geometry_linkage_job_api.py
+++ b/app/tests/test_geometry_linkage_job_api.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.routers.statics as statics_router_module
+import app.services.geometry_linkage_service as linkage_service
+from app.api.schemas import StaticLinkageBuildRequest
+from app.main import app
+from app.services.geometry_linkage_artifacts import (
+    GEOMETRY_LINKAGE_CSV_NAME,
+    GEOMETRY_LINKAGE_NPZ_NAME,
+    GEOMETRY_LINKAGE_QC_JSON_NAME,
+)
+from app.services.geometry_linkage_loader import load_geometry_linkage_from_job_dir
+
+FILE_ID = 'source-file-id'
+KEY1_BYTE = 189
+KEY2_BYTE = 193
+DT = 0.004
+
+
+class _Reader:
+    key1_byte = KEY1_BYTE
+    key2_byte = KEY2_BYTE
+
+    def __init__(self, *, missing_header: int | None = None) -> None:
+        self.traces = np.zeros((4, 8), dtype=np.float32)
+        self.meta = {'dt': DT, 'original_segy_path': '/data/source.sgy'}
+        self._missing_header = missing_header
+        self.headers = {
+            71: np.ones(4, dtype=np.int16),
+            73: np.asarray([0, 0, 25, 25], dtype=np.int32),
+            77: np.asarray([0, 0, 0, 0], dtype=np.int32),
+            81: np.asarray([0, 10, 25, 40], dtype=np.int32),
+            85: np.asarray([0, 0, 0, 0], dtype=np.int32),
+        }
+
+    def ensure_header(self, byte: int) -> np.ndarray:
+        if self._missing_header == int(byte):
+            raise KeyError(byte)
+        return self.headers[int(byte)]
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv('PIPELINE_JOBS_DIR', str(tmp_path / 'jobs'))
+    state = app.state.sv
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+
+
+def _payload(*, mode: str = 'auto_threshold') -> dict[str, Any]:
+    linkage: dict[str, Any]
+    if mode == 'none':
+        linkage = {'mode': 'none', 'prefer_receiver_anchor': False}
+    else:
+        linkage = {
+            'mode': 'auto_threshold',
+            'threshold_m': 20.0,
+            'receiver_location_interval_m': 25.0,
+            'prefer_receiver_anchor': True,
+        }
+    return {
+        'file_id': FILE_ID,
+        'key1_byte': KEY1_BYTE,
+        'key2_byte': KEY2_BYTE,
+        'geometry': {
+            'source_x_byte': 73,
+            'source_y_byte': 77,
+            'receiver_x_byte': 81,
+            'receiver_y_byte': 85,
+            'coordinate_scalar_byte': 71,
+        },
+        'linkage': linkage,
+    }
+
+
+def _request(*, mode: str = 'auto_threshold') -> StaticLinkageBuildRequest:
+    return StaticLinkageBuildRequest.model_validate(_payload(mode=mode))
+
+
+def _run_job_sync(**kwargs: Any) -> object:
+    target = kwargs['target']
+    args = kwargs.get('args', ())
+    extra_kwargs = kwargs.get('kwargs') or {}
+    target(*args, **extra_kwargs)
+    return object()
+
+
+def _install_reader(
+    client: TestClient,
+    tmp_path: Path,
+    *,
+    missing_header: int | None = None,
+) -> None:
+    store_dir = tmp_path / 'trace-store'
+    store_dir.mkdir()
+    state = client.app.state.sv
+    state.file_registry.update(FILE_ID, store_path=store_dir, dt=DT)
+    with state.lock:
+        state.cached_readers[f'{FILE_ID}_{KEY1_BYTE}_{KEY2_BYTE}'] = _Reader(
+            missing_header=missing_header,
+        )
+
+
+def test_static_linkage_build_endpoint_creates_geometry_linkage_job(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+
+    def _capture_start_job_thread(**kwargs: Any) -> object:
+        started.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        _capture_start_job_thread,
+    )
+
+    response = client.post('/statics/linkage/build', json=_payload())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['state'] == 'queued'
+    assert isinstance(payload['job_id'], str)
+    assert len(started) == 1
+    assert (
+        started[0]['target']
+        is statics_router_module.run_geometry_linkage_build_job
+    )
+
+    state = client.app.state.sv
+    with state.lock:
+        job = dict(state.jobs[payload['job_id']])
+
+    assert job['status'] == 'queued'
+    assert job['job_type'] == 'statics'
+    assert job['statics_kind'] == 'geometry_linkage'
+    assert job['file_id'] == FILE_ID
+    assert job['key1_byte'] == KEY1_BYTE
+    assert job['key2_byte'] == KEY2_BYTE
+
+
+@pytest.mark.parametrize('mode', ['none', 'auto_threshold'])
+def test_static_linkage_build_job_writes_expected_artifacts(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    _install_reader(client, tmp_path)
+    monkeypatch.setattr(statics_router_module, 'start_job_thread', _run_job_sync)
+
+    response = client.post('/statics/linkage/build', json=_payload(mode=mode))
+
+    assert response.status_code == 200
+    job_id = response.json()['job_id']
+    status_response = client.get(f'/statics/job/{job_id}/status')
+    files_response = client.get(f'/statics/job/{job_id}/files')
+
+    assert status_response.json() == {
+        'state': 'done',
+        'progress': 1.0,
+        'message': '',
+    }
+    assert [item['name'] for item in files_response.json()['files']] == [
+        GEOMETRY_LINKAGE_CSV_NAME,
+        GEOMETRY_LINKAGE_NPZ_NAME,
+        GEOMETRY_LINKAGE_QC_JSON_NAME,
+        'job_meta.json',
+    ]
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+        registry_keys = set(client.app.state.sv.file_registry.records)
+    job_dir = Path(str(job['artifacts_dir']))
+    loaded = load_geometry_linkage_from_job_dir(
+        job_dir,
+        expected_n_traces=4,
+        expected_key1_byte=KEY1_BYTE,
+        expected_key2_byte=KEY2_BYTE,
+    )
+    meta = json.loads((job_dir / 'job_meta.json').read_text(encoding='utf-8'))
+
+    assert loaded.mode == mode
+    assert meta['job_type'] == 'statics'
+    assert meta['statics_kind'] == 'geometry_linkage'
+    assert meta['source_file_id'] == FILE_ID
+    assert meta['request']['linkage']['mode'] == mode
+    assert meta['inputs']['geometry']['source_x_byte'] == 73
+    assert meta['artifacts'] == {
+        'linkage_npz': GEOMETRY_LINKAGE_NPZ_NAME,
+        'linkage_csv': GEOMETRY_LINKAGE_CSV_NAME,
+        'qc_json': GEOMETRY_LINKAGE_QC_JSON_NAME,
+    }
+    assert not (job_dir / 'corrected_file.json').exists()
+    assert 'corrected_file_id' not in job
+    assert registry_keys == {FILE_ID}
+
+
+def test_static_linkage_build_job_downloads_artifacts(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_reader(client, tmp_path)
+    monkeypatch.setattr(statics_router_module, 'start_job_thread', _run_job_sync)
+    response = client.post('/statics/linkage/build', json=_payload())
+    job_id = response.json()['job_id']
+
+    for name in (
+        GEOMETRY_LINKAGE_NPZ_NAME,
+        GEOMETRY_LINKAGE_CSV_NAME,
+        GEOMETRY_LINKAGE_QC_JSON_NAME,
+        'job_meta.json',
+    ):
+        download_response = client.get(
+            f'/statics/job/{job_id}/download',
+            params={'name': name},
+        )
+        assert download_response.status_code == 200
+        assert download_response.content
+
+
+def test_static_linkage_build_job_self_validates_npz(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_reader(client, tmp_path)
+    calls: list[dict[str, Any]] = []
+    original_loader = linkage_service.load_geometry_linkage_from_job_dir
+
+    def _recording_loader(*args: Any, **kwargs: Any) -> object:
+        calls.append({'args': args, 'kwargs': kwargs})
+        return original_loader(*args, **kwargs)
+
+    monkeypatch.setattr(
+        linkage_service,
+        'load_geometry_linkage_from_job_dir',
+        _recording_loader,
+    )
+    monkeypatch.setattr(statics_router_module, 'start_job_thread', _run_job_sync)
+
+    response = client.post('/statics/linkage/build', json=_payload())
+
+    assert response.status_code == 200
+    assert len(calls) == 1
+    assert calls[0]['kwargs'] == {
+        'expected_n_traces': 4,
+        'expected_key1_byte': KEY1_BYTE,
+        'expected_key2_byte': KEY2_BYTE,
+    }
+
+
+def test_static_linkage_build_endpoint_rejects_invalid_schema_with_422(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+    payload = _payload()
+    payload['linkage']['threshold_m'] = 0.0
+
+    response = client.post('/statics/linkage/build', json=payload)
+
+    assert response.status_code == 422
+    assert started == []
+
+
+def test_static_linkage_build_job_invalid_file_id_becomes_error_status(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(statics_router_module, 'start_job_thread', _run_job_sync)
+
+    response = client.post('/statics/linkage/build', json=_payload())
+    job_id = response.json()['job_id']
+    status_response = client.get(f'/statics/job/{job_id}/status')
+
+    assert response.status_code == 200
+    assert status_response.json()['state'] == 'error'
+    assert status_response.json()['message'] == 'File ID not found'
+
+
+def test_static_linkage_build_job_header_validation_error_becomes_error_status(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_reader(client, tmp_path, missing_header=73)
+    monkeypatch.setattr(statics_router_module, 'start_job_thread', _run_job_sync)
+
+    response = client.post('/statics/linkage/build', json=_payload())
+    job_id = response.json()['job_id']
+    status_response = client.get(f'/statics/job/{job_id}/status')
+
+    assert status_response.json()['state'] == 'error'
+    assert 'failed to read geometry linkage header byte 73' in (
+        status_response.json()['message']
+    )
+
+
+def test_static_linkage_build_job_cancel_before_artifact_write(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_reader(client, tmp_path)
+    job_id = 'geometry-linkage-job-id'
+    job_dir = tmp_path / 'linkage-job'
+    state = client.app.state.sv
+    with state.lock:
+        state.jobs.create_static_job(
+            job_id,
+            file_id=FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='geometry_linkage',
+            artifacts_dir=str(job_dir),
+        )
+
+    original_builder = linkage_service.build_geometry_linkage
+
+    def _build_and_cancel(*args: Any, **kwargs: Any) -> object:
+        result = original_builder(*args, **kwargs)
+        with state.lock:
+            state.jobs.request_cancel(job_id)
+        return result
+
+    monkeypatch.setattr(linkage_service, 'build_geometry_linkage', _build_and_cancel)
+
+    linkage_service.run_geometry_linkage_build_job(job_id, _request(), state)
+
+    with state.lock:
+        job = dict(state.jobs[job_id])
+    assert job['status'] == 'cancelled'
+    assert (job_dir / 'job_meta.json').is_file()
+    assert not (job_dir / GEOMETRY_LINKAGE_NPZ_NAME).exists()
+    assert not (job_dir / GEOMETRY_LINKAGE_CSV_NAME).exists()
+    assert not (job_dir / GEOMETRY_LINKAGE_QC_JSON_NAME).exists()


### PR DESCRIPTION
Closes #342

## Summary
- [statics api] /statics/linkage/build job APIを追加する

## Changed files
- `app/api/routers/statics.py`
- `app/api/schemas.py`
- `app/services/geometry_linkage_service.py`
- `app/tests/test_geometry_linkage_job_api.py`

## Checks
- `.work/codex/checks.log`: 1125 passed in 45.87s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
