### PR TITLE
P1-01 refactor(statics): move refraction result dataclasses to a dependency-light types module

### DIFF
--- a/app/services/refraction_static_apply_trace_store.py
+++ b/app/services/refraction_static_apply_trace_store.py
@@ -29,7 +29,11 @@ from app.services.refraction_static_artifacts import (
     REFRACTION_STATIC_QC_JSON_NAME,
     REFRACTION_STATIC_SOLUTION_NPZ_NAME,
 )
-from app.services.refraction_static_datum import RefractionDatumStaticsResult
+from app.services.refraction_static_types import (
+    RefractionDatumStaticsResult,
+    RefractionStaticApplyTraceStoreResult,
+    RefractionTraceShiftValidationResult,
+)
 from app.services.trace_store_index_validation import validate_sorted_to_original
 from app.services.trace_store_registration import (
     register_trace_store,
@@ -63,55 +67,6 @@ _OPTIONAL_SOLUTION_METADATA_KEYS = (
 
 class RefractionStaticTraceStoreApplyError(ValueError):
     """Raised when refraction statics cannot be applied to a TraceStore."""
-
-
-@dataclass(frozen=True)
-class RefractionTraceShiftValidationResult:
-    trace_shift_s_sorted: np.ndarray
-    trace_static_valid_mask_sorted: np.ndarray
-    trace_static_status_sorted: np.ndarray
-    trace_static_status_counts: dict[str, int]
-    max_abs_shift_ms: float
-    max_abs_applied_shift_ms: float
-    exceeds_max_abs_shift_count: int
-    n_valid_trace_shifts: int
-    n_invalid_trace_shifts: int
-    n_zero_trace_shifts: int
-    n_positive_trace_shifts: int
-    n_negative_trace_shifts: int
-
-
-@dataclass(frozen=True)
-class RefractionStaticApplyTraceStoreResult:
-    source_file_id: str
-    corrected_file_id: str | None
-
-    source_trace_store_path: Path
-    corrected_trace_store_path: Path | None
-
-    n_traces: int
-    n_samples: int
-    sample_interval_s: float
-
-    interpolation: str
-    fill_value: float
-    output_dtype: str
-
-    applied_shift_s_sorted: np.ndarray
-    applied_shift_ms_sorted: np.ndarray
-    trace_static_valid_mask_sorted: np.ndarray
-    trace_static_status_sorted: np.ndarray
-
-    max_abs_applied_shift_ms: float
-    n_valid_trace_shifts: int
-    n_invalid_trace_shifts: int
-    n_zero_trace_shifts: int
-    n_positive_trace_shifts: int
-    n_negative_trace_shifts: int
-
-    corrected_file_json: Path | None
-    qc_json: Path | None
-    qc: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -13,8 +13,11 @@ from uuid import uuid4
 import numpy as np
 
 from app.api.schemas import RefractionStaticApplyRequest
-from app.services.refraction_static_datum import RefractionDatumStaticsResult
 from app.services.refraction_static_status import REFRACTION_STATIC_STATUSES
+from app.services.refraction_static_types import (
+    RefractionDatumStaticsResult,
+    RefractionStaticArtifactSet,
+)
 
 REFRACTION_STATIC_SOLUTION_NPZ_NAME = 'refraction_static_solution.npz'
 REFRACTION_STATIC_QC_JSON_NAME = 'refraction_static_qc.json'
@@ -161,20 +164,6 @@ _COMPONENT_COLUMNS = (
 
 class RefractionStaticArtifactError(ValueError):
     """Raised when final refraction static artifacts cannot be written."""
-
-
-@dataclass(frozen=True)
-class RefractionStaticArtifactSet:
-    job_dir: Path
-    solution_npz: Path
-    qc_json: Path
-    refraction_statics_csv: Path
-    near_surface_model_csv: Path
-    first_break_residuals_csv: Path
-    refraction_static_components_csv: Path
-    manifest_json: Path | None
-    artifact_names: tuple[str, ...]
-    qc: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/app/services/refraction_static_bedrock.py
+++ b/app/services/refraction_static_bedrock.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import csv
-from dataclasses import dataclass
 import json
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 from uuid import uuid4
 
 import numpy as np
@@ -18,17 +17,17 @@ from app.api.schemas import (
 )
 from app.core.state import AppState
 from app.services.refraction_static_design_matrix import (
-    RefractionStaticDesignMatrix,
     build_refraction_static_design_matrix,
-)
-from app.services.refraction_static_inputs import (
-    RefractionStaticInputModel,
-    build_refraction_static_input_model,
 )
 from app.services.refraction_static_solver import (
     RefractionStaticSolverError,
-    RefractionStaticSolverResult,
     solve_refraction_static_bounded_ls,
+)
+from app.services.refraction_static_types import (
+    RefractionBedrockSlownessResult,
+    RefractionStaticDesignMatrix,
+    RefractionStaticInputModel,
+    RefractionStaticSolverResult,
 )
 
 REFRACTION_BEDROCK_QC_JSON_NAME = 'refraction_bedrock_velocity_qc.json'
@@ -53,42 +52,6 @@ class RefractionBedrockSlownessError(ValueError):
     """Raised when global bedrock slowness cannot be estimated."""
 
 
-@dataclass(frozen=True)
-class RefractionBedrockSlownessResult:
-    """Integration result for the solve-global bedrock slowness workflow."""
-
-    bedrock_velocity_mode: Literal['solve_global']
-    weathering_velocity_m_s: float
-
-    bedrock_slowness_s_per_m: float
-    bedrock_velocity_m_s: float
-    bedrock_velocity_status: str
-
-    min_bedrock_velocity_m_s: float
-    max_bedrock_velocity_m_s: float
-    lower_bedrock_slowness_s_per_m: float
-    upper_bedrock_slowness_s_per_m: float
-
-    active_node_id: np.ndarray
-    active_node_half_intercept_time_s: np.ndarray
-
-    row_trace_index_sorted: np.ndarray
-    row_source_node_id: np.ndarray
-    row_receiver_node_id: np.ndarray
-    row_distance_m: np.ndarray
-    observed_pick_time_s: np.ndarray
-    modeled_pick_time_s: np.ndarray
-    residual_time_s: np.ndarray
-    used_row_mask: np.ndarray
-    rejected_by_robust_mask: np.ndarray
-
-    input_model: RefractionStaticInputModel | None
-    design_matrix: RefractionStaticDesignMatrix | None
-    solver_result: RefractionStaticSolverResult
-
-    qc: dict[str, Any]
-
-
 def estimate_global_bedrock_slowness_from_first_breaks(
     *,
     req: RefractionStaticApplyRequest,
@@ -97,6 +60,8 @@ def estimate_global_bedrock_slowness_from_first_breaks(
 ) -> RefractionBedrockSlownessResult:
     """Build refraction inputs from a request and estimate global bedrock slowness."""
     _require_solve_global(req.model)
+    from app.services.refraction_static_inputs import build_refraction_static_input_model
+
     try:
         input_model = build_refraction_static_input_model(
             req=req,

--- a/app/services/refraction_static_datum.py
+++ b/app/services/refraction_static_datum.py
@@ -18,8 +18,11 @@ from app.api.schemas import (
 )
 from app.core.state import AppState
 from app.services.job_artifact_refs import resolve_job_artifact_path
-from app.services.refraction_static_weathering_replacement import (
+from app.services.refraction_static_types import (
+    RefractionDatumStaticsResult,
     RefractionWeatheringReplacementStaticsResult,
+)
+from app.services.refraction_static_weathering_replacement import (
     compute_weathering_replacement_statics_from_first_breaks,
 )
 
@@ -162,116 +165,6 @@ _TRACE_PREVIEW_COLUMNS = (
 
 class RefractionDatumStaticsError(ValueError):
     """Raised when datum refraction static outputs cannot be built."""
-
-
-@dataclass(frozen=True)
-class RefractionDatumStaticsResult:
-    """Composed refraction static components in TraceStore sorted trace order."""
-
-    bedrock_velocity_mode: Literal['solve_global', 'fixed_global']
-    bedrock_slowness_s_per_m: float
-    bedrock_velocity_m_s: float
-    weathering_velocity_m_s: float
-    replacement_slowness_delta_s_per_m: float
-
-    datum_mode: str
-    floating_datum_mode: str
-    flat_datum_elevation_m: float | None
-
-    node_id: np.ndarray
-    node_x_m: np.ndarray
-    node_y_m: np.ndarray
-    node_surface_elevation_m: np.ndarray
-    node_kind: np.ndarray
-    node_weathering_thickness_m: np.ndarray
-    node_refractor_elevation_m: np.ndarray
-    node_half_intercept_time_s: np.ndarray
-    node_weathering_replacement_shift_s: np.ndarray
-    node_floating_datum_elevation_m: np.ndarray
-    node_solution_status: np.ndarray
-    node_datum_status: np.ndarray
-    node_weathering_status: np.ndarray
-    node_pick_count: np.ndarray
-    node_used_pick_count: np.ndarray
-    node_rejected_pick_count: np.ndarray
-    node_residual_rms_s: np.ndarray
-    node_residual_mad_s: np.ndarray
-
-    source_endpoint_key: np.ndarray
-    source_id: np.ndarray
-    source_node_id: np.ndarray
-    source_x_m: np.ndarray
-    source_y_m: np.ndarray
-    source_surface_elevation_m: np.ndarray
-    source_half_intercept_time_s: np.ndarray
-    source_weathering_thickness_m: np.ndarray
-    source_refractor_elevation_m: np.ndarray
-    source_floating_datum_elevation_m: np.ndarray
-    source_weathering_replacement_shift_s: np.ndarray
-    source_floating_datum_elevation_shift_s: np.ndarray
-    source_flat_datum_shift_s: np.ndarray
-    source_refraction_shift_s: np.ndarray
-    source_datum_status: np.ndarray
-
-    receiver_endpoint_key: np.ndarray
-    receiver_id: np.ndarray
-    receiver_node_id: np.ndarray
-    receiver_x_m: np.ndarray
-    receiver_y_m: np.ndarray
-    receiver_surface_elevation_m: np.ndarray
-    receiver_half_intercept_time_s: np.ndarray
-    receiver_weathering_thickness_m: np.ndarray
-    receiver_refractor_elevation_m: np.ndarray
-    receiver_floating_datum_elevation_m: np.ndarray
-    receiver_weathering_replacement_shift_s: np.ndarray
-    receiver_floating_datum_elevation_shift_s: np.ndarray
-    receiver_flat_datum_shift_s: np.ndarray
-    receiver_refraction_shift_s: np.ndarray
-    receiver_datum_status: np.ndarray
-
-    sorted_trace_index: np.ndarray
-    valid_observation_mask_sorted: np.ndarray
-    used_observation_mask_sorted: np.ndarray
-    source_node_id_sorted: np.ndarray
-    receiver_node_id_sorted: np.ndarray
-    source_surface_elevation_m_sorted: np.ndarray
-    receiver_surface_elevation_m_sorted: np.ndarray
-    source_floating_datum_elevation_m_sorted: np.ndarray
-    receiver_floating_datum_elevation_m_sorted: np.ndarray
-    source_weathering_thickness_m_sorted: np.ndarray
-    receiver_weathering_thickness_m_sorted: np.ndarray
-    source_refractor_elevation_m_sorted: np.ndarray
-    receiver_refractor_elevation_m_sorted: np.ndarray
-    source_half_intercept_time_s_sorted: np.ndarray
-    receiver_half_intercept_time_s_sorted: np.ndarray
-    source_weathering_replacement_shift_s_sorted: np.ndarray
-    receiver_weathering_replacement_shift_s_sorted: np.ndarray
-    source_floating_datum_elevation_shift_s_sorted: np.ndarray
-    receiver_floating_datum_elevation_shift_s_sorted: np.ndarray
-    source_flat_datum_shift_s_sorted: np.ndarray
-    receiver_flat_datum_shift_s_sorted: np.ndarray
-    source_refraction_shift_s_sorted: np.ndarray
-    receiver_refraction_shift_s_sorted: np.ndarray
-    weathering_replacement_trace_shift_s_sorted: np.ndarray
-    floating_datum_elevation_shift_s_sorted: np.ndarray
-    flat_datum_shift_s_sorted: np.ndarray
-    refraction_trace_shift_s_sorted: np.ndarray
-    trace_static_status_sorted: np.ndarray
-    trace_static_valid_mask_sorted: np.ndarray
-    estimated_first_break_time_s_sorted: np.ndarray
-    first_break_residual_s_sorted: np.ndarray
-
-    row_trace_index_sorted: np.ndarray
-    row_source_node_id: np.ndarray
-    row_receiver_node_id: np.ndarray
-    row_distance_m: np.ndarray
-    observed_pick_time_s: np.ndarray
-    modeled_pick_time_s: np.ndarray
-    residual_time_s: np.ndarray
-    used_row_mask: np.ndarray
-    rejected_by_robust_mask: np.ndarray
-
-    qc: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/app/services/refraction_static_design_matrix.py
+++ b/app/services/refraction_static_design_matrix.py
@@ -2,50 +2,22 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, Literal
 
 import numpy as np
 from scipy import sparse
 
 from app.api.schemas import RefractionStaticModelRequest
-from app.services.refraction_static_inputs import RefractionStaticInputModel
+from app.services.refraction_static_types import (
+    RefractionStaticDesignMatrix,
+    RefractionStaticInputModel,
+)
 
 BedrockVelocityMode = Literal['solve_global', 'fixed_global']
 
 
 class RefractionStaticDesignMatrixError(ValueError):
     """Raised when refraction static design matrix inputs are inconsistent."""
-
-
-@dataclass(frozen=True)
-class RefractionStaticDesignMatrix:
-    matrix: sparse.csr_matrix
-    rhs_s: np.ndarray
-
-    observed_pick_time_s: np.ndarray
-    row_trace_index_sorted: np.ndarray
-    row_source_node_id: np.ndarray
-    row_receiver_node_id: np.ndarray
-    row_distance_m: np.ndarray
-
-    active_node_id: np.ndarray
-    inactive_node_id: np.ndarray
-    node_id_to_col: dict[int, int]
-    source_node_col: np.ndarray
-    receiver_node_col: np.ndarray
-
-    bedrock_slowness_col: int | None
-    bedrock_velocity_mode: BedrockVelocityMode
-    fixed_bedrock_velocity_m_s: float | None
-    fixed_bedrock_slowness_s_per_m: float | None
-
-    n_total_nodes: int
-    n_active_nodes: int
-    n_observations: int
-    n_parameters: int
-
-    qc: dict[str, Any]
 
 
 def build_refraction_static_design_matrix(

--- a/app/services/refraction_static_half_intercept.py
+++ b/app/services/refraction_static_half_intercept.py
@@ -14,20 +14,18 @@ import numpy as np
 from app.api.schemas import RefractionStaticApplyRequest
 from app.core.state import AppState
 from app.services.refraction_static_bedrock import (
-    RefractionBedrockSlownessResult,
     estimate_global_bedrock_slowness_from_input_model,
 )
 from app.services.refraction_static_design_matrix import (
-    RefractionStaticDesignMatrix,
     build_refraction_static_design_matrix,
 )
-from app.services.refraction_static_inputs import (
+from app.services.refraction_static_solver import solve_refraction_static_bounded_ls
+from app.services.refraction_static_types import (
+    RefractionBedrockSlownessResult,
+    RefractionHalfInterceptTimeResult,
+    RefractionStaticDesignMatrix,
     RefractionStaticInputModel,
-    build_refraction_static_input_model,
-)
-from app.services.refraction_static_solver import (
     RefractionStaticSolverResult,
-    solve_refraction_static_bounded_ls,
 )
 
 REFRACTION_HALF_INTERCEPT_QC_JSON_NAME = 'refraction_half_intercept_qc.json'
@@ -106,85 +104,6 @@ class RefractionHalfInterceptTimeError(ValueError):
 
 
 @dataclass(frozen=True)
-class RefractionHalfInterceptTimeResult:
-    """Full node, endpoint, trace-order, and QC output for GLI half-intercepts."""
-
-    bedrock_velocity_mode: Literal['solve_global', 'fixed_global']
-    bedrock_slowness_s_per_m: float
-    bedrock_velocity_m_s: float
-    weathering_velocity_m_s: float
-
-    node_id: np.ndarray
-    node_x_m: np.ndarray
-    node_y_m: np.ndarray
-    node_elevation_m: np.ndarray
-    node_kind: np.ndarray
-
-    node_half_intercept_time_s: np.ndarray
-    node_half_intercept_time_ms: np.ndarray
-    node_solution_status: np.ndarray
-
-    node_pick_count: np.ndarray
-    node_used_pick_count: np.ndarray
-    node_rejected_pick_count: np.ndarray
-    node_residual_mean_s: np.ndarray
-    node_residual_median_s: np.ndarray
-    node_residual_rms_s: np.ndarray
-    node_residual_mad_s: np.ndarray
-    node_residual_max_abs_s: np.ndarray
-
-    source_endpoint_key: np.ndarray
-    source_id: np.ndarray
-    source_node_id: np.ndarray
-    source_x_m: np.ndarray
-    source_y_m: np.ndarray
-    source_elevation_m: np.ndarray
-    source_half_intercept_time_s: np.ndarray
-    source_solution_status: np.ndarray
-    source_pick_count: np.ndarray
-    source_residual_rms_s: np.ndarray
-
-    receiver_endpoint_key: np.ndarray
-    receiver_id: np.ndarray
-    receiver_node_id: np.ndarray
-    receiver_x_m: np.ndarray
-    receiver_y_m: np.ndarray
-    receiver_elevation_m: np.ndarray
-    receiver_half_intercept_time_s: np.ndarray
-    receiver_solution_status: np.ndarray
-    receiver_pick_count: np.ndarray
-    receiver_residual_rms_s: np.ndarray
-
-    sorted_trace_index: np.ndarray
-    source_endpoint_key_sorted: np.ndarray
-    receiver_endpoint_key_sorted: np.ndarray
-    source_elevation_m_sorted: np.ndarray
-    receiver_elevation_m_sorted: np.ndarray
-    source_node_id_sorted: np.ndarray
-    receiver_node_id_sorted: np.ndarray
-    source_half_intercept_time_s_sorted: np.ndarray
-    receiver_half_intercept_time_s_sorted: np.ndarray
-    estimated_intercept_time_sum_s_sorted: np.ndarray
-    estimated_bedrock_moveout_time_s_sorted: np.ndarray
-    estimated_first_break_time_s_sorted: np.ndarray
-    first_break_residual_s_sorted: np.ndarray
-    valid_observation_mask_sorted: np.ndarray
-    used_observation_mask_sorted: np.ndarray
-
-    row_trace_index_sorted: np.ndarray
-    row_source_node_id: np.ndarray
-    row_receiver_node_id: np.ndarray
-    row_distance_m: np.ndarray
-    observed_pick_time_s: np.ndarray
-    modeled_pick_time_s: np.ndarray
-    residual_time_s: np.ndarray
-    used_row_mask: np.ndarray
-    rejected_by_robust_mask: np.ndarray
-
-    qc: dict[str, Any]
-
-
-@dataclass(frozen=True)
 class _ValidatedInputs:
     n_traces: int
     node_id: np.ndarray
@@ -256,6 +175,8 @@ def estimate_refraction_half_intercept_times_from_first_breaks(
     job_dir: Path | None = None,
 ) -> RefractionHalfInterceptTimeResult:
     """Build inputs, solve the GLI system, and emit the half-intercept model."""
+    from app.services.refraction_static_inputs import build_refraction_static_input_model
+
     try:
         input_model = build_refraction_static_input_model(
             req=req,

--- a/app/services/refraction_static_inputs.py
+++ b/app/services/refraction_static_inputs.py
@@ -25,6 +25,10 @@ from app.services.geometry_linkage_loader import (
 )
 from app.services.job_artifact_refs import resolve_job_artifact_path
 from app.services.reader import get_reader
+from app.services.refraction_static_types import (
+    RefractionEndpointTable,
+    RefractionStaticInputModel,
+)
 from app.services.trace_store_index_validation import validate_sorted_to_original
 from app.trace_store.reader import TraceStoreSectionReader
 from app.utils.pick_cache_file1d_mem import path_for_file
@@ -80,59 +84,6 @@ _PREVIEW_COLUMNS = (
     'source_node_id',
     'receiver_node_id',
 )
-
-
-@dataclass(frozen=True)
-class RefractionEndpointTable:
-    node_id: np.ndarray
-    endpoint_id: np.ndarray
-    x_m: np.ndarray
-    y_m: np.ndarray
-    elevation_m: np.ndarray
-    kind: np.ndarray
-    pick_count: np.ndarray
-
-
-@dataclass(frozen=True)
-class RefractionStaticInputModel:
-    file_id: str
-    n_traces: int
-
-    sorted_trace_index: np.ndarray
-    pick_time_s_sorted: np.ndarray
-    valid_pick_mask_sorted: np.ndarray
-    valid_observation_mask_sorted: np.ndarray
-
-    source_id_sorted: np.ndarray
-    receiver_id_sorted: np.ndarray
-
-    source_x_m_sorted: np.ndarray
-    source_y_m_sorted: np.ndarray
-    receiver_x_m_sorted: np.ndarray
-    receiver_y_m_sorted: np.ndarray
-
-    source_elevation_m_sorted: np.ndarray
-    receiver_elevation_m_sorted: np.ndarray
-    source_depth_m_sorted: np.ndarray | None
-
-    geometry_distance_m_sorted: np.ndarray
-    offset_m_sorted: np.ndarray | None
-    distance_m_sorted: np.ndarray
-
-    source_endpoint_key_sorted: np.ndarray
-    receiver_endpoint_key_sorted: np.ndarray
-
-    source_node_id_sorted: np.ndarray
-    receiver_node_id_sorted: np.ndarray
-    node_x_m: np.ndarray
-    node_y_m: np.ndarray
-    node_elevation_m: np.ndarray
-    node_kind: np.ndarray
-
-    rejection_reason_sorted: np.ndarray
-    qc: dict[str, Any]
-    endpoint_table: RefractionEndpointTable
-    metadata: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/app/services/refraction_static_solver.py
+++ b/app/services/refraction_static_solver.py
@@ -9,7 +9,10 @@ import numpy as np
 from scipy import optimize, sparse
 
 from app.api.schemas import RefractionStaticModelRequest, RefractionStaticSolverRequest
-from app.services.refraction_static_design_matrix import RefractionStaticDesignMatrix
+from app.services.refraction_static_types import (
+    RefractionStaticDesignMatrix,
+    RefractionStaticSolverResult,
+)
 
 BedrockVelocityMode = Literal['solve_global', 'fixed_global']
 RobustMethod = Literal['mad', 'sigma']
@@ -20,45 +23,6 @@ _ROBUST_SCALE_FLOOR_S = 1.0e-12
 
 class RefractionStaticSolverError(ValueError):
     """Raised when the bounded refraction static solve cannot be completed."""
-
-
-@dataclass(frozen=True)
-class RefractionStaticSolverResult:
-    """Output from the bounded GLI least-squares solver."""
-
-    parameter_vector: np.ndarray
-
-    active_node_id: np.ndarray
-    active_node_half_intercept_time_s: np.ndarray
-
-    node_id: np.ndarray
-    node_half_intercept_time_s: np.ndarray
-    node_solution_status: np.ndarray
-
-    bedrock_velocity_mode: BedrockVelocityMode
-    bedrock_slowness_s_per_m: float
-    bedrock_velocity_m_s: float
-
-    row_trace_index_sorted: np.ndarray
-    row_source_node_id: np.ndarray
-    row_receiver_node_id: np.ndarray
-    row_distance_m: np.ndarray
-    observed_pick_time_s: np.ndarray
-    modeled_pick_time_s: np.ndarray
-    residual_time_s: np.ndarray
-    used_row_mask: np.ndarray
-    rejected_by_robust_mask: np.ndarray
-
-    solver_status: str
-    solver_message: str
-    solver_cost: float
-    solver_optimality: float | None
-    solver_nit: int | None
-    robust_iteration_count: int
-
-    lower_bounds: np.ndarray
-    upper_bounds: np.ndarray
-    qc: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/app/services/refraction_static_types.py
+++ b/app/services/refraction_static_types.py
@@ -1,0 +1,613 @@
+"""Dependency-light result types for GLI refraction statics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+
+
+BedrockVelocityMode = Literal['solve_global', 'fixed_global']
+
+
+@dataclass(frozen=True)
+class RefractionEndpointTable:
+    node_id: np.ndarray
+    endpoint_id: np.ndarray
+    x_m: np.ndarray
+    y_m: np.ndarray
+    elevation_m: np.ndarray
+    kind: np.ndarray
+    pick_count: np.ndarray
+
+
+@dataclass(frozen=True)
+class RefractionStaticInputModel:
+    file_id: str
+    n_traces: int
+
+    sorted_trace_index: np.ndarray
+    pick_time_s_sorted: np.ndarray
+    valid_pick_mask_sorted: np.ndarray
+    valid_observation_mask_sorted: np.ndarray
+
+    source_id_sorted: np.ndarray
+    receiver_id_sorted: np.ndarray
+
+    source_x_m_sorted: np.ndarray
+    source_y_m_sorted: np.ndarray
+    receiver_x_m_sorted: np.ndarray
+    receiver_y_m_sorted: np.ndarray
+
+    source_elevation_m_sorted: np.ndarray
+    receiver_elevation_m_sorted: np.ndarray
+    source_depth_m_sorted: np.ndarray | None
+
+    geometry_distance_m_sorted: np.ndarray
+    offset_m_sorted: np.ndarray | None
+    distance_m_sorted: np.ndarray
+
+    source_endpoint_key_sorted: np.ndarray
+    receiver_endpoint_key_sorted: np.ndarray
+
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+    node_x_m: np.ndarray
+    node_y_m: np.ndarray
+    node_elevation_m: np.ndarray
+    node_kind: np.ndarray
+
+    rejection_reason_sorted: np.ndarray
+    qc: dict[str, Any]
+    endpoint_table: RefractionEndpointTable
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionStaticDesignMatrix:
+    matrix: Any
+    rhs_s: np.ndarray
+
+    observed_pick_time_s: np.ndarray
+    row_trace_index_sorted: np.ndarray
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    row_distance_m: np.ndarray
+
+    active_node_id: np.ndarray
+    inactive_node_id: np.ndarray
+    node_id_to_col: dict[int, int]
+    source_node_col: np.ndarray
+    receiver_node_col: np.ndarray
+
+    bedrock_slowness_col: int | None
+    bedrock_velocity_mode: BedrockVelocityMode
+    fixed_bedrock_velocity_m_s: float | None
+    fixed_bedrock_slowness_s_per_m: float | None
+
+    n_total_nodes: int
+    n_active_nodes: int
+    n_observations: int
+    n_parameters: int
+
+    qc: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionStaticSolverResult:
+    """Output from the bounded GLI least-squares solver."""
+
+    parameter_vector: np.ndarray
+
+    active_node_id: np.ndarray
+    active_node_half_intercept_time_s: np.ndarray
+
+    node_id: np.ndarray
+    node_half_intercept_time_s: np.ndarray
+    node_solution_status: np.ndarray
+
+    bedrock_velocity_mode: BedrockVelocityMode
+    bedrock_slowness_s_per_m: float
+    bedrock_velocity_m_s: float
+
+    row_trace_index_sorted: np.ndarray
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    row_distance_m: np.ndarray
+    observed_pick_time_s: np.ndarray
+    modeled_pick_time_s: np.ndarray
+    residual_time_s: np.ndarray
+    used_row_mask: np.ndarray
+    rejected_by_robust_mask: np.ndarray
+
+    solver_status: str
+    solver_message: str
+    solver_cost: float
+    solver_optimality: float | None
+    solver_nit: int | None
+    robust_iteration_count: int
+
+    lower_bounds: np.ndarray
+    upper_bounds: np.ndarray
+    qc: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionBedrockSlownessResult:
+    """Integration result for the solve-global bedrock slowness workflow."""
+
+    bedrock_velocity_mode: Literal['solve_global']
+    weathering_velocity_m_s: float
+
+    bedrock_slowness_s_per_m: float
+    bedrock_velocity_m_s: float
+    bedrock_velocity_status: str
+
+    min_bedrock_velocity_m_s: float
+    max_bedrock_velocity_m_s: float
+    lower_bedrock_slowness_s_per_m: float
+    upper_bedrock_slowness_s_per_m: float
+
+    active_node_id: np.ndarray
+    active_node_half_intercept_time_s: np.ndarray
+
+    row_trace_index_sorted: np.ndarray
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    row_distance_m: np.ndarray
+    observed_pick_time_s: np.ndarray
+    modeled_pick_time_s: np.ndarray
+    residual_time_s: np.ndarray
+    used_row_mask: np.ndarray
+    rejected_by_robust_mask: np.ndarray
+
+    input_model: RefractionStaticInputModel | None
+    design_matrix: RefractionStaticDesignMatrix | None
+    solver_result: RefractionStaticSolverResult
+
+    qc: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionHalfInterceptTimeResult:
+    """Full node, endpoint, trace-order, and QC output for GLI half-intercepts."""
+
+    bedrock_velocity_mode: BedrockVelocityMode
+    bedrock_slowness_s_per_m: float
+    bedrock_velocity_m_s: float
+    weathering_velocity_m_s: float
+
+    node_id: np.ndarray
+    node_x_m: np.ndarray
+    node_y_m: np.ndarray
+    node_elevation_m: np.ndarray
+    node_kind: np.ndarray
+
+    node_half_intercept_time_s: np.ndarray
+    node_half_intercept_time_ms: np.ndarray
+    node_solution_status: np.ndarray
+
+    node_pick_count: np.ndarray
+    node_used_pick_count: np.ndarray
+    node_rejected_pick_count: np.ndarray
+    node_residual_mean_s: np.ndarray
+    node_residual_median_s: np.ndarray
+    node_residual_rms_s: np.ndarray
+    node_residual_mad_s: np.ndarray
+    node_residual_max_abs_s: np.ndarray
+
+    source_endpoint_key: np.ndarray
+    source_id: np.ndarray
+    source_node_id: np.ndarray
+    source_x_m: np.ndarray
+    source_y_m: np.ndarray
+    source_elevation_m: np.ndarray
+    source_half_intercept_time_s: np.ndarray
+    source_solution_status: np.ndarray
+    source_pick_count: np.ndarray
+    source_residual_rms_s: np.ndarray
+
+    receiver_endpoint_key: np.ndarray
+    receiver_id: np.ndarray
+    receiver_node_id: np.ndarray
+    receiver_x_m: np.ndarray
+    receiver_y_m: np.ndarray
+    receiver_elevation_m: np.ndarray
+    receiver_half_intercept_time_s: np.ndarray
+    receiver_solution_status: np.ndarray
+    receiver_pick_count: np.ndarray
+    receiver_residual_rms_s: np.ndarray
+
+    sorted_trace_index: np.ndarray
+    source_endpoint_key_sorted: np.ndarray
+    receiver_endpoint_key_sorted: np.ndarray
+    source_elevation_m_sorted: np.ndarray
+    receiver_elevation_m_sorted: np.ndarray
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+    source_half_intercept_time_s_sorted: np.ndarray
+    receiver_half_intercept_time_s_sorted: np.ndarray
+    estimated_intercept_time_sum_s_sorted: np.ndarray
+    estimated_bedrock_moveout_time_s_sorted: np.ndarray
+    estimated_first_break_time_s_sorted: np.ndarray
+    first_break_residual_s_sorted: np.ndarray
+    valid_observation_mask_sorted: np.ndarray
+    used_observation_mask_sorted: np.ndarray
+
+    row_trace_index_sorted: np.ndarray
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    row_distance_m: np.ndarray
+    observed_pick_time_s: np.ndarray
+    modeled_pick_time_s: np.ndarray
+    residual_time_s: np.ndarray
+    used_row_mask: np.ndarray
+    rejected_by_robust_mask: np.ndarray
+
+    qc: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionWeatheringThicknessResult:
+    """Node, endpoint, trace-order, and QC output for GLI weathering thickness."""
+
+    bedrock_velocity_mode: BedrockVelocityMode
+    bedrock_slowness_s_per_m: float
+    bedrock_velocity_m_s: float
+    weathering_velocity_m_s: float
+
+    node_id: np.ndarray
+    node_x_m: np.ndarray
+    node_y_m: np.ndarray
+    node_surface_elevation_m: np.ndarray
+    node_kind: np.ndarray
+
+    node_half_intercept_time_s: np.ndarray
+    node_half_intercept_time_ms: np.ndarray
+    node_weathering_thickness_m: np.ndarray
+    node_refractor_elevation_m: np.ndarray
+    node_solution_status: np.ndarray
+    node_weathering_status: np.ndarray
+
+    node_pick_count: np.ndarray
+    node_used_pick_count: np.ndarray
+    node_rejected_pick_count: np.ndarray
+    node_residual_rms_s: np.ndarray
+    node_residual_mad_s: np.ndarray
+
+    source_endpoint_key: np.ndarray
+    source_id: np.ndarray
+    source_node_id: np.ndarray
+    source_x_m: np.ndarray
+    source_y_m: np.ndarray
+    source_surface_elevation_m: np.ndarray
+    source_half_intercept_time_s: np.ndarray
+    source_weathering_thickness_m: np.ndarray
+    source_refractor_elevation_m: np.ndarray
+    source_weathering_status: np.ndarray
+
+    receiver_endpoint_key: np.ndarray
+    receiver_id: np.ndarray
+    receiver_node_id: np.ndarray
+    receiver_x_m: np.ndarray
+    receiver_y_m: np.ndarray
+    receiver_surface_elevation_m: np.ndarray
+    receiver_half_intercept_time_s: np.ndarray
+    receiver_weathering_thickness_m: np.ndarray
+    receiver_refractor_elevation_m: np.ndarray
+    receiver_weathering_status: np.ndarray
+
+    sorted_trace_index: np.ndarray
+    valid_observation_mask_sorted: np.ndarray
+    used_observation_mask_sorted: np.ndarray
+
+    source_endpoint_key_sorted: np.ndarray
+    receiver_endpoint_key_sorted: np.ndarray
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+
+    source_half_intercept_time_s_sorted: np.ndarray
+    receiver_half_intercept_time_s_sorted: np.ndarray
+
+    source_weathering_thickness_m_sorted: np.ndarray
+    receiver_weathering_thickness_m_sorted: np.ndarray
+    source_refractor_elevation_m_sorted: np.ndarray
+    receiver_refractor_elevation_m_sorted: np.ndarray
+    source_weathering_status_sorted: np.ndarray
+    receiver_weathering_status_sorted: np.ndarray
+
+    estimated_first_break_time_s_sorted: np.ndarray
+    first_break_residual_s_sorted: np.ndarray
+
+    row_trace_index_sorted: np.ndarray
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    row_distance_m: np.ndarray
+    observed_pick_time_s: np.ndarray
+    modeled_pick_time_s: np.ndarray
+    residual_time_s: np.ndarray
+    used_row_mask: np.ndarray
+    rejected_by_robust_mask: np.ndarray
+
+    qc: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionWeatheringReplacementStaticsResult:
+    """Weathering-replacement static component from a GLI weathering model."""
+
+    bedrock_velocity_mode: BedrockVelocityMode
+    bedrock_slowness_s_per_m: float
+    bedrock_velocity_m_s: float
+    weathering_velocity_m_s: float
+    replacement_slowness_delta_s_per_m: float
+
+    node_id: np.ndarray
+    node_x_m: np.ndarray
+    node_y_m: np.ndarray
+    node_surface_elevation_m: np.ndarray
+    node_kind: np.ndarray
+    node_weathering_thickness_m: np.ndarray
+    node_refractor_elevation_m: np.ndarray
+    node_half_intercept_time_s: np.ndarray
+    node_solution_status: np.ndarray
+    node_weathering_status: np.ndarray
+    node_weathering_replacement_shift_s: np.ndarray
+    node_weathering_replacement_shift_ms: np.ndarray
+    node_static_status: np.ndarray
+    node_pick_count: np.ndarray
+    node_used_pick_count: np.ndarray
+    node_rejected_pick_count: np.ndarray
+    node_residual_rms_s: np.ndarray
+    node_residual_mad_s: np.ndarray
+
+    source_endpoint_key: np.ndarray
+    source_id: np.ndarray
+    source_node_id: np.ndarray
+    source_x_m: np.ndarray
+    source_y_m: np.ndarray
+    source_surface_elevation_m: np.ndarray
+    source_half_intercept_time_s: np.ndarray
+    source_weathering_thickness_m: np.ndarray
+    source_refractor_elevation_m: np.ndarray
+    source_weathering_replacement_shift_s: np.ndarray
+    source_static_status: np.ndarray
+
+    receiver_endpoint_key: np.ndarray
+    receiver_id: np.ndarray
+    receiver_node_id: np.ndarray
+    receiver_x_m: np.ndarray
+    receiver_y_m: np.ndarray
+    receiver_surface_elevation_m: np.ndarray
+    receiver_half_intercept_time_s: np.ndarray
+    receiver_weathering_thickness_m: np.ndarray
+    receiver_refractor_elevation_m: np.ndarray
+    receiver_weathering_replacement_shift_s: np.ndarray
+    receiver_static_status: np.ndarray
+
+    sorted_trace_index: np.ndarray
+    valid_observation_mask_sorted: np.ndarray
+    used_observation_mask_sorted: np.ndarray
+    source_endpoint_key_sorted: np.ndarray
+    receiver_endpoint_key_sorted: np.ndarray
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+    source_half_intercept_time_s_sorted: np.ndarray
+    receiver_half_intercept_time_s_sorted: np.ndarray
+    source_weathering_thickness_m_sorted: np.ndarray
+    receiver_weathering_thickness_m_sorted: np.ndarray
+    source_refractor_elevation_m_sorted: np.ndarray
+    receiver_refractor_elevation_m_sorted: np.ndarray
+    source_weathering_replacement_shift_s_sorted: np.ndarray
+    receiver_weathering_replacement_shift_s_sorted: np.ndarray
+    weathering_replacement_trace_shift_s_sorted: np.ndarray
+    source_static_status_sorted: np.ndarray
+    receiver_static_status_sorted: np.ndarray
+    trace_static_status_sorted: np.ndarray
+    trace_static_valid_mask_sorted: np.ndarray
+    estimated_first_break_time_s_sorted: np.ndarray
+    first_break_residual_s_sorted: np.ndarray
+
+    row_trace_index_sorted: np.ndarray
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    row_distance_m: np.ndarray
+    observed_pick_time_s: np.ndarray
+    modeled_pick_time_s: np.ndarray
+    residual_time_s: np.ndarray
+    used_row_mask: np.ndarray
+    rejected_by_robust_mask: np.ndarray
+
+    qc: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionDatumStaticsResult:
+    """Composed refraction static components in TraceStore sorted trace order."""
+
+    bedrock_velocity_mode: BedrockVelocityMode
+    bedrock_slowness_s_per_m: float
+    bedrock_velocity_m_s: float
+    weathering_velocity_m_s: float
+    replacement_slowness_delta_s_per_m: float
+
+    datum_mode: str
+    floating_datum_mode: str
+    flat_datum_elevation_m: float | None
+
+    node_id: np.ndarray
+    node_x_m: np.ndarray
+    node_y_m: np.ndarray
+    node_surface_elevation_m: np.ndarray
+    node_kind: np.ndarray
+    node_weathering_thickness_m: np.ndarray
+    node_refractor_elevation_m: np.ndarray
+    node_half_intercept_time_s: np.ndarray
+    node_weathering_replacement_shift_s: np.ndarray
+    node_floating_datum_elevation_m: np.ndarray
+    node_solution_status: np.ndarray
+    node_datum_status: np.ndarray
+    node_weathering_status: np.ndarray
+    node_pick_count: np.ndarray
+    node_used_pick_count: np.ndarray
+    node_rejected_pick_count: np.ndarray
+    node_residual_rms_s: np.ndarray
+    node_residual_mad_s: np.ndarray
+
+    source_endpoint_key: np.ndarray
+    source_id: np.ndarray
+    source_node_id: np.ndarray
+    source_x_m: np.ndarray
+    source_y_m: np.ndarray
+    source_surface_elevation_m: np.ndarray
+    source_half_intercept_time_s: np.ndarray
+    source_weathering_thickness_m: np.ndarray
+    source_refractor_elevation_m: np.ndarray
+    source_floating_datum_elevation_m: np.ndarray
+    source_weathering_replacement_shift_s: np.ndarray
+    source_floating_datum_elevation_shift_s: np.ndarray
+    source_flat_datum_shift_s: np.ndarray
+    source_refraction_shift_s: np.ndarray
+    source_datum_status: np.ndarray
+
+    receiver_endpoint_key: np.ndarray
+    receiver_id: np.ndarray
+    receiver_node_id: np.ndarray
+    receiver_x_m: np.ndarray
+    receiver_y_m: np.ndarray
+    receiver_surface_elevation_m: np.ndarray
+    receiver_half_intercept_time_s: np.ndarray
+    receiver_weathering_thickness_m: np.ndarray
+    receiver_refractor_elevation_m: np.ndarray
+    receiver_floating_datum_elevation_m: np.ndarray
+    receiver_weathering_replacement_shift_s: np.ndarray
+    receiver_floating_datum_elevation_shift_s: np.ndarray
+    receiver_flat_datum_shift_s: np.ndarray
+    receiver_refraction_shift_s: np.ndarray
+    receiver_datum_status: np.ndarray
+
+    sorted_trace_index: np.ndarray
+    valid_observation_mask_sorted: np.ndarray
+    used_observation_mask_sorted: np.ndarray
+    source_node_id_sorted: np.ndarray
+    receiver_node_id_sorted: np.ndarray
+    source_surface_elevation_m_sorted: np.ndarray
+    receiver_surface_elevation_m_sorted: np.ndarray
+    source_floating_datum_elevation_m_sorted: np.ndarray
+    receiver_floating_datum_elevation_m_sorted: np.ndarray
+    source_weathering_thickness_m_sorted: np.ndarray
+    receiver_weathering_thickness_m_sorted: np.ndarray
+    source_refractor_elevation_m_sorted: np.ndarray
+    receiver_refractor_elevation_m_sorted: np.ndarray
+    source_half_intercept_time_s_sorted: np.ndarray
+    receiver_half_intercept_time_s_sorted: np.ndarray
+    source_weathering_replacement_shift_s_sorted: np.ndarray
+    receiver_weathering_replacement_shift_s_sorted: np.ndarray
+    source_floating_datum_elevation_shift_s_sorted: np.ndarray
+    receiver_floating_datum_elevation_shift_s_sorted: np.ndarray
+    source_flat_datum_shift_s_sorted: np.ndarray
+    receiver_flat_datum_shift_s_sorted: np.ndarray
+    source_refraction_shift_s_sorted: np.ndarray
+    receiver_refraction_shift_s_sorted: np.ndarray
+    weathering_replacement_trace_shift_s_sorted: np.ndarray
+    floating_datum_elevation_shift_s_sorted: np.ndarray
+    flat_datum_shift_s_sorted: np.ndarray
+    refraction_trace_shift_s_sorted: np.ndarray
+    trace_static_status_sorted: np.ndarray
+    trace_static_valid_mask_sorted: np.ndarray
+    estimated_first_break_time_s_sorted: np.ndarray
+    first_break_residual_s_sorted: np.ndarray
+
+    row_trace_index_sorted: np.ndarray
+    row_source_node_id: np.ndarray
+    row_receiver_node_id: np.ndarray
+    row_distance_m: np.ndarray
+    observed_pick_time_s: np.ndarray
+    modeled_pick_time_s: np.ndarray
+    residual_time_s: np.ndarray
+    used_row_mask: np.ndarray
+    rejected_by_robust_mask: np.ndarray
+
+    qc: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionStaticArtifactSet:
+    job_dir: Path
+    solution_npz: Path
+    qc_json: Path
+    refraction_statics_csv: Path
+    near_surface_model_csv: Path
+    first_break_residuals_csv: Path
+    refraction_static_components_csv: Path
+    manifest_json: Path | None
+    artifact_names: tuple[str, ...]
+    qc: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RefractionTraceShiftValidationResult:
+    trace_shift_s_sorted: np.ndarray
+    trace_static_valid_mask_sorted: np.ndarray
+    trace_static_status_sorted: np.ndarray
+    trace_static_status_counts: dict[str, int]
+    max_abs_shift_ms: float
+    max_abs_applied_shift_ms: float
+    exceeds_max_abs_shift_count: int
+    n_valid_trace_shifts: int
+    n_invalid_trace_shifts: int
+    n_zero_trace_shifts: int
+    n_positive_trace_shifts: int
+    n_negative_trace_shifts: int
+
+
+@dataclass(frozen=True)
+class RefractionStaticApplyTraceStoreResult:
+    source_file_id: str
+    corrected_file_id: str | None
+
+    source_trace_store_path: Path
+    corrected_trace_store_path: Path | None
+
+    n_traces: int
+    n_samples: int
+    sample_interval_s: float
+
+    interpolation: str
+    fill_value: float
+    output_dtype: str
+
+    applied_shift_s_sorted: np.ndarray
+    applied_shift_ms_sorted: np.ndarray
+    trace_static_valid_mask_sorted: np.ndarray
+    trace_static_status_sorted: np.ndarray
+
+    max_abs_applied_shift_ms: float
+    n_valid_trace_shifts: int
+    n_invalid_trace_shifts: int
+    n_zero_trace_shifts: int
+    n_positive_trace_shifts: int
+    n_negative_trace_shifts: int
+
+    corrected_file_json: Path | None
+    qc_json: Path | None
+    qc: dict[str, Any]
+
+
+__all__ = [
+    'BedrockVelocityMode',
+    'RefractionBedrockSlownessResult',
+    'RefractionDatumStaticsResult',
+    'RefractionEndpointTable',
+    'RefractionHalfInterceptTimeResult',
+    'RefractionStaticApplyTraceStoreResult',
+    'RefractionStaticArtifactSet',
+    'RefractionStaticDesignMatrix',
+    'RefractionStaticInputModel',
+    'RefractionStaticSolverResult',
+    'RefractionTraceShiftValidationResult',
+    'RefractionWeatheringReplacementStaticsResult',
+    'RefractionWeatheringThicknessResult',
+]

--- a/app/services/refraction_static_weathering.py
+++ b/app/services/refraction_static_weathering.py
@@ -14,8 +14,11 @@ import numpy as np
 from app.api.schemas import RefractionStaticApplyRequest, RefractionStaticModelRequest
 from app.core.state import AppState
 from app.services.refraction_static_half_intercept import (
-    RefractionHalfInterceptTimeResult,
     estimate_refraction_half_intercept_times_from_first_breaks,
+)
+from app.services.refraction_static_types import (
+    RefractionHalfInterceptTimeResult,
+    RefractionWeatheringThicknessResult,
 )
 
 REFRACTION_WEATHERING_QC_JSON_NAME = 'refraction_weathering_thickness_qc.json'
@@ -92,91 +95,6 @@ _TRACE_PREVIEW_COLUMNS = (
 
 class RefractionWeatheringThicknessError(ValueError):
     """Raised when weathering-thickness outputs cannot be built."""
-
-
-@dataclass(frozen=True)
-class RefractionWeatheringThicknessResult:
-    """Node, endpoint, trace-order, and QC output for GLI weathering thickness."""
-
-    bedrock_velocity_mode: Literal['solve_global', 'fixed_global']
-    bedrock_slowness_s_per_m: float
-    bedrock_velocity_m_s: float
-    weathering_velocity_m_s: float
-
-    node_id: np.ndarray
-    node_x_m: np.ndarray
-    node_y_m: np.ndarray
-    node_surface_elevation_m: np.ndarray
-    node_kind: np.ndarray
-
-    node_half_intercept_time_s: np.ndarray
-    node_half_intercept_time_ms: np.ndarray
-    node_weathering_thickness_m: np.ndarray
-    node_refractor_elevation_m: np.ndarray
-    node_solution_status: np.ndarray
-    node_weathering_status: np.ndarray
-
-    node_pick_count: np.ndarray
-    node_used_pick_count: np.ndarray
-    node_rejected_pick_count: np.ndarray
-    node_residual_rms_s: np.ndarray
-    node_residual_mad_s: np.ndarray
-
-    source_endpoint_key: np.ndarray
-    source_id: np.ndarray
-    source_node_id: np.ndarray
-    source_x_m: np.ndarray
-    source_y_m: np.ndarray
-    source_surface_elevation_m: np.ndarray
-    source_half_intercept_time_s: np.ndarray
-    source_weathering_thickness_m: np.ndarray
-    source_refractor_elevation_m: np.ndarray
-    source_weathering_status: np.ndarray
-
-    receiver_endpoint_key: np.ndarray
-    receiver_id: np.ndarray
-    receiver_node_id: np.ndarray
-    receiver_x_m: np.ndarray
-    receiver_y_m: np.ndarray
-    receiver_surface_elevation_m: np.ndarray
-    receiver_half_intercept_time_s: np.ndarray
-    receiver_weathering_thickness_m: np.ndarray
-    receiver_refractor_elevation_m: np.ndarray
-    receiver_weathering_status: np.ndarray
-
-    sorted_trace_index: np.ndarray
-    valid_observation_mask_sorted: np.ndarray
-    used_observation_mask_sorted: np.ndarray
-
-    source_endpoint_key_sorted: np.ndarray
-    receiver_endpoint_key_sorted: np.ndarray
-    source_node_id_sorted: np.ndarray
-    receiver_node_id_sorted: np.ndarray
-
-    source_half_intercept_time_s_sorted: np.ndarray
-    receiver_half_intercept_time_s_sorted: np.ndarray
-
-    source_weathering_thickness_m_sorted: np.ndarray
-    receiver_weathering_thickness_m_sorted: np.ndarray
-    source_refractor_elevation_m_sorted: np.ndarray
-    receiver_refractor_elevation_m_sorted: np.ndarray
-    source_weathering_status_sorted: np.ndarray
-    receiver_weathering_status_sorted: np.ndarray
-
-    estimated_first_break_time_s_sorted: np.ndarray
-    first_break_residual_s_sorted: np.ndarray
-
-    row_trace_index_sorted: np.ndarray
-    row_source_node_id: np.ndarray
-    row_receiver_node_id: np.ndarray
-    row_distance_m: np.ndarray
-    observed_pick_time_s: np.ndarray
-    modeled_pick_time_s: np.ndarray
-    residual_time_s: np.ndarray
-    used_row_mask: np.ndarray
-    rejected_by_robust_mask: np.ndarray
-
-    qc: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/app/services/refraction_static_weathering_replacement.py
+++ b/app/services/refraction_static_weathering_replacement.py
@@ -13,8 +13,11 @@ import numpy as np
 
 from app.api.schemas import RefractionStaticApplyOptions, RefractionStaticApplyRequest
 from app.core.state import AppState
-from app.services.refraction_static_weathering import (
+from app.services.refraction_static_types import (
     RefractionWeatheringThicknessResult,
+    RefractionWeatheringReplacementStaticsResult,
+)
+from app.services.refraction_static_weathering import (
     estimate_weathering_thickness_from_first_breaks,
 )
 
@@ -118,95 +121,6 @@ _TRACE_PREVIEW_COLUMNS = (
 
 class RefractionWeatheringReplacementStaticsError(ValueError):
     """Raised when weathering-replacement static outputs cannot be built."""
-
-
-@dataclass(frozen=True)
-class RefractionWeatheringReplacementStaticsResult:
-    """Weathering-replacement static component from a GLI weathering model."""
-
-    bedrock_velocity_mode: Literal['solve_global', 'fixed_global']
-    bedrock_slowness_s_per_m: float
-    bedrock_velocity_m_s: float
-    weathering_velocity_m_s: float
-    replacement_slowness_delta_s_per_m: float
-
-    node_id: np.ndarray
-    node_x_m: np.ndarray
-    node_y_m: np.ndarray
-    node_surface_elevation_m: np.ndarray
-    node_kind: np.ndarray
-    node_weathering_thickness_m: np.ndarray
-    node_refractor_elevation_m: np.ndarray
-    node_half_intercept_time_s: np.ndarray
-    node_solution_status: np.ndarray
-    node_weathering_status: np.ndarray
-    node_weathering_replacement_shift_s: np.ndarray
-    node_weathering_replacement_shift_ms: np.ndarray
-    node_static_status: np.ndarray
-    node_pick_count: np.ndarray
-    node_used_pick_count: np.ndarray
-    node_rejected_pick_count: np.ndarray
-    node_residual_rms_s: np.ndarray
-    node_residual_mad_s: np.ndarray
-
-    source_endpoint_key: np.ndarray
-    source_id: np.ndarray
-    source_node_id: np.ndarray
-    source_x_m: np.ndarray
-    source_y_m: np.ndarray
-    source_surface_elevation_m: np.ndarray
-    source_half_intercept_time_s: np.ndarray
-    source_weathering_thickness_m: np.ndarray
-    source_refractor_elevation_m: np.ndarray
-    source_weathering_replacement_shift_s: np.ndarray
-    source_static_status: np.ndarray
-
-    receiver_endpoint_key: np.ndarray
-    receiver_id: np.ndarray
-    receiver_node_id: np.ndarray
-    receiver_x_m: np.ndarray
-    receiver_y_m: np.ndarray
-    receiver_surface_elevation_m: np.ndarray
-    receiver_half_intercept_time_s: np.ndarray
-    receiver_weathering_thickness_m: np.ndarray
-    receiver_refractor_elevation_m: np.ndarray
-    receiver_weathering_replacement_shift_s: np.ndarray
-    receiver_static_status: np.ndarray
-
-    sorted_trace_index: np.ndarray
-    valid_observation_mask_sorted: np.ndarray
-    used_observation_mask_sorted: np.ndarray
-    source_endpoint_key_sorted: np.ndarray
-    receiver_endpoint_key_sorted: np.ndarray
-    source_node_id_sorted: np.ndarray
-    receiver_node_id_sorted: np.ndarray
-    source_half_intercept_time_s_sorted: np.ndarray
-    receiver_half_intercept_time_s_sorted: np.ndarray
-    source_weathering_thickness_m_sorted: np.ndarray
-    receiver_weathering_thickness_m_sorted: np.ndarray
-    source_refractor_elevation_m_sorted: np.ndarray
-    receiver_refractor_elevation_m_sorted: np.ndarray
-    source_weathering_replacement_shift_s_sorted: np.ndarray
-    receiver_weathering_replacement_shift_s_sorted: np.ndarray
-    weathering_replacement_trace_shift_s_sorted: np.ndarray
-    source_static_status_sorted: np.ndarray
-    receiver_static_status_sorted: np.ndarray
-    trace_static_status_sorted: np.ndarray
-    trace_static_valid_mask_sorted: np.ndarray
-    estimated_first_break_time_s_sorted: np.ndarray
-    first_break_residual_s_sorted: np.ndarray
-
-    row_trace_index_sorted: np.ndarray
-    row_source_node_id: np.ndarray
-    row_receiver_node_id: np.ndarray
-    row_distance_m: np.ndarray
-    observed_pick_time_s: np.ndarray
-    modeled_pick_time_s: np.ndarray
-    residual_time_s: np.ndarray
-    used_row_mask: np.ndarray
-    rejected_by_robust_mask: np.ndarray
-
-    qc: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -24,7 +24,7 @@ from app.services.refraction_static_artifacts import (
     write_refraction_static_solution_npz,
     write_refraction_static_artifacts,
 )
-from app.services.refraction_static_datum import RefractionDatumStaticsResult
+from app.services.refraction_static_types import RefractionDatumStaticsResult
 
 
 REQUIRED_TRACE_ARRAYS = {

--- a/app/tests/test_refraction_static_bedrock.py
+++ b/app/tests/test_refraction_static_bedrock.py
@@ -21,7 +21,7 @@ from app.services.refraction_static_bedrock import (
 from app.services.refraction_static_design_matrix import (
     build_refraction_static_design_matrix,
 )
-from app.services.refraction_static_inputs import (
+from app.services.refraction_static_types import (
     RefractionEndpointTable,
     RefractionStaticInputModel,
 )
@@ -629,8 +629,10 @@ def test_lower_level_can_retain_debug_objects() -> None:
 def test_estimate_wraps_high_level_input_builder_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    import app.services.refraction_static_inputs as inputs_module
+
     monkeypatch.setattr(
-        bedrock_module,
+        inputs_module,
         'build_refraction_static_input_model',
         lambda **_kwargs: (_ for _ in ()).throw(ValueError('input builder failed')),
     )

--- a/app/tests/test_refraction_static_datum.py
+++ b/app/tests/test_refraction_static_datum.py
@@ -26,7 +26,7 @@ from app.services.refraction_static_datum import (
     compute_flat_datum_shift_s,
     compute_floating_datum_elevation_shift_s,
 )
-from app.services.refraction_static_weathering_replacement import (
+from app.services.refraction_static_types import (
     RefractionWeatheringReplacementStaticsResult,
 )
 

--- a/app/tests/test_refraction_static_design_matrix.py
+++ b/app/tests/test_refraction_static_design_matrix.py
@@ -8,12 +8,12 @@ from scipy import sparse
 
 from app.api.schemas import RefractionStaticModelRequest
 from app.services.refraction_static_design_matrix import (
-    RefractionStaticDesignMatrix,
     build_refraction_static_design_matrix,
     build_refraction_static_design_matrix_from_arrays,
 )
-from app.services.refraction_static_inputs import (
+from app.services.refraction_static_types import (
     RefractionEndpointTable,
+    RefractionStaticDesignMatrix,
     RefractionStaticInputModel,
 )
 

--- a/app/tests/test_refraction_static_half_intercept.py
+++ b/app/tests/test_refraction_static_half_intercept.py
@@ -27,7 +27,7 @@ from app.services.refraction_static_half_intercept import (
     build_refraction_half_intercept_time_model_from_bedrock_result,
     estimate_refraction_half_intercept_times_from_first_breaks,
 )
-from app.services.refraction_static_inputs import (
+from app.services.refraction_static_types import (
     RefractionEndpointTable,
     RefractionStaticInputModel,
 )

--- a/app/tests/test_refraction_static_import_layers.py
+++ b/app/tests/test_refraction_static_import_layers.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+from types import ModuleType
+
+import app.services.refraction_static_bedrock as bedrock
+import app.services.refraction_static_design_matrix as design_matrix
+import app.services.refraction_static_half_intercept as half_intercept
+import app.services.refraction_static_solver as solver
+import app.services.refraction_static_types as refraction_types
+import app.services.refraction_static_weathering as weathering
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FORBIDDEN_IMPORTS = {
+    'app.services.reader',
+    'app.services.refraction_static_inputs',
+    'app.trace_store.reader',
+    'segyio',
+}
+
+
+def _module_source(module: ModuleType) -> str:
+    path = Path(module.__file__ or '')
+    return path.read_text(encoding='utf-8')
+
+
+def _forbidden_modules_imported_by(module_name: str) -> set[str]:
+    code = f"""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+
+for name in {sorted(_FORBIDDEN_IMPORTS)!r}:
+    sys.modules.pop(name, None)
+
+importlib.import_module({module_name!r})
+
+print(json.dumps(sorted(name for name in {sorted(_FORBIDDEN_IMPORTS)!r} if name in sys.modules)))
+"""
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return set(json.loads(result.stdout))
+
+
+def test_refraction_static_types_is_dependency_light() -> None:
+    assert refraction_types.RefractionStaticInputModel is not None
+    assert refraction_types.RefractionStaticDesignMatrix is not None
+    assert refraction_types.RefractionDatumStaticsResult is not None
+
+    source = _module_source(refraction_types)
+
+    assert 'app.api.schemas' not in source
+    assert 'app.services.reader' not in source
+    assert 'app.trace_store.reader' not in source
+    assert 'refraction_static_inputs' not in source
+    assert 'segyio' not in source
+    assert 'scipy' not in source
+
+
+def test_numeric_refraction_modules_import_without_tracestore_readers() -> None:
+    assert design_matrix.RefractionStaticDesignMatrix is not None
+    assert solver.RefractionStaticSolverResult is not None
+    assert bedrock.RefractionBedrockSlownessResult is not None
+    assert half_intercept.RefractionHalfInterceptTimeResult is not None
+    assert weathering.RefractionWeatheringThicknessResult is not None
+
+    for module_name in (
+        'app.services.refraction_static_design_matrix',
+        'app.services.refraction_static_solver',
+        'app.services.refraction_static_bedrock',
+        'app.services.refraction_static_half_intercept',
+        'app.services.refraction_static_weathering',
+    ):
+        assert _forbidden_modules_imported_by(module_name) == set()

--- a/app/tests/test_refraction_static_solver.py
+++ b/app/tests/test_refraction_static_solver.py
@@ -9,7 +9,6 @@ from scipy import sparse
 import app.services.refraction_static_solver as solver_module
 from app.api.schemas import RefractionStaticModelRequest, RefractionStaticSolverRequest
 from app.services.refraction_static_design_matrix import (
-    RefractionStaticDesignMatrix,
     build_refraction_static_design_matrix_from_arrays,
 )
 from app.services.refraction_static_solver import (
@@ -17,6 +16,7 @@ from app.services.refraction_static_solver import (
     solve_refraction_static_bounded_ls,
     solve_refraction_static_bounded_ls_from_matrix,
 )
+from app.services.refraction_static_types import RefractionStaticDesignMatrix
 
 ACTIVE_NODE_ID = np.asarray([10, 20, 30, 40], dtype=np.int64)
 TRUE_HALF_INTERCEPT_S = np.asarray([0.010, 0.020, 0.015, 0.012], dtype=np.float64)

--- a/app/tests/test_refraction_static_weathering_replacement.py
+++ b/app/tests/test_refraction_static_weathering_replacement.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 from app.api.schemas import RefractionStaticApplyOptions
-from app.services.refraction_static_weathering import (
+from app.services.refraction_static_types import (
     RefractionWeatheringThicknessResult,
 )
 import app.services.refraction_static_weathering_replacement as replacement_module


### PR DESCRIPTION
Closes #394

## Summary
- P1-01 refactor(statics): move refraction result dataclasses to a dependency-light types module

## Changed files
- `app/services/refraction_static_apply_trace_store.py`
- `app/services/refraction_static_artifacts.py`
- `app/services/refraction_static_bedrock.py`
- `app/services/refraction_static_datum.py`
- `app/services/refraction_static_design_matrix.py`
- `app/services/refraction_static_half_intercept.py`
- `app/services/refraction_static_inputs.py`
- `app/services/refraction_static_solver.py`
- `app/services/refraction_static_types.py`
- `app/services/refraction_static_weathering.py`
- `app/services/refraction_static_weathering_replacement.py`
- `app/tests/test_refraction_static_artifacts.py`
- `app/tests/test_refraction_static_bedrock.py`
- `app/tests/test_refraction_static_datum.py`
- `app/tests/test_refraction_static_design_matrix.py`
- `app/tests/test_refraction_static_half_intercept.py`
- `app/tests/test_refraction_static_import_layers.py`
- `app/tests/test_refraction_static_solver.py`
- `app/tests/test_refraction_static_weathering_replacement.py`

## Checks
- `.work/codex/checks.log`: 1676 passed in 49.46s

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
