### PR TITLE
PR6-9 [statics time-term] time-term static correction を TraceStore に適用して補正済み file_id を登録する

### DIFF
--- a/app/services/time_term_static_apply_trace_store.py
+++ b/app/services/time_term_static_apply_trace_store.py
@@ -1,0 +1,1099 @@
+"""Apply time-term static solution artifacts to TraceStores."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import nullcontext
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import shutil
+from typing import Any, Literal
+from uuid import uuid4
+
+import numpy as np
+
+from app.core.state import AppState
+from app.services.corrected_trace_store import (
+    TimeShiftedTraceStoreResult,
+    build_time_shifted_trace_store,
+)
+from app.services.reader import get_reader
+from app.services.trace_store_registration import (
+    register_trace_store,
+    trace_store_cache_key,
+)
+from app.utils.baseline_artifacts import has_split_baseline_artifacts
+
+TimeTermTraceStoreApplyMode = Literal['weathering_only', 'final_from_raw']
+
+_CORRECTED_FILE_NAME = 'corrected_file.json'
+_SAFE_STORE_NAME_RE = re.compile(r'[^A-Za-z0-9_.-]+')
+_SCHEMA_VERSION = 1
+_ARTIFACT_KIND = 'time_term_static_solution'
+_ORDER = 'trace_store_sorted'
+_DT_ATOL = 1.0e-9
+_DT_RTOL = 0.0
+_SHIFT_RTOL = 1.0e-7
+_SHIFT_ATOL = 1.0e-9
+_BUILDER_SIGN_CONVENTION = (
+    'corrected(t)=raw(t-shift_s); positive_shift_delays_events'
+)
+_REQUIRED_SOLUTION_FIELDS = {
+    'schema_version',
+    'artifact_kind',
+    'order',
+    'job_id',
+    'input_file_id',
+    'n_traces',
+    'n_samples',
+    'dt',
+    'key1_byte',
+    'key2_byte',
+    'applied_weathering_shift_s_sorted',
+    'final_trace_shift_s_sorted',
+    'datum_trace_shift_s_sorted',
+    'residual_applied_shift_s_sorted',
+    'final_used_trace_mask_sorted',
+    'rejected_trace_mask_sorted',
+    'rejected_iteration_sorted',
+    'estimated_trace_time_term_delay_s_sorted',
+    'node_time_term_s',
+    'sign_convention',
+    'delay_to_shift_convention',
+    'final_shift_convention',
+}
+
+
+@dataclass(frozen=True)
+class TimeTermTraceStoreApplyOptions:
+    mode: TimeTermTraceStoreApplyMode = 'weathering_only'
+    interpolation: str = 'linear'
+    fill_value: float = 0.0
+    output_dtype: str = 'float32'
+    max_abs_shift_ms: float = 500.0
+    register_corrected_file: bool = True
+    corrected_file_id: str | None = None
+    corrected_store_name: str | None = None
+
+
+@dataclass(frozen=True)
+class TimeTermTraceStoreApplyResult:
+    file_id: str
+    store_path: Path
+    store_name: str
+
+    source_file_id: str
+    source_store_path: Path
+
+    solution_npz_path: Path
+    job_id: str | None
+
+    mode: TimeTermTraceStoreApplyMode
+    applied_shift_field: str
+
+    key1_byte: int
+    key2_byte: int
+    dt: float
+    n_traces: int
+    n_samples: int
+
+    shift_min_ms: float
+    shift_max_ms: float
+    shift_mean_ms: float
+    shift_max_abs_ms: float
+
+    corrected_file_json_path: Path | None
+
+
+@dataclass(frozen=True)
+class LoadedTimeTermStaticSolution:
+    path: Path
+    schema_version: int
+    artifact_kind: str
+    order: str
+
+    n_traces: int
+    n_samples: int | None
+    dt: float
+    key1_byte: int | None
+    key2_byte: int | None
+
+    job_id: str | None
+    input_file_id: str | None
+
+    applied_weathering_shift_s_sorted: np.ndarray
+    final_trace_shift_s_sorted: np.ndarray
+    datum_trace_shift_s_sorted: np.ndarray
+    residual_applied_shift_s_sorted: np.ndarray
+
+    final_used_trace_mask_sorted: np.ndarray
+    rejected_trace_mask_sorted: np.ndarray
+    rejected_iteration_sorted: np.ndarray
+
+    estimated_trace_time_term_delay_s_sorted: np.ndarray
+    node_time_term_s: np.ndarray
+
+    sign_convention: str
+    delay_to_shift_convention: str
+    final_shift_convention: str
+
+
+@dataclass(frozen=True)
+class _SourceTraceStoreMeta:
+    raw: dict[str, object]
+    n_traces: int
+    n_samples: int
+    dt: float
+    key1_byte: int
+    key2_byte: int
+    original_segy_path: str
+    source_sha256: str | None
+
+
+def load_time_term_static_solution(
+    npz_path: Path,
+    *,
+    expected_n_traces: int | None = None,
+    expected_dt: float | None = None,
+    expected_key1_byte: int | None = None,
+    expected_key2_byte: int | None = None,
+) -> LoadedTimeTermStaticSolution:
+    """Load and validate a PR6-8 time-term static solution artifact."""
+    path = Path(npz_path)
+    if not path.exists():
+        raise ValueError(f'time_term_static_solution.npz does not exist: {path}')
+    if not path.is_file():
+        raise ValueError(f'time_term_static_solution.npz is not a file: {path}')
+
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            missing = sorted(_REQUIRED_SOLUTION_FIELDS.difference(data.files))
+            if missing:
+                raise ValueError(
+                    'time_term_static_solution.npz is missing required fields: '
+                    + ', '.join(missing)
+                )
+
+            schema_version = _require_scalar_int(
+                data['schema_version'],
+                name='schema_version',
+            )
+            artifact_kind = _require_scalar_str(
+                data['artifact_kind'],
+                name='artifact_kind',
+            )
+            order = _require_scalar_str(data['order'], name='order')
+            job_id = _require_optional_scalar_str(data['job_id'], name='job_id')
+            input_file_id = _require_optional_scalar_str(
+                data['input_file_id'],
+                name='input_file_id',
+            )
+            n_traces = _require_scalar_int(data['n_traces'], name='n_traces')
+            n_samples = _require_scalar_int(data['n_samples'], name='n_samples')
+            dt = _require_scalar_float(data['dt'], name='dt')
+            key1_byte = _require_scalar_int(data['key1_byte'], name='key1_byte')
+            key2_byte = _require_scalar_int(data['key2_byte'], name='key2_byte')
+
+            expected_trace_shape = (n_traces,)
+            applied_weathering = _require_1d_float64(
+                data['applied_weathering_shift_s_sorted'],
+                name='applied_weathering_shift_s_sorted',
+                expected_shape=expected_trace_shape,
+            )
+            final_shift = _require_1d_float64(
+                data['final_trace_shift_s_sorted'],
+                name='final_trace_shift_s_sorted',
+                expected_shape=expected_trace_shape,
+            )
+            datum_shift = _require_1d_float64(
+                data['datum_trace_shift_s_sorted'],
+                name='datum_trace_shift_s_sorted',
+                expected_shape=expected_trace_shape,
+            )
+            residual_shift = _require_1d_float64(
+                data['residual_applied_shift_s_sorted'],
+                name='residual_applied_shift_s_sorted',
+                expected_shape=expected_trace_shape,
+            )
+            final_used = _require_1d_bool(
+                data['final_used_trace_mask_sorted'],
+                name='final_used_trace_mask_sorted',
+                expected_shape=expected_trace_shape,
+            )
+            rejected = _require_1d_bool(
+                data['rejected_trace_mask_sorted'],
+                name='rejected_trace_mask_sorted',
+                expected_shape=expected_trace_shape,
+            )
+            rejected_iteration = _require_1d_int64(
+                data['rejected_iteration_sorted'],
+                name='rejected_iteration_sorted',
+                expected_shape=expected_trace_shape,
+            )
+            estimated_delay = _require_1d_float64(
+                data['estimated_trace_time_term_delay_s_sorted'],
+                name='estimated_trace_time_term_delay_s_sorted',
+                expected_shape=expected_trace_shape,
+            )
+            node_time_term = _require_1d_float64(
+                data['node_time_term_s'],
+                name='node_time_term_s',
+            )
+            sign_convention = _require_scalar_str(
+                data['sign_convention'],
+                name='sign_convention',
+            )
+            delay_to_shift_convention = _require_scalar_str(
+                data['delay_to_shift_convention'],
+                name='delay_to_shift_convention',
+            )
+            final_shift_convention = _require_scalar_str(
+                data['final_shift_convention'],
+                name='final_shift_convention',
+            )
+    except ValueError as exc:
+        if 'Object arrays cannot be loaded' in str(exc):
+            raise ValueError(
+                'time_term_static_solution.npz contains object dtype arrays'
+            ) from exc
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(
+            f'time_term_static_solution.npz could not be loaded: {path}'
+        ) from exc
+
+    if schema_version != _SCHEMA_VERSION:
+        raise ValueError(
+            'time_term_static_solution.npz schema_version mismatch: '
+            f'expected {_SCHEMA_VERSION}, got {schema_version}'
+        )
+    if artifact_kind != _ARTIFACT_KIND:
+        raise ValueError(
+            'time_term_static_solution.npz artifact_kind mismatch: '
+            f'expected {_ARTIFACT_KIND!r}, got {artifact_kind!r}'
+        )
+    if order != _ORDER:
+        raise ValueError(
+            'time_term_static_solution.npz order mismatch: '
+            f'expected {_ORDER!r}, got {order!r}'
+        )
+    if expected_n_traces is not None and n_traces != int(expected_n_traces):
+        raise ValueError(
+            'time_term_static_solution.npz n_traces mismatch: '
+            f'expected {int(expected_n_traces)}, got {n_traces}'
+        )
+    if expected_dt is not None and not np.isclose(
+        dt,
+        float(expected_dt),
+        rtol=_DT_RTOL,
+        atol=_DT_ATOL,
+    ):
+        raise ValueError(
+            'time_term_static_solution.npz dt mismatch: '
+            f'expected {float(expected_dt)}, got {dt}'
+        )
+    if expected_key1_byte is not None and key1_byte != int(expected_key1_byte):
+        raise ValueError(
+            'time_term_static_solution.npz key1_byte mismatch: '
+            f'expected {int(expected_key1_byte)}, got {key1_byte}'
+        )
+    if expected_key2_byte is not None and key2_byte != int(expected_key2_byte):
+        raise ValueError(
+            'time_term_static_solution.npz key2_byte mismatch: '
+            f'expected {int(expected_key2_byte)}, got {key2_byte}'
+        )
+    if not np.allclose(
+        applied_weathering,
+        -estimated_delay,
+        rtol=_SHIFT_RTOL,
+        atol=_SHIFT_ATOL,
+    ):
+        raise ValueError(
+            'applied_weathering_shift_s_sorted must equal '
+            '-estimated_trace_time_term_delay_s_sorted'
+        )
+    expected_final = datum_shift + residual_shift + applied_weathering
+    if not np.allclose(
+        final_shift,
+        expected_final,
+        rtol=_SHIFT_RTOL,
+        atol=_SHIFT_ATOL,
+    ):
+        raise ValueError(
+            'final_trace_shift_s_sorted must equal datum + residual + '
+            'applied_weathering'
+        )
+
+    return LoadedTimeTermStaticSolution(
+        path=path,
+        schema_version=schema_version,
+        artifact_kind=artifact_kind,
+        order=order,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt=dt,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        job_id=job_id,
+        input_file_id=input_file_id,
+        applied_weathering_shift_s_sorted=applied_weathering,
+        final_trace_shift_s_sorted=final_shift,
+        datum_trace_shift_s_sorted=datum_shift,
+        residual_applied_shift_s_sorted=residual_shift,
+        final_used_trace_mask_sorted=final_used,
+        rejected_trace_mask_sorted=rejected,
+        rejected_iteration_sorted=rejected_iteration,
+        estimated_trace_time_term_delay_s_sorted=estimated_delay,
+        node_time_term_s=node_time_term,
+        sign_convention=sign_convention,
+        delay_to_shift_convention=delay_to_shift_convention,
+        final_shift_convention=final_shift_convention,
+    )
+
+
+def select_time_term_shift_for_apply_mode(
+    solution: LoadedTimeTermStaticSolution,
+    *,
+    mode: TimeTermTraceStoreApplyMode,
+) -> tuple[str, np.ndarray]:
+    if mode == 'weathering_only':
+        return (
+            'applied_weathering_shift_s_sorted',
+            solution.applied_weathering_shift_s_sorted,
+        )
+    if mode == 'final_from_raw':
+        return 'final_trace_shift_s_sorted', solution.final_trace_shift_s_sorted
+    raise ValueError(f'unsupported time-term apply mode: {mode}')
+
+
+def apply_time_term_static_correction_to_trace_store(
+    *,
+    source_file_id: str,
+    key1_byte: int,
+    key2_byte: int,
+    solution_npz_path: Path,
+    artifacts_dir: Path | None,
+    state: AppState,
+    options: TimeTermTraceStoreApplyOptions | None = None,
+    cancel_check: Callable[[], bool] | None = None,
+) -> TimeTermTraceStoreApplyResult:
+    """Create and register a time-term-corrected TraceStore."""
+    resolved_options = options or TimeTermTraceStoreApplyOptions()
+    _validate_apply_options(resolved_options)
+    _raise_if_cancelled(cancel_check)
+
+    source_store_path = _resolve_source_store_path(
+        state=state,
+        source_file_id=source_file_id,
+    )
+    source_reader = get_reader(source_file_id, key1_byte, key2_byte, state=state)
+    source_meta = _load_and_validate_source_meta(
+        source_store_path,
+        reader=source_reader,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+    )
+    if not has_split_baseline_artifacts(
+        source_store_path,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        source_sha256=source_meta.source_sha256,
+    ):
+        raise ValueError(
+            'source TraceStore is incomplete: missing split raw-baseline artifacts'
+        )
+    lineage_warnings = _validate_source_lineage_for_weathering_only(source_meta.raw)
+
+    solution = load_time_term_static_solution(
+        Path(solution_npz_path),
+        expected_n_traces=source_meta.n_traces,
+        expected_dt=source_meta.dt,
+        expected_key1_byte=key1_byte,
+        expected_key2_byte=key2_byte,
+    )
+    if solution.n_samples is not None and solution.n_samples != source_meta.n_samples:
+        raise ValueError(
+            'time_term_static_solution.npz n_samples mismatch: '
+            f'expected {source_meta.n_samples}, got {solution.n_samples}'
+        )
+
+    applied_shift_field, trace_shift_s_sorted = select_time_term_shift_for_apply_mode(
+        solution,
+        mode=resolved_options.mode,
+    )
+    trace_shift_s_sorted = _validate_trace_shift_for_apply(
+        trace_shift_s_sorted,
+        field_name=applied_shift_field,
+        expected_n_traces=source_meta.n_traces,
+        max_abs_shift_ms=resolved_options.max_abs_shift_ms,
+    )
+    shift_stats_ms = _shift_stats_ms(trace_shift_s_sorted)
+    _raise_if_cancelled(cancel_check)
+
+    corrected_file_id = _resolve_corrected_file_id(resolved_options.corrected_file_id)
+    corrected_store_path = _corrected_store_path(
+        source_store_path=source_store_path,
+        corrected_file_id=corrected_file_id,
+        corrected_store_name=resolved_options.corrected_store_name,
+        job_id=solution.job_id,
+    )
+    corrected_file_json_path = (
+        Path(artifacts_dir) / _CORRECTED_FILE_NAME
+        if artifacts_dir is not None
+        else None
+    )
+    derived_metadata = _build_derived_metadata(
+        source_meta=source_meta.raw,
+        solution=solution,
+        solution_npz_path=Path(solution_npz_path),
+        applied_shift_field=applied_shift_field,
+        mode=resolved_options.mode,
+        lineage_warnings=lineage_warnings,
+    )
+
+    build_result: TimeShiftedTraceStoreResult | None = None
+    try:
+        _raise_if_cancelled(cancel_check)
+        build_result = build_time_shifted_trace_store(
+            source_store_path=source_store_path,
+            output_store_path=corrected_store_path,
+            trace_shift_s_sorted=trace_shift_s_sorted,
+            fill_value=resolved_options.fill_value,
+            output_dtype=resolved_options.output_dtype,
+            derived_metadata=derived_metadata,
+            from_file_id=source_file_id,
+            original_segy_path=source_meta.original_segy_path,
+            header_bytes_to_materialize=(key1_byte, key2_byte),
+            cancel_check=cancel_check,
+        )
+        _raise_if_cancelled(cancel_check)
+        registered_reader = register_trace_store(
+            state=state,
+            file_id=corrected_file_id,
+            store_dir=build_result.store_path,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
+            dt=build_result.dt,
+            update_registry=True,
+            touch_meta=True,
+        )
+        _verify_registered_trace_store(
+            state=state,
+            file_id=corrected_file_id,
+            store_path=build_result.store_path,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
+            reader=registered_reader,
+        )
+        _raise_if_cancelled(cancel_check)
+        if corrected_file_json_path is not None:
+            _write_json_atomic(
+                corrected_file_json_path,
+                _build_corrected_file_payload(
+                    corrected_file_id=corrected_file_id,
+                    build_result=build_result,
+                    source_file_id=source_file_id,
+                    source_store_path=source_store_path,
+                    solution=solution,
+                    solution_npz_path=Path(solution_npz_path),
+                    mode=resolved_options.mode,
+                    applied_shift_field=applied_shift_field,
+                    shift_stats_ms=shift_stats_ms,
+                ),
+            )
+    except Exception:
+        _cleanup_registration(
+            state,
+            file_id=corrected_file_id,
+            key1_byte=key1_byte,
+            key2_byte=key2_byte,
+        )
+        _cleanup_store(corrected_store_path)
+        if corrected_file_json_path is not None:
+            _cleanup_corrected_file_json(corrected_file_json_path)
+        raise
+
+    return TimeTermTraceStoreApplyResult(
+        file_id=corrected_file_id,
+        store_path=build_result.store_path,
+        store_name=build_result.store_path.name,
+        source_file_id=source_file_id,
+        source_store_path=source_store_path,
+        solution_npz_path=Path(solution_npz_path),
+        job_id=solution.job_id,
+        mode=resolved_options.mode,
+        applied_shift_field=applied_shift_field,
+        key1_byte=key1_byte,
+        key2_byte=key2_byte,
+        dt=build_result.dt,
+        n_traces=build_result.n_traces,
+        n_samples=build_result.n_samples,
+        shift_min_ms=shift_stats_ms['min'],
+        shift_max_ms=shift_stats_ms['max'],
+        shift_mean_ms=shift_stats_ms['mean'],
+        shift_max_abs_ms=shift_stats_ms['max_abs'],
+        corrected_file_json_path=corrected_file_json_path,
+    )
+
+
+def _validate_apply_options(options: TimeTermTraceStoreApplyOptions) -> None:
+    if options.mode == 'final_from_raw':
+        raise ValueError('final_from_raw mode is not implemented yet')
+    if options.mode != 'weathering_only':
+        raise ValueError(f'unsupported time-term apply mode: {options.mode}')
+    if options.interpolation != 'linear':
+        raise ValueError('interpolation must be "linear"')
+    if options.output_dtype != 'float32':
+        raise ValueError('output_dtype must be "float32"')
+    if options.register_corrected_file is not True:
+        raise ValueError('register_corrected_file must be true')
+    _coerce_nonnegative_finite_float(
+        options.max_abs_shift_ms,
+        name='max_abs_shift_ms',
+    )
+
+
+def _raise_if_cancelled(cancel_check: Callable[[], bool] | None) -> None:
+    if cancel_check is not None and cancel_check():
+        raise RuntimeError('time-term static TraceStore apply cancelled')
+
+
+def _resolve_source_store_path(*, state: AppState, source_file_id: str) -> Path:
+    if not isinstance(source_file_id, str) or not source_file_id:
+        raise ValueError('source_file_id must be a non-empty string')
+    try:
+        source_store_path = Path(state.file_registry.get_store_path(source_file_id))
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(
+            f'source_file_id is not registered with a TraceStore: {source_file_id}'
+        ) from exc
+    if not source_store_path.exists():
+        raise ValueError(f'source TraceStore path does not exist: {source_store_path}')
+    if not source_store_path.is_dir():
+        raise ValueError(f'source TraceStore path is not a directory: {source_store_path}')
+    return source_store_path
+
+
+def _load_and_validate_source_meta(
+    source_store_path: Path,
+    *,
+    reader: object,
+    key1_byte: int,
+    key2_byte: int,
+) -> _SourceTraceStoreMeta:
+    meta_path = source_store_path / 'meta.json'
+    if not meta_path.exists():
+        raise ValueError(f'source TraceStore meta.json is missing: {meta_path}')
+    meta = _read_json_object(meta_path, label='source TraceStore meta.json')
+
+    n_traces = _coerce_positive_int(meta.get('n_traces'), name='meta.n_traces')
+    n_samples = _coerce_positive_int(meta.get('n_samples'), name='meta.n_samples')
+    dt = _coerce_positive_finite_float(meta.get('dt'), name='meta.dt')
+
+    key_bytes = meta.get('key_bytes')
+    if not isinstance(key_bytes, dict):
+        raise ValueError('source TraceStore meta.key_bytes must be an object')
+    meta_key1 = _coerce_header_byte(key_bytes.get('key1'), name='meta.key_bytes.key1')
+    meta_key2 = _coerce_header_byte(key_bytes.get('key2'), name='meta.key_bytes.key2')
+    if meta_key1 != int(key1_byte):
+        raise ValueError(
+            f'source TraceStore key1_byte mismatch: expected {key1_byte}, got {meta_key1}'
+        )
+    if meta_key2 != int(key2_byte):
+        raise ValueError(
+            f'source TraceStore key2_byte mismatch: expected {key2_byte}, got {meta_key2}'
+        )
+
+    traces = getattr(reader, 'traces', None)
+    if not isinstance(traces, np.ndarray) or traces.ndim != 2:
+        raise ValueError('source TraceStore reader.traces must be a 2D array')
+    reader_n_traces = int(traces.shape[0])
+    reader_n_samples = int(traces.shape[1])
+    if reader_n_traces != n_traces:
+        raise ValueError(
+            'source TraceStore n_traces mismatch: '
+            f'meta={n_traces}, traces={reader_n_traces}'
+        )
+    if reader_n_samples != n_samples:
+        raise ValueError(
+            'source TraceStore n_samples mismatch: '
+            f'meta={n_samples}, traces={reader_n_samples}'
+        )
+
+    original_segy_path = meta.get('original_segy_path')
+    if not isinstance(original_segy_path, str) or not original_segy_path:
+        raise ValueError('source TraceStore original_segy_path must be a non-empty string')
+    source_sha256 = meta.get('source_sha256')
+    if source_sha256 is not None and not isinstance(source_sha256, str):
+        raise ValueError('source TraceStore source_sha256 must be a string or null')
+
+    return _SourceTraceStoreMeta(
+        raw=meta,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt=dt,
+        key1_byte=meta_key1,
+        key2_byte=meta_key2,
+        original_segy_path=original_segy_path,
+        source_sha256=source_sha256,
+    )
+
+
+def _validate_source_lineage_for_weathering_only(
+    source_meta: dict[str, object],
+) -> list[str]:
+    derived = source_meta.get('derived')
+    if not isinstance(derived, dict):
+        raise ValueError(
+            'weathering_only mode requires a datum/residual corrected TraceStore; '
+            'use final_from_raw for raw TraceStore'
+        )
+    components = _component_dicts(derived)
+    if _components_include(components, 'time_term_static_correction'):
+        raise ValueError('source TraceStore already has time_term_static_correction')
+    if _components_include(components, 'weathering_static_correction'):
+        raise ValueError('source TraceStore already has weathering_static_correction')
+    if source_meta.get('source_sha256') is not None:
+        raise ValueError(
+            'weathering_only mode requires a datum/residual corrected TraceStore; '
+            'use final_from_raw for raw TraceStore'
+        )
+    if _components_include(components, 'residual_static_correction'):
+        return []
+    if _components_include(components, 'datum_static_correction'):
+        return [
+            'weathering_only source has datum_static_correction but no '
+            'residual_static_correction'
+        ]
+    raise ValueError(
+        'weathering_only mode requires a datum/residual corrected TraceStore; '
+        'use final_from_raw for raw TraceStore'
+    )
+
+
+def _build_derived_metadata(
+    *,
+    source_meta: dict[str, object],
+    solution: LoadedTimeTermStaticSolution,
+    solution_npz_path: Path,
+    applied_shift_field: str,
+    mode: TimeTermTraceStoreApplyMode,
+    lineage_warnings: list[str],
+) -> dict[str, object]:
+    derived = source_meta.get('derived')
+    components = _component_dicts(derived if isinstance(derived, dict) else {})
+    components.append(
+        {
+            'name': 'time_term_static_correction',
+            'job_id': solution.job_id,
+            'solution_artifact': solution_npz_path.name,
+            'shift_field': applied_shift_field,
+            'value_kind': 'applied_event_time_shift_s',
+            'apply_mode': mode,
+            'sign_convention': solution.sign_convention,
+            'delay_to_shift_convention': solution.delay_to_shift_convention,
+            'final_shift_convention': solution.final_shift_convention,
+        }
+    )
+    metadata: dict[str, object] = {
+        'applied_to': (
+            'datum_residual_corrected_trace_store'
+            if any(
+                component.get('name') == 'residual_static_correction'
+                for component in components
+            )
+            else 'datum_corrected_trace_store'
+        ),
+        'components': components,
+    }
+    if lineage_warnings:
+        metadata['warnings'] = list(lineage_warnings)
+    return metadata
+
+
+def _validate_trace_shift_for_apply(
+    trace_shift_s_sorted: np.ndarray,
+    *,
+    field_name: str,
+    expected_n_traces: int,
+    max_abs_shift_ms: float,
+) -> np.ndarray:
+    shifts = _require_1d_float64(
+        trace_shift_s_sorted,
+        name=field_name,
+        expected_shape=(int(expected_n_traces),),
+    )
+    max_abs_ms = _coerce_nonnegative_finite_float(
+        max_abs_shift_ms,
+        name='max_abs_shift_ms',
+    )
+    actual_max_abs_ms = float(np.max(np.abs(shifts)) * 1000.0)
+    if actual_max_abs_ms > max_abs_ms:
+        raise ValueError(
+            f'{field_name} exceeds max_abs_shift_ms: '
+            f'{actual_max_abs_ms:.6g} > {max_abs_ms:.6g}'
+        )
+    return shifts
+
+
+def _resolve_corrected_file_id(corrected_file_id: str | None) -> str:
+    if corrected_file_id is None:
+        return str(uuid4())
+    if not isinstance(corrected_file_id, str) or not corrected_file_id:
+        raise ValueError('corrected_file_id must be a non-empty string')
+    return corrected_file_id
+
+
+def _corrected_store_path(
+    *,
+    source_store_path: Path,
+    corrected_file_id: str,
+    corrected_store_name: str | None,
+    job_id: str | None,
+) -> Path:
+    if corrected_store_name is not None:
+        store_name = _validate_corrected_store_name(corrected_store_name)
+    else:
+        source_name = _safe_store_name_component(source_store_path.name)
+        suffix_source = job_id if job_id else corrected_file_id
+        suffix = _safe_store_name_component(str(suffix_source)[:8])
+        store_name = f'{source_name}.statics.time_term.{suffix}'
+    output_path = source_store_path.parent / store_name
+    if output_path.exists() or output_path.is_symlink():
+        raise ValueError(f'corrected output path already exists: {output_path}')
+    return output_path
+
+
+def _validate_corrected_store_name(value: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError('corrected_store_name must be a non-empty string')
+    if Path(value).name != value:
+        raise ValueError('corrected_store_name must not contain path separators')
+    safe = _safe_store_name_component(value)
+    if safe != value:
+        raise ValueError('corrected_store_name contains unsupported characters')
+    return safe
+
+
+def _safe_store_name_component(value: str) -> str:
+    safe = _SAFE_STORE_NAME_RE.sub('_', str(value))
+    if safe in {'', '.', '..'}:
+        raise ValueError('TraceStore name cannot be made filesystem-safe')
+    return safe
+
+
+def _verify_registered_trace_store(
+    *,
+    state: AppState,
+    file_id: str,
+    store_path: Path,
+    key1_byte: int,
+    key2_byte: int,
+    reader: object,
+) -> None:
+    registered_path = Path(state.file_registry.get_store_path(file_id))
+    if registered_path.resolve() != store_path.resolve():
+        raise RuntimeError('registered corrected TraceStore path mismatch')
+    cache_key = trace_store_cache_key(file_id, key1_byte, key2_byte)
+    with state.lock:
+        if cache_key not in state.cached_readers:
+            raise RuntimeError('registered corrected TraceStore reader is missing')
+    key1_values = np.asarray(reader.get_key1_values())
+    if key1_values.size == 0:
+        raise RuntimeError('registered corrected TraceStore has no key1 values')
+    reader.get_section(int(key1_values[0]))
+
+
+def _build_corrected_file_payload(
+    *,
+    corrected_file_id: str,
+    build_result: TimeShiftedTraceStoreResult,
+    source_file_id: str,
+    source_store_path: Path,
+    solution: LoadedTimeTermStaticSolution,
+    solution_npz_path: Path,
+    mode: TimeTermTraceStoreApplyMode,
+    applied_shift_field: str,
+    shift_stats_ms: dict[str, float],
+) -> dict[str, object]:
+    return {
+        'schema_version': 1,
+        'artifact_kind': 'corrected_file',
+        'file_id': corrected_file_id,
+        'store_path': str(build_result.store_path),
+        'store_name': build_result.store_path.name,
+        'derived_from_file_id': source_file_id,
+        'derived_from_store_path': str(source_store_path),
+        'derived_by': 'time_term_static_correction',
+        'job_id': solution.job_id,
+        'solution_artifact': solution_npz_path.name,
+        'apply_mode': mode,
+        'applied_shift_field': applied_shift_field,
+        'key1_byte': int(build_result.key1_byte),
+        'key2_byte': int(build_result.key2_byte),
+        'dt': float(build_result.dt),
+        'n_traces': int(build_result.n_traces),
+        'n_samples': int(build_result.n_samples),
+        'shift_ms': {
+            'min': shift_stats_ms['min'],
+            'max': shift_stats_ms['max'],
+            'mean': shift_stats_ms['mean'],
+            'max_abs': shift_stats_ms['max_abs'],
+        },
+        'sign_convention': _BUILDER_SIGN_CONVENTION,
+        'delay_to_shift_convention': solution.delay_to_shift_convention,
+        'final_shift_convention': solution.final_shift_convention,
+    }
+
+
+def _shift_stats_ms(shift_s: np.ndarray) -> dict[str, float]:
+    shift_ms = np.asarray(shift_s, dtype=np.float64) * 1000.0
+    return {
+        'min': float(np.min(shift_ms)),
+        'max': float(np.max(shift_ms)),
+        'mean': float(np.mean(shift_ms)),
+        'max_abs': float(np.max(np.abs(shift_ms))),
+    }
+
+
+def _write_json_atomic(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.tmp')
+    try:
+        with tmp_path.open('w', encoding='utf-8') as handle:
+            json.dump(
+                payload,
+                handle,
+                allow_nan=False,
+                ensure_ascii=True,
+                sort_keys=True,
+            )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _cleanup_registration(
+    state: AppState,
+    *,
+    file_id: str,
+    key1_byte: int,
+    key2_byte: int,
+) -> None:
+    lock = getattr(state, 'lock', None)
+    context = lock if lock is not None else nullcontext()
+    with context:
+        state.file_registry.pop(file_id, None)
+        state.cached_readers.pop(trace_store_cache_key(file_id, key1_byte, key2_byte), None)
+
+
+def _cleanup_store(output_path: Path) -> None:
+    for tmp_path in output_path.parent.glob(f'{output_path.name}.tmp-*'):
+        if tmp_path.is_dir():
+            shutil.rmtree(tmp_path, ignore_errors=True)
+    if output_path.exists():
+        shutil.rmtree(output_path, ignore_errors=True)
+
+
+def _cleanup_corrected_file_json(path: Path) -> None:
+    path.with_name(f'{path.name}.tmp').unlink(missing_ok=True)
+    path.unlink(missing_ok=True)
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, object]:
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f'{label} is invalid: {path}') from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f'{label} must be an object')
+    return payload
+
+
+def _component_dicts(derived: dict[str, object]) -> list[dict[str, object]]:
+    components = derived.get('components')
+    if components is None:
+        return []
+    if not isinstance(components, list):
+        raise ValueError('source TraceStore derived.components must be a list')
+    output: list[dict[str, object]] = []
+    for index, component in enumerate(components):
+        if not isinstance(component, dict):
+            raise ValueError(
+                f'source TraceStore derived.components[{index}] must be an object'
+            )
+        output.append(dict(component))
+    return output
+
+
+def _components_include(components: list[dict[str, object]], name: str) -> bool:
+    return any(component.get('name') == name for component in components)
+
+
+def _require_1d_float64(
+    value: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    arr = np.asarray(value)
+    _reject_object_dtype(arr, name=name)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be 1-dimensional')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(
+            f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        )
+    if not np.issubdtype(arr.dtype, np.floating):
+        raise ValueError(f'{name} must be a float array')
+    out = np.asarray(arr, dtype=np.float64)
+    if not np.all(np.isfinite(out)):
+        raise ValueError(f'{name} must contain only finite values')
+    return np.ascontiguousarray(out, dtype=np.float64)
+
+
+def _require_1d_bool(
+    value: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(value)
+    _reject_object_dtype(arr, name=name)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be 1-dimensional')
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        )
+    if not np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must have bool dtype')
+    return np.ascontiguousarray(arr, dtype=bool)
+
+
+def _require_1d_int64(
+    value: np.ndarray,
+    *,
+    name: str,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    arr = np.asarray(value)
+    _reject_object_dtype(arr, name=name)
+    if arr.ndim != 1:
+        raise ValueError(f'{name} must be 1-dimensional')
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f'{name} shape mismatch: expected {expected_shape}, got {arr.shape}'
+        )
+    if np.issubdtype(arr.dtype, np.bool_) or not np.issubdtype(
+        arr.dtype,
+        np.integer,
+    ):
+        raise ValueError(f'{name} must have integer dtype')
+    return np.ascontiguousarray(arr, dtype=np.int64)
+
+
+def _require_scalar_int(value: np.ndarray, *, name: str) -> int:
+    arr = np.asarray(value)
+    _reject_object_dtype(arr, name=name)
+    if arr.shape != ():
+        raise ValueError(f'{name} must be a scalar')
+    if np.issubdtype(arr.dtype, np.bool_) or not np.issubdtype(
+        arr.dtype,
+        np.integer,
+    ):
+        raise ValueError(f'{name} must be an integer scalar')
+    return _coerce_positive_int(arr.item(), name=name)
+
+
+def _require_scalar_float(value: np.ndarray, *, name: str) -> float:
+    arr = np.asarray(value)
+    _reject_object_dtype(arr, name=name)
+    if arr.shape != ():
+        raise ValueError(f'{name} must be a scalar')
+    if np.issubdtype(arr.dtype, np.bool_) or not np.issubdtype(
+        arr.dtype,
+        np.number,
+    ):
+        raise ValueError(f'{name} must be a numeric scalar')
+    return _coerce_positive_finite_float(arr.item(), name=name)
+
+
+def _require_scalar_str(value: np.ndarray, *, name: str) -> str:
+    text = _require_optional_scalar_str(value, name=name)
+    if text is None:
+        raise ValueError(f'{name} must be a non-empty string scalar')
+    return text
+
+
+def _require_optional_scalar_str(value: np.ndarray, *, name: str) -> str | None:
+    arr = np.asarray(value)
+    _reject_object_dtype(arr, name=name)
+    if arr.shape != ():
+        raise ValueError(f'{name} must be a scalar')
+    if arr.dtype.kind not in {'U', 'S'}:
+        raise ValueError(f'{name} must be a string scalar')
+    item = arr.item()
+    text = item.decode('utf-8') if isinstance(item, bytes) else str(item)
+    return text if text else None
+
+
+def _reject_object_dtype(arr: np.ndarray, *, name: str) -> None:
+    if arr.dtype == object:
+        raise ValueError(f'{name} must not have object dtype')
+
+
+def _coerce_positive_int(value: Any, *, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be a positive integer')
+    if not isinstance(value, int | np.integer):
+        raise ValueError(f'{name} must be a positive integer')
+    out = int(value)
+    if out <= 0:
+        raise ValueError(f'{name} must be a positive integer')
+    return out
+
+
+def _coerce_header_byte(value: Any, *, name: str) -> int:
+    out = _coerce_positive_int(value, name=name)
+    if out > 240:
+        raise ValueError(f'{name} must be between 1 and 240')
+    return out
+
+
+def _coerce_positive_finite_float(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be finite and greater than 0')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite and greater than 0') from exc
+    if not np.isfinite(out) or out <= 0.0:
+        raise ValueError(f'{name} must be finite and greater than 0')
+    return out
+
+
+def _coerce_nonnegative_finite_float(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f'{name} must be finite and non-negative')
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be finite and non-negative') from exc
+    if not np.isfinite(out) or out < 0.0:
+        raise ValueError(f'{name} must be finite and non-negative')
+    return out
+
+
+__all__ = [
+    'LoadedTimeTermStaticSolution',
+    'TimeTermTraceStoreApplyMode',
+    'TimeTermTraceStoreApplyOptions',
+    'TimeTermTraceStoreApplyResult',
+    'apply_time_term_static_correction_to_trace_store',
+    'load_time_term_static_solution',
+    'select_time_term_shift_for_apply_mode',
+]

--- a/app/tests/test_time_term_static_apply_trace_store.py
+++ b/app/tests/test_time_term_static_apply_trace_store.py
@@ -1,0 +1,618 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import app.services.time_term_static_apply_trace_store as svc
+from app.core.state import AppState, create_app_state
+from app.services.time_term_apply_shift import (
+    DELAY_TO_SHIFT_CONVENTION,
+    FINAL_SHIFT_CONVENTION,
+)
+from app.services.time_term_static_apply_trace_store import (
+    TimeTermTraceStoreApplyOptions,
+    apply_time_term_static_correction_to_trace_store,
+    load_time_term_static_solution,
+    select_time_term_shift_for_apply_mode,
+)
+from app.services.trace_store_baselines import write_trace_store_raw_baseline_artifacts
+from app.services.trace_store_registration import trace_store_cache_key
+
+KEY1 = 189
+KEY2 = 193
+DT = 0.004
+SOURCE_FILE_ID = 'datum-residual-corrected-file-id'
+CORRECTED_FILE_ID = 'time-term-corrected-file-id'
+JOB_ID = 'cccc3333-time-term-job'
+SIGN_CONVENTION = (
+    'estimated_trace_time_term_delay_s = source_node_time_term_s + '
+    'receiver_node_time_term_s; applied_weathering_shift_s = '
+    '-estimated_trace_time_term_delay_s; corrected(t)=raw(t-shift_s)'
+)
+
+
+def _datum_component() -> dict[str, object]:
+    return {
+        'name': 'datum_static_correction',
+        'job_id': 'aaaa1111-datum-job',
+        'solution_artifact': 'datum_static_solution.npz',
+        'shift_field': 'trace_shift_s_sorted',
+        'value_kind': 'applied_event_time_shift_s',
+    }
+
+
+def _residual_component() -> dict[str, object]:
+    return {
+        'name': 'residual_static_correction',
+        'job_id': 'bbbb2222-residual-job',
+        'solution_artifact': 'residual_static_solution.npz',
+        'shift_field': 'applied_residual_shift_s_sorted',
+        'value_kind': 'applied_event_time_shift_s',
+    }
+
+
+def _default_derived() -> dict[str, object]:
+    return {
+        'kind': 'time_shifted_trace_store',
+        'from_file_id': 'raw-file-id',
+        'components': [_datum_component(), _residual_component()],
+    }
+
+
+def _write_source_store(
+    store: Path,
+    *,
+    traces: np.ndarray | None = None,
+    dt: float = DT,
+    derived: dict[str, object] | None = None,
+    include_derived: bool = True,
+    original_segy_path: str = '/data/line001.sgy',
+    source_sha256: str | None = None,
+    write_baseline: bool = True,
+) -> np.ndarray:
+    store.mkdir(parents=True, exist_ok=True)
+    if traces is None:
+        traces = np.zeros((3, 16), dtype=np.float32)
+        traces[:, 8] = 1.0
+    traces = np.asarray(traces, dtype=np.float32)
+    n_traces, n_samples = traces.shape
+    np.save(store / 'traces.npy', traces)
+    key1_values = np.asarray([100], dtype=np.int64)
+    key1_offsets = np.asarray([0], dtype=np.int64)
+    key1_counts = np.asarray([n_traces], dtype=np.int64)
+    np.savez(
+        store / 'index.npz',
+        key1_values=key1_values,
+        key1_offsets=key1_offsets,
+        key1_counts=key1_counts,
+        sorted_to_original=np.arange(n_traces, dtype=np.int64),
+    )
+    np.save(store / f'headers_byte_{KEY1}.npy', np.full(n_traces, 100, dtype=np.int32))
+    np.save(store / f'headers_byte_{KEY2}.npy', np.arange(n_traces, dtype=np.int32))
+
+    meta: dict[str, object] = {
+        'schema_version': 1,
+        'dtype': 'float32',
+        'n_traces': int(n_traces),
+        'n_samples': int(n_samples),
+        'key_bytes': {'key1': KEY1, 'key2': KEY2},
+        'sorted_by': ['key1', 'key2'],
+        'dt': float(dt),
+        'original_segy_path': original_segy_path,
+        'source_sha256': source_sha256,
+    }
+    if include_derived:
+        meta['derived'] = derived if derived is not None else _default_derived()
+    (store / 'meta.json').write_text(json.dumps(meta), encoding='utf-8')
+
+    if write_baseline:
+        trace_sum = traces.sum(axis=1, dtype=np.float64)
+        trace_sumsq = np.einsum('ij,ij->i', traces, traces, dtype=np.float64)
+        write_trace_store_raw_baseline_artifacts(
+            store_path=store,
+            key1_byte=KEY1,
+            key2_byte=KEY2,
+            dtype_base='float32',
+            dt=dt,
+            key1_values=key1_values,
+            key1_offsets=key1_offsets,
+            key1_counts=key1_counts,
+            trace_sum=trace_sum,
+            trace_sumsq=trace_sumsq,
+            n_samples=n_samples,
+            source_sha256=source_sha256,
+        )
+    return traces
+
+
+def _write_solution(
+    path: Path,
+    *,
+    n_traces: int = 3,
+    n_samples: int = 16,
+    dt: float = DT,
+    key1_byte: int = KEY1,
+    key2_byte: int = KEY2,
+    applied_weathering: np.ndarray | None = None,
+    estimated_delay: np.ndarray | None = None,
+    datum_shift: np.ndarray | None = None,
+    residual_shift: np.ndarray | None = None,
+    final_shift: np.ndarray | None = None,
+    artifact_kind: str = 'time_term_static_solution',
+    order: str = 'trace_store_sorted',
+    overrides: dict[str, Any] | None = None,
+    drop_fields: tuple[str, ...] = (),
+) -> Path:
+    if applied_weathering is None:
+        applied_weathering = np.zeros(n_traces, dtype=np.float64)
+    applied_weathering = np.asarray(applied_weathering, dtype=np.float64)
+    if estimated_delay is None:
+        estimated_delay = -applied_weathering
+    if datum_shift is None:
+        datum_shift = np.zeros(n_traces, dtype=np.float64)
+    if residual_shift is None:
+        residual_shift = np.zeros(n_traces, dtype=np.float64)
+    if final_shift is None:
+        final_shift = (
+            np.asarray(datum_shift, dtype=np.float64)
+            + np.asarray(residual_shift, dtype=np.float64)
+            + applied_weathering
+        )
+    payload: dict[str, Any] = {
+        'schema_version': np.asarray(1, dtype=np.int64),
+        'artifact_kind': np.asarray(artifact_kind, dtype=np.str_),
+        'order': np.asarray(order, dtype=np.str_),
+        'job_id': np.asarray(JOB_ID, dtype=np.str_),
+        'input_file_id': np.asarray(SOURCE_FILE_ID, dtype=np.str_),
+        'n_traces': np.asarray(n_traces, dtype=np.int64),
+        'n_samples': np.asarray(n_samples, dtype=np.int64),
+        'dt': np.asarray(dt, dtype=np.float64),
+        'key1_byte': np.asarray(key1_byte, dtype=np.int64),
+        'key2_byte': np.asarray(key2_byte, dtype=np.int64),
+        'applied_weathering_shift_s_sorted': applied_weathering,
+        'final_trace_shift_s_sorted': np.asarray(final_shift, dtype=np.float64),
+        'datum_trace_shift_s_sorted': np.asarray(datum_shift, dtype=np.float64),
+        'residual_applied_shift_s_sorted': np.asarray(
+            residual_shift,
+            dtype=np.float64,
+        ),
+        'final_used_trace_mask_sorted': np.ones(n_traces, dtype=bool),
+        'rejected_trace_mask_sorted': np.zeros(n_traces, dtype=bool),
+        'rejected_iteration_sorted': np.full(n_traces, -1, dtype=np.int64),
+        'estimated_trace_time_term_delay_s_sorted': np.asarray(
+            estimated_delay,
+            dtype=np.float64,
+        ),
+        'node_time_term_s': np.zeros(2, dtype=np.float64),
+        'sign_convention': np.asarray(SIGN_CONVENTION, dtype=np.str_),
+        'delay_to_shift_convention': np.asarray(
+            DELAY_TO_SHIFT_CONVENTION,
+            dtype=np.str_,
+        ),
+        'final_shift_convention': np.asarray(FINAL_SHIFT_CONVENTION, dtype=np.str_),
+    }
+    if overrides:
+        payload.update(overrides)
+    for field in drop_fields:
+        payload.pop(field, None)
+    np.savez(path, **payload)
+    return path
+
+
+def _state_with_store(
+    tmp_path: Path,
+    **store_kwargs: Any,
+) -> tuple[AppState, Path]:
+    state = create_app_state()
+    store = tmp_path / 'line001.sgy.statics.residual.bbbb2222'
+    _write_source_store(store, **store_kwargs)
+    state.file_registry.update(SOURCE_FILE_ID, store_path=str(store), dt=DT)
+    return state, store
+
+
+def _apply(
+    tmp_path: Path,
+    state: AppState,
+    solution_path: Path,
+    *,
+    options: TimeTermTraceStoreApplyOptions | None = None,
+) -> svc.TimeTermTraceStoreApplyResult:
+    if options is None:
+        options = TimeTermTraceStoreApplyOptions(
+            corrected_file_id=CORRECTED_FILE_ID,
+        )
+    return apply_time_term_static_correction_to_trace_store(
+        source_file_id=SOURCE_FILE_ID,
+        key1_byte=KEY1,
+        key2_byte=KEY2,
+        solution_npz_path=solution_path,
+        artifacts_dir=tmp_path / 'job',
+        state=state,
+        options=options,
+    )
+
+
+def test_load_time_term_static_solution_reads_required_fields(tmp_path: Path) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        applied_weathering=np.asarray([-0.004, 0.0, 0.004], dtype=np.float64),
+    )
+
+    solution = load_time_term_static_solution(
+        solution_path,
+        expected_n_traces=3,
+        expected_dt=DT,
+        expected_key1_byte=KEY1,
+        expected_key2_byte=KEY2,
+    )
+
+    assert solution.artifact_kind == 'time_term_static_solution'
+    assert solution.order == 'trace_store_sorted'
+    assert solution.job_id == JOB_ID
+    np.testing.assert_allclose(
+        solution.applied_weathering_shift_s_sorted,
+        np.asarray([-0.004, 0.0, 0.004], dtype=np.float64),
+    )
+
+
+def test_load_time_term_static_solution_rejects_wrong_artifact_kind(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        artifact_kind='other',
+    )
+
+    with pytest.raises(ValueError, match='artifact_kind'):
+        load_time_term_static_solution(solution_path)
+
+
+def test_load_time_term_static_solution_rejects_order_not_sorted(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        order='input_order',
+    )
+
+    with pytest.raises(ValueError, match='order'):
+        load_time_term_static_solution(solution_path)
+
+
+def test_load_time_term_static_solution_rejects_shift_shape_mismatch(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        n_traces=3,
+        overrides={
+            'applied_weathering_shift_s_sorted': np.zeros(2, dtype=np.float64),
+        },
+    )
+
+    with pytest.raises(ValueError, match='shape mismatch'):
+        load_time_term_static_solution(solution_path)
+
+
+def test_load_time_term_static_solution_rejects_delay_to_shift_sign_mismatch(
+    tmp_path: Path,
+) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        applied_weathering=np.asarray([0.001, 0.0, 0.0], dtype=np.float64),
+        estimated_delay=np.asarray([0.001, 0.0, 0.0], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match='must equal'):
+        load_time_term_static_solution(solution_path)
+
+
+def test_load_time_term_static_solution_rejects_object_dtype(tmp_path: Path) -> None:
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        overrides={'artifact_kind': np.asarray({'bad': 'object'}, dtype=object)},
+    )
+
+    with pytest.raises(ValueError, match='object dtype'):
+        load_time_term_static_solution(solution_path)
+
+
+def test_time_term_apply_selects_weathering_shift_for_weathering_only_mode(
+    tmp_path: Path,
+) -> None:
+    solution = load_time_term_static_solution(
+        _write_solution(
+            tmp_path / 'time_term_static_solution.npz',
+            applied_weathering=np.asarray([-0.004, 0.0, 0.004], dtype=np.float64),
+            residual_shift=np.asarray([0.104, 0.2, 0.296], dtype=np.float64),
+            final_shift=np.asarray([0.1, 0.2, 0.3], dtype=np.float64),
+        )
+    )
+
+    field, shift = select_time_term_shift_for_apply_mode(
+        solution,
+        mode='weathering_only',
+    )
+
+    assert field == 'applied_weathering_shift_s_sorted'
+    np.testing.assert_allclose(shift, [-0.004, 0.0, 0.004])
+
+
+def test_time_term_apply_builds_and_registers_corrected_trace_store(
+    tmp_path: Path,
+) -> None:
+    state, store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        applied_weathering=np.asarray([-0.004, 0.0, 0.004], dtype=np.float64),
+    )
+
+    result = _apply(tmp_path, state, solution_path)
+
+    corrected = np.load(result.store_path / 'traces.npy')
+    assert [int(np.argmax(row)) for row in corrected] == [7, 8, 9]
+    assert result.file_id == CORRECTED_FILE_ID
+    assert result.store_name == 'line001.sgy.statics.residual.bbbb2222.statics.time_term.cccc3333'
+    assert result.source_store_path == store
+    assert result.applied_shift_field == 'applied_weathering_shift_s_sorted'
+    assert result.shift_min_ms == pytest.approx(-4.0)
+    assert result.shift_max_ms == pytest.approx(4.0)
+    assert state.file_registry.get_store_path(CORRECTED_FILE_ID) == str(
+        result.store_path
+    )
+    with state.lock:
+        cache_key = trace_store_cache_key(CORRECTED_FILE_ID, KEY1, KEY2)
+        assert cache_key in state.cached_readers
+        reader = state.cached_readers[cache_key]
+    assert reader.get_section(100).arr.shape == (3, 16)
+
+
+def test_time_term_apply_writes_manifest_and_appends_metadata(
+    tmp_path: Path,
+) -> None:
+    state, _store = _state_with_store(tmp_path, original_segy_path='/keep/source.sgy')
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        applied_weathering=np.asarray([-0.004, 0.0, 0.004], dtype=np.float64),
+    )
+
+    result = _apply(tmp_path, state, solution_path)
+
+    assert result.corrected_file_json_path is not None
+    payload = json.loads(result.corrected_file_json_path.read_text(encoding='utf-8'))
+    json.dumps(payload, allow_nan=False)
+    assert payload['schema_version'] == 1
+    assert payload['artifact_kind'] == 'corrected_file'
+    assert payload['file_id'] == CORRECTED_FILE_ID
+    assert payload['derived_by'] == 'time_term_static_correction'
+    assert payload['apply_mode'] == 'weathering_only'
+    assert payload['applied_shift_field'] == 'applied_weathering_shift_s_sorted'
+    assert payload['shift_ms']['max_abs'] == pytest.approx(4.0)
+    assert not (tmp_path / 'job' / 'corrected_file.json.tmp').exists()
+
+    meta = json.loads((result.store_path / 'meta.json').read_text(encoding='utf-8'))
+    assert meta['original_segy_path'] == '/keep/source.sgy'
+    assert meta['source_sha256'] is None
+    components = meta['derived']['components']
+    assert [component['name'] for component in components] == [
+        'datum_static_correction',
+        'residual_static_correction',
+        'time_term_static_correction',
+    ]
+    assert components[-1]['job_id'] == JOB_ID
+    assert components[-1]['shift_field'] == 'applied_weathering_shift_s_sorted'
+    assert components[-1]['apply_mode'] == 'weathering_only'
+
+
+def test_time_term_apply_rejects_final_from_raw_if_not_implemented(
+    tmp_path: Path,
+) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(tmp_path / 'time_term_static_solution.npz')
+
+    with pytest.raises(ValueError, match='final_from_raw mode is not implemented'):
+        _apply(
+            tmp_path,
+            state,
+            solution_path,
+            options=TimeTermTraceStoreApplyOptions(
+                mode='final_from_raw',
+                corrected_file_id=CORRECTED_FILE_ID,
+            ),
+        )
+
+
+def test_time_term_apply_rejects_output_dtype_other_than_float32(
+    tmp_path: Path,
+) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(tmp_path / 'time_term_static_solution.npz')
+
+    with pytest.raises(ValueError, match='output_dtype'):
+        _apply(
+            tmp_path,
+            state,
+            solution_path,
+            options=TimeTermTraceStoreApplyOptions(
+                output_dtype='float64',
+                corrected_file_id=CORRECTED_FILE_ID,
+            ),
+        )
+
+
+def test_time_term_apply_rejects_interpolation_other_than_linear(
+    tmp_path: Path,
+) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(tmp_path / 'time_term_static_solution.npz')
+
+    with pytest.raises(ValueError, match='interpolation'):
+        _apply(
+            tmp_path,
+            state,
+            solution_path,
+            options=TimeTermTraceStoreApplyOptions(
+                interpolation='nearest',
+                corrected_file_id=CORRECTED_FILE_ID,
+            ),
+        )
+
+
+def test_time_term_apply_rejects_non_finite_shift(tmp_path: Path) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        applied_weathering=np.asarray([np.nan, 0.0, 0.0], dtype=np.float64),
+        estimated_delay=np.asarray([0.0, 0.0, 0.0], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match='finite'):
+        _apply(tmp_path, state, solution_path)
+
+
+def test_time_term_apply_rejects_shift_above_max_abs_shift_ms(
+    tmp_path: Path,
+) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        applied_weathering=np.asarray([0.501, 0.0, 0.0], dtype=np.float64),
+    )
+
+    with pytest.raises(ValueError, match='max_abs_shift_ms'):
+        _apply(tmp_path, state, solution_path)
+
+
+def test_time_term_apply_rejects_n_traces_mismatch(tmp_path: Path) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        n_traces=2,
+        n_samples=16,
+    )
+
+    with pytest.raises(ValueError, match='n_traces mismatch'):
+        _apply(tmp_path, state, solution_path)
+
+
+def test_time_term_apply_rejects_dt_mismatch(tmp_path: Path) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        dt=0.006,
+    )
+
+    with pytest.raises(ValueError, match='dt mismatch'):
+        _apply(tmp_path, state, solution_path)
+
+
+def test_time_term_apply_rejects_key_byte_mismatch(tmp_path: Path) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(
+        tmp_path / 'time_term_static_solution.npz',
+        key1_byte=181,
+    )
+
+    with pytest.raises(ValueError, match='key1_byte mismatch'):
+        _apply(tmp_path, state, solution_path)
+
+
+def test_time_term_apply_rejects_raw_store_in_weathering_only_mode(
+    tmp_path: Path,
+) -> None:
+    state, _store = _state_with_store(tmp_path, include_derived=False)
+    solution_path = _write_solution(tmp_path / 'time_term_static_solution.npz')
+
+    with pytest.raises(ValueError, match='weathering_only mode requires'):
+        _apply(tmp_path, state, solution_path)
+
+
+def test_time_term_apply_rejects_source_sha_raw_store_in_weathering_only_mode(
+    tmp_path: Path,
+) -> None:
+    state, _store = _state_with_store(tmp_path, source_sha256='raw-source-sha')
+    solution_path = _write_solution(tmp_path / 'time_term_static_solution.npz')
+
+    with pytest.raises(ValueError, match='weathering_only mode requires'):
+        _apply(tmp_path, state, solution_path)
+
+
+def test_time_term_apply_rejects_double_time_term_application(
+    tmp_path: Path,
+) -> None:
+    derived = _default_derived()
+    derived['components'] = [
+        *_default_derived()['components'],
+        {'name': 'time_term_static_correction', 'job_id': 'old-job'},
+    ]
+    state, _store = _state_with_store(tmp_path, derived=derived)
+    solution_path = _write_solution(tmp_path / 'time_term_static_solution.npz')
+
+    with pytest.raises(ValueError, match='already has time_term_static_correction'):
+        _apply(tmp_path, state, solution_path)
+
+
+def test_time_term_apply_registration_failure_cleans_registry_cache_and_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(tmp_path / 'time_term_static_solution.npz')
+
+    def _fail_register(**kwargs: Any) -> object:
+        state.file_registry.update(
+            str(kwargs['file_id']),
+            store_path=str(kwargs['store_dir']),
+            dt=DT,
+        )
+        with state.lock:
+            state.cached_readers[
+                trace_store_cache_key(str(kwargs['file_id']), KEY1, KEY2)
+            ] = object()
+        raise RuntimeError('registration failed')
+
+    monkeypatch.setattr(svc, 'register_trace_store', _fail_register)
+
+    with pytest.raises(RuntimeError, match='registration failed'):
+        _apply(tmp_path, state, solution_path)
+
+    output = tmp_path / (
+        'line001.sgy.statics.residual.bbbb2222.statics.time_term.cccc3333'
+    )
+    assert not output.exists()
+    assert state.file_registry.get_record(CORRECTED_FILE_ID) is None
+    assert not (tmp_path / 'job' / 'corrected_file.json').exists()
+    with state.lock:
+        assert trace_store_cache_key(CORRECTED_FILE_ID, KEY1, KEY2) not in (
+            state.cached_readers
+        )
+
+
+def test_time_term_apply_build_failure_cleans_partial_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, _store = _state_with_store(tmp_path)
+    solution_path = _write_solution(tmp_path / 'time_term_static_solution.npz')
+
+    def _fail_build(**kwargs: Any) -> object:
+        output_path = Path(kwargs['output_store_path'])
+        output_path.mkdir()
+        output_path.with_name(f'{output_path.name}.tmp-test').mkdir()
+        raise RuntimeError('build failed')
+
+    monkeypatch.setattr(svc, 'build_time_shifted_trace_store', _fail_build)
+
+    with pytest.raises(RuntimeError, match='build failed'):
+        _apply(tmp_path, state, solution_path)
+
+    output = tmp_path / (
+        'line001.sgy.statics.residual.bbbb2222.statics.time_term.cccc3333'
+    )
+    assert not output.exists()
+    assert list(tmp_path.glob(f'{output.name}.tmp-*')) == []
+    assert state.file_registry.get_record(CORRECTED_FILE_ID) is None


### PR DESCRIPTION
Closes #367

## Summary
- PR6-9 [statics time-term] time-term static correction を TraceStore に適用して補正済み file_id を登録する

## Changed files
- `app/services/time_term_static_apply_trace_store.py`
- `app/tests/test_time_term_static_apply_trace_store.py`

## Checks
- `.work/codex/checks.log`: 1365 passed in 47.12s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
