### PR TITLE
Batch: address issues #408-#411

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1429,6 +1429,14 @@ class RefractionStaticFirstLayerRequest(BaseModel):
                 'model.first_layer.min_weathering_velocity_m_s must be less than '
                 'model.first_layer.max_weathering_velocity_m_s'
             )
+        if (
+            self.mode == 'estimate_direct_arrival'
+            and self.weathering_velocity_m_s is not None
+        ):
+            raise ValueError(
+                'model.first_layer.weathering_velocity_m_s must be omitted when '
+                'model.first_layer.mode is estimate_direct_arrival'
+            )
         if self.mode == 'estimate_direct_arrival' and (
             self.min_direct_offset_m is None or self.max_direct_offset_m is None
         ):
@@ -1583,6 +1591,18 @@ class RefractionStaticModelRequest(BaseModel):
             return legacy_velocity
 
         first_layer_velocity = first_layer.weathering_velocity_m_s
+        if first_layer.mode == 'estimate_direct_arrival':
+            if legacy_velocity is not None:
+                raise ValueError(
+                    'model.weathering_velocity_m_s must be omitted when '
+                    'model.first_layer.mode is estimate_direct_arrival'
+                )
+            if first_layer_velocity is not None:
+                raise ValueError(
+                    'model.first_layer.weathering_velocity_m_s must be omitted when '
+                    'model.first_layer.mode is estimate_direct_arrival'
+                )
+            return None
         if (
             legacy_velocity is not None
             and first_layer_velocity is not None
@@ -1593,8 +1613,6 @@ class RefractionStaticModelRequest(BaseModel):
                 'model.first_layer.weathering_velocity_m_s must match when both '
                 'are specified'
             )
-        if first_layer.mode == 'estimate_direct_arrival':
-            return first_layer_velocity
         if first_layer_velocity is None:
             raise ValueError(
                 'model.first_layer.weathering_velocity_m_s is required when '

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Iterable
 from dataclasses import dataclass
 import json
 import os
@@ -113,35 +114,23 @@ _V1_ARTIFACTS: tuple[dict[str, str | bool], ...] = (
         'name': REFRACTION_V1_QC_JSON_NAME,
         'kind': 'json',
         'required': True,
+        'origin': 'upstream',
         'description': 'Direct-arrival V1 estimation QC summary',
     },
     {
         'name': REFRACTION_V1_ESTIMATES_CSV_NAME,
         'kind': 'csv',
         'required': True,
+        'origin': 'upstream',
         'description': 'Per-source direct-arrival V1 estimates',
     },
 )
 
-_OPTIONAL_CONSTANT_V1_ARTIFACTS: tuple[dict[str, str | bool], ...] = (
+_V1_ARTIFACT_NAMES = frozenset(
     {
-        'name': REFRACTION_V1_QC_JSON_NAME,
-        'kind': 'json',
-        'required': False,
-        'description': (
-            'Optional standalone V1 QC summary; constant V1 details are recorded '
-            f'in {REFRACTION_STATIC_QC_JSON_NAME}'
-        ),
-    },
-    {
-        'name': REFRACTION_V1_ESTIMATES_CSV_NAME,
-        'kind': 'csv',
-        'required': False,
-        'description': (
-            'Optional per-source direct-arrival V1 estimates; not produced for '
-            'constant first-layer mode'
-        ),
-    },
+        REFRACTION_V1_QC_JSON_NAME,
+        REFRACTION_V1_ESTIMATES_CSV_NAME,
+    }
 )
 
 _T1LSST_1LAYER_ARTIFACTS: tuple[dict[str, str | bool], ...] = (
@@ -333,8 +322,17 @@ def write_refraction_static_artifacts(
     req: RefractionStaticApplyRequest,
     job_dir: Path,
     resolved_first_layer: ResolvedRefractionFirstLayer | None = None,
+    upstream_artifact_names: Iterable[str] = (),
 ) -> RefractionStaticArtifactSet:
-    """Write the final refraction statics NPZ, QC, CSV, and manifest artifacts."""
+    """Write final refraction statics artifacts and an artifact manifest.
+
+    This writer owns only the final refraction statics artifacts it writes in
+    this function.  Upstream artifacts, currently the direct-arrival V1 QC and
+    estimates files, are included in the manifest only when their plain file
+    names are passed via ``upstream_artifact_names``.  Declared upstream
+    artifacts must already exist in ``job_dir`` and are validated with a
+    dedicated upstream-artifact error.
+    """
     root = _validate_job_dir(job_dir)
     values = _validate_result(result)
     request = RefractionStaticApplyRequest.model_validate(req)
@@ -343,11 +341,21 @@ def write_refraction_static_artifacts(
         req=request,
         resolved_first_layer=resolved_first_layer,
     )
-    artifact_entries = _artifact_entries_for_request(request, first_layer)
+    upstream_names = _validate_upstream_artifact_names(
+        upstream_artifact_names,
+        resolved_first_layer=first_layer,
+    )
+    _validate_declared_upstream_artifacts(root, upstream_names)
+    artifact_entries = _artifact_entries_for_request(
+        request,
+        first_layer,
+        upstream_artifact_names=upstream_names,
+    )
     qc = build_refraction_static_qc_payload(
         result=values.result,
         req=request,
         resolved_first_layer=first_layer,
+        upstream_artifact_names=upstream_names,
     )
     manifest = _build_manifest_payload(artifact_entries)
     _assert_strict_json(manifest, artifact_name=REFRACTION_STATIC_ARTIFACTS_JSON_NAME)
@@ -434,15 +442,12 @@ def write_refraction_static_artifacts(
         artifact_paths = artifact_paths + (
             paths.refraction_t1lsst_1layer_components_csv,
         )
-    artifact_paths = artifact_paths + tuple(
-        root / str(item['name']) for item in _v1_artifact_entries(request, first_layer)
-        if bool(item['required'])
-    )
     for artifact_path in artifact_paths:
         if not artifact_path.is_file():
             raise RefractionStaticArtifactError(
                 f'artifact file missing after write: {artifact_path.name}'
             )
+    _validate_declared_upstream_artifacts(root, upstream_names)
     return paths
 
 
@@ -891,6 +896,7 @@ def build_refraction_static_qc_payload(
     result: RefractionDatumStaticsResult,
     req: RefractionStaticApplyRequest,
     resolved_first_layer: ResolvedRefractionFirstLayer | None = None,
+    upstream_artifact_names: Iterable[str] = (),
 ) -> dict[str, Any]:
     values = _validate_result(result)
     r = values.result
@@ -909,7 +915,15 @@ def build_refraction_static_qc_payload(
         ]
     )
     request = _request_summary(req)
-    artifact_entries = _artifact_entries_for_request(req, first_layer)
+    upstream_names = _validate_upstream_artifact_names(
+        upstream_artifact_names,
+        resolved_first_layer=first_layer,
+    )
+    artifact_entries = _artifact_entries_for_request(
+        req,
+        first_layer,
+        upstream_artifact_names=upstream_names,
+    )
     payload: dict[str, Any] = {
         'artifact_version': ARTIFACT_VERSION,
         'method': METHOD,
@@ -1752,11 +1766,18 @@ def _request_summary(req: RefractionStaticApplyRequest) -> dict[str, Any]:
 def _artifact_entries_for_request(
     req: RefractionStaticApplyRequest,
     resolved_first_layer: ResolvedRefractionFirstLayer | None = None,
+    *,
+    upstream_artifact_names: Iterable[str] = (),
 ) -> tuple[dict[str, str | bool], ...]:
     return (
         _ARTIFACTS
         + _t1lsst_artifact_entries(req)
-        + _v1_artifact_entries(req, resolved_first_layer)
+        + _upstream_artifact_entries(
+            _validate_upstream_artifact_names(
+                upstream_artifact_names,
+                resolved_first_layer=resolved_first_layer,
+            )
+        )
     )
 
 
@@ -1768,18 +1789,69 @@ def _t1lsst_artifact_entries(
     return ()
 
 
-def _v1_artifact_entries(
-    req: RefractionStaticApplyRequest,
-    resolved_first_layer: ResolvedRefractionFirstLayer | None = None,
-) -> tuple[dict[str, str | bool], ...]:
+def _validate_upstream_artifact_names(
+    names: Iterable[str],
+    *,
+    resolved_first_layer: ResolvedRefractionFirstLayer | None,
+) -> tuple[str, ...]:
+    seen: set[str] = set()
+    values: list[str] = []
+    for name in names:
+        if not isinstance(name, str):
+            raise RefractionStaticArtifactError(
+                'upstream artifact names must be strings'
+            )
+        if name in seen:
+            continue
+        if name not in _V1_ARTIFACT_NAMES:
+            raise RefractionStaticArtifactError(
+                f'unsupported upstream artifact: {name}'
+            )
+        seen.add(name)
+        values.append(name)
+
+    if not values:
+        return ()
+
     mode = (
         resolved_first_layer.mode
         if resolved_first_layer is not None
-        else req.model.first_layer_mode
+        else None
     )
-    if mode == 'estimate_direct_arrival':
-        return _V1_ARTIFACTS
-    return _OPTIONAL_CONSTANT_V1_ARTIFACTS
+    if mode != 'estimate_direct_arrival':
+        raise RefractionStaticArtifactError(
+            'upstream V1 artifacts are only valid when first-layer mode is '
+            'estimate_direct_arrival'
+        )
+
+    value_set = set(values)
+    if value_set != _V1_ARTIFACT_NAMES:
+        expected = ', '.join(sorted(_V1_ARTIFACT_NAMES))
+        raise RefractionStaticArtifactError(
+            f'upstream V1 artifacts must include both: {expected}'
+        )
+    return tuple(
+        str(item['name']) for item in _V1_ARTIFACTS if str(item['name']) in value_set
+    )
+
+
+def _validate_declared_upstream_artifacts(
+    root: Path,
+    names: tuple[str, ...],
+) -> None:
+    for name in names:
+        artifact_path = root / name
+        if not artifact_path.is_file():
+            raise RefractionStaticArtifactError(
+                f'declared upstream artifact missing: {name}'
+            )
+
+
+def _upstream_artifact_entries(
+    names: tuple[str, ...],
+) -> tuple[dict[str, str | bool], ...]:
+    name_set = set(names)
+    return tuple(item for item in _V1_ARTIFACTS if str(item['name']) in name_set)
 
 
 def _build_manifest_payload(
@@ -1794,6 +1866,7 @@ def _build_manifest_payload(
                 'name': str(item['name']),
                 'kind': str(item['kind']),
                 'required': bool(item['required']),
+                'origin': str(item.get('origin', 'final')),
             }
             for item in artifact_entries
         ],

--- a/app/services/refraction_static_first_layer.py
+++ b/app/services/refraction_static_first_layer.py
@@ -33,6 +33,26 @@ def resolve_weathering_velocity_m_s(
     return velocity
 
 
+def normalize_refraction_first_layer_request(
+    model: Any,
+) -> ResolvedRefractionFirstLayer:
+    """Resolve a schema model's first-layer/V1 block to the downstream V1."""
+    mode = getattr(model, 'first_layer_mode')
+    velocity = float(getattr(model, 'resolved_weathering_velocity_m_s'))
+    status = 'estimated' if mode == 'estimate_direct_arrival' else 'resolved_constant'
+    return ResolvedRefractionFirstLayer(
+        mode=mode,
+        weathering_velocity_m_s=velocity,
+        status=status,
+        qc={
+            'v1_mode': mode,
+            'weathering_velocity_m_s': velocity,
+            'resolved_weathering_velocity_m_s': velocity,
+            'v1_status': status,
+        },
+    )
+
+
 def validate_resolved_first_layer_velocity_match(
     *,
     weathering_velocity_m_s: Any,
@@ -89,4 +109,3 @@ def _positive_finite(value: Any, *, name: str) -> float:
 
 def _velocities_close(left: float, right: float) -> bool:
     return bool(np.isclose(float(left), float(right), rtol=1.0e-6, atol=1.0e-6))
-

--- a/app/services/refraction_static_half_intercept.py
+++ b/app/services/refraction_static_half_intercept.py
@@ -179,10 +179,12 @@ def estimate_refraction_half_intercept_times_from_first_breaks(
     resolved_first_layer: ResolvedRefractionFirstLayer | None = None,
 ) -> RefractionHalfInterceptTimeResult:
     """Build inputs, solve the GLI system, and emit the half-intercept model."""
-    from app.services.refraction_static_inputs import build_refraction_static_input_model
-
     try:
         if input_model is None:
+            from app.services.refraction_static_inputs import (
+                build_refraction_static_input_model,
+            )
+
             input_model = build_refraction_static_input_model(
                 req=req,
                 state=state,

--- a/app/services/refraction_static_service.py
+++ b/app/services/refraction_static_service.py
@@ -26,6 +26,8 @@ from app.services.refraction_static_types import (
     ResolvedRefractionFirstLayer,
 )
 from app.services.refraction_static_v1 import (
+    REFRACTION_V1_ESTIMATES_CSV_NAME,
+    REFRACTION_V1_QC_JSON_NAME,
     estimate_global_v1_from_direct_arrivals,
     write_refraction_v1_artifacts,
 )
@@ -42,6 +44,7 @@ class _ResolvedFirstLayerRequest:
     req: RefractionStaticApplyRequest
     resolved: ResolvedRefractionFirstLayer
     input_model: RefractionStaticInputModel | None
+    upstream_artifact_names: tuple[str, ...] = ()
 
 
 class RefractionFirstLayerNotImplemented(NotImplementedError):
@@ -102,6 +105,10 @@ def resolve_refraction_first_layer_request(
             },
         ),
         input_model=input_model,
+        upstream_artifact_names=(
+            REFRACTION_V1_QC_JSON_NAME,
+            REFRACTION_V1_ESTIMATES_CSV_NAME,
+        ),
     )
 
 
@@ -253,6 +260,7 @@ def _run_refraction_static_apply_job_body(
         req=active_req,
         job_dir=job_dir,
         resolved_first_layer=first_layer.resolved,
+        upstream_artifact_names=first_layer.upstream_artifact_names,
     )
     if active_req.apply.register_corrected_file:
         _set_job_progress_message(

--- a/app/services/refraction_static_service.py
+++ b/app/services/refraction_static_service.py
@@ -105,12 +105,8 @@ def resolve_refraction_first_layer_request(
         first_layer=first_layer,
     )
     write_refraction_v1_artifacts(job_dir, estimate)
-    resolved_req = _request_with_resolved_first_layer_velocity(
-        req,
-        weathering_velocity_m_s=estimate.resolved_weathering_velocity_m_s,
-    )
     return _ResolvedFirstLayerRequest(
-        req=resolved_req,
+        req=req,
         resolved=ResolvedRefractionFirstLayer(
             mode='estimate_direct_arrival',
             weathering_velocity_m_s=estimate.resolved_weathering_velocity_m_s,
@@ -124,26 +120,6 @@ def resolve_refraction_first_layer_request(
         ),
         input_model=input_model,
     )
-
-
-def _request_with_resolved_first_layer_velocity(
-    req: RefractionStaticApplyRequest,
-    *,
-    weathering_velocity_m_s: float,
-) -> RefractionStaticApplyRequest:
-    first_layer = req.model.first_layer
-    if first_layer is None:
-        raise ValueError('model.first_layer is required for V1 estimation')
-    resolved_first_layer = first_layer.model_copy(
-        update={'weathering_velocity_m_s': float(weathering_velocity_m_s)}
-    )
-    resolved_model = req.model.model_copy(
-        update={
-            'weathering_velocity_m_s': None,
-            'first_layer': resolved_first_layer,
-        }
-    )
-    return req.model_copy(update={'model': resolved_model})
 
 
 def _request_without_moveout_offset_gates(

--- a/app/services/refraction_static_service.py
+++ b/app/services/refraction_static_service.py
@@ -9,7 +9,7 @@ import time
 from typing import Any
 from uuid import uuid4
 
-from app.api.schemas import RefractionStaticApplyRequest, RefractionStaticModelRequest
+from app.api.schemas import RefractionStaticApplyRequest
 from app.core.state import AppState
 from app.services.job_runner import JobCompletion, JobFailure, run_job_with_lifecycle
 from app.services.refraction_static_apply_trace_store import (
@@ -17,6 +17,9 @@ from app.services.refraction_static_apply_trace_store import (
 )
 from app.services.refraction_static_artifacts import write_refraction_static_artifacts
 from app.services.refraction_static_datum import build_refraction_datum_statics
+from app.services.refraction_static_first_layer import (
+    normalize_refraction_first_layer_request,
+)
 from app.services.refraction_static_inputs import build_refraction_static_input_model
 from app.services.refraction_static_types import (
     RefractionStaticInputModel,
@@ -43,26 +46,6 @@ class _ResolvedFirstLayerRequest:
 
 class RefractionFirstLayerNotImplemented(NotImplementedError):
     """Raised when a requested first-layer mode is accepted but not implemented."""
-
-
-def normalize_refraction_first_layer_request(
-    model: RefractionStaticModelRequest,
-) -> ResolvedRefractionFirstLayer:
-    """Resolve the first-layer/V1 request block to the V1 used downstream."""
-    mode = model.first_layer_mode
-    velocity = float(model.resolved_weathering_velocity_m_s)
-    status = 'estimated' if mode == 'estimate_direct_arrival' else 'resolved_constant'
-    return ResolvedRefractionFirstLayer(
-        mode=mode,
-        weathering_velocity_m_s=velocity,
-        status=status,
-        qc={
-            'v1_mode': mode,
-            'weathering_velocity_m_s': velocity,
-            'resolved_weathering_velocity_m_s': velocity,
-            'v1_status': status,
-        },
-    )
 
 
 def resolve_refraction_first_layer_request(

--- a/app/services/refraction_static_v1.py
+++ b/app/services/refraction_static_v1.py
@@ -38,6 +38,21 @@ _CSV_COLUMNS = (
 class RefractionV1EstimationError(ValueError):
     """Raised when direct-arrival V1 cannot be estimated."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        n_valid_groups: int | None = None,
+        min_groups: int | None = None,
+        group_status_counts: dict[str, int] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.n_valid_groups = n_valid_groups
+        self.min_groups = min_groups
+        self.group_status_counts = (
+            dict(group_status_counts) if group_status_counts is not None else None
+        )
+
 
 @dataclass(frozen=True)
 class RefractionV1EstimateResult:
@@ -172,14 +187,32 @@ def estimate_global_v1_from_direct_arrivals(
     n_valid_groups = int(np.count_nonzero(valid_group_mask))
     if n_valid_groups < min_groups:
         status_counts = _status_counts(group_status_arr)
-        if status_counts.get('velocity_out_of_bounds', 0) > 0:
+        if _all_groups_velocity_out_of_bounds(
+            n_valid_groups=n_valid_groups,
+            status_counts=status_counts,
+        ):
             raise RefractionV1EstimationError(
-                'No valid direct-arrival V1 groups remain within '
-                'model.first_layer velocity bounds.'
+                _v1_group_failure_message(
+                    'No valid direct-arrival V1 groups remain within '
+                    'model.first_layer velocity bounds',
+                    n_valid_groups=n_valid_groups,
+                    min_groups=min_groups,
+                    status_counts=status_counts,
+                ),
+                n_valid_groups=n_valid_groups,
+                min_groups=min_groups,
+                group_status_counts=status_counts,
             )
         raise RefractionV1EstimationError(
-            'Insufficient valid direct-arrival V1 groups: '
-            f'{n_valid_groups} valid groups, require at least {min_groups}.'
+            _v1_group_failure_message(
+                'Insufficient valid direct-arrival V1 groups',
+                n_valid_groups=n_valid_groups,
+                min_groups=min_groups,
+                status_counts=status_counts,
+            ),
+            n_valid_groups=n_valid_groups,
+            min_groups=min_groups,
+            group_status_counts=status_counts,
         )
 
     valid_v1 = group_v1_arr[valid_group_mask]
@@ -471,6 +504,51 @@ def _residual_mad(residual_s: np.ndarray) -> float:
 def _status_counts(status: np.ndarray) -> dict[str, int]:
     values, counts = np.unique(np.asarray(status).astype(str), return_counts=True)
     return {str(value): int(count) for value, count in zip(values, counts, strict=True)}
+
+
+def _all_groups_velocity_out_of_bounds(
+    *,
+    n_valid_groups: int,
+    status_counts: dict[str, int],
+) -> bool:
+    n_groups = sum(status_counts.values())
+    return (
+        n_valid_groups == 0
+        and n_groups > 0
+        and status_counts.get('velocity_out_of_bounds', 0) == n_groups
+    )
+
+
+def _v1_group_failure_message(
+    prefix: str,
+    *,
+    n_valid_groups: int,
+    min_groups: int,
+    status_counts: dict[str, int],
+) -> str:
+    return (
+        f'{prefix}: {n_valid_groups} valid groups, require at least {min_groups}. '
+        f'Status counts: {_format_status_counts(status_counts)}.'
+    )
+
+
+def _format_status_counts(status_counts: dict[str, int]) -> str:
+    preferred_order = (
+        'ok',
+        'velocity_out_of_bounds',
+        'insufficient_picks',
+        'insufficient_picks_after_robust',
+        'nonpositive_slope',
+        'insufficient_offset_aperture',
+        'invalid_residual_statistics',
+        'nonfinite_candidate',
+        'fit_failed',
+    )
+    ordered = [status for status in preferred_order if status in status_counts]
+    ordered.extend(sorted(set(status_counts) - set(ordered)))
+    if not ordered:
+        return 'none'
+    return ', '.join(f'{status}={status_counts[status]}' for status in ordered)
 
 
 def _estimate_rows(result: RefractionV1EstimateResult) -> list[dict[str, object]]:

--- a/app/tests/_refraction_static_artifact_helpers.py
+++ b/app/tests/_refraction_static_artifact_helpers.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+
+from app.api.schemas import RefractionStaticApplyRequest
+from app.services.refraction_static_types import (
+    RefractionDatumStaticsResult,
+    ResolvedRefractionFirstLayer,
+)
+
+
+def _request() -> RefractionStaticApplyRequest:
+    return RefractionStaticApplyRequest.model_validate(
+        {
+            'file_id': 'raw-file-id',
+            'key1_byte': 189,
+            'key2_byte': 193,
+            'pick_source': {
+                'kind': 'batch_predicted_npz',
+                'job_id': 'pick-job',
+                'artifact_name': 'predicted_picks_time_s.npz',
+            },
+            'linkage': {'mode': 'none'},
+            'model': {
+                'method': 'gli_variable_thickness',
+                'weathering_velocity_m_s': 800.0,
+                'bedrock_velocity_mode': 'solve_global',
+            },
+            'datum': {
+                'mode': 'floating_and_flat',
+                'floating_datum_mode': 'constant',
+                'floating_datum_elevation_m': 120.0,
+                'flat_datum_elevation_m': 300.0,
+            },
+            'apply': {
+                'mode': 'refraction_from_raw',
+                'interpolation': 'linear',
+                'fill_value': 0.0,
+                'max_abs_shift_ms': 250.0,
+                'output_dtype': 'float32',
+                'register_corrected_file': False,
+            },
+        }
+    )
+
+
+def _estimated_v1_request() -> RefractionStaticApplyRequest:
+    payload = _request().model_dump(mode='json')
+    payload['model']['weathering_velocity_m_s'] = None
+    payload['model']['first_layer'] = {
+        'mode': 'estimate_direct_arrival',
+        'min_direct_offset_m': 20.0,
+        'max_direct_offset_m': 140.0,
+    }
+    return RefractionStaticApplyRequest.model_validate(payload)
+
+
+def _resolved_estimated_v1() -> ResolvedRefractionFirstLayer:
+    return ResolvedRefractionFirstLayer(
+        mode='estimate_direct_arrival',
+        weathering_velocity_m_s=812.5,
+        status='estimated',
+        qc={
+            'v1_mode': 'estimate_direct_arrival',
+            'weathering_velocity_m_s': 812.5,
+            'resolved_weathering_velocity_m_s': 812.5,
+            'v1_status': 'estimated',
+        },
+    )
+
+
+def _result() -> RefractionDatumStaticsResult:
+    n_traces = 4
+    sorted_trace_index = np.arange(n_traces, dtype=np.int64)
+    valid_observation = np.asarray([True, True, True, False], dtype=bool)
+    used_observation = np.asarray([True, False, True, False], dtype=bool)
+    trace_valid = np.asarray([True, True, False, True], dtype=bool)
+    trace_status = np.asarray(
+        ['ok', 'ok', 'not_observed', 'ok'],
+        dtype='<U32',
+    )
+
+    node_id = np.asarray([0, 1, 2], dtype=np.int64)
+    node_surface = np.asarray([100.0, 110.0, 120.0], dtype=np.float64)
+    node_thickness = np.asarray([10.0, 12.0, 14.0], dtype=np.float64)
+    node_half = np.asarray([0.010, 0.012, 0.014], dtype=np.float64)
+    node_weathering_shift = np.asarray([-0.0085, -0.0102, -0.0119])
+
+    source_node_sorted = np.asarray([0, 1, 0, 1], dtype=np.int64)
+    receiver_node_sorted = np.asarray([1, 2, 2, 1], dtype=np.int64)
+    source_half_sorted = np.asarray([0.010, 0.012, 0.010, 0.012])
+    receiver_half_sorted = np.asarray([0.012, 0.014, 0.014, 0.012])
+    source_thickness_sorted = np.asarray([10.0, 12.0, 10.0, 12.0])
+    receiver_thickness_sorted = np.asarray([12.0, 14.0, 14.0, 12.0])
+    source_weathering_sorted = np.asarray([-0.0085, -0.0102, -0.0085, -0.0102])
+    receiver_weathering_sorted = np.asarray([-0.0102, -0.0119, -0.0119, -0.0102])
+    weathering_trace = source_weathering_sorted + receiver_weathering_sorted
+    source_floating_sorted = np.asarray([0.0010, 0.0015, 0.0010, 0.0015])
+    receiver_floating_sorted = np.asarray([0.0015, 0.0020, 0.0020, 0.0015])
+    source_flat_sorted = np.asarray([0.010, 0.011, 0.010, 0.011])
+    receiver_flat_sorted = np.asarray([0.011, 0.012, 0.012, 0.011])
+    source_refraction_sorted = (
+        source_weathering_sorted + source_floating_sorted + source_flat_sorted
+    )
+    receiver_refraction_sorted = (
+        receiver_weathering_sorted + receiver_floating_sorted + receiver_flat_sorted
+    )
+    refraction_trace = source_refraction_sorted + receiver_refraction_sorted
+    refraction_trace[2] = np.nan
+
+    return RefractionDatumStaticsResult(
+        bedrock_velocity_mode='solve_global',
+        bedrock_slowness_s_per_m=1.0 / 2500.0,
+        bedrock_velocity_m_s=2500.0,
+        weathering_velocity_m_s=800.0,
+        replacement_slowness_delta_s_per_m=(1.0 / 2500.0) - (1.0 / 800.0),
+        datum_mode='floating_and_flat',
+        floating_datum_mode='constant',
+        flat_datum_elevation_m=300.0,
+        node_id=node_id,
+        node_x_m=np.asarray([0.0, 50.0, 100.0]),
+        node_y_m=np.asarray([0.0, 5.0, 10.0]),
+        node_surface_elevation_m=node_surface,
+        node_kind=np.asarray(['source', 'both', 'receiver'], dtype='<U16'),
+        node_weathering_thickness_m=node_thickness,
+        node_refractor_elevation_m=node_surface - node_thickness,
+        node_half_intercept_time_s=node_half,
+        node_weathering_replacement_shift_s=node_weathering_shift,
+        node_floating_datum_elevation_m=np.asarray([120.0, 120.0, 120.0]),
+        node_solution_status=np.asarray(['solved', 'solved', 'inactive'], dtype='<U16'),
+        node_datum_status=np.asarray(['ok', 'ok', 'inactive'], dtype='<U16'),
+        node_weathering_status=np.asarray(
+            ['ok', 'zero_thickness', 'inactive'],
+            dtype='<U16',
+        ),
+        node_pick_count=np.asarray([4, 3, 2], dtype=np.int64),
+        node_used_pick_count=np.asarray([4, 2, 1], dtype=np.int64),
+        node_rejected_pick_count=np.asarray([0, 1, 1], dtype=np.int64),
+        node_residual_rms_s=np.asarray([0.001, 0.002, 0.003]),
+        node_residual_mad_s=np.asarray([0.0005, 0.0010, 0.0015]),
+        source_endpoint_key=np.asarray(['s0', 's1'], dtype='<U2'),
+        source_id=np.asarray([100, 101], dtype=np.int64),
+        source_node_id=np.asarray([0, 1], dtype=np.int64),
+        source_x_m=np.asarray([0.0, 50.0]),
+        source_y_m=np.asarray([0.0, 5.0]),
+        source_surface_elevation_m=np.asarray([100.0, 110.0]),
+        source_half_intercept_time_s=np.asarray([0.010, 0.012]),
+        source_weathering_thickness_m=np.asarray([10.0, 12.0]),
+        source_refractor_elevation_m=np.asarray([90.0, 98.0]),
+        source_floating_datum_elevation_m=np.asarray([120.0, 120.0]),
+        source_weathering_replacement_shift_s=np.asarray([-0.0085, -0.0102]),
+        source_floating_datum_elevation_shift_s=np.asarray([0.0010, 0.0015]),
+        source_flat_datum_shift_s=np.asarray([0.010, 0.011]),
+        source_refraction_shift_s=np.asarray([0.0025, 0.0023]),
+        source_datum_status=np.asarray(['ok', 'ok'], dtype='<U16'),
+        receiver_endpoint_key=np.asarray(['r0', 'r1'], dtype='<U2'),
+        receiver_id=np.asarray([200, 201], dtype=np.int64),
+        receiver_node_id=np.asarray([1, 2], dtype=np.int64),
+        receiver_x_m=np.asarray([55.0, 105.0]),
+        receiver_y_m=np.asarray([5.0, 10.0]),
+        receiver_surface_elevation_m=np.asarray([110.0, 120.0]),
+        receiver_half_intercept_time_s=np.asarray([0.012, 0.014]),
+        receiver_weathering_thickness_m=np.asarray([12.0, 14.0]),
+        receiver_refractor_elevation_m=np.asarray([98.0, 106.0]),
+        receiver_floating_datum_elevation_m=np.asarray([120.0, 120.0]),
+        receiver_weathering_replacement_shift_s=np.asarray([-0.0102, -0.0119]),
+        receiver_floating_datum_elevation_shift_s=np.asarray([0.0015, 0.0020]),
+        receiver_flat_datum_shift_s=np.asarray([0.011, 0.012]),
+        receiver_refraction_shift_s=np.asarray([0.0023, 0.0021]),
+        receiver_datum_status=np.asarray(['ok', 'ok'], dtype='<U16'),
+        sorted_trace_index=sorted_trace_index,
+        valid_observation_mask_sorted=valid_observation,
+        used_observation_mask_sorted=used_observation,
+        source_node_id_sorted=source_node_sorted,
+        receiver_node_id_sorted=receiver_node_sorted,
+        source_surface_elevation_m_sorted=np.asarray([100.0, 110.0, 100.0, 110.0]),
+        receiver_surface_elevation_m_sorted=np.asarray([110.0, 120.0, 120.0, 110.0]),
+        source_floating_datum_elevation_m_sorted=np.full(n_traces, 120.0),
+        receiver_floating_datum_elevation_m_sorted=np.full(n_traces, 120.0),
+        source_weathering_thickness_m_sorted=source_thickness_sorted,
+        receiver_weathering_thickness_m_sorted=receiver_thickness_sorted,
+        source_refractor_elevation_m_sorted=np.asarray([90.0, 98.0, 90.0, 98.0]),
+        receiver_refractor_elevation_m_sorted=np.asarray([98.0, 106.0, 106.0, 98.0]),
+        source_half_intercept_time_s_sorted=source_half_sorted,
+        receiver_half_intercept_time_s_sorted=receiver_half_sorted,
+        source_weathering_replacement_shift_s_sorted=source_weathering_sorted,
+        receiver_weathering_replacement_shift_s_sorted=receiver_weathering_sorted,
+        source_floating_datum_elevation_shift_s_sorted=source_floating_sorted,
+        receiver_floating_datum_elevation_shift_s_sorted=receiver_floating_sorted,
+        source_flat_datum_shift_s_sorted=source_flat_sorted,
+        receiver_flat_datum_shift_s_sorted=receiver_flat_sorted,
+        source_refraction_shift_s_sorted=source_refraction_sorted,
+        receiver_refraction_shift_s_sorted=receiver_refraction_sorted,
+        weathering_replacement_trace_shift_s_sorted=weathering_trace,
+        floating_datum_elevation_shift_s_sorted=(
+            source_floating_sorted + receiver_floating_sorted
+        ),
+        flat_datum_shift_s_sorted=source_flat_sorted + receiver_flat_sorted,
+        refraction_trace_shift_s_sorted=refraction_trace,
+        trace_static_status_sorted=trace_status,
+        trace_static_valid_mask_sorted=trace_valid,
+        estimated_first_break_time_s_sorted=np.asarray([0.05, 0.06, 0.07, np.nan]),
+        first_break_residual_s_sorted=np.asarray([0.001, -0.002, -0.001, np.nan]),
+        row_trace_index_sorted=np.asarray([0, 1, 2], dtype=np.int64),
+        row_source_node_id=np.asarray([0, 1, 0], dtype=np.int64),
+        row_receiver_node_id=np.asarray([1, 2, 2], dtype=np.int64),
+        row_distance_m=np.asarray([100.0, 200.0, 300.0]),
+        observed_pick_time_s=np.asarray([0.050, 0.060, 0.070]),
+        modeled_pick_time_s=np.asarray([0.049, 0.062, 0.071]),
+        residual_time_s=np.asarray([0.001, -0.002, -0.001]),
+        used_row_mask=np.asarray([True, False, True], dtype=bool),
+        rejected_by_robust_mask=np.asarray([False, True, False], dtype=bool),
+        qc={
+            'robust_iteration_count': 1,
+            'floating_datum_below_refractor_count': 0,
+            'flat_datum_below_refractor_count': 0,
+        },
+    )
+
+
+def _result_with_weathering_velocity(
+    weathering_velocity_m_s: float,
+) -> RefractionDatumStaticsResult:
+    return replace(
+        _result(),
+        weathering_velocity_m_s=weathering_velocity_m_s,
+        replacement_slowness_delta_s_per_m=(
+            (1.0 / 2500.0) - (1.0 / weathering_velocity_m_s)
+        ),
+    )

--- a/app/tests/_refraction_static_synthetic.py
+++ b/app/tests/_refraction_static_synthetic.py
@@ -154,7 +154,7 @@ def synthetic_direct_arrival_input_model() -> RefractionStaticInputModel:
 
 def run_synthetic_refraction_statics(
     *,
-    state: Any,
+    state: Any | None = None,
     req: RefractionStaticApplyRequest | None = None,
     input_model: RefractionStaticInputModel | None = None,
 ) -> RefractionDatumStaticsResult:

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -61,7 +61,7 @@ from app.tests.test_refraction_static_apply_trace_store import (
     _valid_result,
     _write_source_store,
 )
-from app.tests.test_refraction_static_artifacts import _result as _artifact_result
+from app.tests._refraction_static_artifact_helpers import _result as _artifact_result
 
 
 FINAL_REFRACTION_ARTIFACTS = {

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -235,6 +235,36 @@ def test_refraction_static_apply_endpoint_rejects_invalid_schema_without_job(
         assert len(client.app.state.sv.jobs) == 0
 
 
+def test_refraction_static_rejects_public_estimated_v1_value(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+    payload = _payload()
+    payload['model']['weathering_velocity_m_s'] = None
+    payload['model']['first_layer'] = {
+        'mode': 'estimate_direct_arrival',
+        'weathering_velocity_m_s': 812.5,
+        'min_direct_offset_m': 20.0,
+        'max_direct_offset_m': 140.0,
+    }
+
+    response = client.post('/statics/refraction/apply', json=payload)
+
+    assert response.status_code == 422
+    assert 'model.first_layer.weathering_velocity_m_s must be omitted' in (
+        response.text
+    )
+    assert started == []
+    with client.app.state.sv.lock:
+        assert len(client.app.state.sv.jobs) == 0
+
+
 def test_run_refraction_static_apply_job_writes_artifacts_and_completes(
     client: TestClient,
     tmp_path: Path,
@@ -324,7 +354,7 @@ def test_run_refraction_static_apply_job_writes_artifacts_and_completes(
     assert job['message'] == 'refraction_static_artifacts_written_artifact_only'
 
 
-def test_run_refraction_static_apply_job_estimates_v1_before_downstream_work(
+def test_refraction_static_job_uses_resolved_first_layer_dataclass_downstream(
     client: TestClient,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -362,6 +392,7 @@ def test_run_refraction_static_apply_job_estimates_v1_before_downstream_work(
     datum_result = object()
     build_calls: list[RefractionStaticApplyRequest] = []
     replacement_calls: list[dict[str, Any]] = []
+    datum_calls: list[dict[str, Any]] = []
     artifact_calls: list[dict[str, Any]] = []
     v1_write_calls: list[dict[str, Any]] = []
     estimate = RefractionV1EstimateResult(
@@ -420,6 +451,10 @@ def test_run_refraction_static_apply_job_estimates_v1_before_downstream_work(
         artifact_calls.append(kwargs)
         return object()
 
+    def _capture_datum_build(**kwargs: Any) -> object:
+        datum_calls.append(kwargs)
+        return datum_result
+
     monkeypatch.setattr(
         refraction_service_module,
         'write_refraction_v1_artifacts',
@@ -433,7 +468,7 @@ def test_run_refraction_static_apply_job_estimates_v1_before_downstream_work(
     monkeypatch.setattr(
         refraction_service_module,
         'build_refraction_datum_statics',
-        lambda **_kwargs: datum_result,
+        _capture_datum_build,
     )
     monkeypatch.setattr(
         refraction_service_module,
@@ -447,18 +482,25 @@ def test_run_refraction_static_apply_job_estimates_v1_before_downstream_work(
     assert v1_write_calls[0]['args'] == (job_dir, estimate)
     assert len(build_calls) == 2
     assert build_calls[0].moveout.min_offset_m is None
+    assert build_calls[1] is req
     assert build_calls[1].moveout.min_offset_m == pytest.approx(240.0)
     assert len(replacement_calls) == 1
-    resolved_req = replacement_calls[0]['req']
-    assert resolved_req is not req
+    downstream_req = replacement_calls[0]['req']
+    assert downstream_req is req
     assert replacement_calls[0]['input_model'] is weathering_input_model
-    assert resolved_req.model.first_layer_mode == 'estimate_direct_arrival'
-    assert resolved_req.model.resolved_weathering_velocity_m_s == pytest.approx(812.5)
+    assert downstream_req.model.first_layer_mode == 'estimate_direct_arrival'
+    assert downstream_req.model.first_layer is not None
+    assert downstream_req.model.first_layer.weathering_velocity_m_s is None
+    with pytest.raises(ValueError, match='requires a resolved weathering velocity'):
+        _ = downstream_req.model.resolved_weathering_velocity_m_s
     replacement_resolved = replacement_calls[0]['resolved_first_layer']
     assert replacement_resolved.mode == 'estimate_direct_arrival'
     assert replacement_resolved.weathering_velocity_m_s == pytest.approx(812.5)
+    assert len(datum_calls) == 1
+    assert datum_calls[0]['weathering_replacement_result'] is replacement_result
+    assert datum_calls[0]['resolved_first_layer'] is replacement_resolved
     assert len(artifact_calls) == 1
-    assert artifact_calls[0]['req'] is resolved_req
+    assert artifact_calls[0]['req'] is req
     resolved_first_layer = artifact_calls[0]['resolved_first_layer']
     assert resolved_first_layer is replacement_resolved
     assert resolved_first_layer.mode == 'estimate_direct_arrival'

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -505,6 +505,10 @@ def test_refraction_static_job_uses_resolved_first_layer_dataclass_downstream(
     assert resolved_first_layer is replacement_resolved
     assert resolved_first_layer.mode == 'estimate_direct_arrival'
     assert resolved_first_layer.weathering_velocity_m_s == pytest.approx(812.5)
+    assert artifact_calls[0]['upstream_artifact_names'] == (
+        REFRACTION_V1_QC_JSON_NAME,
+        REFRACTION_V1_ESTIMATES_CSV_NAME,
+    )
 
 
 def test_run_refraction_static_apply_job_registers_corrected_file_when_requested(
@@ -623,11 +627,8 @@ def test_run_refraction_static_apply_job_artifact_only_writes_real_final_artifac
     assert qc['status_counts']['node_solution_status']['solved'] == 2
     assert qc['status_counts']['node_weathering_status']['zero_thickness'] == 1
     assert qc['status_counts']['trace_static_status']['not_observed'] == 1
-    expected_qc_artifacts = (
-        FINAL_REFRACTION_ARTIFACTS - {REFRACTION_STATIC_ARTIFACTS_JSON_NAME}
-    ) | {
-        REFRACTION_V1_QC_JSON_NAME,
-        REFRACTION_V1_ESTIMATES_CSV_NAME,
+    expected_qc_artifacts = FINAL_REFRACTION_ARTIFACTS - {
+        REFRACTION_STATIC_ARTIFACTS_JSON_NAME
     }
     assert {item['name'] for item in qc['artifacts']} == expected_qc_artifacts
 
@@ -683,11 +684,44 @@ def test_refraction_static_job_lists_v1_artifacts_when_v1_estimated(
     manifest = json.loads(
         (job_dir / REFRACTION_STATIC_ARTIFACTS_JSON_NAME).read_text(encoding='utf-8')
     )
-    manifest_names = {item['name'] for item in manifest['artifacts']}
+    manifest_artifacts = {item['name']: item for item in manifest['artifacts']}
+    manifest_names = set(manifest_artifacts)
     assert REFRACTION_V1_QC_JSON_NAME in manifest_names
     assert REFRACTION_V1_ESTIMATES_CSV_NAME in manifest_names
+    assert manifest_artifacts[REFRACTION_V1_QC_JSON_NAME]['origin'] == 'upstream'
+    assert (
+        manifest_artifacts[REFRACTION_V1_ESTIMATES_CSV_NAME]['origin'] == 'upstream'
+    )
     qc = json.loads((job_dir / REFRACTION_STATIC_QC_JSON_NAME).read_text())
     assert REFRACTION_V1_QC_JSON_NAME in {item['name'] for item in qc['artifacts']}
+
+
+def test_refraction_static_download_new_v1_artifacts(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_id = 'refraction-download-new-v1-artifacts-e2e'
+    job_dir = tmp_path / 'jobs' / job_id
+    payload = _payload()
+    _enable_v1_estimation(payload)
+    req = RefractionStaticApplyRequest.model_validate(payload)
+    _create_refraction_job(client, job_id=job_id, req=req, job_dir=job_dir)
+    _stub_upstream_refraction_result(monkeypatch, datum_result=_artifact_result())
+    _stub_v1_estimation(monkeypatch)
+
+    run_refraction_static_apply_job(job_id, req, client.app.state.sv)
+
+    for artifact_name in (
+        REFRACTION_V1_QC_JSON_NAME,
+        REFRACTION_V1_ESTIMATES_CSV_NAME,
+    ):
+        response = client.get(
+            f'/statics/job/{job_id}/download',
+            params={'name': artifact_name},
+        )
+        assert response.status_code == 200
+        assert response.content
 
 
 def test_refraction_static_job_lists_t1lsst_artifact_when_conversion_enabled(

--- a/app/tests/test_refraction_static_apply_trace_store.py
+++ b/app/tests/test_refraction_static_apply_trace_store.py
@@ -25,7 +25,7 @@ from app.services.refraction_static_artifacts import (
     write_refraction_static_solution_npz,
 )
 from app.services.trace_store_registration import trace_store_cache_key
-from app.tests.test_refraction_static_artifacts import _result as _artifact_result
+from app.tests._refraction_static_artifact_helpers import _result as _artifact_result
 
 KEY1 = 189
 KEY2 = 193

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -109,6 +109,11 @@ EXPECTED_FILENAMES = {
     REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
 }
 
+UPSTREAM_V1_ARTIFACT_NAMES = (
+    REFRACTION_V1_QC_JSON_NAME,
+    REFRACTION_V1_ESTIMATES_CSV_NAME,
+)
+
 
 def test_write_refraction_static_artifacts_npz_schema(tmp_path: Path) -> None:
     paths = write_refraction_static_artifacts(
@@ -234,14 +239,10 @@ def test_write_refraction_static_artifacts_qc_json(tmp_path: Path) -> None:
     assert payload['status_counts']['trace_static_status']['ok'] == 3
     assert payload['status_counts']['node_datum_status']['ok'] == 2
     assert payload['first_break_fit']['residual_rms_ms'] == pytest.approx(1.0)
-    assert len(payload['artifacts']) == 11
-    artifact_descriptions = {
-        item['name']: item['description'] for item in payload['artifacts']
-    }
-    assert 'constant V1 details' in artifact_descriptions[REFRACTION_V1_QC_JSON_NAME]
-    assert 'not produced for constant' in artifact_descriptions[
-        REFRACTION_V1_ESTIMATES_CSV_NAME
-    ]
+    assert len(payload['artifacts']) == 9
+    artifact_names = {item['name'] for item in payload['artifacts']}
+    assert REFRACTION_V1_QC_JSON_NAME not in artifact_names
+    assert REFRACTION_V1_ESTIMATES_CSV_NAME not in artifact_names
     json.dumps(payload, allow_nan=False)
     assert not _contains_absolute_path(payload)
 
@@ -310,19 +311,10 @@ def test_refraction_static_artifacts_manifest_and_download_visibility(
     manifest = json.loads(
         (tmp_path / REFRACTION_STATIC_ARTIFACTS_JSON_NAME).read_text(encoding='utf-8')
     )
-    assert {item['name'] for item in manifest['artifacts']} == {
-        REFRACTION_STATIC_SOLUTION_NPZ_NAME,
-        REFRACTION_STATIC_QC_JSON_NAME,
-        REFRACTION_STATICS_CSV_NAME,
-        NEAR_SURFACE_MODEL_CSV_NAME,
-        FIRST_BREAK_RESIDUALS_CSV_NAME,
-        REFRACTION_STATIC_COMPONENTS_CSV_NAME,
-        SOURCE_STATIC_TABLE_CSV_NAME,
-        RECEIVER_STATIC_TABLE_CSV_NAME,
-        SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
-        REFRACTION_V1_QC_JSON_NAME,
-        REFRACTION_V1_ESTIMATES_CSV_NAME,
-    }
+    assert {item['name'] for item in manifest['artifacts']} == (
+        EXPECTED_FILENAMES - {REFRACTION_STATIC_ARTIFACTS_JSON_NAME}
+    )
+    assert {item['origin'] for item in manifest['artifacts']} == {'final'}
 
     state = app.state.sv
     with state.lock:
@@ -352,7 +344,72 @@ def test_refraction_static_artifacts_manifest_and_download_visibility(
             state.jobs.clear()
 
 
-def test_refraction_static_manifest_marks_constant_v1_artifacts_optional(
+def test_refraction_static_manifest_includes_v1_artifacts_after_v1_estimation(
+    tmp_path: Path,
+) -> None:
+    _write_upstream_v1_artifacts(tmp_path)
+
+    write_refraction_static_artifacts(
+        result=_result_with_weathering_velocity(812.5),
+        req=_estimated_v1_request(),
+        job_dir=tmp_path,
+        resolved_first_layer=_resolved_estimated_v1(),
+        upstream_artifact_names=UPSTREAM_V1_ARTIFACT_NAMES,
+    )
+
+    manifest = json.loads(
+        (tmp_path / REFRACTION_STATIC_ARTIFACTS_JSON_NAME).read_text(encoding='utf-8')
+    )
+    artifacts = {item['name']: item for item in manifest['artifacts']}
+    assert artifacts[REFRACTION_V1_QC_JSON_NAME]['required'] is True
+    assert artifacts[REFRACTION_V1_QC_JSON_NAME]['origin'] == 'upstream'
+    assert artifacts[REFRACTION_V1_ESTIMATES_CSV_NAME]['required'] is True
+    assert artifacts[REFRACTION_V1_ESTIMATES_CSV_NAME]['origin'] == 'upstream'
+    assert artifacts[REFRACTION_STATIC_SOLUTION_NPZ_NAME]['origin'] == 'final'
+
+    qc = json.loads((tmp_path / REFRACTION_STATIC_QC_JSON_NAME).read_text())
+    qc_artifacts = {item['name']: item for item in qc['artifacts']}
+    assert REFRACTION_V1_QC_JSON_NAME in qc_artifacts
+    assert REFRACTION_V1_ESTIMATES_CSV_NAME in qc_artifacts
+
+
+def test_refraction_static_artifact_writer_missing_upstream_v1_artifacts_error_is_clear(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(
+        RefractionStaticArtifactError,
+        match='declared upstream artifact missing: refraction_v1_qc.json',
+    ):
+        write_refraction_static_artifacts(
+            result=_result_with_weathering_velocity(812.5),
+            req=_estimated_v1_request(),
+            job_dir=tmp_path,
+            resolved_first_layer=_resolved_estimated_v1(),
+            upstream_artifact_names=UPSTREAM_V1_ARTIFACT_NAMES,
+        )
+
+
+def test_refraction_static_artifact_writer_estimated_v1_omits_unprovided_upstream_artifacts(
+    tmp_path: Path,
+) -> None:
+    write_refraction_static_artifacts(
+        result=_result_with_weathering_velocity(812.5),
+        req=_estimated_v1_request(),
+        job_dir=tmp_path,
+        resolved_first_layer=_resolved_estimated_v1(),
+    )
+
+    manifest = json.loads(
+        (tmp_path / REFRACTION_STATIC_ARTIFACTS_JSON_NAME).read_text(encoding='utf-8')
+    )
+    artifacts = {item['name']: item for item in manifest['artifacts']}
+    assert REFRACTION_V1_QC_JSON_NAME not in artifacts
+    assert REFRACTION_V1_ESTIMATES_CSV_NAME not in artifacts
+    assert not (tmp_path / REFRACTION_V1_QC_JSON_NAME).exists()
+    assert not (tmp_path / REFRACTION_V1_ESTIMATES_CSV_NAME).exists()
+
+
+def test_refraction_static_artifact_writer_constant_v1_does_not_require_v1_files(
     tmp_path: Path,
 ) -> None:
     write_refraction_static_artifacts(
@@ -365,15 +422,16 @@ def test_refraction_static_manifest_marks_constant_v1_artifacts_optional(
         (tmp_path / REFRACTION_STATIC_ARTIFACTS_JSON_NAME).read_text(encoding='utf-8')
     )
     artifacts = {item['name']: item for item in manifest['artifacts']}
-    assert artifacts[REFRACTION_V1_QC_JSON_NAME]['required'] is False
-    assert artifacts[REFRACTION_V1_ESTIMATES_CSV_NAME]['required'] is False
+    assert REFRACTION_V1_QC_JSON_NAME not in artifacts
+    assert REFRACTION_V1_ESTIMATES_CSV_NAME not in artifacts
     assert not (tmp_path / REFRACTION_V1_QC_JSON_NAME).exists()
     assert not (tmp_path / REFRACTION_V1_ESTIMATES_CSV_NAME).exists()
 
     qc = json.loads((tmp_path / REFRACTION_STATIC_QC_JSON_NAME).read_text())
     qc_artifacts = {item['name']: item for item in qc['artifacts']}
-    assert REFRACTION_V1_QC_JSON_NAME in qc_artifacts
-    assert REFRACTION_V1_ESTIMATES_CSV_NAME in qc_artifacts
+    assert REFRACTION_V1_QC_JSON_NAME not in qc_artifacts
+    assert REFRACTION_V1_ESTIMATES_CSV_NAME not in qc_artifacts
+    assert qc['velocity']['v1_mode'] == 'constant'
 
 
 def test_refraction_static_manifest_strict_json(tmp_path: Path) -> None:
@@ -393,6 +451,7 @@ def test_refraction_static_manifest_strict_json(tmp_path: Path) -> None:
         'name',
         'kind',
         'required',
+        'origin',
     }.issubset(payload['artifacts'][0])
 
 
@@ -539,3 +598,14 @@ def _contains_absolute_path(value: object) -> bool:
     if isinstance(value, list):
         return any(_contains_absolute_path(item) for item in value)
     return False
+
+
+def _write_upstream_v1_artifacts(root: Path) -> None:
+    (root / REFRACTION_V1_QC_JSON_NAME).write_text(
+        '{"v1_status":"estimated"}',
+        encoding='utf-8',
+    )
+    (root / REFRACTION_V1_ESTIMATES_CSV_NAME).write_text(
+        'group_kind,group_key,status\nsource_endpoint,source:1,ok\n',
+        encoding='utf-8',
+    )

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -150,7 +150,6 @@ def _estimated_v1_request() -> RefractionStaticApplyRequest:
     payload['model']['weathering_velocity_m_s'] = None
     payload['model']['first_layer'] = {
         'mode': 'estimate_direct_arrival',
-        'weathering_velocity_m_s': 812.5,
         'min_direct_offset_m': 20.0,
         'max_direct_offset_m': 140.0,
     }

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -7,11 +7,8 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from fastapi.testclient import TestClient
 
 import app.services.refraction_static_artifacts as artifact_module
-from app.api.schemas import RefractionStaticApplyRequest
-from app.main import app
 from app.services.refraction_static_artifacts import (
     FIRST_BREAK_RESIDUALS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
@@ -29,9 +26,12 @@ from app.services.refraction_static_artifacts import (
     write_refraction_static_solution_npz,
     write_refraction_static_artifacts,
 )
-from app.services.refraction_static_types import (
-    RefractionDatumStaticsResult,
-    ResolvedRefractionFirstLayer,
+from app.tests._refraction_static_artifact_helpers import (
+    _estimated_v1_request,
+    _request,
+    _resolved_estimated_v1,
+    _result,
+    _result_with_weathering_velocity,
 )
 
 
@@ -108,227 +108,6 @@ EXPECTED_FILENAMES = {
     SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
     REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
 }
-
-
-def _request() -> RefractionStaticApplyRequest:
-    return RefractionStaticApplyRequest.model_validate(
-        {
-            'file_id': 'raw-file-id',
-            'key1_byte': 189,
-            'key2_byte': 193,
-            'pick_source': {
-                'kind': 'batch_predicted_npz',
-                'job_id': 'pick-job',
-                'artifact_name': 'predicted_picks_time_s.npz',
-            },
-            'linkage': {'mode': 'none'},
-            'model': {
-                'method': 'gli_variable_thickness',
-                'weathering_velocity_m_s': 800.0,
-                'bedrock_velocity_mode': 'solve_global',
-            },
-            'datum': {
-                'mode': 'floating_and_flat',
-                'floating_datum_mode': 'constant',
-                'floating_datum_elevation_m': 120.0,
-                'flat_datum_elevation_m': 300.0,
-            },
-            'apply': {
-                'mode': 'refraction_from_raw',
-                'interpolation': 'linear',
-                'fill_value': 0.0,
-                'max_abs_shift_ms': 250.0,
-                'output_dtype': 'float32',
-                'register_corrected_file': False,
-            },
-        }
-    )
-
-
-def _estimated_v1_request() -> RefractionStaticApplyRequest:
-    payload = _request().model_dump(mode='json')
-    payload['model']['weathering_velocity_m_s'] = None
-    payload['model']['first_layer'] = {
-        'mode': 'estimate_direct_arrival',
-        'min_direct_offset_m': 20.0,
-        'max_direct_offset_m': 140.0,
-    }
-    return RefractionStaticApplyRequest.model_validate(payload)
-
-
-def _resolved_estimated_v1() -> ResolvedRefractionFirstLayer:
-    return ResolvedRefractionFirstLayer(
-        mode='estimate_direct_arrival',
-        weathering_velocity_m_s=812.5,
-        status='estimated',
-        qc={
-            'v1_mode': 'estimate_direct_arrival',
-            'weathering_velocity_m_s': 812.5,
-            'resolved_weathering_velocity_m_s': 812.5,
-            'v1_status': 'estimated',
-        },
-    )
-
-
-def _result() -> RefractionDatumStaticsResult:
-    n_traces = 4
-    sorted_trace_index = np.arange(n_traces, dtype=np.int64)
-    valid_observation = np.asarray([True, True, True, False], dtype=bool)
-    used_observation = np.asarray([True, False, True, False], dtype=bool)
-    trace_valid = np.asarray([True, True, False, True], dtype=bool)
-    trace_status = np.asarray(
-        ['ok', 'ok', 'not_observed', 'ok'],
-        dtype='<U32',
-    )
-
-    node_id = np.asarray([0, 1, 2], dtype=np.int64)
-    node_surface = np.asarray([100.0, 110.0, 120.0], dtype=np.float64)
-    node_thickness = np.asarray([10.0, 12.0, 14.0], dtype=np.float64)
-    node_half = np.asarray([0.010, 0.012, 0.014], dtype=np.float64)
-    node_weathering_shift = np.asarray([-0.0085, -0.0102, -0.0119])
-
-    source_node_sorted = np.asarray([0, 1, 0, 1], dtype=np.int64)
-    receiver_node_sorted = np.asarray([1, 2, 2, 1], dtype=np.int64)
-    source_half_sorted = np.asarray([0.010, 0.012, 0.010, 0.012])
-    receiver_half_sorted = np.asarray([0.012, 0.014, 0.014, 0.012])
-    source_thickness_sorted = np.asarray([10.0, 12.0, 10.0, 12.0])
-    receiver_thickness_sorted = np.asarray([12.0, 14.0, 14.0, 12.0])
-    source_weathering_sorted = np.asarray([-0.0085, -0.0102, -0.0085, -0.0102])
-    receiver_weathering_sorted = np.asarray([-0.0102, -0.0119, -0.0119, -0.0102])
-    weathering_trace = source_weathering_sorted + receiver_weathering_sorted
-    source_floating_sorted = np.asarray([0.0010, 0.0015, 0.0010, 0.0015])
-    receiver_floating_sorted = np.asarray([0.0015, 0.0020, 0.0020, 0.0015])
-    source_flat_sorted = np.asarray([0.010, 0.011, 0.010, 0.011])
-    receiver_flat_sorted = np.asarray([0.011, 0.012, 0.012, 0.011])
-    source_refraction_sorted = (
-        source_weathering_sorted + source_floating_sorted + source_flat_sorted
-    )
-    receiver_refraction_sorted = (
-        receiver_weathering_sorted + receiver_floating_sorted + receiver_flat_sorted
-    )
-    refraction_trace = source_refraction_sorted + receiver_refraction_sorted
-    refraction_trace[2] = np.nan
-
-    return RefractionDatumStaticsResult(
-        bedrock_velocity_mode='solve_global',
-        bedrock_slowness_s_per_m=1.0 / 2500.0,
-        bedrock_velocity_m_s=2500.0,
-        weathering_velocity_m_s=800.0,
-        replacement_slowness_delta_s_per_m=(1.0 / 2500.0) - (1.0 / 800.0),
-        datum_mode='floating_and_flat',
-        floating_datum_mode='constant',
-        flat_datum_elevation_m=300.0,
-        node_id=node_id,
-        node_x_m=np.asarray([0.0, 50.0, 100.0]),
-        node_y_m=np.asarray([0.0, 5.0, 10.0]),
-        node_surface_elevation_m=node_surface,
-        node_kind=np.asarray(['source', 'both', 'receiver'], dtype='<U16'),
-        node_weathering_thickness_m=node_thickness,
-        node_refractor_elevation_m=node_surface - node_thickness,
-        node_half_intercept_time_s=node_half,
-        node_weathering_replacement_shift_s=node_weathering_shift,
-        node_floating_datum_elevation_m=np.asarray([120.0, 120.0, 120.0]),
-        node_solution_status=np.asarray(['solved', 'solved', 'inactive'], dtype='<U16'),
-        node_datum_status=np.asarray(['ok', 'ok', 'inactive'], dtype='<U16'),
-        node_weathering_status=np.asarray(
-            ['ok', 'zero_thickness', 'inactive'],
-            dtype='<U16',
-        ),
-        node_pick_count=np.asarray([4, 3, 2], dtype=np.int64),
-        node_used_pick_count=np.asarray([4, 2, 1], dtype=np.int64),
-        node_rejected_pick_count=np.asarray([0, 1, 1], dtype=np.int64),
-        node_residual_rms_s=np.asarray([0.001, 0.002, 0.003]),
-        node_residual_mad_s=np.asarray([0.0005, 0.0010, 0.0015]),
-        source_endpoint_key=np.asarray(['s0', 's1'], dtype='<U2'),
-        source_id=np.asarray([100, 101], dtype=np.int64),
-        source_node_id=np.asarray([0, 1], dtype=np.int64),
-        source_x_m=np.asarray([0.0, 50.0]),
-        source_y_m=np.asarray([0.0, 5.0]),
-        source_surface_elevation_m=np.asarray([100.0, 110.0]),
-        source_half_intercept_time_s=np.asarray([0.010, 0.012]),
-        source_weathering_thickness_m=np.asarray([10.0, 12.0]),
-        source_refractor_elevation_m=np.asarray([90.0, 98.0]),
-        source_floating_datum_elevation_m=np.asarray([120.0, 120.0]),
-        source_weathering_replacement_shift_s=np.asarray([-0.0085, -0.0102]),
-        source_floating_datum_elevation_shift_s=np.asarray([0.0010, 0.0015]),
-        source_flat_datum_shift_s=np.asarray([0.010, 0.011]),
-        source_refraction_shift_s=np.asarray([0.0025, 0.0023]),
-        source_datum_status=np.asarray(['ok', 'ok'], dtype='<U16'),
-        receiver_endpoint_key=np.asarray(['r0', 'r1'], dtype='<U2'),
-        receiver_id=np.asarray([200, 201], dtype=np.int64),
-        receiver_node_id=np.asarray([1, 2], dtype=np.int64),
-        receiver_x_m=np.asarray([55.0, 105.0]),
-        receiver_y_m=np.asarray([5.0, 10.0]),
-        receiver_surface_elevation_m=np.asarray([110.0, 120.0]),
-        receiver_half_intercept_time_s=np.asarray([0.012, 0.014]),
-        receiver_weathering_thickness_m=np.asarray([12.0, 14.0]),
-        receiver_refractor_elevation_m=np.asarray([98.0, 106.0]),
-        receiver_floating_datum_elevation_m=np.asarray([120.0, 120.0]),
-        receiver_weathering_replacement_shift_s=np.asarray([-0.0102, -0.0119]),
-        receiver_floating_datum_elevation_shift_s=np.asarray([0.0015, 0.0020]),
-        receiver_flat_datum_shift_s=np.asarray([0.011, 0.012]),
-        receiver_refraction_shift_s=np.asarray([0.0023, 0.0021]),
-        receiver_datum_status=np.asarray(['ok', 'ok'], dtype='<U16'),
-        sorted_trace_index=sorted_trace_index,
-        valid_observation_mask_sorted=valid_observation,
-        used_observation_mask_sorted=used_observation,
-        source_node_id_sorted=source_node_sorted,
-        receiver_node_id_sorted=receiver_node_sorted,
-        source_surface_elevation_m_sorted=np.asarray([100.0, 110.0, 100.0, 110.0]),
-        receiver_surface_elevation_m_sorted=np.asarray([110.0, 120.0, 120.0, 110.0]),
-        source_floating_datum_elevation_m_sorted=np.full(n_traces, 120.0),
-        receiver_floating_datum_elevation_m_sorted=np.full(n_traces, 120.0),
-        source_weathering_thickness_m_sorted=source_thickness_sorted,
-        receiver_weathering_thickness_m_sorted=receiver_thickness_sorted,
-        source_refractor_elevation_m_sorted=np.asarray([90.0, 98.0, 90.0, 98.0]),
-        receiver_refractor_elevation_m_sorted=np.asarray([98.0, 106.0, 106.0, 98.0]),
-        source_half_intercept_time_s_sorted=source_half_sorted,
-        receiver_half_intercept_time_s_sorted=receiver_half_sorted,
-        source_weathering_replacement_shift_s_sorted=source_weathering_sorted,
-        receiver_weathering_replacement_shift_s_sorted=receiver_weathering_sorted,
-        source_floating_datum_elevation_shift_s_sorted=source_floating_sorted,
-        receiver_floating_datum_elevation_shift_s_sorted=receiver_floating_sorted,
-        source_flat_datum_shift_s_sorted=source_flat_sorted,
-        receiver_flat_datum_shift_s_sorted=receiver_flat_sorted,
-        source_refraction_shift_s_sorted=source_refraction_sorted,
-        receiver_refraction_shift_s_sorted=receiver_refraction_sorted,
-        weathering_replacement_trace_shift_s_sorted=weathering_trace,
-        floating_datum_elevation_shift_s_sorted=(
-            source_floating_sorted + receiver_floating_sorted
-        ),
-        flat_datum_shift_s_sorted=source_flat_sorted + receiver_flat_sorted,
-        refraction_trace_shift_s_sorted=refraction_trace,
-        trace_static_status_sorted=trace_status,
-        trace_static_valid_mask_sorted=trace_valid,
-        estimated_first_break_time_s_sorted=np.asarray([0.05, 0.06, 0.07, np.nan]),
-        first_break_residual_s_sorted=np.asarray([0.001, -0.002, -0.001, np.nan]),
-        row_trace_index_sorted=np.asarray([0, 1, 2], dtype=np.int64),
-        row_source_node_id=np.asarray([0, 1, 0], dtype=np.int64),
-        row_receiver_node_id=np.asarray([1, 2, 2], dtype=np.int64),
-        row_distance_m=np.asarray([100.0, 200.0, 300.0]),
-        observed_pick_time_s=np.asarray([0.050, 0.060, 0.070]),
-        modeled_pick_time_s=np.asarray([0.049, 0.062, 0.071]),
-        residual_time_s=np.asarray([0.001, -0.002, -0.001]),
-        used_row_mask=np.asarray([True, False, True], dtype=bool),
-        rejected_by_robust_mask=np.asarray([False, True, False], dtype=bool),
-        qc={
-            'robust_iteration_count': 1,
-            'floating_datum_below_refractor_count': 0,
-            'flat_datum_below_refractor_count': 0,
-        },
-    )
-
-
-def _result_with_weathering_velocity(
-    weathering_velocity_m_s: float,
-) -> RefractionDatumStaticsResult:
-    return replace(
-        _result(),
-        weathering_velocity_m_s=weathering_velocity_m_s,
-        replacement_slowness_delta_s_per_m=(
-            (1.0 / 2500.0) - (1.0 / weathering_velocity_m_s)
-        ),
-    )
 
 
 def test_write_refraction_static_artifacts_npz_schema(tmp_path: Path) -> None:
@@ -519,6 +298,10 @@ def test_write_refraction_static_artifacts_csvs(tmp_path: Path) -> None:
 def test_refraction_static_artifacts_manifest_and_download_visibility(
     tmp_path: Path,
 ) -> None:
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
     write_refraction_static_artifacts(
         result=_result(),
         req=_request(),

--- a/app/tests/test_refraction_static_import_layers.py
+++ b/app/tests/test_refraction_static_import_layers.py
@@ -10,17 +10,23 @@ import app.services.refraction_static_bedrock as bedrock
 import app.services.refraction_static_design_matrix as design_matrix
 import app.services.refraction_static_half_intercept as half_intercept
 import app.services.refraction_static_solver as solver
+import app.services.refraction_static_t1lsst as t1lsst
 import app.services.refraction_static_types as refraction_types
+import app.services.refraction_static_v1 as v1
 import app.services.refraction_static_weathering as weathering
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _FORBIDDEN_IMPORTS = {
+    'app.api.routers',
+    'app.main',
     'app.services.reader',
+    'app.services.refraction_static_service',
     'app.services.refraction_static_inputs',
     'app.trace_store.reader',
     'segyio',
 }
+_FORBIDDEN_IMPORT_PREFIXES = ('app.api.routers.',)
 
 
 def _module_source(module: ModuleType) -> str:
@@ -41,7 +47,12 @@ for name in {sorted(_FORBIDDEN_IMPORTS)!r}:
 
 importlib.import_module({module_name!r})
 
-print(json.dumps(sorted(name for name in {sorted(_FORBIDDEN_IMPORTS)!r} if name in sys.modules)))
+forbidden = set({sorted(_FORBIDDEN_IMPORTS)!r})
+imported = []
+for name in sys.modules:
+    if name in forbidden or name.startswith({_FORBIDDEN_IMPORT_PREFIXES!r}):
+        imported.append(name)
+print(json.dumps(sorted(imported)))
 """
     result = subprocess.run(
         [sys.executable, '-c', code],
@@ -83,3 +94,34 @@ def test_numeric_refraction_modules_import_without_tracestore_readers() -> None:
         'app.services.refraction_static_weathering',
     ):
         assert _forbidden_modules_imported_by(module_name) == set()
+
+
+def test_refraction_static_v1_imports_without_reader_or_segyio() -> None:
+    assert v1.RefractionV1EstimateResult is not None
+
+    assert _forbidden_modules_imported_by('app.services.refraction_static_v1') == set()
+
+
+def test_refraction_static_t1lsst_imports_without_reader_or_segyio() -> None:
+    assert t1lsst.RefractionT1LSSTError is not None
+
+    assert (
+        _forbidden_modules_imported_by('app.services.refraction_static_t1lsst')
+        == set()
+    )
+
+
+def test_refraction_static_schema_tests_do_not_import_service_or_reader() -> None:
+    assert (
+        _forbidden_modules_imported_by('app.tests.test_refraction_static_schema')
+        == set()
+    )
+
+
+def test_refraction_static_artifact_helpers_do_not_import_app_main() -> None:
+    assert (
+        _forbidden_modules_imported_by(
+            'app.tests._refraction_static_artifact_helpers'
+        )
+        == set()
+    )

--- a/app/tests/test_refraction_static_schema.py
+++ b/app/tests/test_refraction_static_schema.py
@@ -88,7 +88,7 @@ def test_refraction_static_rejects_conflicting_legacy_and_first_layer_v1() -> No
         )
 
 
-def test_refraction_static_first_layer_estimate_direct_arrival_schema_valid() -> None:
+def test_refraction_static_estimate_direct_arrival_public_request_valid_without_v1() -> None:
     model = RefractionStaticModelRequest.model_validate(
         _model_payload(
             weathering_velocity_m_s=None,
@@ -110,26 +110,41 @@ def test_refraction_static_first_layer_estimate_direct_arrival_schema_valid() ->
         normalize_refraction_first_layer_request(model)
 
 
-def test_refraction_static_resolved_v1_estimated_path() -> None:
-    model = RefractionStaticModelRequest.model_validate(
-        _model_payload(
-            weathering_velocity_m_s=None,
-            first_layer={
-                'mode': 'estimate_direct_arrival',
-                'weathering_velocity_m_s': 812.5,
-                'min_direct_offset_m': 20.0,
-                'max_direct_offset_m': 140.0,
-            },
+def test_refraction_static_model_rejects_estimated_first_layer_v1_value() -> None:
+    with pytest.raises(
+        ValidationError,
+        match='model.first_layer.weathering_velocity_m_s must be omitted when '
+        'model.first_layer.mode is estimate_direct_arrival',
+    ):
+        RefractionStaticModelRequest.model_validate(
+            _model_payload(
+                weathering_velocity_m_s=None,
+                first_layer={
+                    'mode': 'estimate_direct_arrival',
+                    'weathering_velocity_m_s': 812.5,
+                    'min_direct_offset_m': 20.0,
+                    'max_direct_offset_m': 140.0,
+                },
+            )
         )
-    )
 
-    resolved = normalize_refraction_first_layer_request(model)
 
-    assert resolved.mode == 'estimate_direct_arrival'
-    assert resolved.status == 'estimated'
-    assert resolved.weathering_velocity_m_s == pytest.approx(812.5)
-    assert resolved.qc['v1_mode'] == 'estimate_direct_arrival'
-    assert resolved.qc['resolved_weathering_velocity_m_s'] == pytest.approx(812.5)
+def test_refraction_static_model_rejects_estimated_legacy_v1_value() -> None:
+    with pytest.raises(
+        ValidationError,
+        match='model.weathering_velocity_m_s must be omitted when '
+        'model.first_layer.mode is estimate_direct_arrival',
+    ):
+        RefractionStaticModelRequest.model_validate(
+            _model_payload(
+                weathering_velocity_m_s=812.5,
+                first_layer={
+                    'mode': 'estimate_direct_arrival',
+                    'min_direct_offset_m': 20.0,
+                    'max_direct_offset_m': 140.0,
+                },
+            )
+        )
 
 
 def test_refraction_static_first_layer_estimate_requires_direct_offset_gate() -> None:

--- a/app/tests/test_refraction_static_schema.py
+++ b/app/tests/test_refraction_static_schema.py
@@ -4,7 +4,9 @@ import pytest
 from pydantic import ValidationError
 
 from app.api.schemas import RefractionStaticModelRequest
-from app.services.refraction_static_service import normalize_refraction_first_layer_request
+from app.services.refraction_static_first_layer import (
+    normalize_refraction_first_layer_request,
+)
 
 
 def _model_payload(**overrides: object) -> dict[str, object]:

--- a/app/tests/test_refraction_static_source_receiver_tables.py
+++ b/app/tests/test_refraction_static_source_receiver_tables.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from app.main import app
 from app.services.refraction_static_artifacts import (
     RECEIVER_STATIC_TABLE_CSV_NAME,
     SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
@@ -22,7 +21,7 @@ from app.tests._refraction_static_synthetic import (
     run_synthetic_refraction_statics,
     synthetic_refraction_apply_request,
 )
-from app.tests.test_refraction_static_artifacts import _request, _result
+from app.tests._refraction_static_artifact_helpers import _request, _result
 
 
 SOURCE_COLUMNS = [
@@ -128,7 +127,7 @@ def test_source_receiver_static_tables_have_one_row_per_endpoint(
     tmp_path: Path,
 ) -> None:
     req = synthetic_refraction_apply_request()
-    result = run_synthetic_refraction_statics(state=app.state.sv, req=req)
+    result = run_synthetic_refraction_statics(req=req)
 
     paths = write_refraction_static_artifacts(
         result=result,

--- a/app/tests/test_refraction_static_t1lsst.py
+++ b/app/tests/test_refraction_static_t1lsst.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from app.api.schemas import RefractionStaticApplyRequest
-from app.main import app
 from app.services.refraction_static_artifacts import (
     REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
     write_refraction_static_artifacts,
@@ -39,7 +38,7 @@ from app.tests._refraction_static_synthetic import (
     run_synthetic_refraction_statics,
     synthetic_refraction_apply_request,
 )
-from app.tests.test_refraction_static_artifacts import _request, _result
+from app.tests._refraction_static_artifact_helpers import _request, _result
 
 
 def _t1lsst_request() -> RefractionStaticApplyRequest:
@@ -137,7 +136,7 @@ def test_t1lsst_1layer_matches_existing_weathering_replacement(
     tmp_path: Path,
 ) -> None:
     req = synthetic_refraction_apply_request(conversion_mode='t1lsst_1layer')
-    result = run_synthetic_refraction_statics(state=app.state.sv, req=req)
+    result = run_synthetic_refraction_statics(req=req)
 
     paths = write_refraction_static_artifacts(
         result=result,

--- a/app/tests/test_refraction_static_v1.py
+++ b/app/tests/test_refraction_static_v1.py
@@ -142,6 +142,7 @@ def test_v1_estimate_global_from_direct_arrivals(tmp_path: Path) -> None:
     )
     assert result.qc['v1_status'] == 'estimated'
     assert result.qc['n_used_groups'] == 6
+    assert result.qc['group_status_counts'] == {'ok': 6}
     assert set(result.group_status.tolist()) == {'ok'}
     assert np.any(result.group_n_used < result.group_n_candidates)
 
@@ -205,10 +206,52 @@ def test_v1_estimate_fails_with_insufficient_picks() -> None:
         )
 
 
-def test_v1_estimate_rejects_velocity_outside_bounds() -> None:
+def test_v1_estimate_partial_failures_reports_status_counts() -> None:
+    offsets = (20.0, 40.0, 60.0, 80.0, 100.0, 120.0)
+    overrides = {
+        (2, offset_index): 0.016 + offset / 2200.0
+        for offset_index, offset in enumerate(offsets)
+    }
+    for source_index in range(3, 7):
+        for offset_index in (4, 5):
+            overrides[(source_index, offset_index)] = np.nan
+    model = _input_model(
+        intercept_by_source=(0.010, 0.012, 0.014, 0.016, 0.018, 0.020, 0.022),
+        offsets_m=offsets,
+        pick_overrides=overrides,
+    )
+
+    with pytest.raises(RefractionV1EstimationError) as exc_info:
+        estimate_global_v1_from_direct_arrivals(
+            input_model=model,
+            first_layer=_first_layer(
+                min_groups=3,
+                min_weathering_velocity_m_s=500.0,
+                max_weathering_velocity_m_s=1200.0,
+            ),
+        )
+
+    message = str(exc_info.value)
+    assert message.startswith('Insufficient valid direct-arrival V1 groups')
+    assert '2 valid groups, require at least 3' in message
+    assert 'Status counts:' in message
+    assert 'ok=2' in message
+    assert 'velocity_out_of_bounds=1' in message
+    assert 'insufficient_picks=4' in message
+    assert 'No valid direct-arrival V1 groups remain within' not in message
+    assert exc_info.value.n_valid_groups == 2
+    assert exc_info.value.min_groups == 3
+    assert exc_info.value.group_status_counts == {
+        'insufficient_picks': 4,
+        'ok': 2,
+        'velocity_out_of_bounds': 1,
+    }
+
+
+def test_v1_estimate_all_out_of_bounds_error_mentions_velocity_bounds() -> None:
     model = _input_model(v1_m_s=2200.0)
 
-    with pytest.raises(RefractionV1EstimationError, match='velocity bounds'):
+    with pytest.raises(RefractionV1EstimationError) as exc_info:
         estimate_global_v1_from_direct_arrivals(
             input_model=model,
             first_layer=_first_layer(
@@ -216,3 +259,33 @@ def test_v1_estimate_rejects_velocity_outside_bounds() -> None:
                 max_weathering_velocity_m_s=1200.0,
             ),
         )
+
+    message = str(exc_info.value)
+    assert message.startswith(
+        'No valid direct-arrival V1 groups remain within '
+        'model.first_layer velocity bounds'
+    )
+    assert '0 valid groups, require at least 3' in message
+    assert 'Status counts: velocity_out_of_bounds=3.' in message
+    assert exc_info.value.n_valid_groups == 0
+    assert exc_info.value.min_groups == 3
+    assert exc_info.value.group_status_counts == {'velocity_out_of_bounds': 3}
+
+
+def test_v1_estimate_insufficient_groups_error_reports_valid_and_required_counts() -> None:
+    model = _input_model(intercept_by_source=(0.010, 0.012))
+
+    with pytest.raises(RefractionV1EstimationError) as exc_info:
+        estimate_global_v1_from_direct_arrivals(
+            input_model=model,
+            first_layer=_first_layer(min_groups=3),
+        )
+
+    message = str(exc_info.value)
+    assert message.startswith('Insufficient valid direct-arrival V1 groups')
+    assert '2 valid groups, require at least 3' in message
+    assert 'Status counts: ok=2.' in message
+    assert 'velocity bounds' not in message
+    assert exc_info.value.n_valid_groups == 2
+    assert exc_info.value.min_groups == 3
+    assert exc_info.value.group_status_counts == {'ok': 2}


### PR DESCRIPTION
Closes #408
Closes #409
Closes #410
Closes #411

## Issues
- #408 [statics][refraction] Reject unresolved `estimate_direct_arrival` V1 values at API boundary
- #409 [tests][statics] Keep refraction Phase 1 unit tests dependency-light and avoid `app.main` imports
- #410 [statics][refraction] Clarify final artifact writer contract for V1 estimation artifacts
- #411 [statics][refraction] Improve V1 estimator QC and error messages for partial group failures

Batch range: #408-#411
