### PR TITLE
PR6-fix [statics time-term] numerical layer import decoupling と request schema parity を修正する

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1026,11 +1026,16 @@ class TimeTermStaticMoveoutRequest(BaseModel):
 
     model_config = ConfigDict(extra='forbid')
 
-    model: Literal['head_wave_linear_offset', 'linear_offset', 'none'] = (
-        'head_wave_linear_offset'
-    )
+    model: Literal[
+        'head_wave_linear_offset',
+        'reciprocal_head_wave',
+        'linear_offset',
+        'none',
+    ] = 'head_wave_linear_offset'
+    distance_source: Literal['geometry', 'offset_header', 'auto'] = 'geometry'
     offset_byte: int | None = 37
     allow_missing_offset: bool = False
+    max_geometry_offset_mismatch_m: float | None = None
 
     @field_validator('offset_byte', mode='before')
     @classmethod
@@ -1044,16 +1049,22 @@ class TimeTermStaticMoveoutRequest(BaseModel):
     def _check_allow_missing_offset(cls, value: object) -> bool:
         return _require_bool(value, 'moveout.allow_missing_offset')
 
+    @field_validator('max_geometry_offset_mismatch_m', mode='before')
+    @classmethod
+    def _check_max_geometry_offset_mismatch_m(cls, value: object) -> float | None:
+        if value is None:
+            return None
+        return _require_nonnegative_finite_float(
+            value,
+            'moveout.max_geometry_offset_mismatch_m',
+        )
+
     @model_validator(mode='after')
     def _check_offset_requirement(self) -> 'TimeTermStaticMoveoutRequest':
-        if (
-            self.model != 'none'
-            and not self.allow_missing_offset
-            and self.offset_byte is None
-        ):
+        if self.distance_source == 'offset_header' and self.offset_byte is None:
             raise ValueError(
-                'moveout.offset_byte is required when moveout.model is not none '
-                'and moveout.allow_missing_offset is false'
+                'moveout.offset_byte is required when '
+                'moveout.distance_source is offset_header'
             )
         return self
 
@@ -1064,27 +1075,29 @@ class TimeTermStaticRobustRequest(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
     enabled: bool = True
+    method: Literal['mad', 'sigma'] = 'mad'
+    threshold: float = 3.5
     max_iterations: int = 5
-    mad_threshold: float = 3.5
     min_used_fraction: float = 0.5
+    min_used_observations: int = 1
 
     @field_validator('enabled', mode='before')
     @classmethod
     def _check_enabled(cls, value: object) -> bool:
         return _require_bool(value, 'solver.robust.enabled')
 
+    @field_validator('threshold', mode='before')
+    @classmethod
+    def _check_threshold(cls, value: object) -> float:
+        return _require_positive_finite_float(
+            value,
+            'solver.robust.threshold',
+        )
+
     @field_validator('max_iterations', mode='before')
     @classmethod
     def _check_max_iterations(cls, value: object) -> int:
         return _require_positive_int(value, 'solver.robust.max_iterations')
-
-    @field_validator('mad_threshold', mode='before')
-    @classmethod
-    def _check_mad_threshold(cls, value: object) -> float:
-        return _require_positive_finite_float(
-            value,
-            'solver.robust.mad_threshold',
-        )
 
     @field_validator('min_used_fraction', mode='before')
     @classmethod
@@ -1096,6 +1109,11 @@ class TimeTermStaticRobustRequest(BaseModel):
         if fraction > 1.0:
             raise ValueError('solver.robust.min_used_fraction must be <= 1')
         return fraction
+
+    @field_validator('min_used_observations', mode='before')
+    @classmethod
+    def _check_min_used_observations(cls, value: object) -> int:
+        return _require_positive_int(value, 'solver.robust.min_used_observations')
 
 
 class TimeTermStaticSolverRequest(BaseModel):

--- a/app/services/time_term_design_matrix.py
+++ b/app/services/time_term_design_matrix.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy import sparse
 
 from app.services.time_term_moveout import TimeTermMoveoutResult
-from app.services.time_term_static_inputs import TimeTermInversionInputs
+from app.services.time_term_types import TimeTermInversionInputs
 
 
 @dataclass(frozen=True)

--- a/app/services/time_term_moveout.py
+++ b/app/services/time_term_moveout.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import numpy as np
 
-from app.services.time_term_static_inputs import TimeTermInversionInputs
+from app.services.time_term_types import TimeTermInversionInputs
 
 TimeTermMoveoutModel = Literal[
     'head_wave_linear_offset',

--- a/app/services/time_term_static_inputs.py
+++ b/app/services/time_term_static_inputs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -24,60 +24,15 @@ from app.services.pick_source_loader import (
 )
 from app.services.reader import get_reader
 from app.services.residual_static_inputs import load_source_receiver_id_headers_sorted
+from app.services.time_term_types import (
+    ORDER,
+    SIGN_CONVENTION,
+    TimeTermInversionInputs,
+)
 from app.trace_store.reader import TraceStoreSectionReader
 from app.utils.segy_scalars import apply_segy_scalar
 
-ORDER = 'trace_store_sorted'
-SIGN_CONVENTION = (
-    'pick_time_after_static_s = pick_time_raw_s '
-    '+ datum_trace_shift_s + residual_applied_shift_s; '
-    'residual_applied_shift_s is an applied event-time shift, not an estimated delay'
-)
 _DT_TOLERANCE = 1e-9
-
-
-@dataclass(frozen=True)
-class TimeTermInversionInputs:
-    """Trace-level arrays aligned to TraceStore sorted trace order."""
-
-    n_traces: int
-    n_samples: int
-    dt: float
-    key1_byte: int
-    key2_byte: int
-
-    pick_time_raw_s_sorted: np.ndarray
-    valid_pick_mask_sorted: np.ndarray
-
-    datum_trace_shift_s_sorted: np.ndarray
-    residual_applied_shift_s_sorted: np.ndarray
-    pick_time_after_static_s_sorted: np.ndarray
-
-    source_node_id_sorted: np.ndarray
-    receiver_node_id_sorted: np.ndarray
-    n_nodes: int
-
-    source_id_sorted: np.ndarray
-    receiver_id_sorted: np.ndarray
-    offset_sorted: np.ndarray | None
-
-    source_x_m_sorted: np.ndarray
-    source_y_m_sorted: np.ndarray
-    receiver_x_m_sorted: np.ndarray
-    receiver_y_m_sorted: np.ndarray
-    source_elevation_m_sorted: np.ndarray
-    receiver_elevation_m_sorted: np.ndarray
-    source_depth_m_sorted: np.ndarray
-
-    input_file_id: str
-    pick_source_description: str
-    datum_solution_path: Path | None
-    residual_solution_path: Path | None
-    linkage_artifact_path: Path | None
-
-    order: str = ORDER
-    sign_convention: str = SIGN_CONVENTION
-    metadata: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -309,8 +264,12 @@ def build_time_term_inversion_inputs_from_sources(
             'linkage_mode': linkage.mode,
             'coordinate_unit': request.geometry.coordinate_unit,
             'elevation_unit': request.geometry.elevation_unit,
+            'distance_source': request.moveout.distance_source,
             'offset_byte': request.moveout.offset_byte,
             'allow_missing_offset': request.moveout.allow_missing_offset,
+            'max_geometry_offset_mismatch_m': (
+                request.moveout.max_geometry_offset_mismatch_m
+            ),
         },
     )
     validate_time_term_inversion_inputs(inputs, offset_required=_offset_required(request))
@@ -888,15 +847,27 @@ def _load_optional_offset_header_sorted(
     moveout = request.moveout
     if moveout.model == 'none':
         return None
+    if (
+        moveout.distance_source == 'geometry'
+        and moveout.max_geometry_offset_mismatch_m is None
+    ):
+        return None
     if moveout.offset_byte is None:
-        if moveout.allow_missing_offset:
-            return None
-        raise ValueError('offset_byte is required by moveout configuration')
+        if moveout.distance_source == 'offset_header':
+            raise ValueError('offset_byte is required by moveout configuration')
+        if moveout.max_geometry_offset_mismatch_m is not None:
+            raise ValueError('offset_byte is required for geometry offset QC')
+        return None
     n_traces = _coerce_positive_int(expected_n_traces, name='expected_n_traces')
     try:
         values = _read_reader_header(reader, byte=moveout.offset_byte, role='offset')
     except ValueError:
-        if moveout.allow_missing_offset:
+        if (
+            moveout.distance_source == 'auto'
+            and moveout.max_geometry_offset_mismatch_m is None
+        ):
+            return None
+        if moveout.allow_missing_offset and moveout.distance_source != 'offset_header':
             return None
         raise
     offset = _coerce_1d_finite_float64(
@@ -931,8 +902,7 @@ def _normalize_linear_unit(values: np.ndarray, *, unit: str, name: str) -> np.nd
 def _offset_required(request: TimeTermStaticApplyRequest) -> bool:
     return (
         request.moveout.model != 'none'
-        and not request.moveout.allow_missing_offset
-        and request.moveout.offset_byte is not None
+        and request.moveout.distance_source == 'offset_header'
     )
 
 

--- a/app/services/time_term_types.py
+++ b/app/services/time_term_types.py
@@ -1,0 +1,62 @@
+"""Pure data types for time-term static inversion services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+ORDER = 'trace_store_sorted'
+SIGN_CONVENTION = (
+    'pick_time_after_static_s = pick_time_raw_s '
+    '+ datum_trace_shift_s + residual_applied_shift_s; '
+    'residual_applied_shift_s is an applied event-time shift, not an estimated delay'
+)
+
+
+@dataclass(frozen=True)
+class TimeTermInversionInputs:
+    """Trace-level arrays aligned to TraceStore sorted trace order."""
+
+    n_traces: int
+    n_samples: int
+    dt: float
+    key1_byte: int
+    key2_byte: int
+
+    pick_time_raw_s_sorted: np.ndarray
+    valid_pick_mask_sorted: np.ndarray
+
+    datum_trace_shift_s_sorted: np.ndarray
+    residual_applied_shift_s_sorted: np.ndarray
+    pick_time_after_static_s_sorted: np.ndarray
+
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+    n_nodes: int
+
+    source_id_sorted: np.ndarray
+    receiver_id_sorted: np.ndarray
+    offset_sorted: np.ndarray | None
+
+    source_x_m_sorted: np.ndarray
+    source_y_m_sorted: np.ndarray
+    receiver_x_m_sorted: np.ndarray
+    receiver_y_m_sorted: np.ndarray
+    source_elevation_m_sorted: np.ndarray
+    receiver_elevation_m_sorted: np.ndarray
+    source_depth_m_sorted: np.ndarray
+
+    input_file_id: str
+    pick_source_description: str
+    datum_solution_path: Path | None
+    residual_solution_path: Path | None
+    linkage_artifact_path: Path | None
+
+    order: str = ORDER
+    sign_convention: str = SIGN_CONVENTION
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+__all__ = ['ORDER', 'SIGN_CONVENTION', 'TimeTermInversionInputs']

--- a/app/tests/test_time_term_design_matrix.py
+++ b/app/tests/test_time_term_design_matrix.py
@@ -14,7 +14,7 @@ from app.services.time_term_design_matrix import (
     summarize_time_term_design_matrix,
 )
 from app.services.time_term_moveout import TimeTermMoveoutResult
-from app.services.time_term_static_inputs import TimeTermInversionInputs
+from app.services.time_term_types import TimeTermInversionInputs
 
 N_TRACES = 4
 N_SAMPLES = 64

--- a/app/tests/test_time_term_import_layering.py
+++ b/app/tests/test_time_term_import_layering.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_NUMERIC_MODULE_PATHS = [
+    'app/services/time_term_types.py',
+    'app/services/time_term_moveout.py',
+    'app/services/time_term_design_matrix.py',
+    'app/services/time_term_sparse_solver.py',
+    'app/services/time_term_robust_solver.py',
+]
+
+
+def _source(path: str) -> str:
+    return Path(path).read_text(encoding='utf-8')
+
+
+@pytest.mark.parametrize('path', _NUMERIC_MODULE_PATHS)
+def test_time_term_numeric_services_do_not_import_api_reader_or_segyio(
+    path: str,
+) -> None:
+    source = _source(path)
+
+    assert 'app.api.schemas' not in source
+    assert 'app.services.reader' not in source
+    assert 'TraceStoreSectionReader' not in source
+    assert 'app.trace_store.reader' not in source
+    assert 'fastapi' not in source
+    assert 'segyio' not in source
+
+
+@pytest.mark.parametrize(
+    'path',
+    [
+        'app/services/time_term_moveout.py',
+        'app/services/time_term_design_matrix.py',
+        'app/services/time_term_sparse_solver.py',
+        'app/services/time_term_robust_solver.py',
+    ],
+)
+def test_time_term_numeric_services_do_not_import_static_inputs(path: str) -> None:
+    assert 'time_term_static_inputs' not in _source(path)
+
+
+def test_time_term_numeric_services_import_without_segyio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for module_name in (
+        'app.services.time_term_types',
+        'app.services.time_term_moveout',
+        'app.services.time_term_design_matrix',
+        'app.services.time_term_sparse_solver',
+        'app.services.time_term_robust_solver',
+        'app.services.time_term_static_inputs',
+        'app.trace_store.reader',
+    ):
+        sys.modules.pop(module_name, None)
+    monkeypatch.setitem(sys.modules, 'segyio', None)
+
+    for module_name in (
+        'app.services.time_term_types',
+        'app.services.time_term_moveout',
+        'app.services.time_term_design_matrix',
+        'app.services.time_term_sparse_solver',
+        'app.services.time_term_robust_solver',
+    ):
+        importlib.import_module(module_name)
+
+    assert 'app.services.time_term_static_inputs' not in sys.modules

--- a/app/tests/test_time_term_moveout.py
+++ b/app/tests/test_time_term_moveout.py
@@ -14,7 +14,7 @@ from app.services.time_term_moveout import (
     compute_time_term_moveout,
     summarize_time_term_moveout,
 )
-from app.services.time_term_static_inputs import TimeTermInversionInputs
+from app.services.time_term_types import TimeTermInversionInputs
 
 N_TRACES = 5
 N_SAMPLES = 64

--- a/app/tests/test_time_term_static_inputs.py
+++ b/app/tests/test_time_term_static_inputs.py
@@ -337,10 +337,7 @@ def test_time_term_inputs_builds_full_object_with_shifts_geometry_and_linkage(
     assert inputs.n_nodes > 0
     np.testing.assert_array_equal(inputs.source_id_sorted, [100, 100, 200, 300])
     np.testing.assert_array_equal(inputs.receiver_id_sorted, [1, 2, 1, 2])
-    np.testing.assert_allclose(
-        inputs.offset_sorted,
-        np.asarray([-100.0, -50.0, 50.0, 100.0]) * 0.3048,
-    )
+    assert inputs.offset_sorted is None
 
     np.testing.assert_allclose(
         inputs.source_x_m_sorted,
@@ -363,6 +360,34 @@ def test_time_term_inputs_builds_full_object_with_shifts_geometry_and_linkage(
         np.asarray([900.0, 100.0, 300.0, 200.0]) * 0.3048,
     )
     assert inputs.sign_convention.startswith('pick_time_after_static_s')
+
+
+def test_time_term_inputs_loads_offset_for_offset_header_distance(
+    tmp_path: Path,
+) -> None:
+    linkage_path = _write_linkage(tmp_path / GEOMETRY_LINKAGE_NPZ_NAME)
+    req = _request(
+        moveout={
+            'model': 'head_wave_linear_offset',
+            'distance_source': 'offset_header',
+            'offset_byte': OFFSET_BYTE,
+            'allow_missing_offset': False,
+        },
+    )
+
+    inputs = build_time_term_inversion_inputs_from_sources(
+        request=req,
+        reader=_Reader(),
+        pick_source=_pick_source(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+        linkage_artifact_path=linkage_path,
+    )
+
+    np.testing.assert_allclose(
+        inputs.offset_sorted,
+        np.asarray([-100.0, -50.0, 50.0, 100.0]) * 0.3048,
+    )
 
 
 def test_time_term_inputs_loads_manual_pick_export_original_to_sorted_order(
@@ -580,12 +605,20 @@ def test_time_term_inputs_rejects_non_finite_geometry(tmp_path: Path) -> None:
 
 def test_time_term_inputs_requires_offset_when_moveout_requires_offset(
     tmp_path: Path,
-    ) -> None:
+) -> None:
     linkage_path = _write_linkage(tmp_path / GEOMETRY_LINKAGE_NPZ_NAME)
+    req = _request(
+        moveout={
+            'model': 'head_wave_linear_offset',
+            'distance_source': 'offset_header',
+            'offset_byte': OFFSET_BYTE,
+            'allow_missing_offset': False,
+        },
+    )
 
     with pytest.raises(ValueError, match='failed to read offset header'):
         build_time_term_inversion_inputs_from_sources(
-            request=_request(),
+            request=req,
             reader=_Reader(missing_headers={OFFSET_BYTE}),
             pick_source=_pick_source(),
             expected_dt=DT,
@@ -599,6 +632,7 @@ def test_time_term_inputs_allows_missing_offset_when_configured(tmp_path: Path) 
     req = _request(
         moveout={
             'model': 'head_wave_linear_offset',
+            'distance_source': 'auto',
             'offset_byte': OFFSET_BYTE,
             'allow_missing_offset': True,
         },
@@ -606,6 +640,48 @@ def test_time_term_inputs_allows_missing_offset_when_configured(tmp_path: Path) 
 
     inputs = build_time_term_inversion_inputs_from_sources(
         request=req,
+        reader=_Reader(missing_headers={OFFSET_BYTE}),
+        pick_source=_pick_source(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+        linkage_artifact_path=linkage_path,
+    )
+
+    assert inputs.offset_sorted is None
+
+
+def test_time_term_inputs_auto_distance_treats_missing_default_offset_as_optional(
+    tmp_path: Path,
+) -> None:
+    linkage_path = _write_linkage(tmp_path / GEOMETRY_LINKAGE_NPZ_NAME)
+    req = _request(
+        moveout={
+            'model': 'head_wave_linear_offset',
+            'distance_source': 'auto',
+            'allow_missing_offset': False,
+        },
+    )
+
+    inputs = build_time_term_inversion_inputs_from_sources(
+        request=req,
+        reader=_Reader(missing_headers={OFFSET_BYTE}),
+        pick_source=_pick_source(),
+        expected_dt=DT,
+        expected_n_samples=N_SAMPLES,
+        linkage_artifact_path=linkage_path,
+    )
+
+    assert req.moveout.offset_byte == OFFSET_BYTE
+    assert inputs.offset_sorted is None
+
+
+def test_time_term_inputs_geometry_distance_does_not_read_default_offset_header(
+    tmp_path: Path,
+) -> None:
+    linkage_path = _write_linkage(tmp_path / GEOMETRY_LINKAGE_NPZ_NAME)
+
+    inputs = build_time_term_inversion_inputs_from_sources(
+        request=_request(),
         reader=_Reader(missing_headers={OFFSET_BYTE}),
         pick_source=_pick_source(),
         expected_dt=DT,
@@ -638,8 +714,16 @@ def test_time_term_inputs_rejects_no_valid_picks(tmp_path: Path) -> None:
 
 def test_summarize_time_term_inversion_inputs_is_json_safe(tmp_path: Path) -> None:
     linkage_path = _write_linkage(tmp_path / GEOMETRY_LINKAGE_NPZ_NAME)
+    req = _request(
+        moveout={
+            'model': 'head_wave_linear_offset',
+            'distance_source': 'offset_header',
+            'offset_byte': OFFSET_BYTE,
+            'allow_missing_offset': False,
+        },
+    )
     inputs = build_time_term_inversion_inputs_from_sources(
-        request=_request(),
+        request=req,
         reader=_Reader(),
         pick_source=_pick_source(),
         expected_dt=DT,

--- a/app/tests/test_time_term_static_request.py
+++ b/app/tests/test_time_term_static_request.py
@@ -97,6 +97,7 @@ def _payload() -> dict[str, Any]:
         },
         'moveout': {
             'model': 'head_wave_linear_offset',
+            'distance_source': 'geometry',
             'offset_byte': 37,
             'allow_missing_offset': False,
         },
@@ -105,9 +106,11 @@ def _payload() -> dict[str, Any]:
             'gauge': 'mean_zero',
             'robust': {
                 'enabled': True,
+                'method': 'mad',
+                'threshold': 3.5,
                 'max_iterations': 5,
-                'mad_threshold': 3.5,
                 'min_used_fraction': 0.5,
+                'min_used_observations': 1,
             },
         },
         'apply': {
@@ -260,10 +263,62 @@ def test_time_term_request_rejects_invalid_units() -> None:
 
 def test_time_term_request_rejects_invalid_moveout_offset_config() -> None:
     payload = _payload()
+    payload['moveout']['distance_source'] = 'offset_header'
     payload['moveout']['offset_byte'] = None
 
     with pytest.raises(ValidationError, match='moveout.offset_byte is required'):
         _validate(payload)
+
+
+def test_time_term_request_accepts_reciprocal_head_wave_model() -> None:
+    payload = _payload()
+    payload['moveout']['model'] = 'reciprocal_head_wave'
+
+    req = _validate(payload)
+
+    assert req.moveout.model == 'reciprocal_head_wave'
+
+
+def test_time_term_request_accepts_distance_source_geometry_without_offset_byte() -> None:
+    payload = _payload()
+    payload['moveout']['distance_source'] = 'geometry'
+    payload['moveout']['offset_byte'] = None
+
+    req = _validate(payload)
+
+    assert req.moveout.distance_source == 'geometry'
+    assert req.moveout.offset_byte is None
+
+
+def test_time_term_request_accepts_distance_source_offset_header_with_offset_byte() -> None:
+    payload = _payload()
+    payload['moveout']['distance_source'] = 'offset_header'
+    payload['moveout']['offset_byte'] = 37
+
+    req = _validate(payload)
+
+    assert req.moveout.distance_source == 'offset_header'
+    assert req.moveout.offset_byte == 37
+
+
+def test_time_term_request_accepts_distance_source_auto_without_offset_byte() -> None:
+    payload = _payload()
+    payload['moveout']['distance_source'] = 'auto'
+    payload['moveout']['offset_byte'] = None
+
+    req = _validate(payload)
+
+    assert req.moveout.distance_source == 'auto'
+    assert req.moveout.offset_byte is None
+
+
+def test_time_term_request_accepts_max_geometry_offset_mismatch() -> None:
+    payload = _payload()
+    payload['moveout']['max_geometry_offset_mismatch_m'] = 2.5
+
+    req = _validate(payload)
+
+    assert req.moveout.max_geometry_offset_mismatch_m == pytest.approx(2.5)
 
 
 def test_time_term_linkage_required_rejects_missing_job() -> None:
@@ -279,8 +334,9 @@ def test_time_term_linkage_required_rejects_missing_job() -> None:
     [
         (('solver', 'damping'), -0.1, 'solver.damping'),
         (('solver', 'robust', 'max_iterations'), 0, 'max_iterations'),
-        (('solver', 'robust', 'mad_threshold'), 0.0, 'mad_threshold'),
+        (('solver', 'robust', 'threshold'), 0.0, 'threshold'),
         (('solver', 'robust', 'min_used_fraction'), 1.1, 'min_used_fraction'),
+        (('solver', 'robust', 'min_used_observations'), 0, 'min_used_observations'),
         (('apply', 'max_abs_shift_ms'), 0.0, 'max_abs_shift_ms'),
     ],
 )
@@ -296,6 +352,25 @@ def test_time_term_request_rejects_invalid_solver_and_apply_values(
     target[field_path[-1]] = value
 
     with pytest.raises(ValidationError, match=match):
+        _validate(payload)
+
+
+@pytest.mark.parametrize('method', ['mad', 'sigma'])
+def test_time_term_request_accepts_robust_method(method: str) -> None:
+    payload = _payload()
+    payload['solver']['robust']['method'] = method
+
+    req = _validate(payload)
+
+    assert req.solver.robust.method == method
+    assert req.solver.robust.threshold == pytest.approx(3.5)
+
+
+def test_time_term_request_rejects_unknown_robust_method() -> None:
+    payload = _payload()
+    payload['solver']['robust']['method'] = 'median'
+
+    with pytest.raises(ValidationError, match='method'):
         _validate(payload)
 
 


### PR DESCRIPTION
Closes #361

## Summary
- PR6-fix [statics time-term] numerical layer import decoupling と request schema parity を修正する

## Changed files
- `app/api/schemas.py`
- `app/services/time_term_design_matrix.py`
- `app/services/time_term_moveout.py`
- `app/services/time_term_static_inputs.py`
- `app/services/time_term_types.py`
- `app/tests/test_time_term_design_matrix.py`
- `app/tests/test_time_term_import_layering.py`
- `app/tests/test_time_term_moveout.py`
- `app/tests/test_time_term_static_inputs.py`
- `app/tests/test_time_term_static_request.py`

## Checks
- `.work/codex/checks.log`: 1310 passed in 47.09s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
