### PR TITLE
PR6-4 [statics time-term] source/receiver node time-term design matrix builder を追加する

### DIFF
--- a/app/services/time_term_design_matrix.py
+++ b/app/services/time_term_design_matrix.py
@@ -1,0 +1,486 @@
+"""Design matrix builder for source/receiver node time-term inversion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy import sparse
+
+from app.services.time_term_moveout import TimeTermMoveoutResult
+from app.services.time_term_static_inputs import TimeTermInversionInputs
+
+
+@dataclass(frozen=True)
+class TimeTermDesignMatrixOptions:
+    min_observations: int = 1
+    include_only_valid_picks: bool = True
+    include_only_valid_moveout: bool = True
+
+
+@dataclass(frozen=True)
+class TimeTermDesignMatrix:
+    matrix: sparse.csr_matrix
+    data_s: np.ndarray
+
+    n_traces: int
+    n_observations: int
+    n_nodes: int
+
+    used_trace_mask_sorted: np.ndarray
+    row_trace_index_sorted: np.ndarray
+    trace_to_row_index_sorted: np.ndarray
+
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    row_pick_time_after_static_s: np.ndarray
+    row_moveout_time_s: np.ndarray
+    row_data_s: np.ndarray
+
+    source_observation_count_by_node: np.ndarray
+    receiver_observation_count_by_node: np.ndarray
+    total_observation_count_by_node: np.ndarray
+
+
+def build_time_term_design_matrix(
+    inputs: TimeTermInversionInputs,
+    moveout: TimeTermMoveoutResult,
+    *,
+    options: TimeTermDesignMatrixOptions | None = None,
+) -> TimeTermDesignMatrix:
+    """Build observation rows for node time-term unknowns in sorted trace order."""
+    opts = _validate_options(options)
+    n_traces = _coerce_positive_int(inputs.n_traces, name='n_traces')
+    n_nodes = _coerce_positive_int(inputs.n_nodes, name='n_nodes')
+    _coerce_positive_finite_float(inputs.dt, name='dt')
+    expected_shape = (n_traces,)
+
+    valid_pick_mask = _coerce_1d_bool_array(
+        inputs.valid_pick_mask_sorted,
+        name='valid_pick_mask_sorted',
+        expected_shape=expected_shape,
+    )
+    valid_moveout_mask = _coerce_1d_bool_array(
+        moveout.valid_moveout_mask_sorted,
+        name='valid_moveout_mask_sorted',
+        expected_shape=expected_shape,
+    )
+    pick_time_after_static = _coerce_1d_real_numeric_float64(
+        inputs.pick_time_after_static_s_sorted,
+        name='pick_time_after_static_s_sorted',
+        expected_shape=expected_shape,
+    )
+    moveout_time = _coerce_1d_real_numeric_float64(
+        moveout.moveout_time_s_sorted,
+        name='moveout_time_s_sorted',
+        expected_shape=expected_shape,
+    )
+    source_node_id = _coerce_1d_integer_int64(
+        inputs.source_node_id_sorted,
+        name='source_node_id_sorted',
+        expected_shape=expected_shape,
+    )
+    receiver_node_id = _coerce_1d_integer_int64(
+        inputs.receiver_node_id_sorted,
+        name='receiver_node_id_sorted',
+        expected_shape=expected_shape,
+    )
+    _validate_node_range(source_node_id, receiver_node_id, n_nodes=n_nodes)
+
+    candidate_mask = _candidate_trace_mask(
+        valid_pick_mask=valid_pick_mask,
+        valid_moveout_mask=valid_moveout_mask,
+        options=opts,
+    )
+    _validate_finite_at_mask(
+        pick_time_after_static,
+        mask=candidate_mask,
+        name='pick_time_after_static_s_sorted',
+        mask_name='candidate traces',
+    )
+    _validate_finite_nonnegative_at_mask(
+        moveout_time,
+        mask=candidate_mask,
+        name='moveout_time_s_sorted',
+        mask_name='candidate traces',
+    )
+    used_trace_mask = np.ascontiguousarray(
+        candidate_mask
+        & np.isfinite(pick_time_after_static)
+        & np.isfinite(moveout_time)
+        & (moveout_time >= 0.0),
+        dtype=bool,
+    )
+    row_trace_index = np.ascontiguousarray(
+        np.flatnonzero(used_trace_mask),
+        dtype=np.int64,
+    )
+    n_observations = int(row_trace_index.shape[0])
+    if n_observations <= 0:
+        raise ValueError('at least one usable time-term observation is required')
+    if n_observations < opts.min_observations:
+        raise ValueError(
+            'not enough usable time-term observations: '
+            f'{n_observations} < {opts.min_observations}'
+        )
+
+    trace_to_row_index = np.full(n_traces, -1, dtype=np.int64)
+    trace_to_row_index[row_trace_index] = np.arange(n_observations, dtype=np.int64)
+
+    row_source_node_id = np.ascontiguousarray(
+        source_node_id[row_trace_index],
+        dtype=np.int64,
+    )
+    row_receiver_node_id = np.ascontiguousarray(
+        receiver_node_id[row_trace_index],
+        dtype=np.int64,
+    )
+    row_pick_time_after_static = np.ascontiguousarray(
+        pick_time_after_static[row_trace_index],
+        dtype=np.float64,
+    )
+    row_moveout_time = np.ascontiguousarray(
+        moveout_time[row_trace_index],
+        dtype=np.float64,
+    )
+    row_data_s = np.ascontiguousarray(
+        row_pick_time_after_static - row_moveout_time,
+        dtype=np.float64,
+    )
+
+    matrix = _build_sparse_matrix(
+        row_source_node_id,
+        row_receiver_node_id,
+        n_observations=n_observations,
+        n_nodes=n_nodes,
+    )
+    source_count = np.bincount(row_source_node_id, minlength=n_nodes).astype(
+        np.int64,
+        copy=False,
+    )
+    receiver_count = np.bincount(row_receiver_node_id, minlength=n_nodes).astype(
+        np.int64,
+        copy=False,
+    )
+    total_count = np.ascontiguousarray(source_count + receiver_count, dtype=np.int64)
+
+    return TimeTermDesignMatrix(
+        matrix=matrix,
+        data_s=row_data_s,
+        n_traces=n_traces,
+        n_observations=n_observations,
+        n_nodes=n_nodes,
+        used_trace_mask_sorted=used_trace_mask,
+        row_trace_index_sorted=row_trace_index,
+        trace_to_row_index_sorted=trace_to_row_index,
+        row_source_node_id=row_source_node_id,
+        row_receiver_node_id=row_receiver_node_id,
+        row_pick_time_after_static_s=row_pick_time_after_static,
+        row_moveout_time_s=row_moveout_time,
+        row_data_s=row_data_s,
+        source_observation_count_by_node=np.ascontiguousarray(
+            source_count,
+            dtype=np.int64,
+        ),
+        receiver_observation_count_by_node=np.ascontiguousarray(
+            receiver_count,
+            dtype=np.int64,
+        ),
+        total_observation_count_by_node=total_count,
+    )
+
+
+def summarize_time_term_design_matrix(
+    design: TimeTermDesignMatrix,
+) -> dict[str, object]:
+    """Return a JSON-safe summary for future artifacts and job logs."""
+    n_traces = _coerce_positive_int(design.n_traces, name='n_traces')
+    n_nodes = _coerce_positive_int(design.n_nodes, name='n_nodes')
+    n_observations = _coerce_positive_int(
+        design.n_observations,
+        name='n_observations',
+    )
+    if design.matrix.shape != (n_observations, n_nodes):
+        raise ValueError('matrix shape does not match design dimensions')
+    data_s = _coerce_1d_real_numeric_float64(
+        design.data_s,
+        name='data_s',
+        expected_shape=(n_observations,),
+    )
+    source_count = _coerce_1d_integer_int64(
+        design.source_observation_count_by_node,
+        name='source_observation_count_by_node',
+        expected_shape=(n_nodes,),
+    )
+    receiver_count = _coerce_1d_integer_int64(
+        design.receiver_observation_count_by_node,
+        name='receiver_observation_count_by_node',
+        expected_shape=(n_nodes,),
+    )
+    total_count = _coerce_1d_integer_int64(
+        design.total_observation_count_by_node,
+        name='total_observation_count_by_node',
+        expected_shape=(n_nodes,),
+    )
+    n_nodes_with_source = int(np.count_nonzero(source_count > 0))
+    n_nodes_with_receiver = int(np.count_nonzero(receiver_count > 0))
+    n_nodes_with_any = int(np.count_nonzero(total_count > 0))
+
+    return {
+        'n_traces': n_traces,
+        'n_observations': n_observations,
+        'n_nodes': n_nodes,
+        'observation_fraction': _fraction(n_observations, n_traces),
+        'matrix_shape': [int(design.matrix.shape[0]), int(design.matrix.shape[1])],
+        'matrix_nnz': int(design.matrix.nnz),
+        'source_observation_count_by_node': _stats_payload(source_count),
+        'receiver_observation_count_by_node': _stats_payload(receiver_count),
+        'total_observation_count_by_node': _stats_payload(total_count),
+        'data_s': _stats_payload(data_s),
+        'data_ms': _stats_payload(data_s * 1000.0),
+        'n_nodes_with_source_observations': n_nodes_with_source,
+        'n_nodes_with_receiver_observations': n_nodes_with_receiver,
+        'n_nodes_with_any_observations': n_nodes_with_any,
+        'n_nodes_without_observations': int(n_nodes - n_nodes_with_any),
+    }
+
+
+def _validate_options(
+    options: TimeTermDesignMatrixOptions | None,
+) -> TimeTermDesignMatrixOptions:
+    opts = TimeTermDesignMatrixOptions() if options is None else options
+    min_observations = _coerce_nonnegative_int(
+        opts.min_observations,
+        name='min_observations',
+    )
+    include_only_valid_picks = _coerce_bool(
+        opts.include_only_valid_picks,
+        name='include_only_valid_picks',
+    )
+    include_only_valid_moveout = _coerce_bool(
+        opts.include_only_valid_moveout,
+        name='include_only_valid_moveout',
+    )
+    return TimeTermDesignMatrixOptions(
+        min_observations=min_observations,
+        include_only_valid_picks=include_only_valid_picks,
+        include_only_valid_moveout=include_only_valid_moveout,
+    )
+
+
+def _candidate_trace_mask(
+    *,
+    valid_pick_mask: np.ndarray,
+    valid_moveout_mask: np.ndarray,
+    options: TimeTermDesignMatrixOptions,
+) -> np.ndarray:
+    candidate_mask = np.ones(valid_pick_mask.shape, dtype=bool)
+    if options.include_only_valid_picks:
+        candidate_mask &= valid_pick_mask
+    if options.include_only_valid_moveout:
+        candidate_mask &= valid_moveout_mask
+    return np.ascontiguousarray(candidate_mask, dtype=bool)
+
+
+def _build_sparse_matrix(
+    row_source_node_id: np.ndarray,
+    row_receiver_node_id: np.ndarray,
+    *,
+    n_observations: int,
+    n_nodes: int,
+) -> sparse.csr_matrix:
+    row_indices = np.repeat(np.arange(n_observations, dtype=np.int64), 2)
+    col_indices = np.empty(n_observations * 2, dtype=np.int64)
+    col_indices[0::2] = row_source_node_id
+    col_indices[1::2] = row_receiver_node_id
+    data = np.ones(n_observations * 2, dtype=np.float64)
+    matrix = sparse.coo_matrix(
+        (data, (row_indices, col_indices)),
+        shape=(n_observations, n_nodes),
+        dtype=np.float64,
+    ).tocsr()
+    matrix.sum_duplicates()
+    matrix.sort_indices()
+
+    expected_nnz = int(
+        n_observations + np.count_nonzero(row_source_node_id != row_receiver_node_id)
+    )
+    if matrix.shape != (n_observations, n_nodes):
+        raise ValueError('time-term design matrix shape mismatch')
+    if matrix.nnz != expected_nnz:
+        raise ValueError('time-term design matrix nnz mismatch')
+    return matrix
+
+
+def _validate_node_range(
+    source: np.ndarray,
+    receiver: np.ndarray,
+    *,
+    n_nodes: int,
+) -> None:
+    if np.any(source < 0) or np.any(receiver < 0):
+        raise ValueError('node ids must be non-negative')
+    if np.any(source >= n_nodes) or np.any(receiver >= n_nodes):
+        raise ValueError('node ids must be less than n_nodes')
+
+
+def _validate_finite_at_mask(
+    values: np.ndarray,
+    *,
+    mask: np.ndarray,
+    name: str,
+    mask_name: str,
+) -> None:
+    if np.any(~np.isfinite(values[mask])):
+        raise ValueError(f'{name} must be finite for {mask_name}')
+
+
+def _validate_finite_nonnegative_at_mask(
+    values: np.ndarray,
+    *,
+    mask: np.ndarray,
+    name: str,
+    mask_name: str,
+) -> None:
+    _validate_finite_at_mask(values, mask=mask, name=name, mask_name=mask_name)
+    if np.any(values[mask] < 0.0):
+        raise ValueError(f'{name} must be non-negative for {mask_name}')
+
+
+def _coerce_1d_real_numeric_float64(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a numeric dtype')
+    return np.ascontiguousarray(arr, dtype=np.float64)
+
+
+def _coerce_1d_integer_int64(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must contain integer values')
+    if np.issubdtype(arr.dtype, np.integer):
+        return np.ascontiguousarray(arr, dtype=np.int64)
+    if not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must contain integer values')
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(arr_f64)):
+        raise ValueError(f'{name} must contain only finite values')
+    if not np.all(arr_f64 == np.rint(arr_f64)):
+        raise ValueError(f'{name} must contain integer values')
+    return np.ascontiguousarray(arr_f64, dtype=np.int64)
+
+
+def _coerce_1d_bool_array(
+    values: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if not np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must have bool dtype')
+    return np.ascontiguousarray(arr, dtype=bool)
+
+
+def _coerce_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer')
+    out = int(value)
+    if out <= 0:
+        raise ValueError(f'{name} must be greater than 0')
+    return out
+
+
+def _coerce_nonnegative_int(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer')
+    out = int(value)
+    if out < 0:
+        raise ValueError(f'{name} must be non-negative')
+    return out
+
+
+def _coerce_positive_finite_float(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f'{name} must be finite and greater than 0')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite and greater than 0') from exc
+    if not np.isfinite(out) or out <= 0.0:
+        raise ValueError(f'{name} must be finite and greater than 0')
+    return out
+
+
+def _coerce_bool(value: object, *, name: str) -> bool:
+    if not isinstance(value, (bool, np.bool_)):
+        raise ValueError(f'{name} must be bool')
+    return bool(value)
+
+
+def _stats_payload(values: np.ndarray) -> dict[str, float | int | None]:
+    arr = _coerce_1d_real_numeric_float64(values, name='summary values')
+    finite = np.ascontiguousarray(arr[np.isfinite(arr)], dtype=np.float64)
+    count = int(finite.shape[0])
+    if count == 0:
+        return {
+            'count': 0,
+            'min': None,
+            'max': None,
+            'mean': None,
+            'median': None,
+            'std': None,
+            'max_abs': None,
+        }
+    return {
+        'count': count,
+        'min': float(np.min(finite)),
+        'max': float(np.max(finite)),
+        'mean': float(np.mean(finite)),
+        'median': float(np.median(finite)),
+        'std': float(np.std(finite, ddof=0)),
+        'max_abs': float(np.max(np.abs(finite))),
+    }
+
+
+def _fraction(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return float(numerator / denominator)
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'TimeTermDesignMatrix',
+    'TimeTermDesignMatrixOptions',
+    'build_time_term_design_matrix',
+    'summarize_time_term_design_matrix',
+]

--- a/app/tests/test_time_term_design_matrix.py
+++ b/app/tests/test_time_term_design_matrix.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from app.services.time_term_design_matrix import (
+    TimeTermDesignMatrixOptions,
+    build_time_term_design_matrix,
+    summarize_time_term_design_matrix,
+)
+from app.services.time_term_moveout import TimeTermMoveoutResult
+from app.services.time_term_static_inputs import TimeTermInversionInputs
+
+N_TRACES = 4
+N_SAMPLES = 64
+DT = 0.004
+N_NODES = 3
+
+SOURCE_NODE_ID = np.asarray([0, 0, 1, 2], dtype=np.int64)
+RECEIVER_NODE_ID = np.asarray([1, 2, 2, 2], dtype=np.int64)
+PICK_TIME_AFTER_STATIC = np.asarray([0.10, 0.20, 0.30, 0.40], dtype=np.float64)
+MOVEOUT_TIME = np.asarray([0.01, 0.02, 0.03, 0.04], dtype=np.float64)
+VALID_PICK_MASK = np.asarray([True, True, False, True])
+VALID_MOVEOUT_MASK = np.asarray([True, True, True, True])
+
+
+def _inputs(**overrides: Any) -> TimeTermInversionInputs:
+    payload: dict[str, Any] = {
+        'n_traces': N_TRACES,
+        'n_samples': N_SAMPLES,
+        'dt': DT,
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'pick_time_raw_s_sorted': PICK_TIME_AFTER_STATIC.copy(),
+        'valid_pick_mask_sorted': VALID_PICK_MASK.copy(),
+        'datum_trace_shift_s_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'residual_applied_shift_s_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'pick_time_after_static_s_sorted': PICK_TIME_AFTER_STATIC.copy(),
+        'source_node_id_sorted': SOURCE_NODE_ID.copy(),
+        'receiver_node_id_sorted': RECEIVER_NODE_ID.copy(),
+        'n_nodes': N_NODES,
+        'source_id_sorted': np.asarray([10, 10, 20, 30], dtype=np.int64),
+        'receiver_id_sorted': np.asarray([20, 30, 30, 30], dtype=np.int64),
+        'offset_sorted': np.asarray([100.0, 200.0, 300.0, 0.0]),
+        'source_x_m_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'source_y_m_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'receiver_x_m_sorted': np.ones(N_TRACES, dtype=np.float64),
+        'receiver_y_m_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'source_elevation_m_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'receiver_elevation_m_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'source_depth_m_sorted': np.zeros(N_TRACES, dtype=np.float64),
+        'input_file_id': 'file-id',
+        'pick_source_description': 'test-picks',
+        'datum_solution_path': Path('datum.npz'),
+        'residual_solution_path': Path('residual.npz'),
+        'linkage_artifact_path': Path('geometry_linkage.npz'),
+    }
+    payload.update(overrides)
+    return TimeTermInversionInputs(**payload)
+
+
+def _moveout(**overrides: Any) -> TimeTermMoveoutResult:
+    payload: dict[str, Any] = {
+        'model': 'head_wave_linear_offset',
+        'refractor_velocity_m_s': 2500.0,
+        'distance_source': 'geometry',
+        'distance_m_sorted': MOVEOUT_TIME * 2500.0,
+        'moveout_time_s_sorted': MOVEOUT_TIME.copy(),
+        'valid_moveout_mask_sorted': VALID_MOVEOUT_MASK.copy(),
+        'reciprocal_pair_index_sorted': np.full(N_TRACES, -1, dtype=np.int64),
+        'has_reciprocal_pair_mask_sorted': np.zeros(N_TRACES, dtype=bool),
+        'geometry_distance_m_sorted': MOVEOUT_TIME * 2500.0,
+        'offset_abs_m_sorted': None,
+        'geometry_offset_mismatch_m_sorted': None,
+    }
+    payload.update(overrides)
+    return TimeTermMoveoutResult(**payload)
+
+
+def _build(
+    inputs: TimeTermInversionInputs | None = None,
+    moveout: TimeTermMoveoutResult | None = None,
+    *,
+    options: TimeTermDesignMatrixOptions | None = None,
+):
+    return build_time_term_design_matrix(
+        _inputs() if inputs is None else inputs,
+        _moveout() if moveout is None else moveout,
+        options=options,
+    )
+
+
+def test_time_term_design_matrix_builds_csr_matrix_for_simple_nodes() -> None:
+    design = _build()
+
+    assert sparse.isspmatrix_csr(design.matrix)
+    assert design.matrix.shape == (3, 3)
+    np.testing.assert_allclose(
+        design.matrix.toarray(),
+        [
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 0.0, 2.0],
+        ],
+    )
+
+
+def test_time_term_design_matrix_data_vector_subtracts_moveout() -> None:
+    design = _build()
+
+    np.testing.assert_allclose(design.data_s, [0.09, 0.18, 0.36])
+    np.testing.assert_allclose(design.row_data_s, [0.09, 0.18, 0.36])
+    np.testing.assert_allclose(
+        design.row_pick_time_after_static_s - design.row_moveout_time_s,
+        design.data_s,
+    )
+
+
+def test_time_term_design_matrix_uses_only_valid_pick_and_moveout_rows() -> None:
+    design = _build(
+        inputs=_inputs(valid_pick_mask_sorted=np.asarray([True, False, True, True])),
+        moveout=_moveout(
+            valid_moveout_mask_sorted=np.asarray([True, True, False, True])
+        ),
+    )
+
+    np.testing.assert_array_equal(design.row_trace_index_sorted, [0, 3])
+    np.testing.assert_array_equal(
+        design.used_trace_mask_sorted,
+        [True, False, False, True],
+    )
+
+
+def test_time_term_design_matrix_preserves_sorted_trace_row_order() -> None:
+    design = _build(
+        inputs=_inputs(valid_pick_mask_sorted=np.asarray([False, True, True, False])),
+        moveout=_moveout(valid_moveout_mask_sorted=np.ones(N_TRACES, dtype=bool)),
+    )
+
+    np.testing.assert_array_equal(design.row_trace_index_sorted, [1, 2])
+
+
+def test_time_term_design_matrix_builds_trace_to_row_index() -> None:
+    design = _build()
+
+    np.testing.assert_array_equal(design.trace_to_row_index_sorted, [0, 1, -1, 2])
+
+
+def test_time_term_design_matrix_row_has_source_and_receiver_coefficients() -> None:
+    design = _build()
+
+    np.testing.assert_allclose(design.matrix.toarray()[0], [1.0, 1.0, 0.0])
+    np.testing.assert_allclose(design.matrix.toarray()[1], [1.0, 0.0, 1.0])
+
+
+def test_time_term_design_matrix_same_source_receiver_node_has_coefficient_two() -> None:
+    design = _build()
+
+    assert design.matrix[2, 2] == pytest.approx(2.0)
+    assert design.matrix.nnz == 5
+
+
+def test_time_term_design_matrix_counts_source_receiver_observations_by_node() -> None:
+    design = _build()
+
+    np.testing.assert_array_equal(
+        design.source_observation_count_by_node,
+        [2, 0, 1],
+    )
+    np.testing.assert_array_equal(
+        design.receiver_observation_count_by_node,
+        [0, 1, 2],
+    )
+    np.testing.assert_array_equal(
+        design.total_observation_count_by_node,
+        [2, 1, 3],
+    )
+
+
+def test_time_term_design_matrix_counts_same_node_trace_as_two_total_contributions() -> None:
+    design = _build()
+
+    assert design.total_observation_count_by_node[2] == 3
+
+
+def test_time_term_design_matrix_rejects_shape_mismatch() -> None:
+    with pytest.raises(ValueError, match='moveout_time_s_sorted shape mismatch'):
+        _build(
+            moveout=_moveout(
+                moveout_time_s_sorted=np.asarray([0.01, 0.02], dtype=np.float64)
+            )
+        )
+
+
+def test_time_term_design_matrix_rejects_non_bool_valid_masks() -> None:
+    with pytest.raises(ValueError, match='valid_pick_mask_sorted'):
+        _build(inputs=_inputs(valid_pick_mask_sorted=np.asarray([1, 1, 0, 1])))
+
+    with pytest.raises(ValueError, match='valid_moveout_mask_sorted'):
+        _build(moveout=_moveout(valid_moveout_mask_sorted=np.asarray([1, 1, 1, 1])))
+
+
+def test_time_term_design_matrix_rejects_node_id_out_of_range() -> None:
+    with pytest.raises(ValueError, match='node ids must be less than n_nodes'):
+        _build(inputs=_inputs(source_node_id_sorted=np.asarray([0, 0, 3, 2])))
+
+
+def test_time_term_design_matrix_rejects_negative_moveout_on_used_trace() -> None:
+    moveout_time = MOVEOUT_TIME.copy()
+    moveout_time[0] = -0.01
+
+    with pytest.raises(ValueError, match='moveout_time_s_sorted'):
+        _build(moveout=_moveout(moveout_time_s_sorted=moveout_time))
+
+
+def test_time_term_design_matrix_rejects_non_finite_moveout_on_used_trace() -> None:
+    moveout_time = MOVEOUT_TIME.copy()
+    moveout_time[0] = np.inf
+
+    with pytest.raises(ValueError, match='moveout_time_s_sorted'):
+        _build(moveout=_moveout(moveout_time_s_sorted=moveout_time))
+
+
+def test_time_term_design_matrix_rejects_non_finite_pick_on_used_trace() -> None:
+    pick_time = PICK_TIME_AFTER_STATIC.copy()
+    pick_time[0] = np.nan
+
+    with pytest.raises(ValueError, match='pick_time_after_static_s_sorted'):
+        _build(inputs=_inputs(pick_time_after_static_s_sorted=pick_time))
+
+
+def test_time_term_design_matrix_allows_nan_pick_on_unused_trace() -> None:
+    pick_time = PICK_TIME_AFTER_STATIC.copy()
+    pick_time[2] = np.nan
+
+    design = _build(inputs=_inputs(pick_time_after_static_s_sorted=pick_time))
+
+    np.testing.assert_array_equal(design.row_trace_index_sorted, [0, 1, 3])
+
+
+def test_time_term_design_matrix_rejects_no_usable_observations() -> None:
+    with pytest.raises(ValueError, match='at least one usable'):
+        _build(inputs=_inputs(valid_pick_mask_sorted=np.zeros(N_TRACES, dtype=bool)))
+
+
+def test_time_term_design_matrix_respects_min_observations() -> None:
+    with pytest.raises(ValueError, match='not enough usable'):
+        _build(options=TimeTermDesignMatrixOptions(min_observations=4))
+
+
+def test_time_term_design_matrix_can_include_invalid_pick_rows_when_requested() -> None:
+    design = _build(
+        options=TimeTermDesignMatrixOptions(include_only_valid_picks=False)
+    )
+
+    np.testing.assert_array_equal(design.row_trace_index_sorted, [0, 1, 2, 3])
+    assert design.n_observations == 4
+
+
+def test_time_term_design_matrix_does_not_add_gauge_or_damping_rows() -> None:
+    design = _build()
+
+    assert design.matrix.shape[0] == design.n_observations
+    assert design.matrix.shape[0] == design.row_trace_index_sorted.shape[0]
+
+
+def test_summarize_time_term_design_matrix_is_json_safe() -> None:
+    summary = summarize_time_term_design_matrix(_build())
+
+    json.dumps(summary, allow_nan=False)
+    assert summary['n_traces'] == N_TRACES
+    assert summary['n_observations'] == 3
+    assert summary['n_nodes'] == N_NODES
+    assert summary['observation_fraction'] == pytest.approx(0.75)
+    assert summary['matrix_shape'] == [3, 3]
+    assert summary['matrix_nnz'] == 5
+    assert summary['n_nodes_with_any_observations'] == 3
+    assert summary['n_nodes_without_observations'] == 0
+    assert summary['data_ms']['count'] == 3


### PR DESCRIPTION
Closes #354

## Summary
- PR6-4 [statics time-term] source/receiver node time-term design matrix builder を追加する

## Changed files
- `app/services/time_term_design_matrix.py`
- `app/tests/test_time_term_design_matrix.py`

## Checks
- `.work/codex/checks.log`: 1246 passed in 46.73s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
