### PR TITLE
PR6-1 [statics time-term] time-term inversion request schema と velocity/linkage validation を追加する

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -21,6 +21,7 @@ from app.api.schemas import (
     StaticLinkageBuildResponse,
     StaticJobFilesResponse,
     StaticJobStatusResponse,
+    TimeTermStaticApplyRequest,
 )
 from app.core.state import AppState
 from app.services.datum_static_service import run_datum_static_apply_job
@@ -31,6 +32,7 @@ from app.services.job_manager import JobManager
 from app.services.job_runner import request_job_cancel, start_job_thread
 from app.services.pipeline_artifacts import get_job_dir, maybe_cleanup_expired_jobs
 from app.services.residual_static_service import run_residual_static_apply_job
+from app.services.time_term_static_service import validate_time_term_request
 
 router = APIRouter()
 
@@ -191,6 +193,26 @@ def residual_static_apply(
     )
 
     return {'job_id': job_id, 'state': status}
+
+
+@router.post('/statics/time-term/apply')
+def time_term_static_apply(
+    req: TimeTermStaticApplyRequest,
+    request: Request,
+) -> dict[str, str]:
+    state = get_state(request.app)
+    cleanup_in_memory_state(state)
+    maybe_cleanup_expired_jobs()
+
+    try:
+        validate_time_term_request(req, state=state)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    raise HTTPException(
+        status_code=501,
+        detail='time-term inversion solver is not implemented yet',
+    )
 
 
 @router.get(

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -867,3 +867,307 @@ class ResidualStaticApplyResponse(BaseModel):
 
     job_id: str
     state: str
+
+
+class TimeTermStaticPickSourceRequest(BaseModel):
+    """First-break pick source reference for time-term static inversion."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['batch_predicted_npz', 'manual_npz_artifact', 'manual_memmap']
+    job_id: str | None = None
+    artifact_name: str | None = None
+
+    @model_validator(mode='after')
+    def _check_ref(self) -> 'TimeTermStaticPickSourceRequest':
+        if self.kind == 'manual_memmap':
+            if self.job_id is not None or self.artifact_name is not None:
+                raise ValueError(
+                    'pick_source.job_id/artifact_name must be omitted for manual_memmap'
+                )
+            return self
+
+        if not self.job_id:
+            raise ValueError('pick_source.job_id is required for artifact sources')
+        if self.kind == 'batch_predicted_npz':
+            self.artifact_name = self.artifact_name or 'predicted_picks_time_s.npz'
+        if not self.artifact_name:
+            raise ValueError(
+                'pick_source.artifact_name is required for artifact sources'
+            )
+        _validate_artifact_basename(
+            self.artifact_name,
+            'pick_source.artifact_name',
+        )
+        if self.kind == 'manual_npz_artifact' and not self.artifact_name.endswith(
+            '.npz'
+        ):
+            raise ValueError('pick_source.artifact_name must end with .npz')
+        return self
+
+
+class TimeTermStaticGeometryRequest(BaseModel):
+    """Trace header configuration for time-term static inversion."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    source_id_byte: int = 9
+    receiver_id_byte: int = 13
+    source_x_byte: int = 73
+    source_y_byte: int = 77
+    receiver_x_byte: int = 81
+    receiver_y_byte: int = 85
+    source_elevation_byte: int = 45
+    receiver_elevation_byte: int = 41
+    source_depth_byte: int | None = None
+    coordinate_scalar_byte: int = 71
+    elevation_scalar_byte: int = 69
+    coordinate_unit: Literal['m', 'ft'] = 'm'
+    elevation_unit: Literal['m', 'ft'] = 'm'
+
+    @field_validator(
+        'source_id_byte',
+        'receiver_id_byte',
+        'source_x_byte',
+        'source_y_byte',
+        'receiver_x_byte',
+        'receiver_y_byte',
+        'source_elevation_byte',
+        'receiver_elevation_byte',
+        'coordinate_scalar_byte',
+        'elevation_scalar_byte',
+        mode='before',
+    )
+    @classmethod
+    def _check_header_byte(cls, value: object, info: Any) -> int:
+        return require_trace_header_byte(value, f'geometry.{info.field_name}')
+
+    @field_validator('source_depth_byte', mode='before')
+    @classmethod
+    def _check_optional_header_byte(cls, value: object) -> int | None:
+        if value is None:
+            return None
+        return require_trace_header_byte(value, 'geometry.source_depth_byte')
+
+    @model_validator(mode='after')
+    def _check_distinct_endpoint_ids(self) -> 'TimeTermStaticGeometryRequest':
+        if self.source_id_byte == self.receiver_id_byte:
+            raise ValueError('geometry.source_id_byte and receiver_id_byte must differ')
+        return self
+
+
+class TimeTermStaticLinkageRequest(BaseModel):
+    """Source/receiver endpoint linkage artifact reference."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    mode: Literal['required', 'optional', 'none'] = 'required'
+    job_id: str | None = None
+    artifact_name: str = 'geometry_linkage.npz'
+
+    @field_validator('artifact_name', mode='before')
+    @classmethod
+    def _check_artifact_name(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise ValueError('linkage.artifact_name must be a plain file name')
+        return _validate_artifact_basename(value, 'linkage.artifact_name')
+
+    @model_validator(mode='after')
+    def _check_ref(self) -> 'TimeTermStaticLinkageRequest':
+        if self.mode == 'required' and not self.job_id:
+            raise ValueError('linkage.job_id is required when linkage.mode is required')
+        if self.mode == 'none' and self.job_id is not None:
+            raise ValueError('linkage.job_id must be omitted when linkage.mode is none')
+        if self.job_id is not None and not self.job_id:
+            raise ValueError('linkage.job_id must be a non-empty string')
+        return self
+
+
+class TimeTermStaticVelocityRequest(BaseModel):
+    """Velocity parameters for time-term static inversion."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    replacement_velocity_m_s: float
+    refractor_velocity_m_s: float
+    weathering_velocity_m_s: float | None = None
+
+    @field_validator(
+        'replacement_velocity_m_s',
+        'refractor_velocity_m_s',
+        mode='before',
+    )
+    @classmethod
+    def _check_positive_velocity(cls, value: object, info: Any) -> float:
+        return _require_positive_finite_float(value, f'velocity.{info.field_name}')
+
+    @field_validator('weathering_velocity_m_s', mode='before')
+    @classmethod
+    def _check_optional_positive_velocity(cls, value: object) -> float | None:
+        if value is None:
+            return None
+        return _require_positive_finite_float(
+            value,
+            'velocity.weathering_velocity_m_s',
+        )
+
+    @model_validator(mode='after')
+    def _check_head_wave_velocity_order(self) -> 'TimeTermStaticVelocityRequest':
+        if self.refractor_velocity_m_s <= self.replacement_velocity_m_s:
+            raise ValueError(
+                'velocity.refractor_velocity_m_s must be greater than '
+                'velocity.replacement_velocity_m_s'
+            )
+        return self
+
+
+class TimeTermStaticMoveoutRequest(BaseModel):
+    """Moveout model configuration for time-term static inversion."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    model: Literal['head_wave_linear_offset', 'linear_offset', 'none'] = (
+        'head_wave_linear_offset'
+    )
+    offset_byte: int | None = 37
+    allow_missing_offset: bool = False
+
+    @field_validator('offset_byte', mode='before')
+    @classmethod
+    def _check_offset_byte(cls, value: object) -> int | None:
+        if value is None:
+            return None
+        return require_trace_header_byte(value, 'moveout.offset_byte')
+
+    @field_validator('allow_missing_offset', mode='before')
+    @classmethod
+    def _check_allow_missing_offset(cls, value: object) -> bool:
+        return _require_bool(value, 'moveout.allow_missing_offset')
+
+    @model_validator(mode='after')
+    def _check_offset_requirement(self) -> 'TimeTermStaticMoveoutRequest':
+        if (
+            self.model != 'none'
+            and not self.allow_missing_offset
+            and self.offset_byte is None
+        ):
+            raise ValueError(
+                'moveout.offset_byte is required when moveout.model is not none '
+                'and moveout.allow_missing_offset is false'
+            )
+        return self
+
+
+class TimeTermStaticRobustRequest(BaseModel):
+    """Robust outlier-rejection options for time-term inversion."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    enabled: bool = True
+    max_iterations: int = 5
+    mad_threshold: float = 3.5
+    min_used_fraction: float = 0.5
+
+    @field_validator('enabled', mode='before')
+    @classmethod
+    def _check_enabled(cls, value: object) -> bool:
+        return _require_bool(value, 'solver.robust.enabled')
+
+    @field_validator('max_iterations', mode='before')
+    @classmethod
+    def _check_max_iterations(cls, value: object) -> int:
+        return _require_positive_int(value, 'solver.robust.max_iterations')
+
+    @field_validator('mad_threshold', mode='before')
+    @classmethod
+    def _check_mad_threshold(cls, value: object) -> float:
+        return _require_positive_finite_float(
+            value,
+            'solver.robust.mad_threshold',
+        )
+
+    @field_validator('min_used_fraction', mode='before')
+    @classmethod
+    def _check_min_used_fraction(cls, value: object) -> float:
+        fraction = _require_positive_finite_float(
+            value,
+            'solver.robust.min_used_fraction',
+        )
+        if fraction > 1.0:
+            raise ValueError('solver.robust.min_used_fraction must be <= 1')
+        return fraction
+
+
+class TimeTermStaticSolverRequest(BaseModel):
+    """Solver options for time-term static inversion."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    damping: float = 0.01
+    gauge: Literal['mean_zero'] = 'mean_zero'
+    robust: TimeTermStaticRobustRequest = Field(
+        default_factory=TimeTermStaticRobustRequest,
+    )
+
+    @field_validator('damping', mode='before')
+    @classmethod
+    def _check_damping(cls, value: object) -> float:
+        return _require_nonnegative_finite_float(value, 'solver.damping')
+
+
+class TimeTermStaticApplyOptions(BaseModel):
+    """Options for a future corrected TraceStore output."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    register_corrected_file: bool = False
+    max_abs_shift_ms: float = 250.0
+    output_dtype: Literal['float32'] = 'float32'
+
+    @field_validator('register_corrected_file', mode='before')
+    @classmethod
+    def _check_register_corrected_file_bool(cls, value: object) -> bool:
+        return _require_bool(value, 'apply.register_corrected_file')
+
+    @field_validator('max_abs_shift_ms', mode='before')
+    @classmethod
+    def _check_max_abs_shift_ms(cls, value: object) -> float:
+        return _require_positive_finite_float(value, 'apply.max_abs_shift_ms')
+
+
+class TimeTermStaticApplyRequest(BaseModel):
+    """Request model for future ``/statics/time-term/apply`` jobs."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    file_id: str
+    key1_byte: int = 189
+    key2_byte: int = 193
+    pick_source: TimeTermStaticPickSourceRequest
+    geometry: TimeTermStaticGeometryRequest = Field(
+        default_factory=TimeTermStaticGeometryRequest,
+    )
+    linkage: TimeTermStaticLinkageRequest = Field(
+        default_factory=TimeTermStaticLinkageRequest,
+    )
+    velocity: TimeTermStaticVelocityRequest
+    moveout: TimeTermStaticMoveoutRequest = Field(
+        default_factory=TimeTermStaticMoveoutRequest,
+    )
+    solver: TimeTermStaticSolverRequest = Field(
+        default_factory=TimeTermStaticSolverRequest,
+    )
+    apply: TimeTermStaticApplyOptions = Field(
+        default_factory=TimeTermStaticApplyOptions,
+    )
+
+    @field_validator('key1_byte', 'key2_byte', mode='before')
+    @classmethod
+    def _check_key_header_byte(cls, value: object, info: Any) -> int:
+        return require_trace_header_byte(value, info.field_name)
+
+    @model_validator(mode='after')
+    def _check_values(self) -> 'TimeTermStaticApplyRequest':
+        if not self.file_id:
+            raise ValueError('file_id must be a non-empty string')
+        return self

--- a/app/services/time_term_static_service.py
+++ b/app/services/time_term_static_service.py
@@ -1,0 +1,215 @@
+"""Validation boundary for future time-term static inversion jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from pathlib import Path
+
+import numpy as np
+
+from app.api.schemas import TimeTermStaticApplyRequest
+from app.core.state import AppState
+from app.services.errors import DomainError
+from app.services.geometry_linkage_loader import load_geometry_linkage_artifact
+from app.services.job_artifact_refs import resolve_job_artifact_path
+from app.services.reader import get_reader
+
+
+@dataclass(frozen=True)
+class TimeTermValidationResult:
+    """Validated shallow inputs for a future time-term solver job."""
+
+    file_id: str
+    dt: float
+    n_traces: int
+    linkage_artifact_path: Path | None
+
+
+def validate_time_term_request(
+    req: TimeTermStaticApplyRequest,
+    *,
+    state: AppState,
+) -> TimeTermValidationResult:
+    """Validate request-level preconditions before time-term inversion is implemented."""
+    _validate_file_registered(state, req.file_id)
+    reader = _resolve_reader(state, req)
+    n_traces = _reader_n_traces(reader)
+    dt = _resolve_dt(state, req.file_id, reader=reader)
+    linkage_path = _validate_linkage_artifact(
+        state,
+        req=req,
+        expected_n_traces=n_traces,
+    )
+    return TimeTermValidationResult(
+        file_id=req.file_id,
+        dt=dt,
+        n_traces=n_traces,
+        linkage_artifact_path=linkage_path,
+    )
+
+
+def _validate_file_registered(state: AppState, file_id: str) -> None:
+    if state.file_registry.get_record(file_id) is None:
+        raise ValueError(f'file_id not found: {file_id}')
+
+
+def _resolve_reader(state: AppState, req: TimeTermStaticApplyRequest) -> object:
+    try:
+        return get_reader(req.file_id, req.key1_byte, req.key2_byte, state=state)
+    except DomainError as exc:
+        raise ValueError(exc.detail) from exc
+    except Exception as exc:  # noqa: BLE001
+        msg = f'Could not open TraceStore for file_id {req.file_id}: {exc}'
+        raise ValueError(msg) from exc
+
+
+def _reader_n_traces(reader: object) -> int:
+    n_traces = getattr(reader, 'ntraces', None)
+    if n_traces is None:
+        meta = getattr(reader, 'meta', None)
+        if isinstance(meta, dict):
+            n_traces = meta.get('n_traces')
+    if n_traces is None:
+        traces = getattr(reader, 'traces', None)
+        shape = getattr(traces, 'shape', ())
+        if shape:
+            n_traces = shape[0]
+    if isinstance(n_traces, bool) or not isinstance(n_traces, (int, np.integer)):
+        raise ValueError('TraceStore n_traces must be available')
+    n_traces_int = int(n_traces)
+    if n_traces_int <= 0:
+        raise ValueError('TraceStore n_traces must be greater than 0')
+    return n_traces_int
+
+
+def _resolve_dt(state: AppState, file_id: str, *, reader: object) -> float:
+    dt_raw = None
+    record = state.file_registry.get_record(file_id)
+    if isinstance(record, dict):
+        dt_raw = record.get('dt')
+    if not _is_positive_finite_number(dt_raw):
+        meta = getattr(reader, 'meta', None)
+        if isinstance(meta, dict):
+            dt_raw = meta.get('dt')
+    if not _is_positive_finite_number(dt_raw):
+        try:
+            dt_raw = state.file_registry.get_dt(file_id)
+        except Exception as exc:  # noqa: BLE001
+            msg = f'dt must be finite and greater than 0 for file_id {file_id}'
+            raise ValueError(msg) from exc
+    if not _is_positive_finite_number(dt_raw):
+        raise ValueError(f'dt must be finite and greater than 0 for file_id {file_id}')
+    return float(dt_raw)
+
+
+def _is_positive_finite_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float, np.integer, np.floating))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+        and float(value) > 0.0
+    )
+
+
+def _validate_linkage_artifact(
+    state: AppState,
+    *,
+    req: TimeTermStaticApplyRequest,
+    expected_n_traces: int,
+) -> Path | None:
+    linkage = req.linkage
+    if linkage.mode == 'none':
+        return None
+    if linkage.mode == 'optional' and linkage.job_id is None:
+        return None
+    if not linkage.job_id:
+        raise ValueError('linkage.job_id is required when linkage.mode is required')
+
+    try:
+        path = resolve_job_artifact_path(
+            state,
+            job_id=linkage.job_id,
+            name=linkage.artifact_name,
+            allowed_job_types={'statics'},
+            allowed_statics_kinds={'geometry_linkage'},
+            expected_file_id=req.file_id,
+            expected_key1_byte=req.key1_byte,
+            expected_key2_byte=req.key2_byte,
+            reference_label='linkage',
+        )
+    except ValueError as exc:
+        raise ValueError(f'linkage artifact validation failed: {exc}') from exc
+
+    _validate_linkage_trace_node_arrays(path, expected_n_traces=expected_n_traces)
+    try:
+        load_geometry_linkage_artifact(
+            path,
+            expected_n_traces=expected_n_traces,
+            expected_key1_byte=req.key1_byte,
+            expected_key2_byte=req.key2_byte,
+        )
+    except ValueError as exc:
+        raise ValueError(f'linkage artifact validation failed: {exc}') from exc
+    return path
+
+
+def _validate_linkage_trace_node_arrays(
+    path: Path,
+    *,
+    expected_n_traces: int,
+) -> None:
+    try:
+        npz_file = np.load(path, allow_pickle=False)
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f'Could not read linkage artifact: {path}') from exc
+
+    with npz_file as npz:
+        for name in ('source_node_id_sorted', 'receiver_node_id_sorted'):
+            if name not in npz.files:
+                raise ValueError(f'linkage artifact missing required array: {name}')
+            try:
+                values = np.asarray(npz[name])
+            except Exception as exc:  # noqa: BLE001
+                raise ValueError(f'linkage artifact array {name} could not be read') from exc
+            _validate_node_id_array(
+                values,
+                name=name,
+                expected_n_traces=expected_n_traces,
+            )
+
+
+def _validate_node_id_array(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_n_traces: int,
+) -> None:
+    arr = np.asarray(values)
+    expected_shape = (int(expected_n_traces),)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        )
+    if np.issubdtype(arr.dtype, np.bool_) or not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a real numeric dtype')
+    if np.issubdtype(arr.dtype, np.floating):
+        arr_f64 = arr.astype(np.float64, copy=False)
+        if not np.all(np.isfinite(arr_f64)):
+            raise ValueError(f'{name} must contain only finite values')
+        if not np.all(arr_f64 == np.rint(arr_f64)):
+            raise ValueError(f'{name} must contain only integer values')
+    if np.any(arr < 0):
+        raise ValueError(f'{name} must not contain negative values')
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = ['TimeTermValidationResult', 'validate_time_term_request']

--- a/app/tests/test_time_term_static_request.py
+++ b/app/tests/test_time_term_static_request.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.schemas import TimeTermStaticApplyRequest
+from app.main import app
+from app.services.geometry_linkage_artifacts import (
+    GEOMETRY_LINKAGE_NPZ_NAME,
+    GeometryLinkageArtifactMetadata,
+    build_geometry_linkage_solution_arrays,
+)
+from app.services.geometry_linkage_linker import (
+    GeometryLinkageOptions,
+    build_geometry_linkage,
+)
+from app.services.geometry_linkage_tables import build_endpoint_geometry_tables
+from app.services.geometry_linkage_validation import GeometryLinkageHeaders
+from app.services.time_term_static_service import validate_time_term_request
+
+FILE_ID = 'current-file-id'
+LINKAGE_JOB_ID = 'linkage-job-id'
+KEY1_BYTE = 189
+KEY2_BYTE = 193
+DT = 0.004
+N_TRACES = 5
+
+
+class _Reader:
+    key1_byte = KEY1_BYTE
+    key2_byte = KEY2_BYTE
+
+    def __init__(self, *, dt: float = DT, n_traces: int = N_TRACES) -> None:
+        self.traces = np.zeros((n_traces, 16), dtype=np.float32)
+        self.meta = {'dt': dt, 'n_traces': n_traces}
+
+    def get_n_samples(self) -> int:
+        return int(self.traces.shape[-1])
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv('PIPELINE_JOBS_DIR', str(tmp_path / 'jobs'))
+    state = app.state.sv
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        'file_id': FILE_ID,
+        'key1_byte': KEY1_BYTE,
+        'key2_byte': KEY2_BYTE,
+        'pick_source': {
+            'kind': 'batch_predicted_npz',
+            'job_id': 'batch-job-id',
+            'artifact_name': 'predicted_picks_time_s.npz',
+        },
+        'geometry': {
+            'source_id_byte': 9,
+            'receiver_id_byte': 13,
+            'source_x_byte': 73,
+            'source_y_byte': 77,
+            'receiver_x_byte': 81,
+            'receiver_y_byte': 85,
+            'source_elevation_byte': 45,
+            'receiver_elevation_byte': 41,
+            'source_depth_byte': None,
+            'coordinate_scalar_byte': 71,
+            'elevation_scalar_byte': 69,
+            'coordinate_unit': 'm',
+            'elevation_unit': 'm',
+        },
+        'linkage': {
+            'mode': 'required',
+            'job_id': LINKAGE_JOB_ID,
+            'artifact_name': GEOMETRY_LINKAGE_NPZ_NAME,
+        },
+        'velocity': {
+            'replacement_velocity_m_s': 2000.0,
+            'refractor_velocity_m_s': 4500.0,
+            'weathering_velocity_m_s': None,
+        },
+        'moveout': {
+            'model': 'head_wave_linear_offset',
+            'offset_byte': 37,
+            'allow_missing_offset': False,
+        },
+        'solver': {
+            'damping': 0.01,
+            'gauge': 'mean_zero',
+            'robust': {
+                'enabled': True,
+                'max_iterations': 5,
+                'mad_threshold': 3.5,
+                'min_used_fraction': 0.5,
+            },
+        },
+        'apply': {
+            'register_corrected_file': False,
+            'max_abs_shift_ms': 250.0,
+            'output_dtype': 'float32',
+        },
+    }
+
+
+def _validate(payload: dict[str, Any]) -> TimeTermStaticApplyRequest:
+    return TimeTermStaticApplyRequest.model_validate(deepcopy(payload))
+
+
+def _install_trace_store(client: TestClient, tmp_path: Path, *, dt: float = DT) -> None:
+    state = client.app.state.sv
+    store = tmp_path / 'trace-store'
+    store.mkdir()
+    state.file_registry.set_record(
+        FILE_ID,
+        {
+            'store_path': str(store),
+            'dt': dt,
+        },
+    )
+    with state.lock:
+        state.cached_readers[f'{FILE_ID}_{KEY1_BYTE}_{KEY2_BYTE}'] = _Reader(dt=dt)
+
+
+def _install_linkage_job(
+    client: TestClient,
+    tmp_path: Path,
+    *,
+    payload: dict[str, np.ndarray] | None = None,
+) -> Path:
+    state = client.app.state.sv
+    job_dir = tmp_path / 'linkage-job'
+    job_dir.mkdir()
+    arrays = _linkage_payload() if payload is None else payload
+    with (job_dir / GEOMETRY_LINKAGE_NPZ_NAME).open('wb') as handle:
+        np.savez(handle, **arrays)
+    with state.lock:
+        state.jobs.create_static_job(
+            LINKAGE_JOB_ID,
+            file_id=FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='geometry_linkage',
+            artifacts_dir=str(job_dir),
+        )
+    return job_dir / GEOMETRY_LINKAGE_NPZ_NAME
+
+
+def _linkage_payload() -> dict[str, np.ndarray]:
+    headers = GeometryLinkageHeaders(
+        source_x=np.asarray([0.0, 10.0, 11.0, 30.0, 0.0], dtype=np.float64),
+        source_y=np.asarray([0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        receiver_x=np.asarray([0.0, 100.0, 100.0, 0.0, 100.0], dtype=np.float64),
+        receiver_y=np.asarray([0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64),
+        coordinate_scalar=np.ones(N_TRACES, dtype=np.int64),
+        checked_bytes=(71, 73, 77, 81, 85),
+    )
+    tables = build_endpoint_geometry_tables(headers)
+    linkage = build_geometry_linkage(
+        tables,
+        GeometryLinkageOptions(
+            mode='auto_threshold',
+            threshold_m=1.1,
+            receiver_location_interval_m=25.0,
+        ),
+    )
+    return build_geometry_linkage_solution_arrays(
+        tables,
+        linkage,
+        metadata=GeometryLinkageArtifactMetadata(
+            job_id=LINKAGE_JOB_ID,
+            input_file_id=FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            source_x_byte=73,
+            source_y_byte=77,
+            receiver_x_byte=81,
+            receiver_y_byte=85,
+            coordinate_scalar_byte=71,
+        ),
+    )
+
+
+def test_time_term_request_accepts_minimal_valid_schema() -> None:
+    payload = {
+        'file_id': FILE_ID,
+        'pick_source': {
+            'kind': 'batch_predicted_npz',
+            'job_id': 'batch-job-id',
+        },
+        'linkage': {
+            'mode': 'required',
+            'job_id': LINKAGE_JOB_ID,
+        },
+        'velocity': {
+            'replacement_velocity_m_s': 2000.0,
+            'refractor_velocity_m_s': 4500.0,
+        },
+    }
+
+    req = _validate(payload)
+
+    assert req.pick_source.artifact_name == 'predicted_picks_time_s.npz'
+    assert req.linkage.artifact_name == GEOMETRY_LINKAGE_NPZ_NAME
+    assert req.geometry.coordinate_unit == 'm'
+    assert req.moveout.model == 'head_wave_linear_offset'
+    assert req.solver.robust.max_iterations == 5
+    assert req.apply.register_corrected_file is False
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('replacement_velocity_m_s', 0.0),
+        ('refractor_velocity_m_s', 0.0),
+        ('weathering_velocity_m_s', 0.0),
+    ],
+)
+def test_time_term_request_rejects_non_positive_velocities(
+    field: str,
+    value: float,
+) -> None:
+    payload = _payload()
+    payload['velocity'][field] = value
+
+    with pytest.raises(ValidationError, match=field):
+        _validate(payload)
+
+
+def test_time_term_request_rejects_refractor_velocity_not_greater_than_replacement_velocity() -> None:
+    payload = _payload()
+    payload['velocity']['refractor_velocity_m_s'] = 1500.0
+
+    with pytest.raises(ValidationError, match='refractor_velocity_m_s'):
+        _validate(payload)
+
+
+def test_time_term_request_rejects_invalid_units() -> None:
+    payload = _payload()
+    payload['geometry']['coordinate_unit'] = 'km'
+
+    with pytest.raises(ValidationError, match='coordinate_unit'):
+        _validate(payload)
+
+
+def test_time_term_request_rejects_invalid_moveout_offset_config() -> None:
+    payload = _payload()
+    payload['moveout']['offset_byte'] = None
+
+    with pytest.raises(ValidationError, match='moveout.offset_byte is required'):
+        _validate(payload)
+
+
+def test_time_term_linkage_required_rejects_missing_job() -> None:
+    payload = _payload()
+    del payload['linkage']['job_id']
+
+    with pytest.raises(ValidationError, match='linkage.job_id is required'):
+        _validate(payload)
+
+
+@pytest.mark.parametrize(
+    ('field_path', 'value', 'match'),
+    [
+        (('solver', 'damping'), -0.1, 'solver.damping'),
+        (('solver', 'robust', 'max_iterations'), 0, 'max_iterations'),
+        (('solver', 'robust', 'mad_threshold'), 0.0, 'mad_threshold'),
+        (('solver', 'robust', 'min_used_fraction'), 1.1, 'min_used_fraction'),
+        (('apply', 'max_abs_shift_ms'), 0.0, 'max_abs_shift_ms'),
+    ],
+)
+def test_time_term_request_rejects_invalid_solver_and_apply_values(
+    field_path: tuple[str, ...],
+    value: object,
+    match: str,
+) -> None:
+    payload = _payload()
+    target = payload
+    for key in field_path[:-1]:
+        target = target[key]
+    target[field_path[-1]] = value
+
+    with pytest.raises(ValidationError, match=match):
+        _validate(payload)
+
+
+def test_validate_time_term_request_accepts_valid_preconditions(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _install_trace_store(client, tmp_path)
+    linkage_path = _install_linkage_job(client, tmp_path)
+
+    result = validate_time_term_request(
+        _validate(_payload()),
+        state=client.app.state.sv,
+    )
+
+    assert result.file_id == FILE_ID
+    assert result.dt == pytest.approx(DT)
+    assert result.n_traces == N_TRACES
+    assert result.linkage_artifact_path == linkage_path
+
+
+def test_validate_time_term_request_accepts_optional_linkage_without_artifact(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _install_trace_store(client, tmp_path)
+    payload = _payload()
+    payload['linkage'] = {'mode': 'optional'}
+
+    result = validate_time_term_request(
+        _validate(payload),
+        state=client.app.state.sv,
+    )
+
+    assert result.linkage_artifact_path is None
+
+
+def test_validate_time_term_request_rejects_unknown_file_id(client: TestClient) -> None:
+    with pytest.raises(ValueError, match='file_id not found'):
+        validate_time_term_request(_validate(_payload()), state=client.app.state.sv)
+
+
+def test_time_term_linkage_rejects_missing_artifact(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _install_trace_store(client, tmp_path)
+    job_dir = tmp_path / 'linkage-job'
+    job_dir.mkdir()
+    state = client.app.state.sv
+    with state.lock:
+        state.jobs.create_static_job(
+            LINKAGE_JOB_ID,
+            file_id=FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='geometry_linkage',
+            artifacts_dir=str(job_dir),
+        )
+
+    with pytest.raises(ValueError, match='job artifact not found'):
+        validate_time_term_request(_validate(_payload()), state=state)
+
+
+def test_time_term_linkage_rejects_shape_mismatch(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _install_trace_store(client, tmp_path)
+    payload = _linkage_payload()
+    payload['source_node_id_sorted'] = payload['source_node_id_sorted'][:-1]
+    _install_linkage_job(client, tmp_path, payload=payload)
+
+    with pytest.raises(ValueError, match='source_node_id_sorted shape mismatch'):
+        validate_time_term_request(
+            _validate(_payload()),
+            state=client.app.state.sv,
+        )
+
+
+def test_time_term_linkage_rejects_negative_node_ids(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _install_trace_store(client, tmp_path)
+    payload = _linkage_payload()
+    source_nodes = payload['source_node_id_sorted'].copy()
+    source_nodes[0] = -1
+    payload['source_node_id_sorted'] = source_nodes
+    _install_linkage_job(client, tmp_path, payload=payload)
+
+    with pytest.raises(ValueError, match='source_node_id_sorted.*negative'):
+        validate_time_term_request(
+            _validate(_payload()),
+            state=client.app.state.sv,
+        )
+
+
+def test_time_term_apply_endpoint_returns_not_implemented_after_validation(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _install_trace_store(client, tmp_path)
+    _install_linkage_job(client, tmp_path)
+
+    response = client.post('/statics/time-term/apply', json=_payload())
+
+    assert response.status_code == 501
+    assert response.json() == {
+        'detail': 'time-term inversion solver is not implemented yet'
+    }
+
+
+def test_time_term_apply_endpoint_returns_validation_error_before_not_implemented(
+    client: TestClient,
+) -> None:
+    response = client.post('/statics/time-term/apply', json=_payload())
+
+    assert response.status_code == 400
+    assert 'file_id not found' in response.json()['detail']


### PR DESCRIPTION
Closes #348

## Summary
- PR6-1 [statics time-term] time-term inversion request schema と velocity/linkage validation を追加する

## Changed files
- `app/api/routers/statics.py`
- `app/api/schemas.py`
- `app/services/time_term_static_service.py`
- `app/tests/test_time_term_static_request.py`

## Checks
- `.work/codex/checks.log`: 1180 passed in 48.26s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
