### PR TITLE
[statics linkage] geometry_linkage recordのlink先・method・distance整合性検証を強化する

### DIFF
--- a/app/services/geometry_linkage_artifacts.py
+++ b/app/services/geometry_linkage_artifacts.py
@@ -40,6 +40,8 @@ _KNOWN_METHODS = {
     'source_fallback',
     'source_independent',
 }
+_DISTANCE_RTOL = 1.0e-9
+_DISTANCE_ATOL = 1.0e-9
 
 _CSV_COLUMNS = [
     'endpoint_kind',
@@ -676,6 +678,16 @@ def _validate_records(
             record.distance_m,
             name=f'records[{index}].distance_m',
         )
+        _validate_record_method_link_contract(
+            record,
+            index=index,
+            source_endpoint_x_m=source_endpoint_x_m,
+            source_endpoint_y_m=source_endpoint_y_m,
+            receiver_endpoint_x_m=receiver_endpoint_x_m,
+            receiver_endpoint_y_m=receiver_endpoint_y_m,
+            source_node_id_by_endpoint=source_node_id_by_endpoint,
+            receiver_node_id_by_endpoint=receiver_node_id_by_endpoint,
+        )
     return tuple(records)
 
 
@@ -726,6 +738,152 @@ def _validate_record_link(record: EndpointLinkageRecord, *, index: int) -> None:
     linked_to_id = int(record.linked_to_id)
     if linked_to_id < 0:
         raise ValueError(f'records[{index}].linked_to_id must be nonnegative')
+
+
+def _validate_record_method_link_contract(
+    record: EndpointLinkageRecord,
+    *,
+    index: int,
+    source_endpoint_x_m: np.ndarray,
+    source_endpoint_y_m: np.ndarray,
+    receiver_endpoint_x_m: np.ndarray,
+    receiver_endpoint_y_m: np.ndarray,
+    source_node_id_by_endpoint: np.ndarray,
+    receiver_node_id_by_endpoint: np.ndarray,
+) -> None:
+    no_link_endpoint_kind_by_method = {
+        'receiver_seed': 'receiver',
+        'none_mode_receiver_independent': 'receiver',
+        'none_mode_source_independent': 'source',
+        'source_independent': 'source',
+    }
+    no_link_endpoint_kind = no_link_endpoint_kind_by_method.get(record.method)
+    if no_link_endpoint_kind is not None:
+        if record.endpoint_kind != no_link_endpoint_kind:
+            raise ValueError(
+                f'records[{index}].method {record.method!r} requires '
+                f'{no_link_endpoint_kind} endpoint'
+            )
+        if (
+            record.linked_to_kind is not None
+            or record.linked_to_id is not None
+            or record.distance_m is not None
+        ):
+            raise ValueError(
+                f'records[{index}].method {record.method!r} requires empty link '
+                'and no distance_m'
+            )
+        return
+
+    if record.method == 'receiver_anchor':
+        if record.endpoint_kind != 'source':
+            raise ValueError(
+                f'records[{index}].receiver_anchor requires source endpoint'
+            )
+        if record.linked_to_kind != 'receiver':
+            raise ValueError(
+                f'records[{index}].receiver_anchor requires linked_to_kind receiver'
+            )
+        linked_receiver_id = _record_linked_to_id_in_range(
+            record,
+            index=index,
+            endpoint_count=int(receiver_endpoint_x_m.shape[0]),
+            linked_to_kind='receiver',
+        )
+        expected_node_id = int(receiver_node_id_by_endpoint[linked_receiver_id])
+        if int(record.node_id) != expected_node_id:
+            raise ValueError(
+                f'records[{index}].node_id must match linked receiver node'
+            )
+        endpoint_id = int(record.endpoint_id)
+        expected_distance_m = float(
+            np.hypot(
+                source_endpoint_x_m[endpoint_id]
+                - receiver_endpoint_x_m[linked_receiver_id],
+                source_endpoint_y_m[endpoint_id]
+                - receiver_endpoint_y_m[linked_receiver_id],
+            )
+        )
+        _validate_record_distance_matches(
+            record,
+            index=index,
+            expected_distance_m=expected_distance_m,
+        )
+        return
+
+    if record.method == 'source_fallback':
+        if record.endpoint_kind != 'source':
+            raise ValueError(
+                f'records[{index}].source_fallback requires source endpoint'
+            )
+        if record.linked_to_kind != 'source':
+            raise ValueError(
+                f'records[{index}].source_fallback requires linked_to_kind source'
+            )
+        linked_source_id = _record_linked_to_id_in_range(
+            record,
+            index=index,
+            endpoint_count=int(source_endpoint_x_m.shape[0]),
+            linked_to_kind='source',
+        )
+        endpoint_id = int(record.endpoint_id)
+        if linked_source_id == endpoint_id:
+            raise ValueError(f'records[{index}].source_fallback must not self-link')
+        expected_node_id = int(source_node_id_by_endpoint[linked_source_id])
+        if int(record.node_id) != expected_node_id:
+            raise ValueError(
+                f'records[{index}].node_id must match linked source node'
+            )
+        expected_distance_m = float(
+            np.hypot(
+                source_endpoint_x_m[endpoint_id] - source_endpoint_x_m[linked_source_id],
+                source_endpoint_y_m[endpoint_id] - source_endpoint_y_m[linked_source_id],
+            )
+        )
+        _validate_record_distance_matches(
+            record,
+            index=index,
+            expected_distance_m=expected_distance_m,
+        )
+
+
+def _record_linked_to_id_in_range(
+    record: EndpointLinkageRecord,
+    *,
+    index: int,
+    endpoint_count: int,
+    linked_to_kind: str,
+) -> int:
+    if record.linked_to_id is None:
+        raise ValueError(
+            f'records[{index}].linked_to_id is required for {record.method}'
+        )
+    linked_to_id = int(record.linked_to_id)
+    if linked_to_id < 0 or linked_to_id >= endpoint_count:
+        raise ValueError(
+            f'records[{index}].linked_to_id is out of range for {linked_to_kind}'
+        )
+    return linked_to_id
+
+
+def _validate_record_distance_matches(
+    record: EndpointLinkageRecord,
+    *,
+    index: int,
+    expected_distance_m: float,
+) -> None:
+    if record.distance_m is None:
+        raise ValueError(f'records[{index}].distance_m is required for {record.method}')
+    distance_m = float(record.distance_m)
+    if not np.isclose(
+        distance_m,
+        expected_distance_m,
+        rtol=_DISTANCE_RTOL,
+        atol=_DISTANCE_ATOL,
+    ):
+        raise ValueError(
+            f'records[{index}].distance_m must match endpoint geometry distance'
+        )
 
 
 def _record_arrays(

--- a/app/services/geometry_linkage_loader.py
+++ b/app/services/geometry_linkage_loader.py
@@ -27,6 +27,8 @@ _KNOWN_RECORD_METHODS = {
     'source_fallback',
     'source_independent',
 }
+_DISTANCE_RTOL = 1.0e-9
+_DISTANCE_ATOL = 1.0e-9
 
 _SCALAR_FIELDS = (
     'schema_version',
@@ -1117,6 +1119,15 @@ def _validate_records(
     _validate_record_values(
         n_source_endpoints=n_source_endpoints,
         n_receiver_endpoints=n_receiver_endpoints,
+        source_endpoint_x_m=source_endpoint_x_m,
+        source_endpoint_y_m=source_endpoint_y_m,
+        source_node_id_by_endpoint=source_node_id_by_endpoint,
+        receiver_endpoint_x_m=receiver_endpoint_x_m,
+        receiver_endpoint_y_m=receiver_endpoint_y_m,
+        receiver_node_id_by_endpoint=receiver_node_id_by_endpoint,
+        record_endpoint_kind=record_endpoint_kind,
+        record_endpoint_id=record_endpoint_id,
+        record_node_id=record_node_id,
         record_linked_to_kind=record_linked_to_kind,
         record_linked_to_id=record_linked_to_id,
         record_distance_m=record_distance_m,
@@ -1141,6 +1152,15 @@ def _validate_record_values(
     *,
     n_source_endpoints: int,
     n_receiver_endpoints: int,
+    source_endpoint_x_m: np.ndarray,
+    source_endpoint_y_m: np.ndarray,
+    source_node_id_by_endpoint: np.ndarray,
+    receiver_endpoint_x_m: np.ndarray,
+    receiver_endpoint_y_m: np.ndarray,
+    receiver_node_id_by_endpoint: np.ndarray,
+    record_endpoint_kind: np.ndarray,
+    record_endpoint_id: np.ndarray,
+    record_node_id: np.ndarray,
     record_linked_to_kind: np.ndarray,
     record_linked_to_id: np.ndarray,
     record_distance_m: np.ndarray,
@@ -1162,6 +1182,9 @@ def _validate_record_values(
     for index, linked_to_kind in enumerate(record_linked_to_kind):
         linked_to_id = int(record_linked_to_id[index])
         distance_m = float(record_distance_m[index])
+        endpoint_kind = str(record_endpoint_kind[index])
+        endpoint_id = int(record_endpoint_id[index])
+        method = str(record_method[index])
         if linked_to_kind == '':
             if linked_to_id != -1:
                 raise ValueError(
@@ -1171,21 +1194,150 @@ def _validate_record_values(
                 raise ValueError(
                     f'record_distance_m[{index}] must be NaN when record_linked_to_kind is empty'
                 )
-            continue
-
-        endpoint_count = (
-            n_source_endpoints
-            if linked_to_kind == 'source'
-            else n_receiver_endpoints
+        else:
+            endpoint_count = (
+                n_source_endpoints
+                if linked_to_kind == 'source'
+                else n_receiver_endpoints
+            )
+            if linked_to_id < 0 or linked_to_id >= endpoint_count:
+                raise ValueError(
+                    f'record_linked_to_id[{index}] is out of range for {linked_to_kind}'
+                )
+            if not np.isfinite(distance_m) or distance_m < 0.0:
+                raise ValueError(
+                    f'record_distance_m[{index}] must be finite and greater than or equal to 0'
+                )
+        _validate_record_method_link_contract(
+            index=index,
+            endpoint_kind=endpoint_kind,
+            endpoint_id=endpoint_id,
+            node_id=int(record_node_id[index]),
+            linked_to_kind=str(linked_to_kind),
+            linked_to_id=linked_to_id,
+            distance_m=distance_m,
+            method=method,
+            source_endpoint_x_m=source_endpoint_x_m,
+            source_endpoint_y_m=source_endpoint_y_m,
+            source_node_id_by_endpoint=source_node_id_by_endpoint,
+            receiver_endpoint_x_m=receiver_endpoint_x_m,
+            receiver_endpoint_y_m=receiver_endpoint_y_m,
+            receiver_node_id_by_endpoint=receiver_node_id_by_endpoint,
         )
-        if linked_to_id < 0 or linked_to_id >= endpoint_count:
+
+
+def _validate_record_method_link_contract(
+    *,
+    index: int,
+    endpoint_kind: str,
+    endpoint_id: int,
+    node_id: int,
+    linked_to_kind: str,
+    linked_to_id: int,
+    distance_m: float,
+    method: str,
+    source_endpoint_x_m: np.ndarray,
+    source_endpoint_y_m: np.ndarray,
+    source_node_id_by_endpoint: np.ndarray,
+    receiver_endpoint_x_m: np.ndarray,
+    receiver_endpoint_y_m: np.ndarray,
+    receiver_node_id_by_endpoint: np.ndarray,
+) -> None:
+    no_link_endpoint_kind_by_method = {
+        'receiver_seed': 'receiver',
+        'none_mode_receiver_independent': 'receiver',
+        'none_mode_source_independent': 'source',
+        'source_independent': 'source',
+    }
+    no_link_endpoint_kind = no_link_endpoint_kind_by_method.get(method)
+    if no_link_endpoint_kind is not None:
+        if endpoint_kind != no_link_endpoint_kind:
             raise ValueError(
-                f'record_linked_to_id[{index}] is out of range for {linked_to_kind}'
+                f'record_method[{index}] {method!r} requires {no_link_endpoint_kind} endpoint'
             )
-        if not np.isfinite(distance_m) or distance_m < 0.0:
+        if linked_to_kind != '' or linked_to_id != -1 or not np.isnan(distance_m):
             raise ValueError(
-                f'record_distance_m[{index}] must be finite and greater than or equal to 0'
+                f'record_method[{index}] {method!r} requires empty link and NaN distance_m'
             )
+        return
+
+    if method == 'receiver_anchor':
+        if endpoint_kind != 'source':
+            raise ValueError(
+                f'record_method[{index}] receiver_anchor requires source endpoint'
+            )
+        if linked_to_kind != 'receiver':
+            raise ValueError(
+                f'record_method[{index}] receiver_anchor requires linked_to_kind receiver'
+            )
+        expected_node_id = int(receiver_node_id_by_endpoint[linked_to_id])
+        if node_id != expected_node_id:
+            raise ValueError(
+                f'record_node_id[{index}] does not match linked receiver node'
+            )
+        expected_distance_m = float(
+            np.hypot(
+                source_endpoint_x_m[endpoint_id]
+                - receiver_endpoint_x_m[linked_to_id],
+                source_endpoint_y_m[endpoint_id]
+                - receiver_endpoint_y_m[linked_to_id],
+            )
+        )
+        _validate_record_distance_matches(
+            index=index,
+            distance_m=distance_m,
+            expected_distance_m=expected_distance_m,
+        )
+        return
+
+    if method == 'source_fallback':
+        if endpoint_kind != 'source':
+            raise ValueError(
+                f'record_method[{index}] source_fallback requires source endpoint'
+            )
+        if linked_to_kind != 'source':
+            raise ValueError(
+                f'record_method[{index}] source_fallback requires linked_to_kind source'
+            )
+        if linked_to_id == endpoint_id:
+            raise ValueError(
+                f'record_linked_to_id[{index}] source_fallback must not self-link'
+            )
+        expected_node_id = int(source_node_id_by_endpoint[linked_to_id])
+        if node_id != expected_node_id:
+            raise ValueError(
+                f'record_node_id[{index}] does not match linked source node'
+            )
+        expected_distance_m = float(
+            np.hypot(
+                source_endpoint_x_m[endpoint_id]
+                - source_endpoint_x_m[linked_to_id],
+                source_endpoint_y_m[endpoint_id]
+                - source_endpoint_y_m[linked_to_id],
+            )
+        )
+        _validate_record_distance_matches(
+            index=index,
+            distance_m=distance_m,
+            expected_distance_m=expected_distance_m,
+        )
+
+
+def _validate_record_distance_matches(
+    *,
+    index: int,
+    distance_m: float,
+    expected_distance_m: float,
+) -> None:
+    if not np.isclose(
+        distance_m,
+        expected_distance_m,
+        rtol=_DISTANCE_RTOL,
+        atol=_DISTANCE_ATOL,
+    ):
+        raise ValueError(
+            f'record_distance_m[{index}] does not match endpoint geometry distance'
+        )
 
 
 def _validate_record_methods_for_mode(

--- a/app/tests/test_geometry_linkage_artifacts.py
+++ b/app/tests/test_geometry_linkage_artifacts.py
@@ -583,6 +583,161 @@ def test_write_geometry_linkage_artifacts_rejects_negative_distance(
         )
 
 
+def test_write_geometry_linkage_artifacts_rejects_receiver_anchor_linked_to_source(
+    tmp_path: Path,
+) -> None:
+    tables, linkage = _auto_case()
+    index = _first_record_index(linkage, 'receiver_anchor')
+    bad_records = _replace_record(
+        linkage.records,
+        index,
+        linked_to_kind='source',
+        linked_to_id=0,
+    )
+    bad_linkage = replace(linkage, records=bad_records)
+
+    with pytest.raises(ValueError, match='receiver_anchor.*linked_to_kind receiver'):
+        write_geometry_linkage_artifacts(
+            job_dir=tmp_path,
+            tables=tables,
+            linkage=bad_linkage,
+        )
+
+
+def test_write_geometry_linkage_artifacts_rejects_source_fallback_linked_to_receiver(
+    tmp_path: Path,
+) -> None:
+    tables, linkage = _auto_case()
+    index = _first_record_index(linkage, 'source_fallback')
+    bad_records = _replace_record(
+        linkage.records,
+        index,
+        linked_to_kind='receiver',
+        linked_to_id=0,
+    )
+    bad_linkage = replace(linkage, records=bad_records)
+
+    with pytest.raises(ValueError, match='source_fallback.*linked_to_kind source'):
+        write_geometry_linkage_artifacts(
+            job_dir=tmp_path,
+            tables=tables,
+            linkage=bad_linkage,
+        )
+
+
+@pytest.mark.parametrize('method', ['receiver_seed', 'source_independent'])
+def test_write_geometry_linkage_artifacts_rejects_unlinked_record_with_link(
+    tmp_path: Path,
+    method: str,
+) -> None:
+    tables, linkage = _auto_case()
+    index = _first_record_index(linkage, method)
+    bad_records = _replace_record(
+        linkage.records,
+        index,
+        linked_to_kind='receiver',
+        linked_to_id=0,
+        distance_m=0.0,
+    )
+    bad_linkage = replace(linkage, records=bad_records)
+
+    with pytest.raises(ValueError, match=f'{method}.*empty link'):
+        write_geometry_linkage_artifacts(
+            job_dir=tmp_path,
+            tables=tables,
+            linkage=bad_linkage,
+        )
+
+
+def test_write_geometry_linkage_artifacts_rejects_source_fallback_self_link(
+    tmp_path: Path,
+) -> None:
+    tables, linkage = _auto_case()
+    index = _first_record_index(linkage, 'source_fallback')
+    endpoint_id = int(linkage.records[index].endpoint_id)
+    bad_records = _replace_record(
+        linkage.records,
+        index,
+        linked_to_id=endpoint_id,
+        distance_m=0.0,
+    )
+    bad_linkage = replace(linkage, records=bad_records)
+
+    with pytest.raises(ValueError, match='source_fallback must not self-link'):
+        write_geometry_linkage_artifacts(
+            job_dir=tmp_path,
+            tables=tables,
+            linkage=bad_linkage,
+        )
+
+
+def test_write_geometry_linkage_artifacts_rejects_linked_endpoint_out_of_range(
+    tmp_path: Path,
+) -> None:
+    tables, linkage = _auto_case()
+    index = _first_record_index(linkage, 'receiver_anchor')
+    bad_records = _replace_record(
+        linkage.records,
+        index,
+        linked_to_id=linkage.n_receiver_endpoints,
+    )
+    bad_linkage = replace(linkage, records=bad_records)
+
+    with pytest.raises(ValueError, match='out of range for receiver'):
+        write_geometry_linkage_artifacts(
+            job_dir=tmp_path,
+            tables=tables,
+            linkage=bad_linkage,
+        )
+
+
+def test_write_geometry_linkage_artifacts_rejects_linked_node_mismatch(
+    tmp_path: Path,
+) -> None:
+    tables, linkage = _auto_case()
+    index = _first_record_index(linkage, 'receiver_anchor')
+    source_id = int(linkage.records[index].endpoint_id)
+    bad_records = _replace_record(
+        linkage.records,
+        index,
+        linked_to_id=1,
+        distance_m=float(
+            np.hypot(
+                tables.source_endpoints.x_m[source_id] - tables.receiver_endpoints.x_m[1],
+                tables.source_endpoints.y_m[source_id] - tables.receiver_endpoints.y_m[1],
+            )
+        ),
+    )
+    bad_linkage = replace(linkage, records=bad_records)
+
+    with pytest.raises(ValueError, match='linked receiver node'):
+        write_geometry_linkage_artifacts(
+            job_dir=tmp_path,
+            tables=tables,
+            linkage=bad_linkage,
+        )
+
+
+def test_write_geometry_linkage_artifacts_rejects_record_distance_mismatch(
+    tmp_path: Path,
+) -> None:
+    tables, linkage = _auto_case()
+    index = _first_record_index(linkage, 'receiver_anchor')
+    bad_records = _replace_record(
+        linkage.records,
+        index,
+        distance_m=float(linkage.records[index].distance_m or 0.0) + 1.0,
+    )
+    bad_linkage = replace(linkage, records=bad_records)
+
+    with pytest.raises(ValueError, match='distance_m.*endpoint geometry distance'):
+        write_geometry_linkage_artifacts(
+            job_dir=tmp_path,
+            tables=tables,
+            linkage=bad_linkage,
+        )
+
+
 def test_write_geometry_linkage_artifacts_cleans_up_tmp_file_on_npz_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -617,3 +772,22 @@ def _assert_json_contains_no_nan_or_inf(value: object) -> None:
         return
     if isinstance(value, float):
         assert np.isfinite(value)
+
+
+def _first_record_index(linkage: GeometryLinkageResult, method: str) -> int:
+    for index, record in enumerate(linkage.records):
+        if record.method == method:
+            return index
+    raise AssertionError(f'missing record method: {method}')
+
+
+def _replace_record(
+    records: tuple[Any, ...],
+    index: int,
+    **changes: object,
+) -> tuple[Any, ...]:
+    return (
+        *records[:index],
+        replace(records[index], **changes),
+        *records[index + 1 :],
+    )

--- a/app/tests/test_geometry_linkage_loader.py
+++ b/app/tests/test_geometry_linkage_loader.py
@@ -332,6 +332,129 @@ def test_load_geometry_linkage_artifact_rejects_invalid_record_distance(
         load_geometry_linkage_artifact(path)
 
 
+def test_load_geometry_linkage_artifact_rejects_receiver_anchor_linked_to_source(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    index = _first_record_index(payload, 'receiver_anchor')
+    payload['record_linked_to_kind'] = payload['record_linked_to_kind'].astype('<U8')
+    payload['record_linked_to_id'] = payload['record_linked_to_id'].copy()
+    payload['record_linked_to_kind'][index] = 'source'
+    payload['record_linked_to_id'][index] = 0
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='receiver_anchor.*linked_to_kind receiver'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_source_fallback_linked_to_receiver(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    index = _first_record_index(payload, 'source_fallback')
+    payload['record_linked_to_kind'] = payload['record_linked_to_kind'].astype('<U8')
+    payload['record_linked_to_id'] = payload['record_linked_to_id'].copy()
+    payload['record_linked_to_kind'][index] = 'receiver'
+    payload['record_linked_to_id'][index] = 0
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='source_fallback.*linked_to_kind source'):
+        load_geometry_linkage_artifact(path)
+
+
+@pytest.mark.parametrize(
+    ('mode', 'method'),
+    [
+        ('auto_threshold', 'receiver_seed'),
+        ('auto_threshold', 'source_independent'),
+        ('none', 'none_mode_receiver_independent'),
+        ('none', 'none_mode_source_independent'),
+    ],
+)
+def test_load_geometry_linkage_artifact_rejects_unlinked_method_with_link(
+    tmp_path: Path,
+    mode: str,
+    method: str,
+) -> None:
+    payload = _payload(mode=mode)
+    index = _first_record_index(payload, method)
+    payload['record_linked_to_kind'] = payload['record_linked_to_kind'].astype('<U8')
+    payload['record_linked_to_id'] = payload['record_linked_to_id'].copy()
+    payload['record_distance_m'] = payload['record_distance_m'].copy()
+    payload['record_linked_to_kind'][index] = 'receiver'
+    payload['record_linked_to_id'][index] = 0
+    payload['record_distance_m'][index] = 0.0
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=f'{method!r} requires empty link'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_source_fallback_self_link(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    index = _first_record_index(payload, 'source_fallback')
+    endpoint_id = int(payload['record_endpoint_id'][index])
+    payload['record_linked_to_id'] = payload['record_linked_to_id'].copy()
+    payload['record_distance_m'] = payload['record_distance_m'].copy()
+    payload['record_linked_to_id'][index] = endpoint_id
+    payload['record_distance_m'][index] = 0.0
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='source_fallback must not self-link'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_linked_endpoint_out_of_range(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    index = _first_record_index(payload, 'receiver_anchor')
+    payload['record_linked_to_id'] = payload['record_linked_to_id'].copy()
+    payload['record_linked_to_id'][index] = int(payload['n_receiver_endpoints'].item())
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='out of range for receiver'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_linked_node_mismatch(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    index = _first_record_index(payload, 'receiver_anchor')
+    payload['record_linked_to_id'] = payload['record_linked_to_id'].copy()
+    payload['record_distance_m'] = payload['record_distance_m'].copy()
+    payload['record_linked_to_id'][index] = 1
+    source_id = int(payload['record_endpoint_id'][index])
+    payload['record_distance_m'][index] = float(
+        np.hypot(
+            payload['source_endpoint_x_m'][source_id]
+            - payload['receiver_endpoint_x_m'][1],
+            payload['source_endpoint_y_m'][source_id]
+            - payload['receiver_endpoint_y_m'][1],
+        )
+    )
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='linked receiver node'):
+        load_geometry_linkage_artifact(path)
+
+
+def test_load_geometry_linkage_artifact_rejects_record_distance_mismatch(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    index = _first_record_index(payload, 'receiver_anchor')
+    payload['record_distance_m'] = payload['record_distance_m'].copy()
+    payload['record_distance_m'][index] += 1.0
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match='record_distance_m.*does not match'):
+        load_geometry_linkage_artifact(path)
+
+
 def test_load_geometry_linkage_artifact_validates_record_order(
     tmp_path: Path,
 ) -> None:
@@ -474,6 +597,12 @@ def _metadata() -> GeometryLinkageArtifactMetadata:
         coordinate_scalar_byte=71,
         header_source_segy_path='/data/input.sgy',
     )
+
+
+def _first_record_index(payload: dict[str, np.ndarray], method: str) -> int:
+    matches = np.flatnonzero(payload['record_method'] == method)
+    assert matches.size > 0
+    return int(matches[0])
 
 
 def _write_payload(tmp_path: Path, payload: dict[str, np.ndarray]) -> Path:


### PR DESCRIPTION
Closes #344

## Summary
- [statics linkage] geometry_linkage recordのlink先・method・distance整合性検証を強化する

## Changed files
- `app/services/geometry_linkage_artifacts.py`
- `app/services/geometry_linkage_loader.py`
- `app/tests/test_geometry_linkage_artifacts.py`
- `app/tests/test_geometry_linkage_loader.py`

## Checks
- `.work/codex/checks.log`: 1143 passed in 46.01s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
