### PR TITLE
PR6-5 [statics time-term] damping・gauge constraint 付き sparse time-term solver を追加する

### DIFF
--- a/app/services/time_term_design_matrix.py
+++ b/app/services/time_term_design_matrix.py
@@ -30,6 +30,8 @@ class TimeTermDesignMatrix:
     used_trace_mask_sorted: np.ndarray
     row_trace_index_sorted: np.ndarray
     trace_to_row_index_sorted: np.ndarray
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
 
     row_source_node_id: np.ndarray
     row_receiver_node_id: np.ndarray
@@ -173,6 +175,8 @@ def build_time_term_design_matrix(
         used_trace_mask_sorted=used_trace_mask,
         row_trace_index_sorted=row_trace_index,
         trace_to_row_index_sorted=trace_to_row_index,
+        source_node_id_sorted=np.ascontiguousarray(source_node_id, dtype=np.int64),
+        receiver_node_id_sorted=np.ascontiguousarray(receiver_node_id, dtype=np.int64),
         row_source_node_id=row_source_node_id,
         row_receiver_node_id=row_receiver_node_id,
         row_pick_time_after_static_s=row_pick_time_after_static,

--- a/app/services/time_term_sparse_solver.py
+++ b/app/services/time_term_sparse_solver.py
@@ -1,0 +1,1130 @@
+"""Sparse least-squares solver for source/receiver node time-term delays."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from scipy import sparse
+from scipy.sparse import linalg as sparse_linalg
+
+from app.services.time_term_design_matrix import TimeTermDesignMatrix
+
+TimeTermGaugeMode = Literal[
+    'none',
+    'mean_zero',
+    'component_mean_zero',
+    'reference_node',
+]
+TimeTermSparseSolverName = Literal['lsmr', 'lsqr']
+
+
+@dataclass(frozen=True)
+class TimeTermSparseSolverOptions:
+    damping_lambda: float = 0.01
+    damping_prior_s: float | np.ndarray = 0.0
+
+    gauge: TimeTermGaugeMode = 'mean_zero'
+    gauge_weight: float = 1.0
+    reference_node_id: int | None = None
+
+    solver: TimeTermSparseSolverName = 'lsmr'
+    atol: float = 1.0e-8
+    btol: float = 1.0e-8
+    conlim: float = 1.0e8
+    maxiter: int | None = None
+
+    min_observations: int = 1
+    min_total_observations_per_node: int = 1
+    require_all_nodes_observed: bool = True
+
+    max_abs_node_time_term_ms: float | None = 500.0
+    max_abs_estimated_trace_delay_ms: float | None = 500.0
+
+
+@dataclass(frozen=True)
+class TimeTermSolverSystem:
+    augmented_matrix: sparse.csr_matrix
+    augmented_data_s: np.ndarray
+
+    n_observation_rows: int
+    n_damping_rows: int
+    n_gauge_rows: int
+    n_augmented_rows: int
+    n_nodes: int
+
+    damping_prior_s: np.ndarray
+    gauge_mode: TimeTermGaugeMode
+    component_id_by_node: np.ndarray
+    n_components: int
+
+    damping_lambda: float
+    gauge_weight: float
+    reference_node_id: int | None
+    min_total_observations_per_node: int
+    total_observation_count_by_node: np.ndarray
+
+
+@dataclass(frozen=True)
+class TimeTermSparseSolverResult:
+    node_time_term_s: np.ndarray
+    estimated_trace_time_term_delay_s_sorted: np.ndarray
+    row_estimated_time_term_delay_s: np.ndarray
+
+    row_residual_before_s: np.ndarray
+    row_residual_after_s: np.ndarray
+    row_residual_after_ms: np.ndarray
+    rms_residual_before_s: float
+    rms_residual_after_s: float
+
+    used_trace_mask_sorted: np.ndarray
+    row_trace_index_sorted: np.ndarray
+
+    solver_name: TimeTermSparseSolverName
+    solver_istop: int
+    solver_iterations: int
+    solver_normr: float
+    solver_normar: float | None
+    solver_conda: float | None
+    solver_message: str
+
+    system: TimeTermSolverSystem
+
+
+@dataclass(frozen=True)
+class _ValidatedTimeTermDesign:
+    matrix: sparse.csr_matrix
+    data_s: np.ndarray
+
+    n_traces: int
+    n_observations: int
+    n_nodes: int
+
+    used_trace_mask_sorted: np.ndarray
+    row_trace_index_sorted: np.ndarray
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+    total_observation_count_by_node: np.ndarray
+
+
+@dataclass(frozen=True)
+class _SparseSolverRawResult:
+    x: np.ndarray
+    istop: int
+    itn: int
+    normr: float
+    normar: float | None
+    conda: float | None
+    message: str
+
+
+def build_time_term_solver_system(
+    design: TimeTermDesignMatrix,
+    *,
+    options: TimeTermSparseSolverOptions | None = None,
+) -> TimeTermSolverSystem:
+    """Build observation, damping, and gauge rows as one CSR system."""
+    system, _, _ = _build_time_term_solver_system(design, options=options)
+    return system
+
+
+def solve_time_term_sparse_least_squares(
+    design: TimeTermDesignMatrix,
+    *,
+    options: TimeTermSparseSolverOptions | None = None,
+) -> TimeTermSparseSolverResult:
+    """Estimate endpoint node time-term delays from a time-term design matrix."""
+    system, validated_design, validated_options = _build_time_term_solver_system(
+        design,
+        options=options,
+    )
+    raw_result = _run_sparse_solver(
+        system.augmented_matrix,
+        system.augmented_data_s,
+        options=validated_options,
+    )
+
+    node_time_term = np.ascontiguousarray(raw_result.x, dtype=np.float64)
+    _validate_all_finite(node_time_term, name='node_time_term_s')
+    _validate_max_abs_ms(
+        node_time_term,
+        max_abs_ms=validated_options.max_abs_node_time_term_ms,
+        name='node_time_term_s',
+        limit_name='max_abs_node_time_term_ms',
+    )
+
+    row_estimated_delay = np.ascontiguousarray(
+        validated_design.matrix @ node_time_term,
+        dtype=np.float64,
+    )
+    if row_estimated_delay.shape != (validated_design.n_observations,):
+        raise ValueError('row_estimated_time_term_delay_s shape mismatch')
+    _validate_all_finite(
+        row_estimated_delay,
+        name='row_estimated_time_term_delay_s',
+    )
+
+    estimated_trace_delay = np.ascontiguousarray(
+        node_time_term[validated_design.source_node_id_sorted]
+        + node_time_term[validated_design.receiver_node_id_sorted],
+        dtype=np.float64,
+    )
+    if estimated_trace_delay.shape != (validated_design.n_traces,):
+        raise ValueError('estimated_trace_time_term_delay_s_sorted shape mismatch')
+    _validate_all_finite(
+        estimated_trace_delay,
+        name='estimated_trace_time_term_delay_s_sorted',
+    )
+    _validate_max_abs_ms(
+        estimated_trace_delay,
+        max_abs_ms=validated_options.max_abs_estimated_trace_delay_ms,
+        name='estimated_trace_time_term_delay_s_sorted',
+        limit_name='max_abs_estimated_trace_delay_ms',
+    )
+
+    residual_before = np.ascontiguousarray(validated_design.data_s, dtype=np.float64)
+    residual_after = np.ascontiguousarray(
+        validated_design.data_s - row_estimated_delay,
+        dtype=np.float64,
+    )
+    _validate_all_finite(residual_after, name='row_residual_after_s')
+
+    return TimeTermSparseSolverResult(
+        node_time_term_s=node_time_term,
+        estimated_trace_time_term_delay_s_sorted=estimated_trace_delay,
+        row_estimated_time_term_delay_s=row_estimated_delay,
+        row_residual_before_s=residual_before,
+        row_residual_after_s=residual_after,
+        row_residual_after_ms=np.ascontiguousarray(
+            residual_after * 1000.0,
+            dtype=np.float64,
+        ),
+        rms_residual_before_s=_rms(residual_before),
+        rms_residual_after_s=_rms(residual_after),
+        used_trace_mask_sorted=np.ascontiguousarray(
+            validated_design.used_trace_mask_sorted,
+            dtype=bool,
+        ),
+        row_trace_index_sorted=np.ascontiguousarray(
+            validated_design.row_trace_index_sorted,
+            dtype=np.int64,
+        ),
+        solver_name=validated_options.solver,
+        solver_istop=raw_result.istop,
+        solver_iterations=raw_result.itn,
+        solver_normr=raw_result.normr,
+        solver_normar=raw_result.normar,
+        solver_conda=raw_result.conda,
+        solver_message=raw_result.message,
+        system=system,
+    )
+
+
+def summarize_time_term_sparse_solver_result(
+    result: TimeTermSparseSolverResult,
+) -> dict[str, object]:
+    """Return a JSON-safe summary for future artifacts and job logs."""
+    system = result.system
+    total_count = _coerce_1d_integer_int64(
+        system.total_observation_count_by_node,
+        name='total_observation_count_by_node',
+        expected_shape=(system.n_nodes,),
+    )
+    min_count = _coerce_nonnegative_int(
+        system.min_total_observations_per_node,
+        name='min_total_observations_per_node',
+    )
+
+    return {
+        'n_nodes': int(system.n_nodes),
+        'n_observations': int(system.n_observation_rows),
+        'n_augmented_rows': int(system.n_augmented_rows),
+        'n_damping_rows': int(system.n_damping_rows),
+        'n_gauge_rows': int(system.n_gauge_rows),
+        'gauge_mode': system.gauge_mode,
+        'damping_lambda': _json_float(system.damping_lambda),
+        'solver_name': result.solver_name,
+        'solver_istop': int(result.solver_istop),
+        'solver_iterations': int(result.solver_iterations),
+        'solver_normr': _optional_json_float(result.solver_normr),
+        'solver_normar': _optional_json_float(result.solver_normar),
+        'solver_conda': _optional_json_float(result.solver_conda),
+        'solver_message': str(result.solver_message),
+        'rms_residual_before_ms': _json_float(
+            _coerce_finite_float(result.rms_residual_before_s, name='rms') * 1000.0
+        ),
+        'rms_residual_after_ms': _json_float(
+            _coerce_finite_float(result.rms_residual_after_s, name='rms') * 1000.0
+        ),
+        'node_time_term_ms': _stats_payload(
+            _coerce_1d_real_numeric_float64(
+                result.node_time_term_s,
+                name='node_time_term_s',
+                expected_shape=(system.n_nodes,),
+            )
+            * 1000.0
+        ),
+        'estimated_trace_time_term_delay_ms': _stats_payload(
+            _coerce_1d_real_numeric_float64(
+                result.estimated_trace_time_term_delay_s_sorted,
+                name='estimated_trace_time_term_delay_s_sorted',
+            )
+            * 1000.0
+        ),
+        'row_residual_after_ms': _stats_payload(
+            _coerce_1d_real_numeric_float64(
+                result.row_residual_after_ms,
+                name='row_residual_after_ms',
+                expected_shape=(system.n_observation_rows,),
+            )
+        ),
+        'n_components': int(system.n_components),
+        'n_unobserved_nodes': int(np.count_nonzero(total_count == 0)),
+        'n_nodes_below_min_observations': int(np.count_nonzero(total_count < min_count)),
+    }
+
+
+def build_node_components(
+    n_nodes: int,
+    row_source_node_id: np.ndarray,
+    row_receiver_node_id: np.ndarray,
+) -> np.ndarray:
+    """Build deterministic connected-component ids from used source/receiver edges."""
+    node_count = _coerce_positive_int(n_nodes, name='n_nodes')
+    source = _coerce_1d_integer_int64(row_source_node_id, name='row_source_node_id')
+    receiver = _coerce_1d_integer_int64(
+        row_receiver_node_id,
+        name='row_receiver_node_id',
+    )
+    if source.shape != receiver.shape:
+        raise ValueError('row_source_node_id and row_receiver_node_id must match')
+    _validate_index_range(source, n_unique=node_count, name='row_source_node_id')
+    _validate_index_range(receiver, n_unique=node_count, name='row_receiver_node_id')
+
+    parent = np.arange(node_count, dtype=np.int64)
+    rank = np.zeros(node_count, dtype=np.int8)
+
+    def find(node: int) -> int:
+        root = node
+        while int(parent[root]) != root:
+            root = int(parent[root])
+        while int(parent[node]) != node:
+            next_node = int(parent[node])
+            parent[node] = root
+            node = next_node
+        return root
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root == right_root:
+            return
+        if rank[left_root] < rank[right_root]:
+            parent[left_root] = right_root
+        elif rank[left_root] > rank[right_root]:
+            parent[right_root] = left_root
+        else:
+            parent[right_root] = left_root
+            rank[left_root] += 1
+
+    for source_node, receiver_node in zip(source, receiver, strict=True):
+        union(int(source_node), int(receiver_node))
+
+    component_by_root: dict[int, int] = {}
+    component_id = np.empty(node_count, dtype=np.int64)
+    for node in range(node_count):
+        root = find(node)
+        component = component_by_root.setdefault(root, len(component_by_root))
+        component_id[node] = component
+    return np.ascontiguousarray(component_id, dtype=np.int64)
+
+
+def build_gauge_matrix(
+    *,
+    n_nodes: int,
+    component_id_by_node: np.ndarray,
+    gauge: TimeTermGaugeMode,
+    gauge_weight: float,
+    reference_node_id: int | None,
+) -> sparse.csr_matrix:
+    """Build gauge rows for a node time-term sparse system."""
+    node_count = _coerce_positive_int(n_nodes, name='n_nodes')
+    mode = _validate_gauge_mode(gauge)
+    component_id = _validate_component_id_by_node(
+        component_id_by_node,
+        n_nodes=node_count,
+    )
+    weight = _coerce_finite_float(gauge_weight, name='gauge_weight')
+    if mode != 'none' and weight <= 0.0:
+        raise ValueError('gauge_weight must be greater than 0 when gauge is not none')
+
+    if mode == 'none':
+        return sparse.csr_matrix((0, node_count), dtype=np.float64)
+
+    if mode == 'mean_zero':
+        data = np.full(node_count, weight / np.sqrt(node_count), dtype=np.float64)
+        rows = np.zeros(node_count, dtype=np.int64)
+        cols = np.arange(node_count, dtype=np.int64)
+        matrix = sparse.coo_matrix(
+            (data, (rows, cols)),
+            shape=(1, node_count),
+            dtype=np.float64,
+        ).tocsr()
+        matrix.sort_indices()
+        return matrix
+
+    if mode == 'component_mean_zero':
+        n_components = _component_count(component_id)
+        row_parts: list[np.ndarray] = []
+        col_parts: list[np.ndarray] = []
+        data_parts: list[np.ndarray] = []
+        for component in range(n_components):
+            nodes = np.flatnonzero(component_id == component).astype(
+                np.int64,
+                copy=False,
+            )
+            if nodes.size == 0:
+                raise ValueError('component_id_by_node must be contiguous')
+            row_parts.append(np.full(nodes.shape, component, dtype=np.int64))
+            col_parts.append(np.ascontiguousarray(nodes, dtype=np.int64))
+            data_parts.append(
+                np.full(
+                    nodes.shape,
+                    weight / np.sqrt(int(nodes.size)),
+                    dtype=np.float64,
+                )
+            )
+        matrix = sparse.coo_matrix(
+            (
+                np.concatenate(data_parts),
+                (np.concatenate(row_parts), np.concatenate(col_parts)),
+            ),
+            shape=(n_components, node_count),
+            dtype=np.float64,
+        ).tocsr()
+        matrix.sort_indices()
+        return matrix
+
+    reference_node = _resolve_reference_node_id(
+        reference_node_id,
+        n_nodes=node_count,
+    )
+    matrix = sparse.coo_matrix(
+        (
+            np.asarray([weight], dtype=np.float64),
+            (np.asarray([0], dtype=np.int64), np.asarray([reference_node], dtype=np.int64)),
+        ),
+        shape=(1, node_count),
+        dtype=np.float64,
+    ).tocsr()
+    matrix.sort_indices()
+    return matrix
+
+
+def _build_time_term_solver_system(
+    design: TimeTermDesignMatrix,
+    *,
+    options: TimeTermSparseSolverOptions | None,
+) -> tuple[
+    TimeTermSolverSystem,
+    _ValidatedTimeTermDesign,
+    TimeTermSparseSolverOptions,
+]:
+    validated_options = _validate_options(options)
+    validated_design = _validate_design(design)
+    damping_prior = _coerce_damping_prior(
+        validated_options.damping_prior_s,
+        n_nodes=validated_design.n_nodes,
+    )
+    reference_node_id = _resolve_options_reference_node_id(
+        validated_options.reference_node_id,
+        gauge=validated_options.gauge,
+        n_nodes=validated_design.n_nodes,
+    )
+    _validate_minimum_observations(
+        validated_design,
+        options=validated_options,
+    )
+
+    component_id = build_node_components(
+        validated_design.n_nodes,
+        validated_design.row_source_node_id,
+        validated_design.row_receiver_node_id,
+    )
+    n_components = _component_count(component_id)
+
+    damping_matrix, damping_data = _build_damping_system(
+        n_nodes=validated_design.n_nodes,
+        damping_lambda=validated_options.damping_lambda,
+        damping_prior_s=damping_prior,
+    )
+    gauge_matrix = build_gauge_matrix(
+        n_nodes=validated_design.n_nodes,
+        component_id_by_node=component_id,
+        gauge=validated_options.gauge,
+        gauge_weight=validated_options.gauge_weight,
+        reference_node_id=reference_node_id,
+    )
+    gauge_data = np.zeros(gauge_matrix.shape[0], dtype=np.float64)
+
+    augmented_matrix = sparse.vstack(
+        [validated_design.matrix, damping_matrix, gauge_matrix],
+        format='csr',
+        dtype=np.float64,
+    )
+    augmented_matrix.sort_indices()
+    augmented_data = np.ascontiguousarray(
+        np.concatenate([validated_design.data_s, damping_data, gauge_data]),
+        dtype=np.float64,
+    )
+    n_augmented_rows = int(augmented_matrix.shape[0])
+    if augmented_matrix.shape != (n_augmented_rows, validated_design.n_nodes):
+        raise ValueError('augmented_matrix shape mismatch')
+    if augmented_data.shape != (n_augmented_rows,):
+        raise ValueError('augmented_data_s shape mismatch')
+    _validate_all_finite(augmented_matrix.data, name='augmented_matrix.data')
+    _validate_all_finite(augmented_data, name='augmented_data_s')
+
+    system = TimeTermSolverSystem(
+        augmented_matrix=augmented_matrix,
+        augmented_data_s=augmented_data,
+        n_observation_rows=validated_design.n_observations,
+        n_damping_rows=int(damping_matrix.shape[0]),
+        n_gauge_rows=int(gauge_matrix.shape[0]),
+        n_augmented_rows=n_augmented_rows,
+        n_nodes=validated_design.n_nodes,
+        damping_prior_s=damping_prior,
+        gauge_mode=validated_options.gauge,
+        component_id_by_node=component_id,
+        n_components=n_components,
+        damping_lambda=validated_options.damping_lambda,
+        gauge_weight=validated_options.gauge_weight,
+        reference_node_id=reference_node_id,
+        min_total_observations_per_node=(
+            validated_options.min_total_observations_per_node
+        ),
+        total_observation_count_by_node=(
+            validated_design.total_observation_count_by_node
+        ),
+    )
+    return system, validated_design, validated_options
+
+
+def _build_damping_system(
+    *,
+    n_nodes: int,
+    damping_lambda: float,
+    damping_prior_s: np.ndarray,
+) -> tuple[sparse.csr_matrix, np.ndarray]:
+    if damping_lambda == 0.0:
+        return (
+            sparse.csr_matrix((0, n_nodes), dtype=np.float64),
+            np.empty(0, dtype=np.float64),
+        )
+    damping_matrix = sparse.eye(
+        n_nodes,
+        n_nodes,
+        format='csr',
+        dtype=np.float64,
+    ) * damping_lambda
+    damping_data = np.ascontiguousarray(
+        damping_lambda * damping_prior_s,
+        dtype=np.float64,
+    )
+    return damping_matrix, damping_data
+
+
+def _run_sparse_solver(
+    matrix: sparse.csr_matrix,
+    rhs_s: np.ndarray,
+    *,
+    options: TimeTermSparseSolverOptions,
+) -> _SparseSolverRawResult:
+    matrix_csr = _coerce_sparse_matrix_float64_csr(matrix)
+    n_rows, n_cols = matrix_csr.shape
+    rhs = _coerce_1d_real_numeric_float64(
+        rhs_s,
+        name='rhs_s',
+        expected_shape=(n_rows,),
+    )
+    _validate_all_finite(rhs, name='rhs_s')
+
+    try:
+        if options.solver == 'lsmr':
+            x, istop, itn, normr, normar, _, conda, _ = sparse_linalg.lsmr(
+                matrix_csr,
+                rhs,
+                damp=0.0,
+                atol=options.atol,
+                btol=options.btol,
+                conlim=options.conlim,
+                maxiter=options.maxiter,
+                show=False,
+            )
+        elif options.solver == 'lsqr':
+            x, istop, itn, normr, _, _, conda, normar, _, _ = sparse_linalg.lsqr(
+                matrix_csr,
+                rhs,
+                damp=0.0,
+                atol=options.atol,
+                btol=options.btol,
+                conlim=options.conlim,
+                iter_lim=options.maxiter,
+                show=False,
+                calc_var=False,
+            )
+        else:
+            raise ValueError(f'unsupported solver: {options.solver!r}')
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(f'{options.solver} solve failed') from exc
+
+    solution = np.ascontiguousarray(x, dtype=np.float64)
+    if solution.shape != (n_cols,):
+        raise ValueError(
+            f'solver x shape mismatch: expected {(n_cols,)}, got {solution.shape}'
+        )
+    _validate_all_finite(solution, name='solver x')
+    return _SparseSolverRawResult(
+        x=solution,
+        istop=int(istop),
+        itn=int(itn),
+        normr=float(normr),
+        normar=float(normar),
+        conda=float(conda),
+        message=_solver_message(options.solver, int(istop)),
+    )
+
+
+def _validate_options(
+    options: TimeTermSparseSolverOptions | None,
+) -> TimeTermSparseSolverOptions:
+    opts = TimeTermSparseSolverOptions() if options is None else options
+    if not isinstance(opts, TimeTermSparseSolverOptions):
+        raise ValueError('options must be a TimeTermSparseSolverOptions instance')
+
+    damping_lambda = _coerce_nonnegative_finite_float(
+        opts.damping_lambda,
+        name='damping_lambda',
+    )
+    gauge = _validate_gauge_mode(opts.gauge)
+    if gauge == 'none' and damping_lambda == 0.0:
+        raise ValueError("gauge='none' requires damping_lambda > 0")
+    gauge_weight = _coerce_finite_float(opts.gauge_weight, name='gauge_weight')
+    if gauge != 'none' and gauge_weight <= 0.0:
+        raise ValueError('gauge_weight must be greater than 0 when gauge is not none')
+    solver = _validate_solver_name(opts.solver)
+
+    return TimeTermSparseSolverOptions(
+        damping_lambda=damping_lambda,
+        damping_prior_s=opts.damping_prior_s,
+        gauge=gauge,
+        gauge_weight=gauge_weight,
+        reference_node_id=opts.reference_node_id,
+        solver=solver,
+        atol=_coerce_positive_finite_float(opts.atol, name='atol'),
+        btol=_coerce_positive_finite_float(opts.btol, name='btol'),
+        conlim=_coerce_positive_finite_float(opts.conlim, name='conlim'),
+        maxiter=_coerce_optional_positive_int(opts.maxiter, name='maxiter'),
+        min_observations=_coerce_positive_int(
+            opts.min_observations,
+            name='min_observations',
+        ),
+        min_total_observations_per_node=_coerce_nonnegative_int(
+            opts.min_total_observations_per_node,
+            name='min_total_observations_per_node',
+        ),
+        require_all_nodes_observed=_coerce_bool(
+            opts.require_all_nodes_observed,
+            name='require_all_nodes_observed',
+        ),
+        max_abs_node_time_term_ms=_coerce_optional_nonnegative_finite_float(
+            opts.max_abs_node_time_term_ms,
+            name='max_abs_node_time_term_ms',
+        ),
+        max_abs_estimated_trace_delay_ms=_coerce_optional_nonnegative_finite_float(
+            opts.max_abs_estimated_trace_delay_ms,
+            name='max_abs_estimated_trace_delay_ms',
+        ),
+    )
+
+
+def _validate_design(design: TimeTermDesignMatrix) -> _ValidatedTimeTermDesign:
+    n_nodes = _coerce_positive_int(design.n_nodes, name='design.n_nodes')
+    n_observations = _coerce_positive_int(
+        design.n_observations,
+        name='design.n_observations',
+    )
+    n_traces = _coerce_positive_int(design.n_traces, name='design.n_traces')
+
+    matrix = _coerce_sparse_matrix_float64_csr(design.matrix)
+    if matrix.shape != (n_observations, n_nodes):
+        raise ValueError('design.matrix shape does not match design dimensions')
+
+    data_s = _coerce_1d_real_numeric_float64(
+        design.data_s,
+        name='design.data_s',
+        expected_shape=(n_observations,),
+    )
+    _validate_all_finite(data_s, name='design.data_s')
+    used_mask = _coerce_1d_bool_array(
+        design.used_trace_mask_sorted,
+        name='design.used_trace_mask_sorted',
+        expected_shape=(n_traces,),
+    )
+    row_trace_index = _coerce_1d_integer_int64(
+        design.row_trace_index_sorted,
+        name='design.row_trace_index_sorted',
+        expected_shape=(n_observations,),
+    )
+    _validate_index_range(
+        row_trace_index,
+        n_unique=n_traces,
+        name='design.row_trace_index_sorted',
+    )
+    row_source = _coerce_1d_integer_int64(
+        design.row_source_node_id,
+        name='design.row_source_node_id',
+        expected_shape=(n_observations,),
+    )
+    row_receiver = _coerce_1d_integer_int64(
+        design.row_receiver_node_id,
+        name='design.row_receiver_node_id',
+        expected_shape=(n_observations,),
+    )
+    _validate_index_range(row_source, n_unique=n_nodes, name='design.row_source_node_id')
+    _validate_index_range(
+        row_receiver,
+        n_unique=n_nodes,
+        name='design.row_receiver_node_id',
+    )
+
+    source_sorted = _coerce_1d_integer_int64(
+        design.source_node_id_sorted,
+        name='design.source_node_id_sorted',
+        expected_shape=(n_traces,),
+    )
+    receiver_sorted = _coerce_1d_integer_int64(
+        design.receiver_node_id_sorted,
+        name='design.receiver_node_id_sorted',
+        expected_shape=(n_traces,),
+    )
+    _validate_index_range(
+        source_sorted,
+        n_unique=n_nodes,
+        name='design.source_node_id_sorted',
+    )
+    _validate_index_range(
+        receiver_sorted,
+        n_unique=n_nodes,
+        name='design.receiver_node_id_sorted',
+    )
+
+    total_count = _node_total_observation_count(
+        row_source,
+        row_receiver,
+        n_nodes=n_nodes,
+    )
+    design_total_count = _coerce_1d_integer_int64(
+        design.total_observation_count_by_node,
+        name='design.total_observation_count_by_node',
+        expected_shape=(n_nodes,),
+    )
+    if np.any(total_count != design_total_count):
+        raise ValueError('design.total_observation_count_by_node does not match rows')
+
+    return _ValidatedTimeTermDesign(
+        matrix=matrix,
+        data_s=data_s,
+        n_traces=n_traces,
+        n_observations=n_observations,
+        n_nodes=n_nodes,
+        used_trace_mask_sorted=used_mask,
+        row_trace_index_sorted=row_trace_index,
+        row_source_node_id=row_source,
+        row_receiver_node_id=row_receiver,
+        source_node_id_sorted=source_sorted,
+        receiver_node_id_sorted=receiver_sorted,
+        total_observation_count_by_node=total_count,
+    )
+
+
+def _validate_minimum_observations(
+    design: _ValidatedTimeTermDesign,
+    *,
+    options: TimeTermSparseSolverOptions,
+) -> None:
+    if design.n_observations < options.min_observations:
+        raise ValueError(
+            'not enough time-term observations: '
+            f'{design.n_observations} < {options.min_observations}'
+        )
+    total_count = design.total_observation_count_by_node
+    if options.require_all_nodes_observed and np.any(total_count == 0):
+        raise ValueError('all nodes must have at least one observation')
+    if np.any(total_count < options.min_total_observations_per_node):
+        raise ValueError(
+            'node observation count is below min_total_observations_per_node'
+        )
+
+
+def _coerce_damping_prior(values: float | np.ndarray, *, n_nodes: int) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim == 0:
+        prior = np.full(n_nodes, float(arr), dtype=np.float64)
+    elif arr.ndim == 1 and arr.shape == (n_nodes,):
+        if not _is_real_numeric_dtype(arr.dtype):
+            raise ValueError('damping_prior_s must have a numeric dtype')
+        prior = np.ascontiguousarray(arr, dtype=np.float64)
+    else:
+        raise ValueError(
+            f'damping_prior_s must be scalar or shape {(n_nodes,)}, got {arr.shape}'
+        )
+    _validate_all_finite(prior, name='damping_prior_s')
+    return prior
+
+
+def _resolve_options_reference_node_id(
+    reference_node_id: int | None,
+    *,
+    gauge: TimeTermGaugeMode,
+    n_nodes: int,
+) -> int | None:
+    if reference_node_id is not None:
+        return _resolve_reference_node_id(reference_node_id, n_nodes=n_nodes)
+    if gauge == 'reference_node':
+        return 0
+    return None
+
+
+def _resolve_reference_node_id(
+    reference_node_id: int | None,
+    *,
+    n_nodes: int,
+) -> int:
+    reference = 0 if reference_node_id is None else reference_node_id
+    if isinstance(reference, (bool, np.bool_)) or not isinstance(
+        reference,
+        (int, np.integer),
+    ):
+        raise ValueError('reference_node_id must be an integer')
+    out = int(reference)
+    if out < 0 or out >= n_nodes:
+        raise ValueError('reference_node_id must be within 0..n_nodes-1')
+    return out
+
+
+def _node_total_observation_count(
+    row_source_node_id: np.ndarray,
+    row_receiver_node_id: np.ndarray,
+    *,
+    n_nodes: int,
+) -> np.ndarray:
+    source_count = np.bincount(row_source_node_id, minlength=n_nodes).astype(
+        np.int64,
+        copy=False,
+    )
+    receiver_count = np.bincount(row_receiver_node_id, minlength=n_nodes).astype(
+        np.int64,
+        copy=False,
+    )
+    return np.ascontiguousarray(source_count + receiver_count, dtype=np.int64)
+
+
+def _component_count(component_id_by_node: np.ndarray) -> int:
+    component_id = _coerce_1d_integer_int64(
+        component_id_by_node,
+        name='component_id_by_node',
+    )
+    if component_id.size == 0:
+        raise ValueError('component_id_by_node must be non-empty')
+    _validate_index_range(
+        component_id,
+        n_unique=int(np.max(component_id)) + 1,
+        name='component_id_by_node',
+    )
+    unique = np.unique(component_id)
+    expected = np.arange(unique.size, dtype=np.int64)
+    if not np.array_equal(unique, expected):
+        raise ValueError('component_id_by_node must be 0-based and contiguous')
+    return int(unique.size)
+
+
+def _validate_component_id_by_node(
+    component_id_by_node: np.ndarray,
+    *,
+    n_nodes: int,
+) -> np.ndarray:
+    component_id = _coerce_1d_integer_int64(
+        component_id_by_node,
+        name='component_id_by_node',
+        expected_shape=(n_nodes,),
+    )
+    _component_count(component_id)
+    return component_id
+
+
+def _coerce_sparse_matrix_float64_csr(matrix: object) -> sparse.csr_matrix:
+    if not sparse.issparse(matrix):
+        raise ValueError('matrix must be a SciPy sparse matrix')
+    if len(matrix.shape) != 2:
+        raise ValueError('matrix must be 2D')
+    n_rows = _coerce_positive_int(matrix.shape[0], name='matrix.shape[0]')
+    n_cols = _coerce_positive_int(matrix.shape[1], name='matrix.shape[1]')
+    dtype = np.dtype(matrix.dtype)
+    if not _is_real_numeric_dtype(dtype):
+        raise ValueError('matrix dtype must be real numeric')
+    matrix_csr = matrix.tocsr().astype(np.float64, copy=False)
+    if matrix_csr.shape != (n_rows, n_cols):
+        raise ValueError('matrix shape changed during CSR conversion')
+    _validate_all_finite(matrix_csr.data, name='matrix.data')
+    return matrix_csr
+
+
+def _coerce_1d_integer_int64(
+    values: object,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must contain integer values')
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(f'{name} must contain integer values')
+    return np.ascontiguousarray(arr, dtype=np.int64)
+
+
+def _coerce_1d_bool_array(
+    values: object,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if not np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must have bool dtype')
+    return np.ascontiguousarray(arr, dtype=bool)
+
+
+def _coerce_1d_real_numeric_float64(
+    values: object,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a numeric dtype')
+    return np.ascontiguousarray(arr, dtype=np.float64)
+
+
+def _coerce_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer')
+    out = int(value)
+    if out <= 0:
+        raise ValueError(f'{name} must be greater than 0')
+    return out
+
+
+def _coerce_nonnegative_int(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer')
+    out = int(value)
+    if out < 0:
+        raise ValueError(f'{name} must be non-negative')
+    return out
+
+
+def _coerce_optional_positive_int(value: object, *, name: str) -> int | None:
+    if value is None:
+        return None
+    return _coerce_positive_int(value, name=name)
+
+
+def _coerce_bool(value: object, *, name: str) -> bool:
+    if not isinstance(value, (bool, np.bool_)):
+        raise ValueError(f'{name} must be bool')
+    return bool(value)
+
+
+def _coerce_nonnegative_finite_float(value: object, *, name: str) -> float:
+    out = _coerce_finite_float(value, name=name)
+    if out < 0.0:
+        raise ValueError(f'{name} must be greater than or equal to 0')
+    return out
+
+
+def _coerce_positive_finite_float(value: object, *, name: str) -> float:
+    out = _coerce_finite_float(value, name=name)
+    if out <= 0.0:
+        raise ValueError(f'{name} must be greater than 0')
+    return out
+
+
+def _coerce_optional_nonnegative_finite_float(
+    value: object,
+    *,
+    name: str,
+) -> float | None:
+    if value is None:
+        return None
+    return _coerce_nonnegative_finite_float(value, name=name)
+
+
+def _coerce_finite_float(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f'{name} must be finite')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite') from exc
+    if not np.isfinite(out):
+        raise ValueError(f'{name} must be finite')
+    return out
+
+
+def _validate_index_range(
+    indices: np.ndarray,
+    *,
+    n_unique: int,
+    name: str,
+) -> None:
+    if indices.size == 0:
+        return
+    if np.any(indices < 0):
+        raise ValueError(f'{name} must be greater than or equal to 0')
+    if np.any(indices >= n_unique):
+        raise ValueError(f'{name} contains values outside 0..{n_unique - 1}')
+
+
+def _validate_all_finite(values: np.ndarray, *, name: str) -> None:
+    if np.any(~np.isfinite(values)):
+        raise ValueError(f'{name} must contain only finite values')
+
+
+def _validate_max_abs_ms(
+    values: np.ndarray,
+    *,
+    max_abs_ms: float | None,
+    name: str,
+    limit_name: str,
+) -> float:
+    arr = _coerce_1d_real_numeric_float64(values, name=name)
+    _validate_all_finite(arr, name=name)
+    max_abs_s = float(np.max(np.abs(arr)))
+    if max_abs_ms is not None and max_abs_s > max_abs_ms / 1000.0:
+        raise ValueError(f'{name} exceeds {limit_name}')
+    return max_abs_s
+
+
+def _validate_gauge_mode(value: object) -> TimeTermGaugeMode:
+    if value in {'none', 'mean_zero', 'component_mean_zero', 'reference_node'}:
+        return value  # type: ignore[return-value]
+    raise ValueError(f'unsupported gauge: {value!r}')
+
+
+def _validate_solver_name(value: object) -> TimeTermSparseSolverName:
+    if value in {'lsmr', 'lsqr'}:
+        return value  # type: ignore[return-value]
+    raise ValueError(f'unsupported solver: {value!r}')
+
+
+def _rms(values: np.ndarray) -> float:
+    arr = _coerce_1d_real_numeric_float64(values, name='rms values')
+    _validate_all_finite(arr, name='rms values')
+    return float(np.sqrt(np.mean(np.square(arr))))
+
+
+def _json_float(value: float) -> float:
+    out = _coerce_finite_float(value, name='summary value')
+    return float(out)
+
+
+def _optional_json_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(out):
+        return None
+    return out
+
+
+def _stats_payload(values: np.ndarray) -> dict[str, float | int | None]:
+    arr = _coerce_1d_real_numeric_float64(values, name='summary values')
+    finite = np.ascontiguousarray(arr[np.isfinite(arr)], dtype=np.float64)
+    count = int(finite.shape[0])
+    if count == 0:
+        return {
+            'count': 0,
+            'min': None,
+            'max': None,
+            'mean': None,
+            'median': None,
+            'std': None,
+            'max_abs': None,
+        }
+    return {
+        'count': count,
+        'min': float(np.min(finite)),
+        'max': float(np.max(finite)),
+        'mean': float(np.mean(finite)),
+        'median': float(np.median(finite)),
+        'std': float(np.std(finite, ddof=0)),
+        'max_abs': float(np.max(np.abs(finite))),
+    }
+
+
+def _solver_message(solver: TimeTermSparseSolverName, istop: int) -> str:
+    messages = {
+        0: 'zero solution is exact',
+        1: 'Ax-b is small enough',
+        2: 'least-squares solution is good enough',
+        3: 'condition estimate exceeded conlim',
+        4: 'Ax-b is small enough for machine precision',
+        5: 'least-squares solution is good enough for machine precision',
+        6: 'condition estimate exceeded conlim for machine precision',
+        7: 'iteration limit reached',
+    }
+    return f'{solver}: {messages.get(istop, f"istop={istop}")}'
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'TimeTermGaugeMode',
+    'TimeTermSolverSystem',
+    'TimeTermSparseSolverName',
+    'TimeTermSparseSolverOptions',
+    'TimeTermSparseSolverResult',
+    'build_gauge_matrix',
+    'build_node_components',
+    'build_time_term_solver_system',
+    'solve_time_term_sparse_least_squares',
+    'summarize_time_term_sparse_solver_result',
+]

--- a/app/tests/test_time_term_sparse_solver.py
+++ b/app/tests/test_time_term_sparse_solver.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from app.services.time_term_design_matrix import TimeTermDesignMatrix
+from app.services.time_term_sparse_solver import (
+    TimeTermSparseSolverOptions,
+    build_time_term_solver_system,
+    solve_time_term_sparse_least_squares,
+    summarize_time_term_sparse_solver_result,
+)
+
+TRUE_NODE_TIME_TERM_S = np.asarray([0.010, -0.002, 0.006], dtype=np.float64)
+SOURCE_NODE_ID_SORTED = np.asarray([0, 0, 1, 2, 1], dtype=np.int64)
+RECEIVER_NODE_ID_SORTED = np.asarray([1, 2, 2, 2, 1], dtype=np.int64)
+ROW_SOURCE_NODE_ID = SOURCE_NODE_ID_SORTED[:4].copy()
+ROW_RECEIVER_NODE_ID = RECEIVER_NODE_ID_SORTED[:4].copy()
+DATA_S = np.asarray([0.008, 0.016, 0.004, 0.012], dtype=np.float64)
+OBSERVATION_MATRIX = sparse.csr_matrix(
+    [
+        [1.0, 1.0, 0.0],
+        [1.0, 0.0, 1.0],
+        [0.0, 1.0, 1.0],
+        [0.0, 0.0, 2.0],
+    ],
+    dtype=np.float64,
+)
+
+
+def _design(**overrides: Any) -> TimeTermDesignMatrix:
+    payload: dict[str, Any] = {
+        'matrix': OBSERVATION_MATRIX.copy(),
+        'data_s': DATA_S.copy(),
+        'n_traces': 5,
+        'n_observations': 4,
+        'n_nodes': 3,
+        'used_trace_mask_sorted': np.asarray([True, True, True, True, False]),
+        'row_trace_index_sorted': np.arange(4, dtype=np.int64),
+        'trace_to_row_index_sorted': np.asarray([0, 1, 2, 3, -1], dtype=np.int64),
+        'source_node_id_sorted': SOURCE_NODE_ID_SORTED.copy(),
+        'receiver_node_id_sorted': RECEIVER_NODE_ID_SORTED.copy(),
+        'row_source_node_id': ROW_SOURCE_NODE_ID.copy(),
+        'row_receiver_node_id': ROW_RECEIVER_NODE_ID.copy(),
+        'row_pick_time_after_static_s': DATA_S.copy(),
+        'row_moveout_time_s': np.zeros(4, dtype=np.float64),
+        'row_data_s': DATA_S.copy(),
+        'source_observation_count_by_node': np.asarray([2, 1, 1], dtype=np.int64),
+        'receiver_observation_count_by_node': np.asarray([0, 1, 3], dtype=np.int64),
+        'total_observation_count_by_node': np.asarray([2, 2, 4], dtype=np.int64),
+    }
+    payload.update(overrides)
+    return TimeTermDesignMatrix(**payload)
+
+
+def _disconnected_design() -> TimeTermDesignMatrix:
+    matrix = sparse.csr_matrix(
+        [
+            [1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    return _design(
+        matrix=matrix,
+        data_s=np.asarray([0.1, 0.2], dtype=np.float64),
+        n_traces=2,
+        n_observations=2,
+        n_nodes=4,
+        used_trace_mask_sorted=np.asarray([True, True]),
+        row_trace_index_sorted=np.asarray([0, 1], dtype=np.int64),
+        trace_to_row_index_sorted=np.asarray([0, 1], dtype=np.int64),
+        source_node_id_sorted=np.asarray([0, 2], dtype=np.int64),
+        receiver_node_id_sorted=np.asarray([1, 3], dtype=np.int64),
+        row_source_node_id=np.asarray([0, 2], dtype=np.int64),
+        row_receiver_node_id=np.asarray([1, 3], dtype=np.int64),
+        row_pick_time_after_static_s=np.asarray([0.1, 0.2], dtype=np.float64),
+        row_moveout_time_s=np.zeros(2, dtype=np.float64),
+        row_data_s=np.asarray([0.1, 0.2], dtype=np.float64),
+        source_observation_count_by_node=np.asarray([1, 0, 1, 0], dtype=np.int64),
+        receiver_observation_count_by_node=np.asarray([0, 1, 0, 1], dtype=np.int64),
+        total_observation_count_by_node=np.asarray([1, 1, 1, 1], dtype=np.int64),
+    )
+
+
+def _unobserved_node_design() -> TimeTermDesignMatrix:
+    matrix = sparse.hstack(
+        [OBSERVATION_MATRIX, sparse.csr_matrix((4, 1), dtype=np.float64)],
+        format='csr',
+    )
+    return _design(
+        matrix=matrix,
+        n_nodes=4,
+        source_node_id_sorted=np.asarray([0, 0, 1, 2, 3], dtype=np.int64),
+        receiver_node_id_sorted=np.asarray([1, 2, 2, 2, 3], dtype=np.int64),
+        source_observation_count_by_node=np.asarray([2, 1, 1, 0], dtype=np.int64),
+        receiver_observation_count_by_node=np.asarray([0, 1, 3, 0], dtype=np.int64),
+        total_observation_count_by_node=np.asarray([2, 2, 4, 0], dtype=np.int64),
+    )
+
+
+def _accurate_options(**overrides: Any) -> TimeTermSparseSolverOptions:
+    payload: dict[str, Any] = {
+        'damping_lambda': 1.0e-10,
+        'gauge': 'none',
+        'solver': 'lsmr',
+        'atol': 1.0e-12,
+        'btol': 1.0e-12,
+        'conlim': 1.0e12,
+        'maxiter': 1000,
+    }
+    payload.update(overrides)
+    return TimeTermSparseSolverOptions(**payload)
+
+
+def test_time_term_solver_system_contains_observation_damping_and_gauge_rows() -> None:
+    system = build_time_term_solver_system(
+        _design(),
+        options=TimeTermSparseSolverOptions(
+            damping_lambda=0.5,
+            gauge='reference_node',
+            gauge_weight=2.0,
+            reference_node_id=1,
+        ),
+    )
+
+    assert sparse.isspmatrix_csr(system.augmented_matrix)
+    assert system.n_observation_rows == 4
+    assert system.n_damping_rows == 3
+    assert system.n_gauge_rows == 1
+    assert system.n_augmented_rows == 8
+    assert system.augmented_matrix.shape == (8, 3)
+    np.testing.assert_allclose(
+        system.augmented_matrix[:4].toarray(),
+        OBSERVATION_MATRIX.toarray(),
+    )
+    np.testing.assert_allclose(system.augmented_data_s[:4], DATA_S)
+
+
+def test_time_term_solver_system_adds_damping_identity_rows() -> None:
+    system = build_time_term_solver_system(
+        _design(),
+        options=TimeTermSparseSolverOptions(damping_lambda=0.25, gauge='none'),
+    )
+
+    np.testing.assert_allclose(
+        system.augmented_matrix[4:7].toarray(),
+        np.eye(3, dtype=np.float64) * 0.25,
+    )
+    np.testing.assert_allclose(system.augmented_data_s[4:7], np.zeros(3))
+
+
+def test_time_term_solver_system_uses_scalar_damping_prior() -> None:
+    system = build_time_term_solver_system(
+        _design(),
+        options=TimeTermSparseSolverOptions(
+            damping_lambda=0.5,
+            damping_prior_s=0.02,
+            gauge='none',
+        ),
+    )
+
+    np.testing.assert_allclose(system.damping_prior_s, np.full(3, 0.02))
+    np.testing.assert_allclose(system.augmented_data_s[4:7], np.full(3, 0.01))
+
+
+def test_time_term_solver_system_uses_array_damping_prior() -> None:
+    prior = np.asarray([0.01, 0.02, 0.03], dtype=np.float64)
+
+    system = build_time_term_solver_system(
+        _design(),
+        options=TimeTermSparseSolverOptions(
+            damping_lambda=0.5,
+            damping_prior_s=prior,
+            gauge='none',
+        ),
+    )
+
+    np.testing.assert_allclose(system.damping_prior_s, prior)
+    np.testing.assert_allclose(system.augmented_data_s[4:7], 0.5 * prior)
+
+
+def test_time_term_solver_system_adds_mean_zero_gauge_row() -> None:
+    system = build_time_term_solver_system(
+        _design(),
+        options=TimeTermSparseSolverOptions(
+            damping_lambda=0.0,
+            gauge='mean_zero',
+            gauge_weight=2.0,
+        ),
+    )
+
+    assert system.n_damping_rows == 0
+    assert system.n_gauge_rows == 1
+    np.testing.assert_allclose(
+        system.augmented_matrix[-1].toarray().ravel(),
+        np.full(3, 2.0 / np.sqrt(3.0), dtype=np.float64),
+    )
+    assert system.augmented_data_s[-1] == 0.0
+
+
+def test_time_term_solver_system_adds_reference_node_gauge_row() -> None:
+    system = build_time_term_solver_system(
+        _design(),
+        options=TimeTermSparseSolverOptions(
+            damping_lambda=0.0,
+            gauge='reference_node',
+            gauge_weight=3.0,
+            reference_node_id=2,
+        ),
+    )
+
+    np.testing.assert_allclose(
+        system.augmented_matrix[-1].toarray().ravel(),
+        [0.0, 0.0, 3.0],
+    )
+    assert system.reference_node_id == 2
+
+
+def test_time_term_solver_system_adds_component_mean_zero_gauge_rows() -> None:
+    system = build_time_term_solver_system(
+        _disconnected_design(),
+        options=TimeTermSparseSolverOptions(
+            damping_lambda=0.0,
+            gauge='component_mean_zero',
+            gauge_weight=2.0,
+        ),
+    )
+
+    assert system.n_components == 2
+    np.testing.assert_array_equal(system.component_id_by_node, [0, 0, 1, 1])
+    np.testing.assert_allclose(
+        system.augmented_matrix[-2:].toarray(),
+        [
+            [2.0 / np.sqrt(2.0), 2.0 / np.sqrt(2.0), 0.0, 0.0],
+            [0.0, 0.0, 2.0 / np.sqrt(2.0), 2.0 / np.sqrt(2.0)],
+        ],
+    )
+
+
+def test_time_term_solver_system_rejects_zero_damping_without_gauge() -> None:
+    with pytest.raises(ValueError, match='damping_lambda'):
+        build_time_term_solver_system(
+            _design(),
+            options=TimeTermSparseSolverOptions(damping_lambda=0.0, gauge='none'),
+        )
+
+
+def test_time_term_solver_system_rejects_invalid_reference_node() -> None:
+    with pytest.raises(ValueError, match='reference_node_id'):
+        build_time_term_solver_system(
+            _design(),
+            options=TimeTermSparseSolverOptions(
+                damping_lambda=0.0,
+                gauge='reference_node',
+                reference_node_id=3,
+            ),
+        )
+
+
+def test_time_term_solver_system_rejects_unobserved_node_when_required() -> None:
+    with pytest.raises(ValueError, match='all nodes'):
+        build_time_term_solver_system(_unobserved_node_design())
+
+
+def test_time_term_solver_system_allows_unobserved_node_when_configured() -> None:
+    system = build_time_term_solver_system(
+        _unobserved_node_design(),
+        options=TimeTermSparseSolverOptions(
+            damping_lambda=0.01,
+            gauge='component_mean_zero',
+            require_all_nodes_observed=False,
+            min_total_observations_per_node=0,
+        ),
+    )
+
+    assert system.n_components == 2
+    np.testing.assert_array_equal(system.component_id_by_node, [0, 0, 0, 1])
+
+
+@pytest.mark.parametrize('solver', ['lsmr', 'lsqr'])
+def test_time_term_sparse_solver_recovers_known_node_time_terms(
+    solver: str,
+) -> None:
+    result = solve_time_term_sparse_least_squares(
+        _design(),
+        options=_accurate_options(solver=solver),
+    )
+
+    np.testing.assert_allclose(
+        result.node_time_term_s,
+        TRUE_NODE_TIME_TERM_S,
+        atol=1.0e-9,
+    )
+    np.testing.assert_allclose(
+        OBSERVATION_MATRIX @ result.node_time_term_s,
+        DATA_S,
+        atol=1.0e-9,
+    )
+
+
+def test_time_term_sparse_solver_reduces_rms_residual() -> None:
+    result = solve_time_term_sparse_least_squares(
+        _design(),
+        options=_accurate_options(),
+    )
+
+    assert result.rms_residual_after_s < result.rms_residual_before_s
+    assert result.rms_residual_after_s < 1.0e-9
+
+
+def test_time_term_sparse_solver_returns_row_residuals_in_observation_order() -> None:
+    result = solve_time_term_sparse_least_squares(
+        _design(),
+        options=_accurate_options(),
+    )
+
+    np.testing.assert_allclose(result.row_residual_before_s, DATA_S)
+    np.testing.assert_allclose(result.row_residual_after_s, np.zeros(4), atol=1.0e-9)
+    np.testing.assert_array_equal(result.row_trace_index_sorted, [0, 1, 2, 3])
+
+
+def test_time_term_sparse_solver_returns_estimated_trace_delay_in_sorted_order() -> None:
+    result = solve_time_term_sparse_least_squares(
+        _design(),
+        options=_accurate_options(),
+    )
+
+    expected = (
+        TRUE_NODE_TIME_TERM_S[SOURCE_NODE_ID_SORTED]
+        + TRUE_NODE_TIME_TERM_S[RECEIVER_NODE_ID_SORTED]
+    )
+    np.testing.assert_allclose(
+        result.estimated_trace_time_term_delay_s_sorted,
+        expected,
+        atol=1.0e-9,
+    )
+
+
+def test_time_term_sparse_solver_same_source_receiver_node_uses_two_times_node_term() -> None:
+    result = solve_time_term_sparse_least_squares(
+        _design(),
+        options=_accurate_options(),
+    )
+
+    assert result.row_estimated_time_term_delay_s[3] == pytest.approx(
+        2.0 * result.node_time_term_s[2],
+        abs=1.0e-12,
+    )
+
+
+def test_time_term_sparse_solver_rejects_non_finite_data_vector() -> None:
+    data = DATA_S.copy()
+    data[0] = np.nan
+
+    with pytest.raises(ValueError, match='data_s'):
+        build_time_term_solver_system(_design(data_s=data))
+
+
+def test_time_term_sparse_solver_rejects_node_time_term_above_limit() -> None:
+    with pytest.raises(ValueError, match='max_abs_node_time_term_ms'):
+        solve_time_term_sparse_least_squares(
+            _design(),
+            options=_accurate_options(max_abs_node_time_term_ms=5.0),
+        )
+
+
+def test_time_term_sparse_solver_rejects_estimated_trace_delay_above_limit() -> None:
+    with pytest.raises(ValueError, match='max_abs_estimated_trace_delay_ms'):
+        solve_time_term_sparse_least_squares(
+            _design(),
+            options=_accurate_options(
+                max_abs_node_time_term_ms=None,
+                max_abs_estimated_trace_delay_ms=5.0,
+            ),
+        )
+
+
+def test_time_term_sparse_solver_result_does_not_expose_applied_shift() -> None:
+    result = solve_time_term_sparse_least_squares(
+        _design(),
+        options=_accurate_options(),
+    )
+
+    assert not hasattr(result, 'applied_weathering_shift_s')
+    assert not hasattr(result, 'applied_trace_time_term_shift_s_sorted')
+
+
+def test_summarize_time_term_sparse_solver_result_is_json_safe() -> None:
+    result = solve_time_term_sparse_least_squares(
+        _design(),
+        options=_accurate_options(),
+    )
+
+    summary = summarize_time_term_sparse_solver_result(result)
+
+    json.dumps(summary, allow_nan=False)
+    assert summary['n_nodes'] == 3
+    assert summary['n_observations'] == 4
+    assert summary['n_damping_rows'] == 3
+    assert summary['n_gauge_rows'] == 0
+    assert summary['gauge_mode'] == 'none'
+    assert summary['solver_name'] == 'lsmr'
+    assert summary['n_unobserved_nodes'] == 0
+    assert summary['node_time_term_ms']['count'] == 3
+
+
+def test_time_term_sparse_solver_rejects_nonfinite_solver_output(monkeypatch) -> None:
+    class BadLsmr:
+        def __call__(self, *args: Any, **kwargs: Any):
+            return (
+                np.asarray([np.nan, 0.0, 0.0], dtype=np.float64),
+                1,
+                1,
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                0.0,
+            )
+
+    import app.services.time_term_sparse_solver as solver_module
+
+    monkeypatch.setattr(solver_module.sparse_linalg, 'lsmr', BadLsmr())
+
+    with pytest.raises(ValueError, match='solver x'):
+        solve_time_term_sparse_least_squares(
+            _design(),
+            options=_accurate_options(),
+        )
+
+
+def test_time_term_sparse_solver_rejects_damping_prior_shape_mismatch() -> None:
+    with pytest.raises(ValueError, match='damping_prior_s'):
+        build_time_term_solver_system(
+            _design(),
+            options=TimeTermSparseSolverOptions(
+                damping_prior_s=np.asarray([0.0, 0.0]),
+            ),
+        )
+
+
+def test_time_term_sparse_solver_rejects_min_observation_violation() -> None:
+    with pytest.raises(ValueError, match='not enough'):
+        build_time_term_solver_system(
+            _design(),
+            options=TimeTermSparseSolverOptions(min_observations=5),
+        )
+
+
+def test_time_term_sparse_solver_rejects_node_below_min_total_observations() -> None:
+    with pytest.raises(ValueError, match='min_total_observations_per_node'):
+        build_time_term_solver_system(
+            _design(),
+            options=TimeTermSparseSolverOptions(min_total_observations_per_node=3),
+        )
+
+
+def test_time_term_sparse_solver_validates_design_total_count_consistency() -> None:
+    bad_design = replace(
+        _design(),
+        total_observation_count_by_node=np.asarray([2, 2, 3], dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match='total_observation_count_by_node'):
+        build_time_term_solver_system(bad_design)


### PR DESCRIPTION
Closes #356

## Summary
- PR6-5 [statics time-term] damping・gauge constraint 付き sparse time-term solver を追加する

## Changed files
- `app/services/time_term_design_matrix.py`
- `app/services/time_term_sparse_solver.py`
- `app/tests/test_time_term_sparse_solver.py`

## Checks
- `.work/codex/checks.log`: 1273 passed in 47.50s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
