### PR TITLE
PR6-10 [statics api] /statics/time-term/apply job endpoint と lifecycle/cancel/download を統合する

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -22,6 +22,7 @@ from app.api.schemas import (
     StaticJobFilesResponse,
     StaticJobStatusResponse,
     TimeTermStaticApplyRequest,
+    TimeTermStaticApplyResponse,
 )
 from app.core.state import AppState
 from app.services.datum_static_service import run_datum_static_apply_job
@@ -32,7 +33,7 @@ from app.services.job_manager import JobManager
 from app.services.job_runner import request_job_cancel, start_job_thread
 from app.services.pipeline_artifacts import get_job_dir, maybe_cleanup_expired_jobs
 from app.services.residual_static_service import run_residual_static_apply_job
-from app.services.time_term_static_service import validate_time_term_request
+from app.services.time_term_static_service import run_time_term_static_apply_job
 
 router = APIRouter()
 
@@ -195,24 +196,37 @@ def residual_static_apply(
     return {'job_id': job_id, 'state': status}
 
 
-@router.post('/statics/time-term/apply')
+@router.post(
+    '/statics/time-term/apply',
+    response_model=TimeTermStaticApplyResponse,
+)
 def time_term_static_apply(
     req: TimeTermStaticApplyRequest,
     request: Request,
-) -> dict[str, str]:
+) -> TimeTermStaticApplyResponse:
     state = get_state(request.app)
     cleanup_in_memory_state(state)
     maybe_cleanup_expired_jobs()
 
-    try:
-        validate_time_term_request(req, state=state)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    job_id = str(uuid4())
+    with state.lock:
+        job_state = state.jobs.create_static_job(
+            job_id,
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            statics_kind='time_term',
+            artifacts_dir=str(get_job_dir(job_id)),
+        )
+        status = job_state['status']
 
-    raise HTTPException(
-        status_code=501,
-        detail='time-term inversion solver is not implemented yet',
+    start_job_thread(
+        thread_factory=threading.Thread,
+        target=run_time_term_static_apply_job,
+        args=(job_id, req, state),
     )
+
+    return {'job_id': job_id, 'state': status}
 
 
 @router.get(

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1134,13 +1134,21 @@ class TimeTermStaticSolverRequest(BaseModel):
 
 
 class TimeTermStaticApplyOptions(BaseModel):
-    """Options for a future corrected TraceStore output."""
+    """Options for time-term artifact output and corrected TraceStore registration."""
 
     model_config = ConfigDict(extra='forbid')
 
+    interpolation: Literal['linear'] = 'linear'
+    fill_value: float = 0.0
+    mode: Literal['weathering_only'] = 'weathering_only'
     register_corrected_file: bool = False
     max_abs_shift_ms: float = 250.0
     output_dtype: Literal['float32'] = 'float32'
+
+    @field_validator('fill_value', mode='before')
+    @classmethod
+    def _check_fill_value(cls, value: object) -> float:
+        return _require_finite_float(value, 'apply.fill_value')
 
     @field_validator('register_corrected_file', mode='before')
     @classmethod
@@ -1189,3 +1197,12 @@ class TimeTermStaticApplyRequest(BaseModel):
         if not self.file_id:
             raise ValueError('file_id must be a non-empty string')
         return self
+
+
+class TimeTermStaticApplyResponse(BaseModel):
+    """Response model for creating a time-term static apply job."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    job_id: str
+    state: str

--- a/app/services/time_term_moveout.py
+++ b/app/services/time_term_moveout.py
@@ -31,6 +31,7 @@ class TimeTermMoveoutConfig:
     model: TimeTermMoveoutModel
     refractor_velocity_m_s: float
     distance_source: MoveoutDistanceSource = 'geometry'
+    offset_byte: int | None = None
     allow_missing_offset: bool = False
     max_geometry_offset_mismatch_m: float | None = None
 
@@ -61,6 +62,12 @@ def compute_time_term_moveout(
     n_traces = _coerce_positive_int(inputs.n_traces, name='n_traces')
     model = _validate_model(config.model)
     distance_source = _validate_distance_source(config.distance_source)
+    offset_byte = _validate_optional_trace_header_byte(
+        config.offset_byte,
+        name='offset_byte',
+    )
+    if model != 'none' and distance_source == 'offset_header' and offset_byte is None:
+        raise ValueError('offset_byte is required for offset_header distance')
     refractor_velocity = _coerce_positive_finite_float(
         config.refractor_velocity_m_s,
         name='refractor_velocity_m_s',
@@ -339,6 +346,17 @@ def _validate_distance_source(value: object) -> MoveoutDistanceSource:
     if value in _DISTANCE_SOURCES:
         return value  # type: ignore[return-value]
     raise ValueError(f'unsupported distance_source: {value!r}')
+
+
+def _validate_optional_trace_header_byte(value: object, *, name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f'{name} must be an integer SEG-Y trace header byte')
+    byte = int(value)
+    if byte < 1 or byte > 240:
+        raise ValueError(f'{name} must be in the range 1..240')
+    return byte
 
 
 def _validate_node_range(

--- a/app/services/time_term_static_service.py
+++ b/app/services/time_term_static_service.py
@@ -1,10 +1,15 @@
-"""Validation boundary for future time-term static inversion jobs."""
+"""Validation and orchestration for time-term static inversion jobs."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import math
 from pathlib import Path
+import shutil
+import time
+from typing import Any
+from uuid import uuid4
 
 import numpy as np
 
@@ -13,7 +18,47 @@ from app.core.state import AppState
 from app.services.errors import DomainError
 from app.services.geometry_linkage_loader import load_geometry_linkage_artifact
 from app.services.job_artifact_refs import resolve_job_artifact_path
+from app.services.job_runner import (
+    JobCancelledError,
+    JobCompletion,
+    JobFailure,
+    ensure_job_not_cancelled,
+    run_job_with_lifecycle,
+)
+from app.services.pipeline_artifacts import get_job_dir
 from app.services.reader import get_reader
+from app.services.time_term_apply_shift import (
+    TimeTermAppliedShiftOptions,
+    build_time_term_applied_shift_result,
+)
+from app.services.time_term_design_matrix import (
+    TimeTermDesignMatrixOptions,
+    build_time_term_design_matrix,
+)
+from app.services.time_term_moveout import (
+    TimeTermMoveoutConfig,
+    compute_time_term_moveout,
+)
+from app.services.time_term_robust_solver import (
+    TimeTermRobustSolverOptions,
+    solve_time_term_robust_least_squares,
+)
+from app.services.time_term_sparse_solver import TimeTermSparseSolverOptions
+from app.services.time_term_static_apply_trace_store import (
+    TimeTermTraceStoreApplyOptions,
+    apply_time_term_static_correction_to_trace_store,
+)
+from app.services.time_term_static_artifacts import (
+    TIME_TERM_STATIC_QC_JSON_NAME,
+    TIME_TERM_STATIC_SOLUTION_NPZ_NAME,
+    TIME_TERM_STATICS_CSV_NAME,
+    TimeTermStaticArtifactMetadata,
+    write_time_term_static_artifacts,
+)
+from app.services.time_term_static_inputs import build_time_term_inversion_inputs
+from app.services.trace_store_registration import trace_store_cache_key
+
+_CORRECTED_FILE_NAME = 'corrected_file.json'
 
 
 @dataclass(frozen=True)
@@ -24,6 +69,16 @@ class TimeTermValidationResult:
     dt: float
     n_traces: int
     linkage_artifact_path: Path | None
+
+
+@dataclass
+class _TimeTermStaticLifecycle:
+    created_ts: float
+    job_dir: Path | None = None
+    corrected_store_path: Path | None = None
+    corrected_file_id: str | None = None
+    key1_byte: int | None = None
+    key2_byte: int | None = None
 
 
 def validate_time_term_request(
@@ -212,4 +267,436 @@ def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
     )
 
 
-__all__ = ['TimeTermValidationResult', 'validate_time_term_request']
+def _resolve_created_ts(state: AppState, job_id: str) -> float:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        if job is None:
+            return time.time()
+        created_ts_obj = job.get('created_ts')
+    return (
+        float(created_ts_obj)
+        if isinstance(created_ts_obj, (int, float))
+        else time.time()
+    )
+
+
+def _resolve_job_dir(state: AppState, job_id: str) -> Path:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        artifacts_dir = job.get('artifacts_dir') if isinstance(job, dict) else None
+    if isinstance(artifacts_dir, str) and artifacts_dir:
+        return Path(artifacts_dir)
+    return get_job_dir(job_id)
+
+
+def _set_job_progress_message(
+    state: AppState,
+    job_id: str,
+    *,
+    progress: float,
+    message: str,
+) -> None:
+    with state.lock:
+        if state.jobs.get(job_id) is None:
+            return
+        state.jobs.set_progress(job_id, progress)
+        state.jobs.set_message(job_id, message)
+
+
+def _is_cancel_requested(state: AppState, job_id: str) -> bool:
+    with state.lock:
+        return state.jobs.is_cancel_requested(job_id)
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+    try:
+        tmp_path.write_text(
+            json.dumps(
+                payload,
+                allow_nan=False,
+                ensure_ascii=True,
+                sort_keys=True,
+            ),
+            encoding='utf-8',
+        )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _write_time_term_job_meta(
+    *,
+    job_id: str,
+    job_dir: Path,
+    req: TimeTermStaticApplyRequest,
+) -> None:
+    _write_json_atomic(
+        job_dir / 'job_meta.json',
+        {
+            'job_id': job_id,
+            'job_type': 'statics',
+            'statics_kind': 'time_term',
+            'source_file_id': req.file_id,
+            'key1_byte': req.key1_byte,
+            'key2_byte': req.key2_byte,
+            'request': req.model_dump(mode='json'),
+            'inputs': {
+                'pick_source': req.pick_source.model_dump(
+                    mode='json',
+                    exclude_none=True,
+                ),
+                'geometry': req.geometry.model_dump(mode='json'),
+                'linkage': req.linkage.model_dump(mode='json', exclude_none=True),
+                'velocity': req.velocity.model_dump(mode='json'),
+                'moveout': req.moveout.model_dump(mode='json'),
+                'solver': req.solver.model_dump(mode='json'),
+                'apply': req.apply.model_dump(mode='json'),
+            },
+            'artifacts': {
+                'solution_npz': TIME_TERM_STATIC_SOLUTION_NPZ_NAME,
+                'qc_json': TIME_TERM_STATIC_QC_JSON_NAME,
+                'statics_csv': TIME_TERM_STATICS_CSV_NAME,
+                'corrected_file_json': _CORRECTED_FILE_NAME,
+            },
+        },
+    )
+
+
+def _moveout_config_from_time_term_request(
+    req: TimeTermStaticApplyRequest,
+) -> TimeTermMoveoutConfig:
+    return TimeTermMoveoutConfig(
+        model=req.moveout.model,
+        refractor_velocity_m_s=req.velocity.refractor_velocity_m_s,
+        distance_source=req.moveout.distance_source,
+        offset_byte=req.moveout.offset_byte,
+        allow_missing_offset=req.moveout.allow_missing_offset,
+        max_geometry_offset_mismatch_m=req.moveout.max_geometry_offset_mismatch_m,
+    )
+
+
+def _sparse_solver_options_from_time_term_request(
+    req: TimeTermStaticApplyRequest,
+) -> TimeTermSparseSolverOptions:
+    return TimeTermSparseSolverOptions(
+        damping_lambda=req.solver.damping,
+        gauge=req.solver.gauge,
+        min_observations=req.solver.robust.min_used_observations,
+        max_abs_node_time_term_ms=req.apply.max_abs_shift_ms,
+        max_abs_estimated_trace_delay_ms=req.apply.max_abs_shift_ms,
+    )
+
+
+def _robust_solver_options_from_time_term_request(
+    req: TimeTermStaticApplyRequest,
+) -> TimeTermRobustSolverOptions:
+    robust = req.solver.robust
+    return TimeTermRobustSolverOptions(
+        enabled=robust.enabled,
+        method=robust.method,
+        threshold=robust.threshold,
+        max_iterations=robust.max_iterations,
+        min_used_fraction=robust.min_used_fraction,
+        min_used_observations=robust.min_used_observations,
+    )
+
+
+def _applied_shift_options_from_time_term_request(
+    req: TimeTermStaticApplyRequest,
+) -> TimeTermAppliedShiftOptions:
+    return TimeTermAppliedShiftOptions(
+        max_abs_weathering_shift_ms=req.apply.max_abs_shift_ms,
+        max_abs_final_shift_ms=req.apply.max_abs_shift_ms,
+        rejected_trace_policy='use_final_model',
+    )
+
+
+def _trace_store_apply_options_from_time_term_request(
+    req: TimeTermStaticApplyRequest,
+) -> TimeTermTraceStoreApplyOptions:
+    return TimeTermTraceStoreApplyOptions(
+        mode=req.apply.mode,
+        interpolation=req.apply.interpolation,
+        fill_value=req.apply.fill_value,
+        output_dtype=req.apply.output_dtype,
+        max_abs_shift_ms=req.apply.max_abs_shift_ms,
+        register_corrected_file=req.apply.register_corrected_file,
+    )
+
+
+def _cleanup_corrected_outputs(
+    state: AppState,
+    lifecycle: _TimeTermStaticLifecycle,
+) -> None:
+    if lifecycle.corrected_file_id is not None:
+        with state.lock:
+            state.file_registry.pop(lifecycle.corrected_file_id, None)
+            if lifecycle.key1_byte is not None and lifecycle.key2_byte is not None:
+                state.cached_readers.pop(
+                    trace_store_cache_key(
+                        lifecycle.corrected_file_id,
+                        lifecycle.key1_byte,
+                        lifecycle.key2_byte,
+                    ),
+                    None,
+                )
+    if lifecycle.corrected_store_path is not None:
+        shutil.rmtree(lifecycle.corrected_store_path, ignore_errors=True)
+    if lifecycle.job_dir is not None:
+        (lifecycle.job_dir / _CORRECTED_FILE_NAME).unlink(missing_ok=True)
+
+
+def _time_term_artifact_metadata(
+    *,
+    job_id: str,
+    req: TimeTermStaticApplyRequest,
+    inputs: object,
+) -> TimeTermStaticArtifactMetadata:
+    return TimeTermStaticArtifactMetadata(
+        job_id=job_id,
+        input_file_id=req.file_id,
+        key1_byte=req.key1_byte,
+        key2_byte=req.key2_byte,
+        request=req.model_dump(mode='json'),
+        pick_source_description=getattr(inputs, 'pick_source_description', None),
+        datum_solution_path=(
+            str(getattr(inputs, 'datum_solution_path'))
+            if getattr(inputs, 'datum_solution_path', None) is not None
+            else None
+        ),
+        residual_solution_path=(
+            str(getattr(inputs, 'residual_solution_path'))
+            if getattr(inputs, 'residual_solution_path', None) is not None
+            else None
+        ),
+        linkage_artifact_path=(
+            str(getattr(inputs, 'linkage_artifact_path'))
+            if getattr(inputs, 'linkage_artifact_path', None) is not None
+            else None
+        ),
+    )
+
+
+def _run_time_term_static_apply_job_body(
+    *,
+    job_id: str,
+    req: TimeTermStaticApplyRequest,
+    state: AppState,
+    lifecycle: _TimeTermStaticLifecycle,
+) -> JobCompletion | None:
+    lifecycle.key1_byte = req.key1_byte
+    lifecycle.key2_byte = req.key2_byte
+    job_dir = _resolve_job_dir(state, job_id)
+    job_dir.mkdir(parents=True, exist_ok=True)
+    lifecycle.job_dir = job_dir
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.02,
+        message='preparing_time_term_static_job',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    _write_time_term_job_meta(job_id=job_id, job_dir=job_dir, req=req)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.05,
+        message='resolving_time_term_inputs',
+    )
+    inputs = build_time_term_inversion_inputs(request=req, state=state)
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.18,
+        message='computing_time_term_moveout',
+    )
+    moveout = compute_time_term_moveout(
+        inputs,
+        _moveout_config_from_time_term_request(req),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.28,
+        message='building_time_term_design_matrix',
+    )
+    design = build_time_term_design_matrix(
+        inputs,
+        moveout,
+        options=TimeTermDesignMatrixOptions(
+            min_observations=req.solver.robust.min_used_observations,
+        ),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.40,
+        message='solving_time_term_statics',
+    )
+    solver_result = solve_time_term_robust_least_squares(
+        design,
+        solver_options=_sparse_solver_options_from_time_term_request(req),
+        robust_options=_robust_solver_options_from_time_term_request(req),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.58,
+        message='building_time_term_applied_shifts',
+    )
+    applied_shift = build_time_term_applied_shift_result(
+        inputs=inputs,
+        solver_result=solver_result,
+        options=_applied_shift_options_from_time_term_request(req),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.68,
+        message='writing_time_term_artifacts',
+    )
+    artifact_paths = write_time_term_static_artifacts(
+        job_dir=job_dir,
+        inputs=inputs,
+        moveout=moveout,
+        design=design,
+        solver_result=solver_result,
+        applied_shift=applied_shift,
+        metadata=_time_term_artifact_metadata(
+            job_id=job_id,
+            req=req,
+            inputs=inputs,
+        ),
+    )
+    ensure_job_not_cancelled(state, job_id)
+
+    if not req.apply.register_corrected_file:
+        _set_job_progress_message(state, job_id, progress=1.0, message='done')
+        return JobCompletion(finished_ts=time.time())
+
+    def cancel_check() -> bool:
+        return _is_cancel_requested(state, job_id)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.80,
+        message='applying_time_term_static_trace_shift',
+    )
+    ensure_job_not_cancelled(state, job_id)
+    try:
+        corrected_result = apply_time_term_static_correction_to_trace_store(
+            source_file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            solution_npz_path=artifact_paths.solution_npz_path,
+            artifacts_dir=job_dir,
+            state=state,
+            options=_trace_store_apply_options_from_time_term_request(req),
+            cancel_check=cancel_check,
+        )
+    except RuntimeError as exc:
+        if 'cancelled' in str(exc).lower() and cancel_check():
+            raise JobCancelledError() from exc
+        raise
+
+    lifecycle.corrected_file_id = corrected_result.file_id
+    lifecycle.corrected_store_path = corrected_result.store_path
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.93,
+        message='registering_time_term_corrected_trace_store',
+    )
+    with state.lock:
+        state.jobs.set_static_corrected_file(
+            job_id,
+            corrected_file_id=corrected_result.file_id,
+            corrected_store_path=str(corrected_result.store_path),
+        )
+    ensure_job_not_cancelled(state, job_id)
+
+    _set_job_progress_message(state, job_id, progress=1.0, message='done')
+    return JobCompletion(finished_ts=time.time())
+
+
+def _handle_time_term_static_job_error(
+    *,
+    state: AppState,
+    lifecycle: _TimeTermStaticLifecycle,
+) -> JobFailure:
+    _cleanup_corrected_outputs(state, lifecycle)
+    return JobFailure(finished_ts=time.time())
+
+
+def _handle_time_term_static_job_cancel(
+    *,
+    state: AppState,
+    lifecycle: _TimeTermStaticLifecycle,
+    exc: JobCancelledError,
+) -> JobCompletion:
+    _cleanup_corrected_outputs(state, lifecycle)
+    finished_ts = float(exc.finished_ts) if exc.finished_ts is not None else time.time()
+    return JobCompletion(finished_ts=finished_ts)
+
+
+def run_time_term_static_apply_job(
+    job_id: str,
+    req: TimeTermStaticApplyRequest,
+    state: AppState,
+) -> None:
+    """Run one time-term static correction job."""
+    lifecycle = _TimeTermStaticLifecycle(created_ts=_resolve_created_ts(state, job_id))
+
+    def worker() -> JobCompletion | None:
+        return _run_time_term_static_apply_job_body(
+            job_id=job_id,
+            req=req,
+            state=state,
+            lifecycle=lifecycle,
+        )
+
+    run_job_with_lifecycle(
+        state=state,
+        job_id=job_id,
+        worker=worker,
+        progress_1_on_done=True,
+        start_progress=0.0,
+        clear_message_on_start=True,
+        on_error=lambda _exc: _handle_time_term_static_job_error(
+            state=state,
+            lifecycle=lifecycle,
+        ),
+        on_cancel=lambda exc: _handle_time_term_static_job_cancel(
+            state=state,
+            lifecycle=lifecycle,
+            exc=exc,
+        ),
+    )
+    with state.lock:
+        job = state.jobs.get(job_id)
+        if job is not None and job.get('status') == 'done':
+            state.jobs.set_message(job_id, 'done')
+
+
+__all__ = [
+    'TimeTermValidationResult',
+    'run_time_term_static_apply_job',
+    'validate_time_term_request',
+]

--- a/app/tests/test_time_term_moveout.py
+++ b/app/tests/test_time_term_moveout.py
@@ -68,6 +68,7 @@ def _compute(
     config_payload: dict[str, Any] = {
         'model': 'head_wave_linear_offset',
         'refractor_velocity_m_s': 2500.0,
+        'offset_byte': 37,
     }
     config_payload.update(config_overrides)
     return compute_time_term_moveout(
@@ -145,6 +146,11 @@ def test_head_wave_moveout_rejects_non_finite_geometry() -> None:
 def test_head_wave_moveout_rejects_missing_offset_when_offset_requested() -> None:
     with pytest.raises(ValueError, match='offset_sorted is required'):
         _compute(_inputs(offset_sorted=None), distance_source='offset_header')
+
+
+def test_head_wave_moveout_rejects_missing_offset_byte_when_offset_requested() -> None:
+    with pytest.raises(ValueError, match='offset_byte is required'):
+        _compute(distance_source='offset_header', offset_byte=None)
 
 
 def test_head_wave_moveout_rejects_non_finite_offset() -> None:

--- a/app/tests/test_time_term_static_job_api.py
+++ b/app/tests/test_time_term_static_job_api.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+from io import BytesIO
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+import app.services.time_term_static_service as time_term_service
+from app.api.schemas import TimeTermStaticApplyRequest
+from app.main import app
+from app.services.time_term_static_apply_trace_store import (
+    TimeTermTraceStoreApplyResult,
+)
+from app.services.time_term_static_artifacts import TimeTermStaticArtifactPaths
+
+FILE_ID = 'datum-residual-corrected-file-id'
+KEY1_BYTE = 189
+KEY2_BYTE = 193
+DT = 0.004
+
+
+class _Inputs:
+    def __init__(self, tmp_path: Path) -> None:
+        self.pick_source_description = 'batch_predicted_npz:predicted_picks_time_s.npz'
+        self.datum_solution_path = None
+        self.residual_solution_path = None
+        self.linkage_artifact_path = tmp_path / 'geometry_linkage.npz'
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv('PIPELINE_JOBS_DIR', str(tmp_path / 'jobs'))
+    state = app.state.sv
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    with state.lock:
+        state.jobs.clear()
+        state.cached_readers.clear()
+        state.file_registry.clear()
+
+
+def _payload(
+    *,
+    register_corrected_file: bool = True,
+    moveout_offset_byte: int | None = 37,
+) -> dict[str, Any]:
+    return {
+        'file_id': FILE_ID,
+        'key1_byte': KEY1_BYTE,
+        'key2_byte': KEY2_BYTE,
+        'pick_source': {
+            'kind': 'batch_predicted_npz',
+            'job_id': 'batch-job-id',
+            'artifact_name': 'predicted_picks_time_s.npz',
+        },
+        'geometry': {
+            'source_id_byte': 9,
+            'receiver_id_byte': 13,
+            'source_x_byte': 73,
+            'source_y_byte': 77,
+            'receiver_x_byte': 81,
+            'receiver_y_byte': 85,
+            'source_elevation_byte': 45,
+            'receiver_elevation_byte': 41,
+            'source_depth_byte': None,
+            'coordinate_scalar_byte': 71,
+            'elevation_scalar_byte': 69,
+            'coordinate_unit': 'm',
+            'elevation_unit': 'm',
+        },
+        'linkage': {
+            'mode': 'required',
+            'job_id': 'linkage-job-id',
+            'artifact_name': 'geometry_linkage.npz',
+        },
+        'velocity': {
+            'replacement_velocity_m_s': 2000.0,
+            'refractor_velocity_m_s': 4500.0,
+            'weathering_velocity_m_s': None,
+        },
+        'moveout': {
+            'model': 'head_wave_linear_offset',
+            'distance_source': 'geometry',
+            'offset_byte': moveout_offset_byte,
+            'allow_missing_offset': False,
+        },
+        'solver': {
+            'damping': 0.01,
+            'gauge': 'mean_zero',
+            'robust': {
+                'enabled': True,
+                'method': 'mad',
+                'threshold': 3.5,
+                'max_iterations': 5,
+                'min_used_fraction': 0.5,
+                'min_used_observations': 1,
+            },
+        },
+        'apply': {
+            'interpolation': 'linear',
+            'fill_value': 0.0,
+            'mode': 'weathering_only',
+            'register_corrected_file': register_corrected_file,
+            'max_abs_shift_ms': 250.0,
+            'output_dtype': 'float32',
+        },
+    }
+
+
+def _request(
+    *,
+    register_corrected_file: bool = True,
+    moveout_offset_byte: int | None = 37,
+) -> TimeTermStaticApplyRequest:
+    return TimeTermStaticApplyRequest.model_validate(
+        _payload(
+            register_corrected_file=register_corrected_file,
+            moveout_offset_byte=moveout_offset_byte,
+        )
+    )
+
+
+def _create_time_term_job(
+    client: TestClient,
+    tmp_path: Path,
+    *,
+    job_id: str = 'time-term-job-id',
+) -> tuple[str, Path]:
+    job_dir = tmp_path / job_id
+    with client.app.state.sv.lock:
+        client.app.state.sv.jobs.create_static_job(
+            job_id,
+            file_id=FILE_ID,
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            statics_kind='time_term',
+            artifacts_dir=str(job_dir),
+        )
+    return job_id, job_dir
+
+
+def _install_success_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    calls: list[str],
+    *,
+    cancel_after_artifacts: tuple[Any, str] | None = None,
+    moveout_configs: list[Any] | None = None,
+) -> None:
+    def _build_inputs(*args: Any, **kwargs: Any) -> _Inputs:
+        calls.append('inputs')
+        return _Inputs(tmp_path)
+
+    def _moveout(*args: Any, **kwargs: Any) -> object:
+        calls.append('moveout')
+        if len(args) >= 2 and moveout_configs is not None:
+            moveout_configs.append(args[1])
+        return object()
+
+    def _design(*args: Any, **kwargs: Any) -> object:
+        calls.append('design')
+        return object()
+
+    def _solve(*args: Any, **kwargs: Any) -> object:
+        calls.append('solver')
+        return object()
+
+    def _applied_shift(*args: Any, **kwargs: Any) -> object:
+        calls.append('applied_shift')
+        return object()
+
+    def _artifacts(*, job_dir: Path, **kwargs: Any) -> TimeTermStaticArtifactPaths:
+        calls.append('artifacts')
+        solution = job_dir / 'time_term_static_solution.npz'
+        qc = job_dir / 'time_term_static_qc.json'
+        csv = job_dir / 'time_term_statics.csv'
+        np.savez(solution, trace=np.asarray([0.0, 1.0], dtype=np.float64))
+        qc.write_text('{"ok": true}', encoding='utf-8')
+        csv.write_text('trace_index,time_term_ms\n0,0.0\n', encoding='utf-8')
+        if cancel_after_artifacts is not None:
+            state, job_id = cancel_after_artifacts
+            with state.lock:
+                state.jobs.request_cancel(job_id)
+        return TimeTermStaticArtifactPaths(
+            solution_npz_path=solution,
+            qc_json_path=qc,
+            statics_csv_path=csv,
+        )
+
+    def _apply(**kwargs: Any) -> TimeTermTraceStoreApplyResult:
+        calls.append('apply')
+        artifacts_dir = Path(kwargs['artifacts_dir'])
+        corrected_store = tmp_path / 'time-term-corrected-store'
+        corrected_store.mkdir(exist_ok=True)
+        corrected_json = artifacts_dir / 'corrected_file.json'
+        corrected_json.write_text(
+            json.dumps({'file_id': 'time-term-corrected-file-id'}),
+            encoding='utf-8',
+        )
+        return TimeTermTraceStoreApplyResult(
+            file_id='time-term-corrected-file-id',
+            store_path=corrected_store,
+            store_name=corrected_store.name,
+            source_file_id=FILE_ID,
+            source_store_path=tmp_path / 'source-store',
+            solution_npz_path=Path(kwargs['solution_npz_path']),
+            job_id='time-term-job-id',
+            mode='weathering_only',
+            applied_shift_field='applied_weathering_shift_s_sorted',
+            key1_byte=KEY1_BYTE,
+            key2_byte=KEY2_BYTE,
+            dt=DT,
+            n_traces=2,
+            n_samples=16,
+            shift_min_ms=0.0,
+            shift_max_ms=0.0,
+            shift_mean_ms=0.0,
+            shift_max_abs_ms=0.0,
+            corrected_file_json_path=corrected_json,
+        )
+
+    monkeypatch.setattr(time_term_service, 'build_time_term_inversion_inputs', _build_inputs)
+    monkeypatch.setattr(time_term_service, 'compute_time_term_moveout', _moveout)
+    monkeypatch.setattr(time_term_service, 'build_time_term_design_matrix', _design)
+    monkeypatch.setattr(
+        time_term_service,
+        'solve_time_term_robust_least_squares',
+        _solve,
+    )
+    monkeypatch.setattr(
+        time_term_service,
+        'build_time_term_applied_shift_result',
+        _applied_shift,
+    )
+    monkeypatch.setattr(
+        time_term_service,
+        'write_time_term_static_artifacts',
+        _artifacts,
+    )
+    monkeypatch.setattr(
+        time_term_service,
+        'apply_time_term_static_correction_to_trace_store',
+        _apply,
+    )
+
+
+def test_run_time_term_static_apply_job_success_with_corrected_file(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, job_dir = _create_time_term_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+
+    time_term_service.run_time_term_static_apply_job(
+        job_id,
+        _request(register_corrected_file=True),
+        client.app.state.sv,
+    )
+
+    assert calls == [
+        'inputs',
+        'moveout',
+        'design',
+        'solver',
+        'applied_shift',
+        'artifacts',
+        'apply',
+    ]
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'done'
+    assert job['progress'] == 1.0
+    assert job['message'] == 'done'
+    assert job['corrected_file_id'] == 'time-term-corrected-file-id'
+
+    files_response = client.get(f'/statics/job/{job_id}/files')
+    assert files_response.status_code == 200
+    assert {item['name'] for item in files_response.json()['files']} == {
+        'job_meta.json',
+        'time_term_static_solution.npz',
+        'time_term_static_qc.json',
+        'time_term_statics.csv',
+        'corrected_file.json',
+    }
+
+    meta = json.loads((job_dir / 'job_meta.json').read_text(encoding='utf-8'))
+    assert meta['job_type'] == 'statics'
+    assert meta['statics_kind'] == 'time_term'
+    assert meta['source_file_id'] == FILE_ID
+    assert meta['artifacts']['solution_npz'] == 'time_term_static_solution.npz'
+
+
+def test_run_time_term_static_apply_job_success_artifacts_only(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir = _create_time_term_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+
+    time_term_service.run_time_term_static_apply_job(
+        job_id,
+        _request(register_corrected_file=False),
+        client.app.state.sv,
+    )
+
+    assert calls == [
+        'inputs',
+        'moveout',
+        'design',
+        'solver',
+        'applied_shift',
+        'artifacts',
+    ]
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'done'
+    assert 'corrected_file_id' not in job
+    files_response = client.get(f'/statics/job/{job_id}/files')
+    assert {item['name'] for item in files_response.json()['files']} == {
+        'job_meta.json',
+        'time_term_static_solution.npz',
+        'time_term_static_qc.json',
+        'time_term_statics.csv',
+    }
+
+
+def test_run_time_term_static_apply_job_passes_moveout_offset_byte(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir = _create_time_term_job(client, tmp_path)
+    calls: list[str] = []
+    moveout_configs: list[Any] = []
+    _install_success_fakes(
+        monkeypatch,
+        tmp_path,
+        calls,
+        moveout_configs=moveout_configs,
+    )
+
+    time_term_service.run_time_term_static_apply_job(
+        job_id,
+        _request(register_corrected_file=False, moveout_offset_byte=41),
+        client.app.state.sv,
+    )
+
+    assert len(moveout_configs) == 1
+    assert moveout_configs[0].offset_byte == 41
+
+
+def test_run_time_term_static_apply_job_cancel_before_solver(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir = _create_time_term_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+    with client.app.state.sv.lock:
+        client.app.state.sv.jobs[job_id]['cancel_requested'] = True
+
+    time_term_service.run_time_term_static_apply_job(
+        job_id,
+        _request(),
+        client.app.state.sv,
+    )
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'cancelled'
+    assert job['message'] == 'The job was cancelled by the user.'
+    assert calls == []
+
+
+def test_run_time_term_static_apply_job_cancel_before_apply(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir = _create_time_term_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(
+        monkeypatch,
+        tmp_path,
+        calls,
+        cancel_after_artifacts=(client.app.state.sv, job_id),
+    )
+
+    time_term_service.run_time_term_static_apply_job(
+        job_id,
+        _request(register_corrected_file=True),
+        client.app.state.sv,
+    )
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'cancelled'
+    assert 'apply' not in calls
+
+
+def test_run_time_term_static_apply_job_failure_sets_error_message(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir = _create_time_term_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+
+    def _raise_solver_error(*args: Any, **kwargs: Any) -> object:
+        raise ValueError('time-term solver mismatch')
+
+    monkeypatch.setattr(
+        time_term_service,
+        'solve_time_term_robust_least_squares',
+        _raise_solver_error,
+    )
+
+    time_term_service.run_time_term_static_apply_job(
+        job_id,
+        _request(),
+        client.app.state.sv,
+    )
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'error'
+    assert job['message'] == 'time-term solver mismatch'
+    assert 'applied_shift' not in calls
+
+
+def test_time_term_static_job_invalid_file_id_becomes_error_status(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir = _create_time_term_job(client, tmp_path)
+
+    time_term_service.run_time_term_static_apply_job(
+        job_id,
+        _request(register_corrected_file=False),
+        client.app.state.sv,
+    )
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'error'
+    assert job['message'] == f'file_id not found: {FILE_ID}'
+
+
+def test_time_term_static_job_download_artifacts(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    job_id, _job_dir = _create_time_term_job(client, tmp_path)
+    calls: list[str] = []
+    _install_success_fakes(monkeypatch, tmp_path, calls)
+    time_term_service.run_time_term_static_apply_job(
+        job_id,
+        _request(register_corrected_file=True),
+        client.app.state.sv,
+    )
+
+    solution_response = client.get(
+        f'/statics/job/{job_id}/download',
+        params={'name': 'time_term_static_solution.npz'},
+    )
+    qc_response = client.get(
+        f'/statics/job/{job_id}/download',
+        params={'name': 'time_term_static_qc.json'},
+    )
+    csv_response = client.get(
+        f'/statics/job/{job_id}/download',
+        params={'name': 'time_term_statics.csv'},
+    )
+    corrected_response = client.get(
+        f'/statics/job/{job_id}/download',
+        params={'name': 'corrected_file.json'},
+    )
+
+    assert solution_response.status_code == 200
+    with np.load(BytesIO(solution_response.content), allow_pickle=False) as data:
+        np.testing.assert_allclose(data['trace'], np.asarray([0.0, 1.0]))
+    assert qc_response.json() == {'ok': True}
+    assert csv_response.text.startswith('trace_index,time_term_ms\n')
+    assert corrected_response.json() == {'file_id': 'time-term-corrected-file-id'}
+
+
+def test_time_term_static_job_download_rejects_path_traversal(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_id, job_dir = _create_time_term_job(client, tmp_path)
+    job_dir.mkdir(parents=True)
+
+    response = client.get(
+        f'/statics/job/{job_id}/download',
+        params={'name': '../time_term_static_solution.npz'},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {'detail': 'Invalid file name'}

--- a/app/tests/test_time_term_static_request.py
+++ b/app/tests/test_time_term_static_request.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+import app.api.routers.statics as statics_router_module
 from app.api.schemas import TimeTermStaticApplyRequest
 from app.main import app
 from app.services.geometry_linkage_artifacts import (
@@ -469,25 +470,47 @@ def test_time_term_linkage_rejects_negative_node_ids(
         )
 
 
-def test_time_term_apply_endpoint_returns_not_implemented_after_validation(
+def test_time_term_apply_endpoint_creates_async_job(
     client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
     _install_trace_store(client, tmp_path)
     _install_linkage_job(client, tmp_path)
 
     response = client.post('/statics/time-term/apply', json=_payload())
 
-    assert response.status_code == 501
-    assert response.json() == {
-        'detail': 'time-term inversion solver is not implemented yet'
-    }
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['state'] == 'queued'
+    assert len(started) == 1
+    assert started[0]['target'] is statics_router_module.run_time_term_static_apply_job
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[payload['job_id']])
+    assert job['job_type'] == 'statics'
+    assert job['statics_kind'] == 'time_term'
 
 
-def test_time_term_apply_endpoint_returns_validation_error_before_not_implemented(
+def test_time_term_apply_endpoint_rejects_invalid_schema_without_starting_job(
     client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    response = client.post('/statics/time-term/apply', json=_payload())
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+    payload = _payload()
+    payload['file_id'] = ''
 
-    assert response.status_code == 400
-    assert 'file_id not found' in response.json()['detail']
+    response = client.post('/statics/time-term/apply', json=payload)
+
+    assert response.status_code == 422
+    assert started == []


### PR DESCRIPTION
Closes #369

## Summary
- PR6-10 [statics api] /statics/time-term/apply job endpoint と lifecycle/cancel/download を統合する

## Changed files
- `app/api/routers/statics.py`
- `app/api/schemas.py`
- `app/services/time_term_moveout.py`
- `app/services/time_term_static_service.py`
- `app/tests/test_time_term_moveout.py`
- `app/tests/test_time_term_static_job_api.py`
- `app/tests/test_time_term_static_request.py`

## Checks
- `.work/codex/checks.log`: 1375 passed in 47.05s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
