### PR TITLE
PR6-7 [statics time-term] estimated weathering delay を applied event-time shift に変換する

### DIFF
--- a/app/services/time_term_apply_shift.py
+++ b/app/services/time_term_apply_shift.py
@@ -1,0 +1,693 @@
+"""Convert time-term estimated delays into applied event-time shifts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from app.services.time_term_robust_solver import TimeTermRobustSolverResult
+from app.services.time_term_sparse_solver import TimeTermSparseSolverResult
+from app.services.time_term_types import ORDER, TimeTermInversionInputs
+
+TimeTermRejectedTracePolicy = Literal['use_final_model']
+
+SIGN_CONVENTION = (
+    'estimated_trace_time_term_delay_s = source_node_time_term_s + '
+    'receiver_node_time_term_s; applied_weathering_shift_s = '
+    '-estimated_trace_time_term_delay_s; corrected(t)=raw(t-shift_s)'
+)
+DELAY_TO_SHIFT_CONVENTION = (
+    'applied_weathering_shift_s_sorted = '
+    '-estimated_trace_time_term_delay_s_sorted'
+)
+FINAL_SHIFT_CONVENTION = (
+    'final_trace_shift_s_sorted = datum_trace_shift_s_sorted '
+    '+ residual_applied_shift_s_sorted '
+    '+ applied_weathering_shift_s_sorted'
+)
+
+
+@dataclass(frozen=True)
+class TimeTermAppliedShiftOptions:
+    max_abs_weathering_shift_ms: float | None = 500.0
+    max_abs_final_shift_ms: float | None = 750.0
+    include_rejected_traces: bool = True
+    rejected_trace_policy: TimeTermRejectedTracePolicy = 'use_final_model'
+
+
+@dataclass(frozen=True)
+class TimeTermAppliedShiftResult:
+    n_traces: int
+    dt: float
+
+    node_time_term_s: np.ndarray
+
+    source_node_time_term_s_sorted: np.ndarray
+    receiver_node_time_term_s_sorted: np.ndarray
+
+    estimated_trace_time_term_delay_s_sorted: np.ndarray
+    applied_weathering_shift_s_sorted: np.ndarray
+
+    datum_trace_shift_s_sorted: np.ndarray
+    residual_applied_shift_s_sorted: np.ndarray
+    final_trace_shift_s_sorted: np.ndarray
+
+    valid_pick_mask_sorted: np.ndarray
+    final_used_trace_mask_sorted: np.ndarray
+    rejected_trace_mask_sorted: np.ndarray
+    rejected_iteration_sorted: np.ndarray
+
+    sign_convention: str
+    order: str
+    metadata: dict[str, object]
+
+
+@dataclass(frozen=True)
+class _ValidatedInputs:
+    n_traces: int
+    dt: float
+    n_nodes: int
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+    datum_trace_shift_s_sorted: np.ndarray
+    residual_applied_shift_s_sorted: np.ndarray
+    valid_pick_mask_sorted: np.ndarray
+
+
+@dataclass(frozen=True)
+class _ExtractedSolverResult:
+    sparse_result: TimeTermSparseSolverResult
+    final_used_trace_mask_sorted: np.ndarray
+    rejected_trace_mask_sorted: np.ndarray
+    rejected_iteration_sorted: np.ndarray
+    solver_result_kind: str
+
+
+def delay_to_applied_shift_s(delay_s: np.ndarray) -> np.ndarray:
+    """Convert an estimated delay into an applied event-time shift."""
+    return np.ascontiguousarray(-np.asarray(delay_s, dtype=np.float64), dtype=np.float64)
+
+
+def compute_estimated_trace_time_term_delay_s(
+    *,
+    node_time_term_s: np.ndarray,
+    source_node_id_sorted: np.ndarray,
+    receiver_node_id_sorted: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute trace-level estimated delay from source/receiver node terms."""
+    node_time_term = _coerce_1d_real_numeric_float64(
+        node_time_term_s,
+        name='node_time_term_s',
+    )
+    _validate_all_finite(node_time_term, name='node_time_term_s')
+    n_nodes = int(node_time_term.shape[0])
+    if n_nodes <= 0:
+        raise ValueError('node_time_term_s must be non-empty')
+
+    source_node_id = _coerce_1d_integer_int64(
+        source_node_id_sorted,
+        name='source_node_id_sorted',
+    )
+    receiver_node_id = _coerce_1d_integer_int64(
+        receiver_node_id_sorted,
+        name='receiver_node_id_sorted',
+    )
+    if source_node_id.shape != receiver_node_id.shape:
+        raise ValueError('source_node_id_sorted and receiver_node_id_sorted must match')
+    _validate_index_range(
+        source_node_id,
+        n_unique=n_nodes,
+        name='source_node_id_sorted',
+    )
+    _validate_index_range(
+        receiver_node_id,
+        n_unique=n_nodes,
+        name='receiver_node_id_sorted',
+    )
+
+    source = np.ascontiguousarray(node_time_term[source_node_id], dtype=np.float64)
+    receiver = np.ascontiguousarray(node_time_term[receiver_node_id], dtype=np.float64)
+    estimated = np.ascontiguousarray(source + receiver, dtype=np.float64)
+    _validate_all_finite(estimated, name='estimated_trace_time_term_delay_s_sorted')
+    return estimated, source, receiver
+
+
+def build_time_term_applied_shift_result(
+    *,
+    inputs: TimeTermInversionInputs,
+    solver_result: TimeTermSparseSolverResult | TimeTermRobustSolverResult,
+    options: TimeTermAppliedShiftOptions | None = None,
+) -> TimeTermAppliedShiftResult:
+    """Build sorted trace-level weathering and final applied shifts."""
+    validated_options = _validate_options(options)
+    validated_inputs = _validate_inputs(inputs)
+    extracted = _extract_final_sparse_result(
+        solver_result,
+        n_traces=validated_inputs.n_traces,
+    )
+    sparse_result = extracted.sparse_result
+
+    node_time_term = _coerce_1d_real_numeric_float64(
+        sparse_result.node_time_term_s,
+        name='node_time_term_s',
+        expected_shape=(validated_inputs.n_nodes,),
+    )
+    _validate_all_finite(node_time_term, name='node_time_term_s')
+    (
+        estimated_delay,
+        source_node_time_term,
+        receiver_node_time_term,
+    ) = compute_estimated_trace_time_term_delay_s(
+        node_time_term_s=node_time_term,
+        source_node_id_sorted=validated_inputs.source_node_id_sorted,
+        receiver_node_id_sorted=validated_inputs.receiver_node_id_sorted,
+    )
+
+    solver_estimated_delay = _coerce_1d_real_numeric_float64(
+        sparse_result.estimated_trace_time_term_delay_s_sorted,
+        name='estimated_trace_time_term_delay_s_sorted',
+        expected_shape=(validated_inputs.n_traces,),
+    )
+    _validate_all_finite(
+        solver_estimated_delay,
+        name='estimated_trace_time_term_delay_s_sorted',
+    )
+    if not np.allclose(solver_estimated_delay, estimated_delay):
+        raise ValueError(
+            'estimated_trace_time_term_delay_s_sorted does not match '
+            'node_time_term_s mapping'
+        )
+
+    applied_weathering_shift = delay_to_applied_shift_s(estimated_delay)
+    _validate_shift_limit(
+        applied_weathering_shift,
+        max_abs_ms=validated_options.max_abs_weathering_shift_ms,
+        limit_name='max_abs_weathering_shift_ms',
+    )
+    final_trace_shift = np.ascontiguousarray(
+        validated_inputs.datum_trace_shift_s_sorted
+        + validated_inputs.residual_applied_shift_s_sorted
+        + applied_weathering_shift,
+        dtype=np.float64,
+    )
+    _validate_all_finite(final_trace_shift, name='final_trace_shift_s_sorted')
+    _validate_shift_limit(
+        final_trace_shift,
+        max_abs_ms=validated_options.max_abs_final_shift_ms,
+        limit_name='max_abs_final_shift_ms',
+    )
+
+    metadata: dict[str, object] = {
+        'kind': 'time_term_applied_shift',
+        'order': ORDER,
+        'delay_to_shift_convention': DELAY_TO_SHIFT_CONVENTION,
+        'final_shift_convention': FINAL_SHIFT_CONVENTION,
+        'rejected_trace_policy': validated_options.rejected_trace_policy,
+        'include_rejected_traces': validated_options.include_rejected_traces,
+        'solver_result_kind': extracted.solver_result_kind,
+    }
+
+    return TimeTermAppliedShiftResult(
+        n_traces=validated_inputs.n_traces,
+        dt=validated_inputs.dt,
+        node_time_term_s=np.ascontiguousarray(node_time_term, dtype=np.float64),
+        source_node_time_term_s_sorted=source_node_time_term,
+        receiver_node_time_term_s_sorted=receiver_node_time_term,
+        estimated_trace_time_term_delay_s_sorted=estimated_delay,
+        applied_weathering_shift_s_sorted=applied_weathering_shift,
+        datum_trace_shift_s_sorted=validated_inputs.datum_trace_shift_s_sorted,
+        residual_applied_shift_s_sorted=validated_inputs.residual_applied_shift_s_sorted,
+        final_trace_shift_s_sorted=final_trace_shift,
+        valid_pick_mask_sorted=validated_inputs.valid_pick_mask_sorted,
+        final_used_trace_mask_sorted=extracted.final_used_trace_mask_sorted,
+        rejected_trace_mask_sorted=extracted.rejected_trace_mask_sorted,
+        rejected_iteration_sorted=extracted.rejected_iteration_sorted,
+        sign_convention=SIGN_CONVENTION,
+        order=ORDER,
+        metadata=metadata,
+    )
+
+
+def summarize_time_term_applied_shift_result(
+    result: TimeTermAppliedShiftResult,
+) -> dict[str, object]:
+    """Return a JSON-safe summary for future artifacts and job logs."""
+    if not isinstance(result, TimeTermAppliedShiftResult):
+        raise ValueError('result must be a TimeTermAppliedShiftResult instance')
+    n_traces = _coerce_positive_int(result.n_traces, name='n_traces')
+    dt = _coerce_positive_finite_float(result.dt, name='dt')
+    expected_shape = (n_traces,)
+
+    valid_pick_mask = _coerce_1d_bool_array(
+        result.valid_pick_mask_sorted,
+        name='valid_pick_mask_sorted',
+        expected_shape=expected_shape,
+    )
+    final_used_mask = _coerce_1d_bool_array(
+        result.final_used_trace_mask_sorted,
+        name='final_used_trace_mask_sorted',
+        expected_shape=expected_shape,
+    )
+    rejected_mask = _coerce_1d_bool_array(
+        result.rejected_trace_mask_sorted,
+        name='rejected_trace_mask_sorted',
+        expected_shape=expected_shape,
+    )
+
+    node_stats = _stats_payload(_coerce_summary_seconds(result.node_time_term_s) * 1000.0)
+    source_stats = _stats_payload(
+        _coerce_summary_seconds(
+            result.source_node_time_term_s_sorted,
+            expected_shape=expected_shape,
+            name='source_node_time_term_s_sorted',
+        )
+        * 1000.0
+    )
+    receiver_stats = _stats_payload(
+        _coerce_summary_seconds(
+            result.receiver_node_time_term_s_sorted,
+            expected_shape=expected_shape,
+            name='receiver_node_time_term_s_sorted',
+        )
+        * 1000.0
+    )
+    estimated_stats = _stats_payload(
+        _coerce_summary_seconds(
+            result.estimated_trace_time_term_delay_s_sorted,
+            expected_shape=expected_shape,
+            name='estimated_trace_time_term_delay_s_sorted',
+        )
+        * 1000.0
+    )
+    weathering_stats = _stats_payload(
+        _coerce_summary_seconds(
+            result.applied_weathering_shift_s_sorted,
+            expected_shape=expected_shape,
+            name='applied_weathering_shift_s_sorted',
+        )
+        * 1000.0
+    )
+    datum_stats = _stats_payload(
+        _coerce_summary_seconds(
+            result.datum_trace_shift_s_sorted,
+            expected_shape=expected_shape,
+            name='datum_trace_shift_s_sorted',
+        )
+        * 1000.0
+    )
+    residual_stats = _stats_payload(
+        _coerce_summary_seconds(
+            result.residual_applied_shift_s_sorted,
+            expected_shape=expected_shape,
+            name='residual_applied_shift_s_sorted',
+        )
+        * 1000.0
+    )
+    final_stats = _stats_payload(
+        _coerce_summary_seconds(
+            result.final_trace_shift_s_sorted,
+            expected_shape=expected_shape,
+            name='final_trace_shift_s_sorted',
+        )
+        * 1000.0
+    )
+
+    return {
+        'kind': 'time_term_applied_shift',
+        'order': str(result.order),
+        'sign_convention': str(result.sign_convention),
+        'n_traces': int(n_traces),
+        'dt': _json_float(dt),
+        'n_valid_picks': int(np.count_nonzero(valid_pick_mask)),
+        'n_final_used_traces': int(np.count_nonzero(final_used_mask)),
+        'n_rejected_traces': int(np.count_nonzero(rejected_mask)),
+        'node_time_term_ms': node_stats,
+        'source_node_time_term_ms': source_stats,
+        'receiver_node_time_term_ms': receiver_stats,
+        'estimated_trace_time_term_delay_ms': estimated_stats,
+        'applied_weathering_shift_ms': weathering_stats,
+        'datum_trace_shift_ms': datum_stats,
+        'residual_applied_shift_ms': residual_stats,
+        'final_trace_shift_ms': final_stats,
+        'max_abs_weathering_shift_ms': weathering_stats['max_abs'],
+        'max_abs_final_shift_ms': final_stats['max_abs'],
+        'rejected_trace_policy': str(
+            result.metadata.get('rejected_trace_policy', 'use_final_model')
+        ),
+        'delay_to_shift_convention': str(
+            result.metadata.get(
+                'delay_to_shift_convention',
+                DELAY_TO_SHIFT_CONVENTION,
+            )
+        ),
+        'final_shift_convention': str(
+            result.metadata.get('final_shift_convention', FINAL_SHIFT_CONVENTION)
+        ),
+    }
+
+
+def _validate_options(
+    options: TimeTermAppliedShiftOptions | None,
+) -> TimeTermAppliedShiftOptions:
+    opts = TimeTermAppliedShiftOptions() if options is None else options
+    if not isinstance(opts, TimeTermAppliedShiftOptions):
+        raise ValueError('options must be a TimeTermAppliedShiftOptions instance')
+    include_rejected_traces = _coerce_bool(
+        opts.include_rejected_traces,
+        name='include_rejected_traces',
+    )
+    if not include_rejected_traces:
+        raise ValueError('include_rejected_traces must be True')
+    rejected_trace_policy = _validate_rejected_trace_policy(opts.rejected_trace_policy)
+    return TimeTermAppliedShiftOptions(
+        max_abs_weathering_shift_ms=_coerce_optional_nonnegative_finite_float(
+            opts.max_abs_weathering_shift_ms,
+            name='max_abs_weathering_shift_ms',
+        ),
+        max_abs_final_shift_ms=_coerce_optional_nonnegative_finite_float(
+            opts.max_abs_final_shift_ms,
+            name='max_abs_final_shift_ms',
+        ),
+        include_rejected_traces=include_rejected_traces,
+        rejected_trace_policy=rejected_trace_policy,
+    )
+
+
+def _validate_inputs(inputs: TimeTermInversionInputs) -> _ValidatedInputs:
+    if not isinstance(inputs, TimeTermInversionInputs):
+        raise ValueError('inputs must be a TimeTermInversionInputs instance')
+    n_traces = _coerce_positive_int(inputs.n_traces, name='inputs.n_traces')
+    dt = _coerce_positive_finite_float(inputs.dt, name='inputs.dt')
+    n_nodes = _coerce_positive_int(inputs.n_nodes, name='inputs.n_nodes')
+    expected_shape = (n_traces,)
+
+    source_node_id = _coerce_1d_integer_int64(
+        inputs.source_node_id_sorted,
+        name='source_node_id_sorted',
+        expected_shape=expected_shape,
+    )
+    receiver_node_id = _coerce_1d_integer_int64(
+        inputs.receiver_node_id_sorted,
+        name='receiver_node_id_sorted',
+        expected_shape=expected_shape,
+    )
+    _validate_index_range(source_node_id, n_unique=n_nodes, name='source_node_id_sorted')
+    _validate_index_range(
+        receiver_node_id,
+        n_unique=n_nodes,
+        name='receiver_node_id_sorted',
+    )
+
+    datum_shift = _coerce_1d_real_numeric_float64(
+        inputs.datum_trace_shift_s_sorted,
+        name='datum_trace_shift_s_sorted',
+        expected_shape=expected_shape,
+    )
+    residual_shift = _coerce_1d_real_numeric_float64(
+        inputs.residual_applied_shift_s_sorted,
+        name='residual_applied_shift_s_sorted',
+        expected_shape=expected_shape,
+    )
+    _validate_all_finite(datum_shift, name='datum_trace_shift_s_sorted')
+    _validate_all_finite(residual_shift, name='residual_applied_shift_s_sorted')
+    valid_pick_mask = _coerce_1d_bool_array(
+        inputs.valid_pick_mask_sorted,
+        name='valid_pick_mask_sorted',
+        expected_shape=expected_shape,
+    )
+
+    return _ValidatedInputs(
+        n_traces=n_traces,
+        dt=dt,
+        n_nodes=n_nodes,
+        source_node_id_sorted=source_node_id,
+        receiver_node_id_sorted=receiver_node_id,
+        datum_trace_shift_s_sorted=datum_shift,
+        residual_applied_shift_s_sorted=residual_shift,
+        valid_pick_mask_sorted=valid_pick_mask,
+    )
+
+
+def _extract_final_sparse_result(
+    solver_result: TimeTermSparseSolverResult | TimeTermRobustSolverResult,
+    *,
+    n_traces: int,
+) -> _ExtractedSolverResult:
+    expected_shape = (n_traces,)
+    if isinstance(solver_result, TimeTermRobustSolverResult):
+        sparse_result = solver_result.final_solver_result
+        if not isinstance(sparse_result, TimeTermSparseSolverResult):
+            raise ValueError(
+                'final_solver_result must be a TimeTermSparseSolverResult instance'
+            )
+        final_used_mask = _coerce_1d_bool_array(
+            solver_result.final_used_trace_mask_sorted,
+            name='final_used_trace_mask_sorted',
+            expected_shape=expected_shape,
+        )
+        rejected_mask = _coerce_1d_bool_array(
+            solver_result.final_rejected_trace_mask_sorted,
+            name='final_rejected_trace_mask_sorted',
+            expected_shape=expected_shape,
+        )
+        rejected_iteration = _coerce_1d_integer_int64(
+            solver_result.rejected_iteration_sorted,
+            name='rejected_iteration_sorted',
+            expected_shape=expected_shape,
+        )
+        return _ExtractedSolverResult(
+            sparse_result=sparse_result,
+            final_used_trace_mask_sorted=final_used_mask,
+            rejected_trace_mask_sorted=rejected_mask,
+            rejected_iteration_sorted=rejected_iteration,
+            solver_result_kind='robust',
+        )
+
+    if isinstance(solver_result, TimeTermSparseSolverResult):
+        final_used_mask = _coerce_1d_bool_array(
+            solver_result.used_trace_mask_sorted,
+            name='used_trace_mask_sorted',
+            expected_shape=expected_shape,
+        )
+        return _ExtractedSolverResult(
+            sparse_result=solver_result,
+            final_used_trace_mask_sorted=final_used_mask,
+            rejected_trace_mask_sorted=np.zeros(expected_shape, dtype=bool),
+            rejected_iteration_sorted=np.full(expected_shape, -1, dtype=np.int64),
+            solver_result_kind='sparse',
+        )
+
+    raise ValueError(
+        'solver_result must be a TimeTermSparseSolverResult or '
+        'TimeTermRobustSolverResult instance'
+    )
+
+
+def _validate_rejected_trace_policy(value: object) -> TimeTermRejectedTracePolicy:
+    if value == 'use_final_model':
+        return 'use_final_model'
+    raise ValueError('unsupported rejected_trace_policy')
+
+
+def _validate_shift_limit(
+    values_s: np.ndarray,
+    *,
+    max_abs_ms: float | None,
+    limit_name: str,
+) -> None:
+    arr = _coerce_1d_real_numeric_float64(values_s, name=limit_name)
+    _validate_all_finite(arr, name=limit_name)
+    if arr.size == 0:
+        raise ValueError(f'{limit_name} values must be non-empty')
+    if max_abs_ms is None:
+        return
+    max_abs_s = float(np.max(np.abs(arr)))
+    if max_abs_s > max_abs_ms / 1000.0:
+        raise ValueError(f'{limit_name} exceeded')
+
+
+def _coerce_summary_seconds(
+    values: object,
+    *,
+    name: str = 'summary values',
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = _coerce_1d_real_numeric_float64(
+        values,
+        name=name,
+        expected_shape=expected_shape,
+    )
+    _validate_all_finite(arr, name=name)
+    return arr
+
+
+def _coerce_1d_real_numeric_float64(
+    values: object,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{name} must have a numeric dtype')
+    return np.ascontiguousarray(arr, dtype=np.float64)
+
+
+def _coerce_1d_integer_int64(
+    values: object,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must contain integer values')
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(f'{name} must contain integer values')
+    return np.ascontiguousarray(arr, dtype=np.int64)
+
+
+def _coerce_1d_bool_array(
+    values: object,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be a 1D array')
+    if arr.shape != expected_shape:
+        raise ValueError(f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}')
+    if not np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must have bool dtype')
+    return np.ascontiguousarray(arr, dtype=bool)
+
+
+def _coerce_positive_int(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer')
+    out = int(value)
+    if out <= 0:
+        raise ValueError(f'{name} must be greater than 0')
+    return out
+
+
+def _coerce_bool(value: object, *, name: str) -> bool:
+    if not isinstance(value, (bool, np.bool_)):
+        raise ValueError(f'{name} must be bool')
+    return bool(value)
+
+
+def _coerce_positive_finite_float(value: object, *, name: str) -> float:
+    out = _coerce_finite_float(value, name=name)
+    if out <= 0.0:
+        raise ValueError(f'{name} must be greater than 0')
+    return out
+
+
+def _coerce_nonnegative_finite_float(value: object, *, name: str) -> float:
+    out = _coerce_finite_float(value, name=name)
+    if out < 0.0:
+        raise ValueError(f'{name} must be greater than or equal to 0')
+    return out
+
+
+def _coerce_optional_nonnegative_finite_float(
+    value: object,
+    *,
+    name: str,
+) -> float | None:
+    if value is None:
+        return None
+    return _coerce_nonnegative_finite_float(value, name=name)
+
+
+def _coerce_finite_float(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f'{name} must be finite')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite') from exc
+    if not np.isfinite(out):
+        raise ValueError(f'{name} must be finite')
+    return out
+
+
+def _validate_index_range(
+    indices: np.ndarray,
+    *,
+    n_unique: int,
+    name: str,
+) -> None:
+    if indices.size == 0:
+        return
+    if np.any(indices < 0):
+        raise ValueError(f'{name} must be greater than or equal to 0')
+    if np.any(indices >= n_unique):
+        raise ValueError(f'{name} contains values outside 0..{n_unique - 1}')
+
+
+def _validate_all_finite(values: np.ndarray, *, name: str) -> None:
+    if np.any(~np.isfinite(values)):
+        raise ValueError(f'{name} must contain only finite values')
+
+
+def _json_float(value: float) -> float:
+    return float(_coerce_finite_float(value, name='summary value'))
+
+
+def _stats_payload(values: np.ndarray) -> dict[str, float | int | None]:
+    arr = _coerce_1d_real_numeric_float64(values, name='summary values')
+    finite = np.ascontiguousarray(arr[np.isfinite(arr)], dtype=np.float64)
+    count = int(finite.shape[0])
+    if count == 0:
+        return {
+            'count': 0,
+            'min': None,
+            'max': None,
+            'mean': None,
+            'median': None,
+            'std': None,
+            'max_abs': None,
+        }
+    return {
+        'count': count,
+        'min': float(np.min(finite)),
+        'max': float(np.max(finite)),
+        'mean': float(np.mean(finite)),
+        'median': float(np.median(finite)),
+        'std': float(np.std(finite, ddof=0)),
+        'max_abs': float(np.max(np.abs(finite))),
+    }
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'DELAY_TO_SHIFT_CONVENTION',
+    'FINAL_SHIFT_CONVENTION',
+    'SIGN_CONVENTION',
+    'TimeTermAppliedShiftOptions',
+    'TimeTermAppliedShiftResult',
+    'TimeTermRejectedTracePolicy',
+    'build_time_term_applied_shift_result',
+    'compute_estimated_trace_time_term_delay_s',
+    'delay_to_applied_shift_s',
+    'summarize_time_term_applied_shift_result',
+]

--- a/app/tests/test_time_term_apply_shift.py
+++ b/app/tests/test_time_term_apply_shift.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from typing import Any
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from app.services.time_term_apply_shift import (
+    DELAY_TO_SHIFT_CONVENTION,
+    FINAL_SHIFT_CONVENTION,
+    SIGN_CONVENTION,
+    TimeTermAppliedShiftOptions,
+    TimeTermAppliedShiftResult,
+    build_time_term_applied_shift_result,
+    delay_to_applied_shift_s,
+    summarize_time_term_applied_shift_result,
+)
+from app.services.time_term_robust_solver import (
+    TimeTermRobustSolverOptions,
+    TimeTermRobustSolverResult,
+)
+from app.services.time_term_sparse_solver import (
+    TimeTermSolverSystem,
+    TimeTermSparseSolverResult,
+)
+from app.services.time_term_types import ORDER, TimeTermInversionInputs
+
+N_TRACES = 3
+N_NODES = 3
+DT = 0.002
+SOURCE_NODE_ID_SORTED = np.asarray([0, 1, 2], dtype=np.int64)
+RECEIVER_NODE_ID_SORTED = np.asarray([1, 2, 2], dtype=np.int64)
+NODE_TIME_TERM_S = np.asarray([0.010, 0.005, -0.002], dtype=np.float64)
+ESTIMATED_DELAY_S = np.asarray([0.015, 0.003, -0.004], dtype=np.float64)
+APPLIED_WEATHERING_SHIFT_S = np.asarray([-0.015, -0.003, 0.004], dtype=np.float64)
+DATUM_SHIFT_S = np.asarray([-0.020, -0.020, -0.020], dtype=np.float64)
+RESIDUAL_SHIFT_S = np.asarray([0.001, 0.002, 0.003], dtype=np.float64)
+FINAL_SHIFT_S = np.asarray([-0.034, -0.021, -0.013], dtype=np.float64)
+VALID_PICK_MASK = np.asarray([True, True, False], dtype=bool)
+USED_TRACE_MASK = np.asarray([True, True, False], dtype=bool)
+
+
+def _inputs(**overrides: Any) -> TimeTermInversionInputs:
+    zeros = np.zeros(N_TRACES, dtype=np.float64)
+    payload: dict[str, Any] = {
+        'n_traces': N_TRACES,
+        'n_samples': 200,
+        'dt': DT,
+        'key1_byte': 189,
+        'key2_byte': 193,
+        'pick_time_raw_s_sorted': np.asarray([0.10, 0.12, 0.14], dtype=np.float64),
+        'valid_pick_mask_sorted': VALID_PICK_MASK.copy(),
+        'datum_trace_shift_s_sorted': DATUM_SHIFT_S.copy(),
+        'residual_applied_shift_s_sorted': RESIDUAL_SHIFT_S.copy(),
+        'pick_time_after_static_s_sorted': np.asarray(
+            [0.081, 0.102, 0.123],
+            dtype=np.float64,
+        ),
+        'source_node_id_sorted': SOURCE_NODE_ID_SORTED.copy(),
+        'receiver_node_id_sorted': RECEIVER_NODE_ID_SORTED.copy(),
+        'n_nodes': N_NODES,
+        'source_id_sorted': np.asarray([100, 101, 102], dtype=np.int64),
+        'receiver_id_sorted': np.asarray([200, 201, 202], dtype=np.int64),
+        'offset_sorted': np.asarray([1000.0, 1200.0, 1400.0], dtype=np.float64),
+        'source_x_m_sorted': zeros.copy(),
+        'source_y_m_sorted': zeros.copy(),
+        'receiver_x_m_sorted': zeros.copy(),
+        'receiver_y_m_sorted': zeros.copy(),
+        'source_elevation_m_sorted': zeros.copy(),
+        'receiver_elevation_m_sorted': zeros.copy(),
+        'source_depth_m_sorted': zeros.copy(),
+        'input_file_id': 'synthetic-file',
+        'pick_source_description': 'synthetic picks',
+        'datum_solution_path': None,
+        'residual_solution_path': None,
+        'linkage_artifact_path': None,
+    }
+    payload.update(overrides)
+    return TimeTermInversionInputs(**payload)
+
+
+def _system(*, n_nodes: int = N_NODES, n_observations: int = 2) -> TimeTermSolverSystem:
+    return TimeTermSolverSystem(
+        augmented_matrix=sparse.csr_matrix(
+            (n_observations, n_nodes),
+            dtype=np.float64,
+        ),
+        augmented_data_s=np.zeros(n_observations, dtype=np.float64),
+        n_observation_rows=n_observations,
+        n_damping_rows=0,
+        n_gauge_rows=0,
+        n_augmented_rows=n_observations,
+        n_nodes=n_nodes,
+        damping_prior_s=np.zeros(n_nodes, dtype=np.float64),
+        gauge_mode='none',
+        component_id_by_node=np.zeros(n_nodes, dtype=np.int64),
+        n_components=1,
+        damping_lambda=0.0,
+        gauge_weight=0.0,
+        reference_node_id=None,
+        min_total_observations_per_node=0,
+        total_observation_count_by_node=np.ones(n_nodes, dtype=np.int64),
+    )
+
+
+def _sparse_result(**overrides: Any) -> TimeTermSparseSolverResult:
+    used_mask = overrides.pop('used_trace_mask_sorted', USED_TRACE_MASK.copy())
+    node_time_term = overrides.pop('node_time_term_s', NODE_TIME_TERM_S.copy())
+    estimated_delay = overrides.pop(
+        'estimated_trace_time_term_delay_s_sorted',
+        ESTIMATED_DELAY_S.copy(),
+    )
+    row_trace_index = np.flatnonzero(used_mask).astype(np.int64, copy=False)
+    n_observations = int(row_trace_index.shape[0])
+    payload: dict[str, Any] = {
+        'node_time_term_s': np.asarray(node_time_term, dtype=np.float64),
+        'estimated_trace_time_term_delay_s_sorted': np.asarray(
+            estimated_delay,
+            dtype=np.float64,
+        ),
+        'row_estimated_time_term_delay_s': ESTIMATED_DELAY_S[row_trace_index],
+        'row_residual_before_s': np.zeros(n_observations, dtype=np.float64),
+        'row_residual_after_s': np.zeros(n_observations, dtype=np.float64),
+        'row_residual_after_ms': np.zeros(n_observations, dtype=np.float64),
+        'rms_residual_before_s': 0.0,
+        'rms_residual_after_s': 0.0,
+        'used_trace_mask_sorted': np.asarray(used_mask, dtype=bool),
+        'row_trace_index_sorted': row_trace_index,
+        'solver_name': 'lsmr',
+        'solver_istop': 1,
+        'solver_iterations': 1,
+        'solver_normr': 0.0,
+        'solver_normar': 0.0,
+        'solver_conda': 1.0,
+        'solver_message': 'synthetic',
+        'system': _system(n_observations=n_observations),
+    }
+    payload.update(overrides)
+    return TimeTermSparseSolverResult(**payload)
+
+
+def _robust_result(**overrides: Any) -> TimeTermRobustSolverResult:
+    final_solver_result = overrides.pop('final_solver_result', _sparse_result())
+    final_used_mask = overrides.pop(
+        'final_used_trace_mask_sorted',
+        np.asarray([False, True, False], dtype=bool),
+    )
+    rejected_mask = overrides.pop(
+        'final_rejected_trace_mask_sorted',
+        np.asarray([True, False, False], dtype=bool),
+    )
+    rejected_iteration = overrides.pop(
+        'rejected_iteration_sorted',
+        np.asarray([0, -1, -1], dtype=np.int64),
+    )
+    payload: dict[str, Any] = {
+        'final_solver_result': final_solver_result,
+        'iterations': (),
+        'initial_used_trace_mask_sorted': USED_TRACE_MASK.copy(),
+        'final_used_trace_mask_sorted': final_used_mask,
+        'final_rejected_trace_mask_sorted': rejected_mask,
+        'rejected_iteration_sorted': rejected_iteration,
+        'initial_row_used_mask': np.ones(2, dtype=bool),
+        'final_row_used_mask': np.ones(1, dtype=bool),
+        'final_row_rejected_mask': np.asarray([True, False], dtype=bool),
+        'row_rejected_iteration': np.asarray([0, -1], dtype=np.int64),
+        'method': 'mad',
+        'enabled': True,
+        'stop_reason': 'converged',
+        'robust_options': TimeTermRobustSolverOptions(),
+        'n_initial_used_traces': int(np.count_nonzero(USED_TRACE_MASK)),
+        'n_final_used_traces': int(np.count_nonzero(final_used_mask)),
+        'n_rejected_traces': int(np.count_nonzero(rejected_mask)),
+        'final_used_fraction': 0.5,
+    }
+    payload.update(overrides)
+    return TimeTermRobustSolverResult(**payload)
+
+
+def _build(
+    *,
+    inputs: TimeTermInversionInputs | None = None,
+    solver_result: TimeTermSparseSolverResult | TimeTermRobustSolverResult | None = None,
+    options: TimeTermAppliedShiftOptions | None = None,
+) -> TimeTermAppliedShiftResult:
+    return build_time_term_applied_shift_result(
+        inputs=_inputs() if inputs is None else inputs,
+        solver_result=_sparse_result() if solver_result is None else solver_result,
+        options=options,
+    )
+
+
+def test_delay_to_applied_shift_negates_delay() -> None:
+    delay = np.asarray([0.010, -0.002, 0.0], dtype=np.float64)
+
+    np.testing.assert_allclose(delay_to_applied_shift_s(delay), [-0.010, 0.002, -0.0])
+
+
+def test_time_term_applied_shift_from_sparse_solver_result() -> None:
+    result = _build()
+
+    assert result.n_traces == N_TRACES
+    assert result.dt == DT
+    np.testing.assert_array_equal(result.final_used_trace_mask_sorted, USED_TRACE_MASK)
+    np.testing.assert_array_equal(
+        result.rejected_trace_mask_sorted,
+        np.zeros(N_TRACES, dtype=bool),
+    )
+    np.testing.assert_array_equal(
+        result.rejected_iteration_sorted,
+        np.full(N_TRACES, -1, dtype=np.int64),
+    )
+
+
+def test_time_term_applied_shift_from_robust_solver_result_uses_final_solver_result() -> None:
+    final_solver = _sparse_result()
+    robust_result = _robust_result(final_solver_result=final_solver)
+
+    result = _build(solver_result=robust_result)
+
+    np.testing.assert_allclose(result.node_time_term_s, NODE_TIME_TERM_S)
+    np.testing.assert_array_equal(
+        result.final_used_trace_mask_sorted,
+        [False, True, False],
+    )
+    np.testing.assert_array_equal(result.rejected_trace_mask_sorted, [True, False, False])
+    np.testing.assert_array_equal(result.rejected_iteration_sorted, [0, -1, -1])
+    assert result.metadata['solver_result_kind'] == 'robust'
+
+
+def test_time_term_applied_shift_recomputes_trace_delay_from_node_terms() -> None:
+    result = _build()
+
+    np.testing.assert_allclose(
+        result.source_node_time_term_s_sorted,
+        [0.010, 0.005, -0.002],
+    )
+    np.testing.assert_allclose(
+        result.receiver_node_time_term_s_sorted,
+        [0.005, -0.002, -0.002],
+    )
+    np.testing.assert_allclose(
+        result.estimated_trace_time_term_delay_s_sorted,
+        ESTIMATED_DELAY_S,
+    )
+
+
+def test_time_term_applied_shift_rejects_solver_trace_delay_mapping_mismatch() -> None:
+    solver_result = _sparse_result(
+        estimated_trace_time_term_delay_s_sorted=ESTIMATED_DELAY_S
+        + np.asarray([0.001, 0.0, 0.0], dtype=np.float64)
+    )
+
+    with pytest.raises(
+        ValueError,
+        match='estimated_trace_time_term_delay_s_sorted does not match node_time_term_s mapping',
+    ):
+        _build(solver_result=solver_result)
+
+
+def test_time_term_applied_shift_is_negative_estimated_delay() -> None:
+    result = _build()
+
+    np.testing.assert_allclose(
+        result.applied_weathering_shift_s_sorted,
+        -result.estimated_trace_time_term_delay_s_sorted,
+    )
+    np.testing.assert_allclose(
+        result.applied_weathering_shift_s_sorted,
+        APPLIED_WEATHERING_SHIFT_S,
+    )
+
+
+def test_time_term_applied_shift_composes_final_shift_with_datum_and_residual() -> None:
+    result = _build()
+
+    np.testing.assert_allclose(result.final_trace_shift_s_sorted, FINAL_SHIFT_S)
+    np.testing.assert_allclose(
+        result.final_trace_shift_s_sorted,
+        DATUM_SHIFT_S + RESIDUAL_SHIFT_S + APPLIED_WEATHERING_SHIFT_S,
+    )
+
+
+def test_time_term_applied_shift_keeps_sorted_trace_order() -> None:
+    result = _build()
+
+    assert result.order == ORDER
+    np.testing.assert_allclose(
+        result.estimated_trace_time_term_delay_s_sorted,
+        [0.015, 0.003, -0.004],
+    )
+    np.testing.assert_allclose(
+        result.final_trace_shift_s_sorted,
+        [-0.034, -0.021, -0.013],
+    )
+
+
+def test_time_term_applied_shift_uses_final_model_for_rejected_traces_by_default() -> None:
+    result = _build(solver_result=_robust_result())
+
+    assert not bool(result.final_used_trace_mask_sorted[0])
+    assert bool(result.rejected_trace_mask_sorted[0])
+    assert result.rejected_iteration_sorted[0] == 0
+    assert result.applied_weathering_shift_s_sorted[0] == pytest.approx(-0.015)
+
+
+def test_time_term_applied_shift_rejects_unsupported_rejected_trace_policy() -> None:
+    with pytest.raises(ValueError, match='unsupported rejected_trace_policy'):
+        _build(
+            options=TimeTermAppliedShiftOptions(
+                rejected_trace_policy='zero_rejected',  # type: ignore[arg-type]
+            )
+        )
+
+
+def test_time_term_applied_shift_rejects_non_finite_node_time_terms() -> None:
+    node_time_term = NODE_TIME_TERM_S.copy()
+    node_time_term[0] = np.nan
+
+    with pytest.raises(ValueError, match='node_time_term_s'):
+        _build(solver_result=_sparse_result(node_time_term_s=node_time_term))
+
+
+def test_time_term_applied_shift_rejects_node_id_out_of_range() -> None:
+    receiver_node_id = RECEIVER_NODE_ID_SORTED.copy()
+    receiver_node_id[1] = N_NODES
+
+    with pytest.raises(ValueError, match='receiver_node_id_sorted'):
+        _build(inputs=_inputs(receiver_node_id_sorted=receiver_node_id))
+
+
+def test_time_term_applied_shift_rejects_datum_shift_shape_mismatch() -> None:
+    with pytest.raises(ValueError, match='datum_trace_shift_s_sorted'):
+        _build(inputs=_inputs(datum_trace_shift_s_sorted=np.zeros(2, dtype=np.float64)))
+
+
+def test_time_term_applied_shift_rejects_residual_shift_shape_mismatch() -> None:
+    with pytest.raises(ValueError, match='residual_applied_shift_s_sorted'):
+        _build(
+            inputs=_inputs(
+                residual_applied_shift_s_sorted=np.zeros(2, dtype=np.float64)
+            )
+        )
+
+
+def test_time_term_applied_shift_rejects_weathering_shift_above_limit() -> None:
+    with pytest.raises(ValueError, match='max_abs_weathering_shift_ms exceeded'):
+        _build(options=TimeTermAppliedShiftOptions(max_abs_weathering_shift_ms=10.0))
+
+
+def test_time_term_applied_shift_rejects_final_shift_above_limit() -> None:
+    with pytest.raises(ValueError, match='max_abs_final_shift_ms exceeded'):
+        _build(
+            options=TimeTermAppliedShiftOptions(
+                max_abs_weathering_shift_ms=None,
+                max_abs_final_shift_ms=30.0,
+            )
+        )
+
+
+def test_time_term_applied_shift_metadata_contains_sign_convention() -> None:
+    result = _build()
+
+    assert result.sign_convention == SIGN_CONVENTION
+    assert result.metadata['delay_to_shift_convention'] == DELAY_TO_SHIFT_CONVENTION
+    assert result.metadata['final_shift_convention'] == FINAL_SHIFT_CONVENTION
+    assert result.metadata['rejected_trace_policy'] == 'use_final_model'
+
+
+def test_time_term_applied_shift_result_does_not_confuse_delay_and_shift_names() -> None:
+    field_names = {field.name for field in fields(TimeTermAppliedShiftResult)}
+
+    assert 'estimated_trace_time_term_delay_s_sorted' in field_names
+    assert 'applied_weathering_shift_s_sorted' in field_names
+    assert not any(
+        'estimated' in field_name and 'shift' in field_name
+        for field_name in field_names
+    )
+    assert not any(
+        'applied' in field_name and 'delay' in field_name
+        for field_name in field_names
+    )
+
+
+def test_summarize_time_term_applied_shift_result_is_json_safe() -> None:
+    result = _build(solver_result=_robust_result())
+
+    summary = summarize_time_term_applied_shift_result(result)
+
+    json.dumps(summary, allow_nan=False)
+    assert summary['n_traces'] == N_TRACES
+    assert summary['dt'] == DT
+    assert summary['n_valid_picks'] == 2
+    assert summary['n_final_used_traces'] == 1
+    assert summary['n_rejected_traces'] == 1
+    assert summary['estimated_trace_time_term_delay_ms']['count'] == N_TRACES
+    assert summary['applied_weathering_shift_ms']['max_abs'] == pytest.approx(15.0)
+    assert summary['final_trace_shift_ms']['max_abs'] == pytest.approx(34.0)
+    assert summary['max_abs_weathering_shift_ms'] == pytest.approx(15.0)
+    assert summary['max_abs_final_shift_ms'] == pytest.approx(34.0)
+    assert summary['rejected_trace_policy'] == 'use_final_model'

--- a/app/tests/test_time_term_import_layering.py
+++ b/app/tests/test_time_term_import_layering.py
@@ -13,6 +13,7 @@ _NUMERIC_MODULE_PATHS = [
     'app/services/time_term_design_matrix.py',
     'app/services/time_term_sparse_solver.py',
     'app/services/time_term_robust_solver.py',
+    'app/services/time_term_apply_shift.py',
 ]
 
 
@@ -41,6 +42,7 @@ def test_time_term_numeric_services_do_not_import_api_reader_or_segyio(
         'app/services/time_term_design_matrix.py',
         'app/services/time_term_sparse_solver.py',
         'app/services/time_term_robust_solver.py',
+        'app/services/time_term_apply_shift.py',
     ],
 )
 def test_time_term_numeric_services_do_not_import_static_inputs(path: str) -> None:
@@ -56,6 +58,7 @@ def test_time_term_numeric_services_import_without_segyio(
         'app.services.time_term_design_matrix',
         'app.services.time_term_sparse_solver',
         'app.services.time_term_robust_solver',
+        'app.services.time_term_apply_shift',
         'app.services.time_term_static_inputs',
         'app.trace_store.reader',
     ):
@@ -68,6 +71,7 @@ def test_time_term_numeric_services_import_without_segyio(
         'app.services.time_term_design_matrix',
         'app.services.time_term_sparse_solver',
         'app.services.time_term_robust_solver',
+        'app.services.time_term_apply_shift',
     ):
         importlib.import_module(module_name)
 


### PR DESCRIPTION
Closes #362

## Summary
- PR6-7 [statics time-term] estimated weathering delay を applied event-time shift に変換する

## Changed files
- `app/services/time_term_apply_shift.py`
- `app/tests/test_time_term_apply_shift.py`
- `app/tests/test_time_term_import_layering.py`

## Checks
- `.work/codex/checks.log`: 1331 passed in 46.77s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
