### PR TITLE
Batch: address issues #430-#434

### DIFF
--- a/app/tests/fixtures/__init__.py
+++ b/app/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable test fixtures."""

--- a/app/tests/fixtures/refraction_synthetic.py
+++ b/app/tests/fixtures/refraction_synthetic.py
@@ -1,0 +1,764 @@
+"""Dependency-light synthetic refraction-static fixture builders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import numpy as np
+
+CoordinateMode = Literal['grid_3d', 'line_2d_projected']
+
+
+@dataclass(frozen=True)
+class SyntheticRefractionCellDataset:
+    coordinate_mode: CoordinateMode
+    cell_size_x_m: float
+    cell_size_y_m: float | None
+    x_coordinate_origin_m: float
+    y_coordinate_origin_m: float
+    line_origin_x_m: float | None
+    line_origin_y_m: float | None
+    line_azimuth_deg: float | None
+    source_x_m: np.ndarray
+    source_y_m: np.ndarray
+    receiver_x_m: np.ndarray
+    receiver_y_m: np.ndarray
+    source_inline_m: np.ndarray | None
+    receiver_inline_m: np.ndarray | None
+    source_id: np.ndarray
+    receiver_id: np.ndarray
+    source_node_id: np.ndarray
+    receiver_node_id: np.ndarray
+    source_endpoint_index: np.ndarray
+    receiver_endpoint_index: np.ndarray
+    offset_m: np.ndarray
+    pick_time_s: np.ndarray
+    valid_mask: np.ndarray
+    true_v1_m_s: float
+    true_cell_v2_m_s: np.ndarray
+    true_source_t1_s: np.ndarray
+    true_receiver_t1_s: np.ndarray
+    true_source_sh1_m: np.ndarray
+    true_receiver_sh1_m: np.ndarray
+    true_source_wcor_s: np.ndarray
+    true_receiver_wcor_s: np.ndarray
+    true_source_static_s: np.ndarray
+    true_receiver_static_s: np.ndarray
+    true_source_v2_m_s: np.ndarray
+    true_receiver_v2_m_s: np.ndarray
+    true_midpoint_v2_m_s: np.ndarray
+    true_cell_ix_for_pick: np.ndarray
+    true_cell_iy_for_pick: np.ndarray
+    true_cell_id_for_pick: np.ndarray
+    true_noise_s: np.ndarray
+    outlier_mask: np.ndarray
+    cell_observation_count: np.ndarray
+    source_endpoint_id: np.ndarray
+    receiver_endpoint_id: np.ndarray
+    source_endpoint_node_id: np.ndarray
+    receiver_endpoint_node_id: np.ndarray
+    source_endpoint_x_m: np.ndarray
+    source_endpoint_y_m: np.ndarray
+    receiver_endpoint_x_m: np.ndarray
+    receiver_endpoint_y_m: np.ndarray
+    source_endpoint_inline_m: np.ndarray | None
+    receiver_endpoint_inline_m: np.ndarray | None
+    true_source_endpoint_t1_s: np.ndarray
+    true_receiver_endpoint_t1_s: np.ndarray
+    true_source_endpoint_sh1_m: np.ndarray
+    true_receiver_endpoint_sh1_m: np.ndarray
+    true_source_endpoint_wcor_s: np.ndarray
+    true_receiver_endpoint_wcor_s: np.ndarray
+    true_source_endpoint_static_s: np.ndarray
+    true_receiver_endpoint_static_s: np.ndarray
+    true_source_endpoint_v2_m_s: np.ndarray
+    true_receiver_endpoint_v2_m_s: np.ndarray
+
+
+def make_clean_2d_cell_refraction_dataset(
+    *,
+    seed: int = 0,
+    v1_m_s: float = 800.0,
+    cell_v2_m_s: Sequence[float] | np.ndarray | None = None,
+    n_sources: int = 9,
+    n_receivers: int = 9,
+    cell_size_x_m: float = 100.0,
+    cell_size_y_m: float | None = None,
+    noise_std_s: float = 0.0,
+    outlier_fraction: float = 0.0,
+) -> SyntheticRefractionCellDataset:
+    """Build a small 2D midpoint-cell fixture using pick=Tsrc+Trec+offset/V2."""
+    v2 = _cell_v2_2d(cell_v2_m_s, default=(2200.0, 2600.0, 3000.0))
+    return _make_dataset(
+        coordinate_mode='grid_3d',
+        seed=seed,
+        v1_m_s=v1_m_s,
+        cell_v2_m_s=v2,
+        n_sources=n_sources,
+        n_receivers=n_receivers,
+        cell_size_x_m=cell_size_x_m,
+        cell_size_y_m=cell_size_y_m,
+        noise_std_s=noise_std_s,
+        outlier_fraction=outlier_fraction,
+    )
+
+
+def make_rotated_2d_line_refraction_dataset(
+    *,
+    seed: int = 0,
+    v1_m_s: float = 800.0,
+    cell_v2_m_s: Sequence[float] | np.ndarray | None = None,
+    n_sources: int = 9,
+    n_receivers: int = 9,
+    cell_size_x_m: float = 100.0,
+    cell_size_y_m: float | None = None,
+    noise_std_s: float = 0.0,
+    outlier_fraction: float = 0.0,
+    line_origin_x_m: float = 1000.0,
+    line_origin_y_m: float = 2000.0,
+    line_azimuth_deg: float = 37.0,
+) -> SyntheticRefractionCellDataset:
+    """Build a rotated line fixture with explicit line_2d_projected truth."""
+    if cell_size_y_m is not None:
+        raise ValueError('line_2d_projected synthetic fixtures require cell_size_y_m=None')
+    v2 = _cell_v2_2d(cell_v2_m_s, default=(2200.0, 2600.0, 3000.0))
+    return _make_dataset(
+        coordinate_mode='line_2d_projected',
+        seed=seed,
+        v1_m_s=v1_m_s,
+        cell_v2_m_s=v2,
+        n_sources=n_sources,
+        n_receivers=n_receivers,
+        cell_size_x_m=cell_size_x_m,
+        cell_size_y_m=None,
+        noise_std_s=noise_std_s,
+        outlier_fraction=outlier_fraction,
+        line_origin_x_m=line_origin_x_m,
+        line_origin_y_m=line_origin_y_m,
+        line_azimuth_deg=line_azimuth_deg,
+    )
+
+
+def make_clean_3d_cell_refraction_dataset(
+    *,
+    seed: int = 0,
+    v1_m_s: float = 800.0,
+    cell_v2_m_s: Sequence[Sequence[float]] | np.ndarray | None = None,
+    n_sources: int = 12,
+    n_receivers: int = 12,
+    cell_size_x_m: float = 100.0,
+    cell_size_y_m: float | None = 120.0,
+    noise_std_s: float = 0.0,
+    outlier_fraction: float = 0.0,
+) -> SyntheticRefractionCellDataset:
+    """Build a 3D grid fixture with known per-cell V2 and endpoint T1 truth."""
+    v2 = _cell_v2_3d(
+        cell_v2_m_s,
+        default=((2200.0, 2600.0, 3000.0), (2400.0, 2800.0, 3200.0)),
+    )
+    return _make_dataset(
+        coordinate_mode='grid_3d',
+        seed=seed,
+        v1_m_s=v1_m_s,
+        cell_v2_m_s=v2,
+        n_sources=n_sources,
+        n_receivers=n_receivers,
+        cell_size_x_m=cell_size_x_m,
+        cell_size_y_m=cell_size_y_m,
+        noise_std_s=noise_std_s,
+        outlier_fraction=outlier_fraction,
+    )
+
+
+def make_low_fold_empty_cell_refraction_dataset(
+    *,
+    seed: int = 0,
+    v1_m_s: float = 800.0,
+    cell_v2_m_s: Sequence[float] | np.ndarray | None = None,
+    n_sources: int = 12,
+    n_receivers: int = 12,
+    cell_size_x_m: float = 100.0,
+    cell_size_y_m: float | None = None,
+    noise_std_s: float = 0.0,
+    outlier_fraction: float = 0.0,
+    min_observations_per_cell: int = 3,
+) -> SyntheticRefractionCellDataset:
+    """Build a 2D fixture with one empty cell and one below-fold cell."""
+    v2 = _cell_v2_2d(cell_v2_m_s, default=(2200.0, 2600.0, 3000.0, 3400.0))
+    desired_counts = {
+        0: min_observations_per_cell + 2,
+        1: max(1, min_observations_per_cell - 1),
+        2: 0,
+        3: min_observations_per_cell + 2,
+    }
+    return _make_dataset(
+        coordinate_mode='grid_3d',
+        seed=seed,
+        v1_m_s=v1_m_s,
+        cell_v2_m_s=v2,
+        n_sources=n_sources,
+        n_receivers=n_receivers,
+        cell_size_x_m=cell_size_x_m,
+        cell_size_y_m=cell_size_y_m,
+        noise_std_s=noise_std_s,
+        outlier_fraction=outlier_fraction,
+        desired_observations_by_cell=desired_counts,
+    )
+
+
+def make_outlier_refraction_dataset(
+    *,
+    seed: int = 0,
+    v1_m_s: float = 800.0,
+    cell_v2_m_s: Sequence[float] | np.ndarray | None = None,
+    n_sources: int = 9,
+    n_receivers: int = 9,
+    cell_size_x_m: float = 100.0,
+    cell_size_y_m: float | None = None,
+    noise_std_s: float = 0.0005,
+    outlier_fraction: float = 0.1,
+) -> SyntheticRefractionCellDataset:
+    """Build a 2D fixture with deterministic large pick-time outliers."""
+    v2 = _cell_v2_2d(cell_v2_m_s, default=(2200.0, 2600.0, 3000.0))
+    return _make_dataset(
+        coordinate_mode='grid_3d',
+        seed=seed,
+        v1_m_s=v1_m_s,
+        cell_v2_m_s=v2,
+        n_sources=n_sources,
+        n_receivers=n_receivers,
+        cell_size_x_m=cell_size_x_m,
+        cell_size_y_m=cell_size_y_m,
+        noise_std_s=noise_std_s,
+        outlier_fraction=outlier_fraction,
+    )
+
+
+def make_v2_spike_smoothing_dataset(
+    *,
+    seed: int = 0,
+    v1_m_s: float = 800.0,
+    cell_v2_m_s: Sequence[float] | np.ndarray | None = None,
+    n_sources: int = 13,
+    n_receivers: int = 13,
+    cell_size_x_m: float = 100.0,
+    cell_size_y_m: float | None = None,
+    noise_std_s: float = 0.0,
+    outlier_fraction: float = 0.0,
+) -> SyntheticRefractionCellDataset:
+    """Build a 2D fixture with a central V2 spike for smoothing tests."""
+    v2 = _cell_v2_2d(
+        cell_v2_m_s,
+        default=(2600.0, 2600.0, 3600.0, 2600.0, 2600.0),
+    )
+    return _make_dataset(
+        coordinate_mode='grid_3d',
+        seed=seed,
+        v1_m_s=v1_m_s,
+        cell_v2_m_s=v2,
+        n_sources=n_sources,
+        n_receivers=n_receivers,
+        cell_size_x_m=cell_size_x_m,
+        cell_size_y_m=cell_size_y_m,
+        noise_std_s=noise_std_s,
+        outlier_fraction=outlier_fraction,
+    )
+
+
+def _make_dataset(
+    *,
+    coordinate_mode: CoordinateMode,
+    seed: int,
+    v1_m_s: float,
+    cell_v2_m_s: np.ndarray,
+    n_sources: int,
+    n_receivers: int,
+    cell_size_x_m: float,
+    cell_size_y_m: float | None,
+    noise_std_s: float,
+    outlier_fraction: float,
+    line_origin_x_m: float | None = None,
+    line_origin_y_m: float | None = None,
+    line_azimuth_deg: float | None = None,
+    desired_observations_by_cell: dict[int, int] | None = None,
+) -> SyntheticRefractionCellDataset:
+    rng = np.random.default_rng(seed)
+    v2 = _validated_v2(cell_v2_m_s, v1_m_s=v1_m_s)
+    n_cell_y, n_cell_x = v2.shape
+    _validate_positive_int(n_sources, name='n_sources')
+    _validate_positive_int(n_receivers, name='n_receivers')
+    cell_size_x = _positive_float(cell_size_x_m, name='cell_size_x_m')
+    cell_size_y = _effective_cell_size_y(
+        cell_size_y_m=cell_size_y_m,
+        number_of_cell_y=n_cell_y,
+    )
+    if coordinate_mode == 'line_2d_projected' and n_cell_y != 1:
+        raise ValueError('line_2d_projected synthetic fixtures require one cell row')
+
+    source_cell_x, source_cell_y = _endpoint_cell_coordinates(
+        n_endpoints=n_sources,
+        number_of_cell_x=n_cell_x,
+        number_of_cell_y=n_cell_y,
+        cell_size_x_m=cell_size_x,
+        cell_size_y_m=cell_size_y,
+        rng=rng,
+        x_fraction=0.25,
+        y_fraction=0.35,
+    )
+    receiver_cell_x, receiver_cell_y = _endpoint_cell_coordinates(
+        n_endpoints=n_receivers,
+        number_of_cell_x=n_cell_x,
+        number_of_cell_y=n_cell_y,
+        cell_size_x_m=cell_size_x,
+        cell_size_y_m=cell_size_y,
+        rng=rng,
+        x_fraction=0.75,
+        y_fraction=0.65,
+    )
+
+    if coordinate_mode == 'line_2d_projected':
+        source_x, source_y = _line_to_map(
+            inline_m=source_cell_x,
+            crossline_m=np.zeros(source_cell_x.shape, dtype=np.float64),
+            line_origin_x_m=_required_float(
+                line_origin_x_m,
+                name='line_origin_x_m',
+            ),
+            line_origin_y_m=_required_float(
+                line_origin_y_m,
+                name='line_origin_y_m',
+            ),
+            line_azimuth_deg=_required_float(
+                line_azimuth_deg,
+                name='line_azimuth_deg',
+            ),
+        )
+        receiver_x, receiver_y = _line_to_map(
+            inline_m=receiver_cell_x,
+            crossline_m=np.zeros(receiver_cell_x.shape, dtype=np.float64),
+            line_origin_x_m=float(line_origin_x_m),
+            line_origin_y_m=float(line_origin_y_m),
+            line_azimuth_deg=float(line_azimuth_deg),
+        )
+        source_inline_endpoint = source_cell_x
+        receiver_inline_endpoint = receiver_cell_x
+    else:
+        source_x = source_cell_x
+        source_y = source_cell_y
+        receiver_x = receiver_cell_x
+        receiver_y = receiver_cell_y
+        source_inline_endpoint = None
+        receiver_inline_endpoint = None
+        line_origin_x_m = None
+        line_origin_y_m = None
+        line_azimuth_deg = None
+
+    source_ix, source_iy = _cell_indices_for_points(
+        x_m=source_cell_x,
+        y_m=source_cell_y,
+        number_of_cell_x=n_cell_x,
+        number_of_cell_y=n_cell_y,
+        cell_size_x_m=cell_size_x,
+        cell_size_y_m=cell_size_y,
+    )
+    receiver_ix, receiver_iy = _cell_indices_for_points(
+        x_m=receiver_cell_x,
+        y_m=receiver_cell_y,
+        number_of_cell_x=n_cell_x,
+        number_of_cell_y=n_cell_y,
+        cell_size_x_m=cell_size_x,
+        cell_size_y_m=cell_size_y,
+    )
+
+    source_v2 = v2[source_iy, source_ix]
+    receiver_v2 = v2[receiver_iy, receiver_ix]
+    source_sh1 = _endpoint_sh1_m(rng, n_sources)
+    receiver_sh1 = _endpoint_sh1_m(rng, n_receivers)
+    source_t1 = _t1_from_sh1(source_sh1, v1_m_s=v1_m_s, v2_m_s=source_v2)
+    receiver_t1 = _t1_from_sh1(receiver_sh1, v1_m_s=v1_m_s, v2_m_s=receiver_v2)
+    source_wcor = _wcor_from_sh1(source_sh1, v1_m_s=v1_m_s, v2_m_s=source_v2)
+    receiver_wcor = _wcor_from_sh1(receiver_sh1, v1_m_s=v1_m_s, v2_m_s=receiver_v2)
+
+    source_index, receiver_index = _observation_endpoint_indices(
+        n_sources=n_sources,
+        n_receivers=n_receivers,
+    )
+    row_source_cell_x = source_cell_x[source_index]
+    row_receiver_cell_x = receiver_cell_x[receiver_index]
+    row_source_cell_y = source_cell_y[source_index]
+    row_receiver_cell_y = receiver_cell_y[receiver_index]
+    midpoint_x = 0.5 * (row_source_cell_x + row_receiver_cell_x)
+    midpoint_y = 0.5 * (row_source_cell_y + row_receiver_cell_y)
+    midpoint_ix, midpoint_iy = _cell_indices_for_points(
+        x_m=midpoint_x,
+        y_m=midpoint_y,
+        number_of_cell_x=n_cell_x,
+        number_of_cell_y=n_cell_y,
+        cell_size_x_m=cell_size_x,
+        cell_size_y_m=cell_size_y,
+    )
+    midpoint_cell_id = midpoint_iy * n_cell_x + midpoint_ix
+    selected = _select_observation_rows(
+        midpoint_cell_id=midpoint_cell_id,
+        desired_observations_by_cell=desired_observations_by_cell,
+        n_cells=int(v2.size),
+    )
+    source_index = source_index[selected]
+    receiver_index = receiver_index[selected]
+    midpoint_ix = midpoint_ix[selected]
+    midpoint_iy = midpoint_iy[selected]
+    midpoint_cell_id = midpoint_cell_id[selected]
+
+    obs_source_x = source_x[source_index]
+    obs_source_y = source_y[source_index]
+    obs_receiver_x = receiver_x[receiver_index]
+    obs_receiver_y = receiver_y[receiver_index]
+    offset_m = np.hypot(obs_receiver_x - obs_source_x, obs_receiver_y - obs_source_y)
+    midpoint_v2 = v2[midpoint_iy, midpoint_ix]
+    noiseless_pick = (
+        source_t1[source_index]
+        + receiver_t1[receiver_index]
+        + offset_m / midpoint_v2
+    )
+    noise_s, outlier_mask = _noise_and_outliers(
+        rng=rng,
+        n_observations=int(noiseless_pick.shape[0]),
+        noise_std_s=noise_std_s,
+        outlier_fraction=outlier_fraction,
+    )
+    pick_time_s = noiseless_pick + noise_s
+
+    source_id_endpoint = 1000 + np.arange(n_sources, dtype=np.int64)
+    receiver_id_endpoint = 2000 + np.arange(n_receivers, dtype=np.int64)
+    source_node_endpoint = np.arange(n_sources, dtype=np.int64)
+    receiver_node_endpoint = n_sources + np.arange(n_receivers, dtype=np.int64)
+    cell_observation_count = np.bincount(midpoint_cell_id, minlength=int(v2.size))
+
+    return SyntheticRefractionCellDataset(
+        coordinate_mode=coordinate_mode,
+        cell_size_x_m=cell_size_x,
+        cell_size_y_m=cell_size_y_m,
+        x_coordinate_origin_m=0.0,
+        y_coordinate_origin_m=0.0,
+        line_origin_x_m=line_origin_x_m,
+        line_origin_y_m=line_origin_y_m,
+        line_azimuth_deg=line_azimuth_deg,
+        source_x_m=_f64(obs_source_x),
+        source_y_m=_f64(obs_source_y),
+        receiver_x_m=_f64(obs_receiver_x),
+        receiver_y_m=_f64(obs_receiver_y),
+        source_inline_m=_optional_take(source_inline_endpoint, source_index),
+        receiver_inline_m=_optional_take(receiver_inline_endpoint, receiver_index),
+        source_id=_i64(source_id_endpoint[source_index]),
+        receiver_id=_i64(receiver_id_endpoint[receiver_index]),
+        source_node_id=_i64(source_node_endpoint[source_index]),
+        receiver_node_id=_i64(receiver_node_endpoint[receiver_index]),
+        source_endpoint_index=_i64(source_index),
+        receiver_endpoint_index=_i64(receiver_index),
+        offset_m=_f64(offset_m),
+        pick_time_s=_f64(pick_time_s),
+        valid_mask=np.ones(pick_time_s.shape, dtype=bool),
+        true_v1_m_s=float(v1_m_s),
+        true_cell_v2_m_s=_f64(v2),
+        true_source_t1_s=_f64(source_t1[source_index]),
+        true_receiver_t1_s=_f64(receiver_t1[receiver_index]),
+        true_source_sh1_m=_f64(source_sh1[source_index]),
+        true_receiver_sh1_m=_f64(receiver_sh1[receiver_index]),
+        true_source_wcor_s=_f64(source_wcor[source_index]),
+        true_receiver_wcor_s=_f64(receiver_wcor[receiver_index]),
+        true_source_static_s=_f64(source_wcor[source_index]),
+        true_receiver_static_s=_f64(receiver_wcor[receiver_index]),
+        true_source_v2_m_s=_f64(source_v2[source_index]),
+        true_receiver_v2_m_s=_f64(receiver_v2[receiver_index]),
+        true_midpoint_v2_m_s=_f64(midpoint_v2),
+        true_cell_ix_for_pick=_i64(midpoint_ix),
+        true_cell_iy_for_pick=_i64(midpoint_iy),
+        true_cell_id_for_pick=_i64(midpoint_cell_id),
+        true_noise_s=_f64(noise_s),
+        outlier_mask=np.ascontiguousarray(outlier_mask, dtype=bool),
+        cell_observation_count=_i64(cell_observation_count),
+        source_endpoint_id=_i64(source_id_endpoint),
+        receiver_endpoint_id=_i64(receiver_id_endpoint),
+        source_endpoint_node_id=_i64(source_node_endpoint),
+        receiver_endpoint_node_id=_i64(receiver_node_endpoint),
+        source_endpoint_x_m=_f64(source_x),
+        source_endpoint_y_m=_f64(source_y),
+        receiver_endpoint_x_m=_f64(receiver_x),
+        receiver_endpoint_y_m=_f64(receiver_y),
+        source_endpoint_inline_m=_optional_f64(source_inline_endpoint),
+        receiver_endpoint_inline_m=_optional_f64(receiver_inline_endpoint),
+        true_source_endpoint_t1_s=_f64(source_t1),
+        true_receiver_endpoint_t1_s=_f64(receiver_t1),
+        true_source_endpoint_sh1_m=_f64(source_sh1),
+        true_receiver_endpoint_sh1_m=_f64(receiver_sh1),
+        true_source_endpoint_wcor_s=_f64(source_wcor),
+        true_receiver_endpoint_wcor_s=_f64(receiver_wcor),
+        true_source_endpoint_static_s=_f64(source_wcor),
+        true_receiver_endpoint_static_s=_f64(receiver_wcor),
+        true_source_endpoint_v2_m_s=_f64(source_v2),
+        true_receiver_endpoint_v2_m_s=_f64(receiver_v2),
+    )
+
+
+def _cell_v2_2d(
+    values: Sequence[float] | np.ndarray | None,
+    *,
+    default: Sequence[float],
+) -> np.ndarray:
+    raw = np.asarray(default if values is None else values, dtype=np.float64)
+    if raw.ndim != 1:
+        raise ValueError('2D synthetic cell_v2_m_s must be one-dimensional')
+    return raw.reshape(1, raw.shape[0])
+
+
+def _cell_v2_3d(
+    values: Sequence[Sequence[float]] | np.ndarray | None,
+    *,
+    default: Sequence[Sequence[float]],
+) -> np.ndarray:
+    raw = np.asarray(default if values is None else values, dtype=np.float64)
+    if raw.ndim != 2:
+        raise ValueError('3D synthetic cell_v2_m_s must be two-dimensional')
+    return raw
+
+
+def _validated_v2(cell_v2_m_s: np.ndarray, *, v1_m_s: float) -> np.ndarray:
+    v1 = _positive_float(v1_m_s, name='v1_m_s')
+    v2 = np.ascontiguousarray(cell_v2_m_s, dtype=np.float64)
+    if v2.ndim != 2 or v2.size == 0:
+        raise ValueError('cell_v2_m_s must be a non-empty 2D array')
+    if not np.all(np.isfinite(v2)) or np.any(v2 <= v1):
+        raise ValueError('all synthetic V2 cells must be finite and greater than V1')
+    return v2
+
+
+def _effective_cell_size_y(
+    *,
+    cell_size_y_m: float | None,
+    number_of_cell_y: int,
+) -> float | None:
+    if number_of_cell_y == 1 and cell_size_y_m is None:
+        return None
+    if cell_size_y_m is None:
+        raise ValueError('cell_size_y_m is required when more than one cell row exists')
+    return _positive_float(cell_size_y_m, name='cell_size_y_m')
+
+
+def _endpoint_cell_coordinates(
+    *,
+    n_endpoints: int,
+    number_of_cell_x: int,
+    number_of_cell_y: int,
+    cell_size_x_m: float,
+    cell_size_y_m: float | None,
+    rng: np.random.Generator,
+    x_fraction: float,
+    y_fraction: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    total_cells = number_of_cell_x * number_of_cell_y
+    cell_id = np.arange(n_endpoints, dtype=np.int64) % total_cells
+    ix = cell_id % number_of_cell_x
+    iy = cell_id // number_of_cell_x
+    x_jitter = rng.uniform(-0.06, 0.06, size=n_endpoints) * cell_size_x_m
+    x_m = (ix.astype(np.float64) + x_fraction) * cell_size_x_m + x_jitter
+    if cell_size_y_m is None:
+        y_m = np.zeros(n_endpoints, dtype=np.float64)
+    else:
+        y_jitter = rng.uniform(-0.06, 0.06, size=n_endpoints) * cell_size_y_m
+        y_m = (iy.astype(np.float64) + y_fraction) * cell_size_y_m + y_jitter
+    return _f64(x_m), _f64(y_m)
+
+
+def _observation_endpoint_indices(
+    *,
+    n_sources: int,
+    n_receivers: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    source_index = np.repeat(np.arange(n_sources, dtype=np.int64), n_receivers)
+    receiver_index = np.tile(np.arange(n_receivers, dtype=np.int64), n_sources)
+    return source_index, receiver_index
+
+
+def _cell_indices_for_points(
+    *,
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+    number_of_cell_x: int,
+    number_of_cell_y: int,
+    cell_size_x_m: float,
+    cell_size_y_m: float | None,
+) -> tuple[np.ndarray, np.ndarray]:
+    ix = np.floor(np.asarray(x_m, dtype=np.float64) / cell_size_x_m).astype(np.int64)
+    if cell_size_y_m is None:
+        iy = np.zeros(ix.shape, dtype=np.int64)
+        inside_y = np.ones(ix.shape, dtype=bool)
+    else:
+        iy = np.floor(np.asarray(y_m, dtype=np.float64) / cell_size_y_m).astype(np.int64)
+        inside_y = (iy >= 0) & (iy < number_of_cell_y)
+    inside_x = (ix >= 0) & (ix < number_of_cell_x)
+    if not bool(np.all(inside_x & inside_y)):
+        raise ValueError('synthetic coordinates produced points outside the cell grid')
+    return ix, iy
+
+
+def _select_observation_rows(
+    *,
+    midpoint_cell_id: np.ndarray,
+    desired_observations_by_cell: dict[int, int] | None,
+    n_cells: int,
+) -> np.ndarray:
+    if desired_observations_by_cell is None:
+        return np.arange(midpoint_cell_id.shape[0], dtype=np.int64)
+
+    desired = {int(key): int(value) for key, value in desired_observations_by_cell.items()}
+    for cell_id, count in desired.items():
+        if cell_id < 0 or cell_id >= n_cells or count < 0:
+            raise ValueError('desired observation counts must reference valid cells')
+
+    selected: list[int] = []
+    used = np.zeros(n_cells, dtype=np.int64)
+    for row_index, raw_cell_id in enumerate(midpoint_cell_id.tolist()):
+        cell_id = int(raw_cell_id)
+        wanted = desired.get(cell_id)
+        if wanted is None:
+            selected.append(row_index)
+            continue
+        if used[cell_id] < wanted:
+            selected.append(row_index)
+            used[cell_id] += 1
+
+    missing = {
+        cell_id: count - int(used[cell_id])
+        for cell_id, count in desired.items()
+        if used[cell_id] < count
+    }
+    if missing:
+        raise ValueError(f'not enough synthetic observations for cells: {missing}')
+    return np.asarray(selected, dtype=np.int64)
+
+
+def _endpoint_sh1_m(
+    rng: np.random.Generator,
+    n_endpoints: int,
+) -> np.ndarray:
+    return _f64(rng.uniform(6.0, 24.0, size=n_endpoints))
+
+
+def _t1_from_sh1(
+    sh1_m: np.ndarray,
+    *,
+    v1_m_s: float,
+    v2_m_s: np.ndarray,
+) -> np.ndarray:
+    # One-layer T1LSST relation inverted from SH1 truth.
+    return _f64(sh1_m * np.sqrt(v2_m_s**2 - v1_m_s**2) / (v1_m_s * v2_m_s))
+
+
+def _wcor_from_sh1(
+    sh1_m: np.ndarray,
+    *,
+    v1_m_s: float,
+    v2_m_s: np.ndarray,
+) -> np.ndarray:
+    # Repo convention uses this negative weathering correction as the shift.
+    return _f64(sh1_m * ((1.0 / v2_m_s) - (1.0 / v1_m_s)))
+
+
+def _noise_and_outliers(
+    *,
+    rng: np.random.Generator,
+    n_observations: int,
+    noise_std_s: float,
+    outlier_fraction: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    if noise_std_s < 0.0:
+        raise ValueError('noise_std_s must be non-negative')
+    if outlier_fraction < 0.0 or outlier_fraction > 1.0:
+        raise ValueError('outlier_fraction must be in [0, 1]')
+    noise = np.zeros(n_observations, dtype=np.float64)
+    if noise_std_s > 0.0:
+        noise = rng.normal(0.0, noise_std_s, size=n_observations)
+
+    outlier_mask = np.zeros(n_observations, dtype=bool)
+    if outlier_fraction > 0.0 and n_observations > 0:
+        n_outliers = max(1, int(round(float(n_observations) * outlier_fraction)))
+        outlier_index = rng.choice(n_observations, size=n_outliers, replace=False)
+        outlier_mask[outlier_index] = True
+        sign = rng.choice(np.asarray([-1.0, 1.0], dtype=np.float64), size=n_outliers)
+        outlier_scale_s = max(0.050, noise_std_s * 20.0)
+        noise[outlier_index] += sign * outlier_scale_s
+
+    return _f64(noise), outlier_mask
+
+
+def _line_to_map(
+    *,
+    inline_m: np.ndarray,
+    crossline_m: np.ndarray,
+    line_origin_x_m: float,
+    line_origin_y_m: float,
+    line_azimuth_deg: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    azimuth_rad = np.deg2rad(float(line_azimuth_deg))
+    inline_unit_x = float(np.sin(azimuth_rad))
+    inline_unit_y = float(np.cos(azimuth_rad))
+    dx = inline_m * inline_unit_x + crossline_m * inline_unit_y
+    dy = inline_m * inline_unit_y - crossline_m * inline_unit_x
+    return (
+        _f64(float(line_origin_x_m) + dx),
+        _f64(float(line_origin_y_m) + dy),
+    )
+
+
+def _positive_float(value: float, *, name: str) -> float:
+    result = float(value)
+    if not np.isfinite(result) or result <= 0.0:
+        raise ValueError(f'{name} must be positive and finite')
+    return result
+
+
+def _required_float(value: float | None, *, name: str) -> float:
+    if value is None:
+        raise ValueError(f'{name} is required')
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f'{name} must be finite')
+    return result
+
+
+def _validate_positive_int(value: int, *, name: str) -> None:
+    if int(value) <= 0:
+        raise ValueError(f'{name} must be positive')
+
+
+def _optional_take(values: np.ndarray | None, index: np.ndarray) -> np.ndarray | None:
+    if values is None:
+        return None
+    return _f64(values[index])
+
+
+def _optional_f64(values: np.ndarray | None) -> np.ndarray | None:
+    if values is None:
+        return None
+    return _f64(values)
+
+
+def _f64(values: np.ndarray) -> np.ndarray:
+    return np.ascontiguousarray(values, dtype=np.float64)
+
+
+def _i64(values: np.ndarray) -> np.ndarray:
+    return np.ascontiguousarray(values, dtype=np.int64)
+
+
+__all__ = [
+    'CoordinateMode',
+    'SyntheticRefractionCellDataset',
+    'make_clean_2d_cell_refraction_dataset',
+    'make_clean_3d_cell_refraction_dataset',
+    'make_low_fold_empty_cell_refraction_dataset',
+    'make_outlier_refraction_dataset',
+    'make_rotated_2d_line_refraction_dataset',
+    'make_v2_spike_smoothing_dataset',
+]

--- a/app/tests/test_refraction_static_cell_line_2d_projected.py
+++ b/app/tests/test_refraction_static_cell_line_2d_projected.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.api.schemas import RefractionStaticRefractorCellRequest
+from app.services.refraction_static_cell_coordinates import (
+    effective_refraction_cell_grid_config,
+    project_refraction_cell_coordinates,
+    project_refraction_cell_points,
+)
+from app.services.refraction_static_cell_grid import (
+    assign_observation_midpoint_cells,
+    build_refraction_cell_grid,
+)
+from app.tests.fixtures.refraction_synthetic import (
+    SyntheticRefractionCellDataset,
+    make_rotated_2d_line_refraction_dataset,
+)
+
+
+def test_line_2d_projected_recovers_inline_coordinates_for_rotated_line() -> None:
+    dataset = make_rotated_2d_line_refraction_dataset(
+        seed=432,
+        line_origin_x_m=1000.0,
+        line_origin_y_m=2000.0,
+        line_azimuth_deg=37.0,
+    )
+    assert dataset.source_endpoint_inline_m is not None
+    assert dataset.receiver_endpoint_inline_m is not None
+
+    source = project_refraction_cell_points(
+        x_m=dataset.source_endpoint_x_m,
+        y_m=dataset.source_endpoint_y_m,
+        mode='line_2d_projected',
+        line_origin_x_m=dataset.line_origin_x_m,
+        line_origin_y_m=dataset.line_origin_y_m,
+        line_azimuth_deg=dataset.line_azimuth_deg,
+    )
+    receiver = project_refraction_cell_points(
+        x_m=dataset.receiver_endpoint_x_m,
+        y_m=dataset.receiver_endpoint_y_m,
+        mode='line_2d_projected',
+        line_origin_x_m=dataset.line_origin_x_m,
+        line_origin_y_m=dataset.line_origin_y_m,
+        line_azimuth_deg=dataset.line_azimuth_deg,
+    )
+
+    np.testing.assert_allclose(source.x_m, dataset.source_endpoint_inline_m)
+    np.testing.assert_allclose(receiver.x_m, dataset.receiver_endpoint_inline_m)
+    np.testing.assert_allclose(source.y_m, 0.0, atol=0.0)
+    np.testing.assert_allclose(receiver.y_m, 0.0, atol=0.0)
+    np.testing.assert_allclose(source.projected_crossline_m, 0.0, atol=1.0e-9)
+    np.testing.assert_allclose(receiver.projected_crossline_m, 0.0, atol=1.0e-9)
+    assert source.qc['coordinate_mode'] == 'line_2d_projected'
+    assert source.qc['line_azimuth_deg'] == pytest.approx(37.0)
+
+
+def test_line_2d_projected_midpoint_cell_assignment_uses_inline_midpoint() -> None:
+    dataset = make_rotated_2d_line_refraction_dataset(seed=432)
+    assert dataset.source_inline_m is not None
+    assert dataset.receiver_inline_m is not None
+    request = _line_cell_request(dataset)
+    grid = build_refraction_cell_grid(effective_refraction_cell_grid_config(request))
+    projected = project_refraction_cell_coordinates(
+        source_x_m=dataset.source_x_m,
+        source_y_m=dataset.source_y_m,
+        receiver_x_m=dataset.receiver_x_m,
+        receiver_y_m=dataset.receiver_y_m,
+        mode='line_2d_projected',
+        line_origin_x_m=dataset.line_origin_x_m,
+        line_origin_y_m=dataset.line_origin_y_m,
+        line_azimuth_deg=dataset.line_azimuth_deg,
+    )
+
+    assignment = assign_observation_midpoint_cells(
+        grid,
+        source_x_m=projected.source_x_m,
+        source_y_m=projected.source_y_m,
+        receiver_x_m=projected.receiver_x_m,
+        receiver_y_m=projected.receiver_y_m,
+    )
+    inline_midpoint_m = 0.5 * (dataset.source_inline_m + dataset.receiver_inline_m)
+    expected_cell_id = np.floor(inline_midpoint_m / dataset.cell_size_x_m).astype(
+        np.int64
+    )
+
+    np.testing.assert_allclose(assignment.x_m, inline_midpoint_m)
+    np.testing.assert_allclose(assignment.y_m, 0.0, atol=0.0)
+    np.testing.assert_array_equal(assignment.cell_id, expected_cell_id)
+    np.testing.assert_array_equal(assignment.cell_id, dataset.true_cell_id_for_pick)
+    assert bool(np.all(assignment.inside_grid_mask))
+
+
+def test_line_2d_projected_requires_single_y_cell() -> None:
+    dataset = make_rotated_2d_line_refraction_dataset(seed=432)
+    payload = _line_cell_request(dataset).model_dump(mode='json')
+    payload.update({'number_of_cell_y': 2, 'size_of_cell_y_m': 100.0})
+
+    with pytest.raises(ValueError, match='number_of_cell_y must be 1'):
+        RefractionStaticRefractorCellRequest.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    'missing_field',
+    ['line_origin_x_m', 'line_origin_y_m', 'line_azimuth_deg'],
+)
+def test_line_2d_projected_requires_line_origin_and_azimuth(
+    missing_field: str,
+) -> None:
+    dataset = make_rotated_2d_line_refraction_dataset(seed=432)
+    payload = _line_cell_request(dataset).model_dump(mode='json')
+    payload[missing_field] = None
+
+    with pytest.raises(ValueError, match='line_origin_x_m'):
+        RefractionStaticRefractorCellRequest.model_validate(payload)
+
+
+def test_rotated_line_grid_3d_and_line_2d_projected_assignments_can_differ() -> None:
+    dataset = make_rotated_2d_line_refraction_dataset(
+        seed=432,
+        line_origin_x_m=1000.0,
+        line_origin_y_m=2000.0,
+        line_azimuth_deg=37.0,
+    )
+    line_request = _line_cell_request(dataset)
+    line_grid = build_refraction_cell_grid(
+        effective_refraction_cell_grid_config(line_request)
+    )
+    line_projected = project_refraction_cell_coordinates(
+        source_x_m=dataset.source_x_m,
+        source_y_m=dataset.source_y_m,
+        receiver_x_m=dataset.receiver_x_m,
+        receiver_y_m=dataset.receiver_y_m,
+        mode='line_2d_projected',
+        line_origin_x_m=dataset.line_origin_x_m,
+        line_origin_y_m=dataset.line_origin_y_m,
+        line_azimuth_deg=dataset.line_azimuth_deg,
+    )
+    line_assignment = assign_observation_midpoint_cells(
+        line_grid,
+        source_x_m=line_projected.source_x_m,
+        source_y_m=line_projected.source_y_m,
+        receiver_x_m=line_projected.receiver_x_m,
+        receiver_y_m=line_projected.receiver_y_m,
+    )
+    grid_3d_grid = build_refraction_cell_grid(
+        _grid_3d_request_covering_rotated_line(dataset)
+    )
+    grid_3d_assignment = assign_observation_midpoint_cells(
+        grid_3d_grid,
+        source_x_m=dataset.source_x_m,
+        source_y_m=dataset.source_y_m,
+        receiver_x_m=dataset.receiver_x_m,
+        receiver_y_m=dataset.receiver_y_m,
+    )
+
+    np.testing.assert_array_equal(line_assignment.cell_id, dataset.true_cell_id_for_pick)
+    assert bool(np.all(grid_3d_assignment.inside_grid_mask))
+    assert not np.array_equal(grid_3d_assignment.cell_id, line_assignment.cell_id)
+    assert int(np.max(line_assignment.iy)) == 0
+    assert int(np.max(grid_3d_assignment.iy)) > 0
+
+
+def _line_cell_request(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionStaticRefractorCellRequest:
+    return RefractionStaticRefractorCellRequest.model_validate(
+        {
+            'number_of_cell_x': int(dataset.true_cell_v2_m_s.shape[1]),
+            'size_of_cell_x_m': dataset.cell_size_x_m,
+            'x_coordinate_origin_m': dataset.x_coordinate_origin_m,
+            'number_of_cell_y': 1,
+            'size_of_cell_y_m': None,
+            'y_coordinate_origin_m': dataset.y_coordinate_origin_m,
+            'assignment_mode': 'midpoint',
+            'outside_grid_policy': 'reject',
+            'coordinate_mode': 'line_2d_projected',
+            'line_origin_x_m': dataset.line_origin_x_m,
+            'line_origin_y_m': dataset.line_origin_y_m,
+            'line_azimuth_deg': dataset.line_azimuth_deg,
+            'min_observations_per_cell': 1,
+            'velocity_smoothing_weight': 0.0,
+            'smoothing_reference_distance_m': None,
+        }
+    )
+
+
+def _grid_3d_request_covering_rotated_line(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionStaticRefractorCellRequest:
+    return RefractionStaticRefractorCellRequest.model_validate(
+        {
+            'number_of_cell_x': 3,
+            'size_of_cell_x_m': dataset.cell_size_x_m,
+            'x_coordinate_origin_m': dataset.line_origin_x_m,
+            'number_of_cell_y': 3,
+            'size_of_cell_y_m': dataset.cell_size_x_m,
+            'y_coordinate_origin_m': dataset.line_origin_y_m,
+            'assignment_mode': 'midpoint',
+            'outside_grid_policy': 'reject',
+            'coordinate_mode': 'grid_3d',
+            'min_observations_per_cell': 1,
+            'velocity_smoothing_weight': 0.0,
+            'smoothing_reference_distance_m': None,
+        }
+    )

--- a/app/tests/test_refraction_static_cell_low_fold.py
+++ b/app/tests/test_refraction_static_cell_low_fold.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import numpy as np
+
+from app.api.schemas import RefractionStaticApplyRequest
+from app.services.refraction_static_artifacts import (
+    REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
+    REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
+    build_refraction_refractor_velocity_grid_arrays,
+    write_refraction_static_artifacts,
+)
+from app.services.refraction_static_design_matrix import (
+    build_refraction_static_design_matrix,
+)
+from app.services.refraction_static_datum import build_refraction_datum_statics
+from app.services.refraction_static_types import (
+    RefractionDatumStaticsResult,
+    RefractionEndpointTable,
+    RefractionStaticInputModel,
+)
+from app.services.refraction_static_weathering_replacement import (
+    compute_weathering_replacement_statics_from_first_breaks,
+)
+from app.tests.fixtures.refraction_synthetic import (
+    SyntheticRefractionCellDataset,
+    make_low_fold_empty_cell_refraction_dataset,
+)
+
+MIN_OBSERVATIONS_PER_CELL = 20
+ACTIVE_CELL_ID = np.asarray([0, 3], dtype=np.int64)
+LOW_FOLD_CELL_ID = 1
+EMPTY_CELL_ID = 2
+
+
+def test_min_observations_per_cell_excludes_low_fold_cells() -> None:
+    dataset, req, input_model = _low_fold_case()
+
+    design = build_refraction_static_design_matrix(
+        input_model=input_model,
+        model=req.model,
+    )
+
+    np.testing.assert_array_equal(
+        dataset.cell_observation_count,
+        [22, 19, 0, 22],
+    )
+    np.testing.assert_array_equal(design.active_cell_id, ACTIVE_CELL_ID)
+    np.testing.assert_array_equal(design.inactive_cell_id, [1, 2])
+    assert design.cell_id_to_col == {
+        0: design.n_active_nodes,
+        3: design.n_active_nodes + 1,
+    }
+    assert LOW_FOLD_CELL_ID not in design.cell_id_to_col
+    assert EMPTY_CELL_ID not in design.cell_id_to_col
+    assert design.rejection_reason_sorted is not None
+    low_fold_rows = dataset.true_cell_id_for_pick == LOW_FOLD_CELL_ID
+    assert np.all(
+        design.rejection_reason_sorted[low_fold_rows]
+        == 'below_min_observations_per_cell'
+    )
+    assert not np.any(
+        np.isin(design.row_trace_index_sorted, np.flatnonzero(low_fold_rows))
+    )
+    assert design.qc['min_observations_per_cell'] == MIN_OBSERVATIONS_PER_CELL
+    assert design.qc['n_low_fold_cells'] == 1
+    assert design.qc['low_fold_cell_id'] == [LOW_FOLD_CELL_ID]
+    assert design.qc['n_observations_rejected_by_low_fold_cell'] == 19
+    assert design.qc['low_fold_cell_rejection_reason'] == (
+        'below_min_observations_per_cell'
+    )
+
+
+def test_low_fold_and_empty_cells_are_reported_in_cell_artifacts(
+    tmp_path: Path,
+) -> None:
+    dataset, req, input_model = _low_fold_case()
+    result = _run_refraction_statics(req=req, input_model=input_model)
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    assert paths.refraction_refractor_velocity_cells_csv is not None
+    rows = {
+        int(row['cell_id']): row
+        for row in _read_csv(paths.refraction_refractor_velocity_cells_csv)
+    }
+    assert [rows[index]['velocity_status'] for index in range(4)] == [
+        'solved',
+        'low_fold',
+        'inactive',
+        'solved',
+    ]
+    assert rows[LOW_FOLD_CELL_ID]['active'] == 'false'
+    assert rows[LOW_FOLD_CELL_ID]['n_observations'] == '19'
+    assert rows[LOW_FOLD_CELL_ID]['n_used_observations'] == '0'
+    assert rows[LOW_FOLD_CELL_ID]['n_rejected_observations'] == '19'
+    assert rows[LOW_FOLD_CELL_ID]['v2_m_s'] == ''
+    assert rows[EMPTY_CELL_ID]['active'] == 'false'
+    assert rows[EMPTY_CELL_ID]['n_observations'] == '0'
+    assert rows[EMPTY_CELL_ID]['n_used_observations'] == '0'
+    assert rows[EMPTY_CELL_ID]['v2_m_s'] == ''
+
+    assert paths.refraction_refractor_velocity_grid_npz is not None
+    assert paths.refraction_refractor_velocity_grid_npz.name == (
+        REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME
+    )
+    with np.load(
+        paths.refraction_refractor_velocity_grid_npz,
+        allow_pickle=False,
+    ) as grid:
+        np.testing.assert_array_equal(
+            grid['n_observations_per_cell'],
+            dataset.cell_observation_count,
+        )
+        np.testing.assert_array_equal(
+            grid['velocity_status'].astype(str),
+            ['solved', 'low_fold', 'inactive', 'solved'],
+        )
+        assert np.isnan(float(grid['v2_m_s'][LOW_FOLD_CELL_ID]))
+        assert np.isnan(float(grid['v2_m_s'][EMPTY_CELL_ID]))
+
+    assert paths.refraction_refractor_velocity_qc_json is not None
+    assert paths.refraction_refractor_velocity_qc_json.name == (
+        REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME
+    )
+    cell_qc = json.loads(
+        paths.refraction_refractor_velocity_qc_json.read_text(encoding='utf-8')
+    )
+    assert cell_qc['min_observations_per_cell'] == MIN_OBSERVATIONS_PER_CELL
+    assert cell_qc['n_low_fold_cells'] == 1
+    assert cell_qc['n_observations_rejected_by_low_fold_cell'] == 19
+    assert cell_qc['low_fold_cell_rejection_reason'] == (
+        'below_min_observations_per_cell'
+    )
+
+
+def test_outside_grid_observations_have_distinct_rejection_reason() -> None:
+    _, req, input_model = _low_fold_case()
+    input_with_outside = _append_outside_grid_observation(input_model)
+
+    design = build_refraction_static_design_matrix(
+        input_model=input_with_outside,
+        model=req.model,
+    )
+
+    outside_trace_index = input_with_outside.n_traces - 1
+    assert outside_trace_index not in design.row_trace_index_sorted.tolist()
+    assert design.rejection_reason_sorted is not None
+    assert (
+        design.rejection_reason_sorted[outside_trace_index]
+        == 'outside_refractor_cell_grid'
+    )
+    assert design.qc['n_observations_outside_grid'] == 1
+    assert design.qc['n_observations_rejected_by_low_fold_cell'] == 19
+    assert design.qc['low_fold_cell_rejection_reason'] == (
+        'below_min_observations_per_cell'
+    )
+
+
+def test_low_fold_and_empty_cells_do_not_emit_solved_velocity_without_fallback() -> None:
+    _, req, input_model = _low_fold_case()
+    result = _run_refraction_statics(req=req, input_model=input_model)
+
+    np.testing.assert_array_equal(result.active_cell_id, ACTIVE_CELL_ID)
+    np.testing.assert_array_equal(result.inactive_cell_id, [1, 2])
+    assert result.cell_bedrock_velocity_m_s is not None
+    assert result.cell_bedrock_velocity_m_s.shape == ACTIVE_CELL_ID.shape
+    np.testing.assert_array_equal(result.cell_velocity_status, ['solved', 'solved'])
+
+    arrays = build_refraction_refractor_velocity_grid_arrays(
+        result=result,
+        req=req,
+    )
+    velocity_status = arrays['velocity_status'].astype(str)
+    assert velocity_status[LOW_FOLD_CELL_ID] == 'low_fold'
+    assert velocity_status[EMPTY_CELL_ID] == 'inactive'
+    assert np.isnan(float(arrays['v2_m_s'][LOW_FOLD_CELL_ID]))
+    assert np.isnan(float(arrays['v2_m_s'][EMPTY_CELL_ID]))
+    assert result.qc['low_fold_cell_id'] == [LOW_FOLD_CELL_ID]
+    assert result.qc['n_low_fold_cells'] == 1
+
+
+def _low_fold_case() -> tuple[
+    SyntheticRefractionCellDataset,
+    RefractionStaticApplyRequest,
+    RefractionStaticInputModel,
+]:
+    dataset = make_low_fold_empty_cell_refraction_dataset(
+        seed=434,
+        n_sources=16,
+        n_receivers=16,
+        min_observations_per_cell=MIN_OBSERVATIONS_PER_CELL,
+    )
+    req = _cell_apply_request(dataset)
+    return dataset, req, _input_model_from_dataset(dataset)
+
+
+def _cell_apply_request(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionStaticApplyRequest:
+    return RefractionStaticApplyRequest.model_validate(
+        {
+            'file_id': 'low-fold-empty-cell-synthetic',
+            'key1_byte': 189,
+            'key2_byte': 193,
+            'pick_source': {
+                'kind': 'batch_predicted_npz',
+                'job_id': 'low-fold-empty-cell-first-breaks',
+                'artifact_name': 'predicted_picks_time_s.npz',
+            },
+            'linkage': {'mode': 'none'},
+            'model': {
+                'method': 'gli_variable_thickness',
+                'weathering_velocity_m_s': dataset.true_v1_m_s,
+                'bedrock_velocity_mode': 'solve_cell',
+                'bedrock_velocity_m_s': None,
+                'initial_bedrock_velocity_m_s': 2600.0,
+                'min_bedrock_velocity_m_s': 1200.0,
+                'max_bedrock_velocity_m_s': 6000.0,
+                'max_weathering_thickness_m': None,
+                'refractor_cell': {
+                    'number_of_cell_x': int(dataset.true_cell_v2_m_s.shape[1]),
+                    'size_of_cell_x_m': dataset.cell_size_x_m,
+                    'x_coordinate_origin_m': dataset.x_coordinate_origin_m,
+                    'number_of_cell_y': 1,
+                    'size_of_cell_y_m': dataset.cell_size_y_m,
+                    'y_coordinate_origin_m': dataset.y_coordinate_origin_m,
+                    'assignment_mode': 'midpoint',
+                    'outside_grid_policy': 'reject',
+                    'coordinate_mode': 'grid_3d',
+                    'min_observations_per_cell': MIN_OBSERVATIONS_PER_CELL,
+                    'velocity_smoothing_weight': 0.0,
+                    'smoothing_reference_distance_m': None,
+                },
+            },
+            'moveout': {
+                'model': 'head_wave_linear_offset',
+                'distance_source': 'geometry',
+                'offset_byte': None,
+                'min_offset_m': None,
+                'max_offset_m': None,
+                'allow_missing_offset': False,
+                'max_geometry_offset_mismatch_m': None,
+            },
+            'solver': {
+                'damping': 0.0,
+                'min_picks_per_node': 1,
+                'max_abs_half_intercept_time_ms': 500.0,
+                'robust': {
+                    'enabled': False,
+                    'method': 'mad',
+                    'threshold': 3.5,
+                    'max_iterations': 5,
+                    'min_used_fraction': 0.5,
+                    'min_used_observations': 1,
+                },
+            },
+            'datum': {'mode': 'none'},
+            'conversion': {'mode': 't1lsst_1layer'},
+            'apply': {
+                'mode': 'refraction_from_raw',
+                'interpolation': 'linear',
+                'fill_value': 0.0,
+                'max_abs_shift_ms': 250.0,
+                'output_dtype': 'float32',
+                'register_corrected_file': False,
+            },
+        }
+    )
+
+
+def _input_model_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionStaticInputModel:
+    n_traces = int(dataset.pick_time_s.shape[0])
+    endpoint_table = _endpoint_table_from_dataset(dataset)
+    node_x_m = np.concatenate(
+        (dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)
+    )
+    node_y_m = np.concatenate(
+        (dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)
+    )
+    node_elevation_m = np.zeros(endpoint_table.node_id.shape, dtype=np.float64)
+    node_kind = np.concatenate(
+        (
+            np.full(dataset.source_endpoint_id.shape, 'source', dtype='<U16'),
+            np.full(dataset.receiver_endpoint_id.shape, 'receiver', dtype='<U16'),
+        )
+    )
+    return RefractionStaticInputModel(
+        file_id='low-fold-empty-cell-synthetic',
+        n_traces=n_traces,
+        sorted_trace_index=np.arange(n_traces, dtype=np.int64),
+        pick_time_s_sorted=dataset.pick_time_s,
+        valid_pick_mask_sorted=np.ones(n_traces, dtype=bool),
+        valid_observation_mask_sorted=dataset.valid_mask,
+        source_id_sorted=dataset.source_id,
+        receiver_id_sorted=dataset.receiver_id,
+        source_x_m_sorted=dataset.source_x_m,
+        source_y_m_sorted=dataset.source_y_m,
+        receiver_x_m_sorted=dataset.receiver_x_m,
+        receiver_y_m_sorted=dataset.receiver_y_m,
+        source_elevation_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        receiver_elevation_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        source_depth_m_sorted=None,
+        geometry_distance_m_sorted=dataset.offset_m,
+        offset_m_sorted=None,
+        distance_m_sorted=dataset.offset_m,
+        source_endpoint_key_sorted=np.asarray(
+            [f'source:{int(value)}' for value in dataset.source_id],
+            dtype='<U32',
+        ),
+        receiver_endpoint_key_sorted=np.asarray(
+            [f'receiver:{int(value)}' for value in dataset.receiver_id],
+            dtype='<U32',
+        ),
+        source_node_id_sorted=dataset.source_node_id,
+        receiver_node_id_sorted=dataset.receiver_node_id,
+        node_x_m=np.ascontiguousarray(node_x_m, dtype=np.float64),
+        node_y_m=np.ascontiguousarray(node_y_m, dtype=np.float64),
+        node_elevation_m=node_elevation_m,
+        node_kind=node_kind,
+        rejection_reason_sorted=np.full(n_traces, 'ok', dtype='<U32'),
+        qc={},
+        endpoint_table=endpoint_table,
+        metadata={'synthetic_model': 'low_fold_empty_cell_refraction'},
+    )
+
+
+def _endpoint_table_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionEndpointTable:
+    node_id = np.concatenate(
+        (dataset.source_endpoint_node_id, dataset.receiver_endpoint_node_id)
+    )
+    endpoint_id = np.concatenate(
+        (dataset.source_endpoint_id, dataset.receiver_endpoint_id)
+    )
+    endpoint_x_m = np.concatenate(
+        (dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)
+    )
+    endpoint_y_m = np.concatenate(
+        (dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)
+    )
+    kind = np.concatenate(
+        (
+            np.full(dataset.source_endpoint_id.shape, 'source', dtype='<U16'),
+            np.full(dataset.receiver_endpoint_id.shape, 'receiver', dtype='<U16'),
+        )
+    )
+    return RefractionEndpointTable(
+        node_id=np.ascontiguousarray(node_id, dtype=np.int64),
+        endpoint_id=np.ascontiguousarray(endpoint_id, dtype=np.int64),
+        x_m=np.ascontiguousarray(endpoint_x_m, dtype=np.float64),
+        y_m=np.ascontiguousarray(endpoint_y_m, dtype=np.float64),
+        elevation_m=np.zeros(node_id.shape, dtype=np.float64),
+        kind=kind,
+        pick_count=np.zeros(node_id.shape, dtype=np.int64),
+    )
+
+
+def _append_outside_grid_observation(
+    input_model: RefractionStaticInputModel,
+) -> RefractionStaticInputModel:
+    source_node_id = int(input_model.source_node_id_sorted[0])
+    receiver_node_id = int(input_model.receiver_node_id_sorted[0])
+    source_x_m = -200.0
+    receiver_x_m = -100.0
+    distance_m = abs(receiver_x_m - source_x_m)
+    pick_time_s = float(input_model.pick_time_s_sorted[0])
+    n_traces = int(input_model.n_traces + 1)
+    return replace(
+        input_model,
+        n_traces=n_traces,
+        sorted_trace_index=_append(input_model.sorted_trace_index, n_traces - 1),
+        pick_time_s_sorted=_append(input_model.pick_time_s_sorted, pick_time_s),
+        valid_pick_mask_sorted=_append(input_model.valid_pick_mask_sorted, True),
+        valid_observation_mask_sorted=_append(
+            input_model.valid_observation_mask_sorted,
+            True,
+        ),
+        source_id_sorted=_append(
+            input_model.source_id_sorted,
+            input_model.source_id_sorted[0],
+        ),
+        receiver_id_sorted=_append(
+            input_model.receiver_id_sorted,
+            input_model.receiver_id_sorted[0],
+        ),
+        source_x_m_sorted=_append(input_model.source_x_m_sorted, source_x_m),
+        source_y_m_sorted=_append(input_model.source_y_m_sorted, 0.0),
+        receiver_x_m_sorted=_append(input_model.receiver_x_m_sorted, receiver_x_m),
+        receiver_y_m_sorted=_append(input_model.receiver_y_m_sorted, 0.0),
+        source_elevation_m_sorted=_append(
+            input_model.source_elevation_m_sorted,
+            0.0,
+        ),
+        receiver_elevation_m_sorted=_append(
+            input_model.receiver_elevation_m_sorted,
+            0.0,
+        ),
+        geometry_distance_m_sorted=_append(
+            input_model.geometry_distance_m_sorted,
+            distance_m,
+        ),
+        distance_m_sorted=_append(input_model.distance_m_sorted, distance_m),
+        source_endpoint_key_sorted=_append(
+            input_model.source_endpoint_key_sorted,
+            f'source:{source_node_id}',
+        ),
+        receiver_endpoint_key_sorted=_append(
+            input_model.receiver_endpoint_key_sorted,
+            f'receiver:{receiver_node_id}',
+        ),
+        source_node_id_sorted=_append(
+            input_model.source_node_id_sorted,
+            source_node_id,
+        ),
+        receiver_node_id_sorted=_append(
+            input_model.receiver_node_id_sorted,
+            receiver_node_id,
+        ),
+        rejection_reason_sorted=_append(input_model.rejection_reason_sorted, 'ok'),
+    )
+
+
+def _append(values: np.ndarray, value: object) -> np.ndarray:
+    return np.ascontiguousarray(
+        np.concatenate((values, np.asarray([value], dtype=values.dtype))),
+        dtype=values.dtype,
+    )
+
+
+def _run_refraction_statics(
+    *,
+    req: RefractionStaticApplyRequest,
+    input_model: RefractionStaticInputModel,
+) -> RefractionDatumStaticsResult:
+    replacement = compute_weathering_replacement_statics_from_first_breaks(
+        req=req,
+        state=None,
+        input_model=input_model,
+    )
+    return build_refraction_datum_statics(
+        weathering_replacement_result=replacement,
+        datum=req.datum,
+        apply_options=req.apply,
+        state=None,
+        file_id=req.file_id,
+        key1_byte=req.key1_byte,
+        key2_byte=req.key2_byte,
+    )
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))

--- a/app/tests/test_refraction_static_cell_synthetic_2d.py
+++ b/app/tests/test_refraction_static_cell_synthetic_2d.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.api.schemas import RefractionStaticModelRequest, RefractionStaticSolverRequest
+from app.services.refraction_static_design_matrix import (
+    build_refraction_static_design_matrix,
+)
+from app.services.refraction_static_solver import solve_refraction_static_bounded_ls
+from app.services.refraction_static_types import (
+    RefractionEndpointTable,
+    RefractionStaticDesignMatrix,
+    RefractionStaticInputModel,
+    RefractionStaticSolverResult,
+)
+from app.tests.fixtures.refraction_synthetic import (
+    SyntheticRefractionCellDataset,
+    make_clean_2d_cell_refraction_dataset,
+)
+
+TRUE_CELL_V2_M_S = np.asarray([2200.0, 2400.0, 2600.0, 2800.0], dtype=np.float64)
+MIN_OBSERVATIONS_PER_CELL = 5
+SLOWNESS_ATOL_S_PER_M = 1.0e-12
+VELOCITY_ATOL_M_S = 1.0e-5
+TIME_ATOL_S = 1.0e-8
+
+
+def test_cell_v2_t1_clean_2d_recovers_known_cell_velocities() -> None:
+    dataset, design, result = _solve_clean_2d_cell_problem()
+
+    expected_cell_id = np.arange(TRUE_CELL_V2_M_S.shape[0], dtype=np.int64)
+    np.testing.assert_array_equal(design.active_cell_id, expected_cell_id)
+    np.testing.assert_array_equal(result.active_cell_id, expected_cell_id)
+    np.testing.assert_array_equal(design.inactive_cell_id, [])
+    np.testing.assert_array_equal(
+        result.row_midpoint_cell_id,
+        dataset.true_cell_id_for_pick[result.row_trace_index_sorted],
+    )
+    assert np.all(dataset.cell_observation_count >= MIN_OBSERVATIONS_PER_CELL)
+
+    np.testing.assert_allclose(
+        result.cell_bedrock_slowness_s_per_m,
+        1.0 / TRUE_CELL_V2_M_S,
+        atol=SLOWNESS_ATOL_S_PER_M,
+        rtol=0.0,
+    )
+    np.testing.assert_allclose(
+        result.cell_bedrock_velocity_m_s,
+        TRUE_CELL_V2_M_S,
+        atol=VELOCITY_ATOL_M_S,
+        rtol=0.0,
+    )
+
+
+def test_cell_v2_t1_clean_2d_predicts_pick_times_with_near_zero_residual() -> None:
+    _, _, result = _solve_clean_2d_cell_problem()
+
+    np.testing.assert_allclose(
+        result.modeled_pick_time_s,
+        result.observed_pick_time_s,
+        atol=TIME_ATOL_S,
+        rtol=0.0,
+    )
+    assert _rms(result.residual_time_s) <= TIME_ATOL_S
+    np.testing.assert_allclose(result.residual_time_s, 0.0, atol=TIME_ATOL_S)
+
+
+def test_cell_v2_t1_clean_2d_summary_velocity_is_reciprocal_consistent() -> None:
+    _, _, result = _solve_clean_2d_cell_problem()
+
+    expected_summary_slowness = float(np.median(1.0 / TRUE_CELL_V2_M_S))
+
+    assert result.bedrock_slowness_s_per_m == pytest.approx(
+        expected_summary_slowness,
+        abs=SLOWNESS_ATOL_S_PER_M,
+    )
+    assert result.bedrock_velocity_m_s == pytest.approx(
+        1.0 / result.bedrock_slowness_s_per_m,
+        abs=VELOCITY_ATOL_M_S,
+    )
+    assert result.qc['bedrock_velocity_solution_kind'] == 'per_cell'
+
+
+def test_cell_v2_t1_clean_2d_t1_is_correct_up_to_gauge() -> None:
+    dataset, design, result = _solve_clean_2d_cell_problem()
+
+    node_t1_by_id = {
+        int(node_id): float(result.node_half_intercept_time_s[index])
+        for index, node_id in enumerate(result.node_id.tolist())
+    }
+    solved_source_t1 = np.asarray(
+        [node_t1_by_id[int(node_id)] for node_id in design.row_source_node_id],
+        dtype=np.float64,
+    )
+    solved_receiver_t1 = np.asarray(
+        [node_t1_by_id[int(node_id)] for node_id in design.row_receiver_node_id],
+        dtype=np.float64,
+    )
+    row_index = result.row_trace_index_sorted
+
+    np.testing.assert_allclose(
+        solved_source_t1 + solved_receiver_t1,
+        dataset.true_source_t1_s[row_index] + dataset.true_receiver_t1_s[row_index],
+        atol=TIME_ATOL_S,
+        rtol=0.0,
+    )
+
+
+def _solve_clean_2d_cell_problem() -> tuple[
+    SyntheticRefractionCellDataset,
+    RefractionStaticDesignMatrix,
+    RefractionStaticSolverResult,
+]:
+    dataset = make_clean_2d_cell_refraction_dataset(
+        seed=431,
+        cell_v2_m_s=TRUE_CELL_V2_M_S,
+        n_sources=12,
+        n_receivers=12,
+        noise_std_s=0.0,
+        outlier_fraction=0.0,
+    )
+    model = _cell_model(dataset)
+    design = build_refraction_static_design_matrix(
+        input_model=_input_model_from_dataset(dataset),
+        model=model,
+    )
+    result = solve_refraction_static_bounded_ls(
+        design_matrix=design,
+        model=model,
+        solver=_solver(),
+    )
+    return dataset, design, result
+
+
+def _cell_model(dataset: SyntheticRefractionCellDataset) -> RefractionStaticModelRequest:
+    return RefractionStaticModelRequest.model_validate(
+        {
+            'method': 'gli_variable_thickness',
+            'weathering_velocity_m_s': dataset.true_v1_m_s,
+            'bedrock_velocity_mode': 'solve_cell',
+            'bedrock_velocity_m_s': None,
+            'initial_bedrock_velocity_m_s': 2600.0,
+            'min_bedrock_velocity_m_s': 1200.0,
+            'max_bedrock_velocity_m_s': 6000.0,
+            'max_weathering_thickness_m': None,
+            'refractor_cell': {
+                'number_of_cell_x': int(dataset.true_cell_v2_m_s.shape[1]),
+                'size_of_cell_x_m': dataset.cell_size_x_m,
+                'x_coordinate_origin_m': dataset.x_coordinate_origin_m,
+                'number_of_cell_y': 1,
+                'size_of_cell_y_m': None,
+                'y_coordinate_origin_m': dataset.y_coordinate_origin_m,
+                'assignment_mode': 'midpoint',
+                'outside_grid_policy': 'reject',
+                'coordinate_mode': 'grid_3d',
+                'min_observations_per_cell': MIN_OBSERVATIONS_PER_CELL,
+                'velocity_smoothing_weight': 0.0,
+                'smoothing_reference_distance_m': None,
+            },
+        }
+    )
+
+
+def _solver() -> RefractionStaticSolverRequest:
+    return RefractionStaticSolverRequest.model_validate(
+        {
+            'damping': 0.0,
+            'min_picks_per_node': 1,
+            'max_abs_half_intercept_time_ms': 200.0,
+            'robust': {
+                'enabled': False,
+                'method': 'mad',
+                'threshold': 3.5,
+                'max_iterations': 5,
+                'min_used_fraction': 0.5,
+                'min_used_observations': 1,
+            },
+        }
+    )
+
+
+def _input_model_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionStaticInputModel:
+    n_traces = int(dataset.pick_time_s.shape[0])
+    endpoint_table = _endpoint_table_from_dataset(dataset)
+    node_x_m = np.concatenate(
+        (dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)
+    )
+    node_y_m = np.concatenate(
+        (dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)
+    )
+    node_elevation_m = np.zeros(endpoint_table.node_id.shape, dtype=np.float64)
+    node_kind = np.concatenate(
+        (
+            np.full(dataset.source_endpoint_id.shape, 'source', dtype='<U16'),
+            np.full(dataset.receiver_endpoint_id.shape, 'receiver', dtype='<U16'),
+        )
+    )
+    return RefractionStaticInputModel(
+        file_id='clean-2d-cell-synthetic',
+        n_traces=n_traces,
+        sorted_trace_index=np.arange(n_traces, dtype=np.int64),
+        pick_time_s_sorted=dataset.pick_time_s,
+        valid_pick_mask_sorted=np.ones(n_traces, dtype=bool),
+        valid_observation_mask_sorted=dataset.valid_mask,
+        source_id_sorted=dataset.source_id,
+        receiver_id_sorted=dataset.receiver_id,
+        source_x_m_sorted=dataset.source_x_m,
+        source_y_m_sorted=dataset.source_y_m,
+        receiver_x_m_sorted=dataset.receiver_x_m,
+        receiver_y_m_sorted=dataset.receiver_y_m,
+        source_elevation_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        receiver_elevation_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        source_depth_m_sorted=None,
+        geometry_distance_m_sorted=dataset.offset_m,
+        offset_m_sorted=None,
+        distance_m_sorted=dataset.offset_m,
+        source_endpoint_key_sorted=np.asarray(
+            [f'source:{int(value)}' for value in dataset.source_id],
+            dtype='<U32',
+        ),
+        receiver_endpoint_key_sorted=np.asarray(
+            [f'receiver:{int(value)}' for value in dataset.receiver_id],
+            dtype='<U32',
+        ),
+        source_node_id_sorted=dataset.source_node_id,
+        receiver_node_id_sorted=dataset.receiver_node_id,
+        node_x_m=np.ascontiguousarray(node_x_m, dtype=np.float64),
+        node_y_m=np.ascontiguousarray(node_y_m, dtype=np.float64),
+        node_elevation_m=node_elevation_m,
+        node_kind=node_kind,
+        rejection_reason_sorted=np.full(n_traces, 'ok', dtype='<U32'),
+        qc={},
+        endpoint_table=endpoint_table,
+        metadata={'synthetic_model': 'clean_2d_cell_refraction'},
+    )
+
+
+def _endpoint_table_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionEndpointTable:
+    node_id = np.concatenate(
+        (dataset.source_endpoint_node_id, dataset.receiver_endpoint_node_id)
+    )
+    endpoint_id = np.concatenate(
+        (dataset.source_endpoint_id, dataset.receiver_endpoint_id)
+    )
+    endpoint_x_m = np.concatenate(
+        (dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)
+    )
+    endpoint_y_m = np.concatenate(
+        (dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)
+    )
+    kind = np.concatenate(
+        (
+            np.full(dataset.source_endpoint_id.shape, 'source', dtype='<U16'),
+            np.full(dataset.receiver_endpoint_id.shape, 'receiver', dtype='<U16'),
+        )
+    )
+    return RefractionEndpointTable(
+        node_id=np.ascontiguousarray(node_id, dtype=np.int64),
+        endpoint_id=np.ascontiguousarray(endpoint_id, dtype=np.int64),
+        x_m=np.ascontiguousarray(endpoint_x_m, dtype=np.float64),
+        y_m=np.ascontiguousarray(endpoint_y_m, dtype=np.float64),
+        elevation_m=np.zeros(node_id.shape, dtype=np.float64),
+        kind=kind,
+        pick_count=np.zeros(node_id.shape, dtype=np.int64),
+    )
+
+
+def _rms(values: np.ndarray) -> float:
+    return float(np.sqrt(np.mean(np.asarray(values, dtype=np.float64) ** 2)))

--- a/app/tests/test_refraction_static_cell_synthetic_3d.py
+++ b/app/tests/test_refraction_static_cell_synthetic_3d.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.api.schemas import RefractionStaticApplyRequest
+from app.services.refraction_static_artifacts import write_refraction_static_artifacts
+from app.services.refraction_static_datum import build_refraction_datum_statics
+from app.services.refraction_static_types import (
+    RefractionDatumStaticsResult,
+    RefractionEndpointTable,
+    RefractionStaticInputModel,
+)
+from app.services.refraction_static_weathering_replacement import (
+    compute_weathering_replacement_statics_from_first_breaks,
+)
+from app.tests.fixtures.refraction_synthetic import (
+    SyntheticRefractionCellDataset,
+    make_clean_3d_cell_refraction_dataset,
+)
+
+TRUE_CELL_V2_M_S = np.asarray(
+    [[2200.0, 2400.0], [2600.0, 2800.0]],
+    dtype=np.float64,
+)
+MIN_OBSERVATIONS_PER_CELL = 5
+SLOWNESS_ATOL_S_PER_M = 1.0e-12
+VELOCITY_ATOL_M_S = 1.0e-5
+TIME_ATOL_S = 1.0e-8
+
+
+def test_cell_v2_t1_clean_3d_recovers_known_velocity_grid() -> None:
+    dataset, result, _ = _solve_clean_3d_cell_problem()
+
+    expected_cell_id = np.arange(TRUE_CELL_V2_M_S.size, dtype=np.int64)
+    np.testing.assert_array_equal(result.active_cell_id, expected_cell_id)
+    np.testing.assert_array_equal(result.inactive_cell_id, [])
+    np.testing.assert_array_equal(result.cell_velocity_status, ['solved'] * 4)
+    assert np.all(dataset.cell_observation_count >= MIN_OBSERVATIONS_PER_CELL)
+
+    np.testing.assert_allclose(
+        result.cell_bedrock_slowness_s_per_m,
+        1.0 / TRUE_CELL_V2_M_S.ravel(),
+        atol=SLOWNESS_ATOL_S_PER_M,
+        rtol=0.0,
+    )
+    np.testing.assert_allclose(
+        result.cell_bedrock_velocity_m_s,
+        TRUE_CELL_V2_M_S.ravel(),
+        atol=VELOCITY_ATOL_M_S,
+        rtol=0.0,
+    )
+    assert result.bedrock_velocity_mode == 'solve_cell'
+    assert result.qc['bedrock_velocity_mode'] == 'solve_cell'
+
+
+def test_cell_v2_t1_clean_3d_midpoint_assignment_uses_x_and_y() -> None:
+    dataset, result, _ = _solve_clean_3d_cell_problem()
+
+    row_index = result.row_trace_index_sorted
+    row_cell_id = _required_array(result.row_midpoint_cell_id)
+    row_ix = row_cell_id % TRUE_CELL_V2_M_S.shape[1]
+    row_iy = row_cell_id // TRUE_CELL_V2_M_S.shape[1]
+
+    np.testing.assert_array_equal(row_cell_id, dataset.true_cell_id_for_pick[row_index])
+    np.testing.assert_array_equal(row_ix, dataset.true_cell_ix_for_pick[row_index])
+    np.testing.assert_array_equal(row_iy, dataset.true_cell_iy_for_pick[row_index])
+    assert set(row_ix.tolist()) == {0, 1}
+    assert set(row_iy.tolist()) == {0, 1}
+
+
+def test_cell_v2_t1_clean_3d_predicts_picks_with_near_zero_residual() -> None:
+    _, result, _ = _solve_clean_3d_cell_problem()
+
+    np.testing.assert_allclose(
+        result.modeled_pick_time_s,
+        result.observed_pick_time_s,
+        atol=TIME_ATOL_S,
+        rtol=0.0,
+    )
+    assert _rms(result.residual_time_s) <= TIME_ATOL_S
+    np.testing.assert_allclose(result.residual_time_s, 0.0, atol=TIME_ATOL_S)
+
+
+def test_cell_v2_t1_clean_3d_velocity_artifact_matches_solution(
+    tmp_path: Path,
+) -> None:
+    dataset, result, req = _solve_clean_3d_cell_problem()
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+    assert paths.refraction_refractor_velocity_cells_csv is not None
+    assert paths.refraction_refractor_velocity_grid_npz is not None
+    assert paths.refraction_refractor_velocity_qc_json is not None
+
+    rows = _read_csv(paths.refraction_refractor_velocity_cells_csv)
+    assert len(rows) == TRUE_CELL_V2_M_S.size
+    for row in rows:
+        cell_id = int(row['cell_id'])
+        ix = cell_id % TRUE_CELL_V2_M_S.shape[1]
+        iy = cell_id // TRUE_CELL_V2_M_S.shape[1]
+        true_v2 = float(TRUE_CELL_V2_M_S[iy, ix])
+
+        assert int(row['ix']) == ix
+        assert int(row['iy']) == iy
+        assert row['active'] == 'true'
+        assert row['velocity_status'] == 'solved'
+        assert int(row['n_observations']) == int(
+            dataset.cell_observation_count[cell_id]
+        )
+        assert int(row['n_used_observations']) == int(
+            dataset.cell_observation_count[cell_id]
+        )
+        assert int(row['n_rejected_observations']) == 0
+        assert float(row['v2_m_s']) == pytest.approx(
+            true_v2,
+            abs=VELOCITY_ATOL_M_S,
+        )
+        assert float(row['slowness_s_per_m']) == pytest.approx(
+            1.0 / true_v2,
+            abs=SLOWNESS_ATOL_S_PER_M,
+        )
+
+    with np.load(paths.refraction_refractor_velocity_grid_npz, allow_pickle=False) as grid:
+        np.testing.assert_array_equal(grid['cell_id'], [0, 1, 2, 3])
+        np.testing.assert_array_equal(grid['ix'], [0, 1, 0, 1])
+        np.testing.assert_array_equal(grid['iy'], [0, 0, 1, 1])
+        np.testing.assert_array_equal(grid['active_cell_mask'], [True] * 4)
+        np.testing.assert_array_equal(grid['n_observations_per_cell'], dataset.cell_observation_count)
+        np.testing.assert_allclose(
+            grid['v2_m_s'],
+            TRUE_CELL_V2_M_S.ravel(),
+            atol=VELOCITY_ATOL_M_S,
+            rtol=0.0,
+        )
+        np.testing.assert_array_equal(grid['velocity_status'], ['solved'] * 4)
+
+    cell_qc = json.loads(
+        paths.refraction_refractor_velocity_qc_json.read_text(encoding='utf-8')
+    )
+    assert cell_qc['coordinate_mode'] == 'grid_3d'
+    assert cell_qc['number_of_cell_x'] == 2
+    assert cell_qc['number_of_cell_y'] == 2
+    assert cell_qc['n_active_cells'] == 4
+    assert cell_qc['n_inactive_cells'] == 0
+    assert cell_qc['n_low_fold_cells'] == 0
+
+
+def _solve_clean_3d_cell_problem() -> tuple[
+    SyntheticRefractionCellDataset,
+    RefractionDatumStaticsResult,
+    RefractionStaticApplyRequest,
+]:
+    dataset = make_clean_3d_cell_refraction_dataset(
+        seed=433,
+        cell_v2_m_s=TRUE_CELL_V2_M_S,
+        n_sources=6,
+        n_receivers=6,
+        cell_size_x_m=500.0,
+        cell_size_y_m=500.0,
+        noise_std_s=0.0,
+        outlier_fraction=0.0,
+    )
+    req = _cell_apply_request(dataset)
+    input_model = _input_model_from_dataset(dataset)
+    replacement = compute_weathering_replacement_statics_from_first_breaks(
+        req=req,
+        state=None,
+        input_model=input_model,
+    )
+    result = build_refraction_datum_statics(
+        weathering_replacement_result=replacement,
+        datum=req.datum,
+        apply_options=req.apply,
+        state=None,
+        file_id=req.file_id,
+        key1_byte=req.key1_byte,
+        key2_byte=req.key2_byte,
+    )
+    return dataset, result, req
+
+
+def _cell_apply_request(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionStaticApplyRequest:
+    return RefractionStaticApplyRequest.model_validate(
+        {
+            'file_id': 'clean-3d-cell-synthetic',
+            'key1_byte': 189,
+            'key2_byte': 193,
+            'pick_source': {
+                'kind': 'batch_predicted_npz',
+                'job_id': 'clean-3d-cell-synthetic-first-breaks',
+                'artifact_name': 'predicted_picks_time_s.npz',
+            },
+            'linkage': {'mode': 'none'},
+            'model': {
+                'method': 'gli_variable_thickness',
+                'weathering_velocity_m_s': dataset.true_v1_m_s,
+                'bedrock_velocity_mode': 'solve_cell',
+                'bedrock_velocity_m_s': None,
+                'initial_bedrock_velocity_m_s': 2500.0,
+                'min_bedrock_velocity_m_s': 1200.0,
+                'max_bedrock_velocity_m_s': 6000.0,
+                'max_weathering_thickness_m': None,
+                'refractor_cell': {
+                    'number_of_cell_x': int(dataset.true_cell_v2_m_s.shape[1]),
+                    'size_of_cell_x_m': dataset.cell_size_x_m,
+                    'x_coordinate_origin_m': dataset.x_coordinate_origin_m,
+                    'number_of_cell_y': int(dataset.true_cell_v2_m_s.shape[0]),
+                    'size_of_cell_y_m': dataset.cell_size_y_m,
+                    'y_coordinate_origin_m': dataset.y_coordinate_origin_m,
+                    'assignment_mode': 'midpoint',
+                    'outside_grid_policy': 'reject',
+                    'coordinate_mode': 'grid_3d',
+                    'min_observations_per_cell': MIN_OBSERVATIONS_PER_CELL,
+                    'velocity_smoothing_weight': 0.0,
+                    'smoothing_reference_distance_m': None,
+                },
+            },
+            'moveout': {
+                'model': 'head_wave_linear_offset',
+                'distance_source': 'geometry',
+                'offset_byte': None,
+                'min_offset_m': None,
+                'max_offset_m': None,
+                'allow_missing_offset': False,
+                'max_geometry_offset_mismatch_m': None,
+            },
+            'solver': {
+                'damping': 0.0,
+                'min_picks_per_node': 1,
+                'max_abs_half_intercept_time_ms': 500.0,
+                'robust': {
+                    'enabled': False,
+                    'method': 'mad',
+                    'threshold': 3.5,
+                    'max_iterations': 5,
+                    'min_used_fraction': 0.5,
+                    'min_used_observations': 1,
+                },
+            },
+            'datum': {'mode': 'none'},
+            'conversion': {'mode': 't1lsst_1layer'},
+            'apply': {
+                'mode': 'refraction_from_raw',
+                'interpolation': 'linear',
+                'fill_value': 0.0,
+                'max_abs_shift_ms': 250.0,
+                'output_dtype': 'float32',
+                'register_corrected_file': False,
+            },
+        }
+    )
+
+
+def _input_model_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionStaticInputModel:
+    n_traces = int(dataset.pick_time_s.shape[0])
+    endpoint_table = _endpoint_table_from_dataset(dataset)
+    node_x_m = np.concatenate(
+        (dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)
+    )
+    node_y_m = np.concatenate(
+        (dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)
+    )
+    node_elevation_m = np.zeros(endpoint_table.node_id.shape, dtype=np.float64)
+    node_kind = np.concatenate(
+        (
+            np.full(dataset.source_endpoint_id.shape, 'source', dtype='<U16'),
+            np.full(dataset.receiver_endpoint_id.shape, 'receiver', dtype='<U16'),
+        )
+    )
+    return RefractionStaticInputModel(
+        file_id='clean-3d-cell-synthetic',
+        n_traces=n_traces,
+        sorted_trace_index=np.arange(n_traces, dtype=np.int64),
+        pick_time_s_sorted=dataset.pick_time_s,
+        valid_pick_mask_sorted=np.ones(n_traces, dtype=bool),
+        valid_observation_mask_sorted=dataset.valid_mask,
+        source_id_sorted=dataset.source_id,
+        receiver_id_sorted=dataset.receiver_id,
+        source_x_m_sorted=dataset.source_x_m,
+        source_y_m_sorted=dataset.source_y_m,
+        receiver_x_m_sorted=dataset.receiver_x_m,
+        receiver_y_m_sorted=dataset.receiver_y_m,
+        source_elevation_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        receiver_elevation_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        source_depth_m_sorted=None,
+        geometry_distance_m_sorted=dataset.offset_m,
+        offset_m_sorted=None,
+        distance_m_sorted=dataset.offset_m,
+        source_endpoint_key_sorted=np.asarray(
+            [f'source:{int(value)}' for value in dataset.source_id],
+            dtype='<U32',
+        ),
+        receiver_endpoint_key_sorted=np.asarray(
+            [f'receiver:{int(value)}' for value in dataset.receiver_id],
+            dtype='<U32',
+        ),
+        source_node_id_sorted=dataset.source_node_id,
+        receiver_node_id_sorted=dataset.receiver_node_id,
+        node_x_m=np.ascontiguousarray(node_x_m, dtype=np.float64),
+        node_y_m=np.ascontiguousarray(node_y_m, dtype=np.float64),
+        node_elevation_m=node_elevation_m,
+        node_kind=node_kind,
+        rejection_reason_sorted=np.full(n_traces, 'ok', dtype='<U32'),
+        qc={},
+        endpoint_table=endpoint_table,
+        metadata={'synthetic_model': 'clean_3d_cell_refraction'},
+    )
+
+
+def _endpoint_table_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionEndpointTable:
+    node_id = np.concatenate(
+        (dataset.source_endpoint_node_id, dataset.receiver_endpoint_node_id)
+    )
+    endpoint_id = np.concatenate(
+        (dataset.source_endpoint_id, dataset.receiver_endpoint_id)
+    )
+    endpoint_x_m = np.concatenate(
+        (dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)
+    )
+    endpoint_y_m = np.concatenate(
+        (dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)
+    )
+    kind = np.concatenate(
+        (
+            np.full(dataset.source_endpoint_id.shape, 'source', dtype='<U16'),
+            np.full(dataset.receiver_endpoint_id.shape, 'receiver', dtype='<U16'),
+        )
+    )
+    return RefractionEndpointTable(
+        node_id=np.ascontiguousarray(node_id, dtype=np.int64),
+        endpoint_id=np.ascontiguousarray(endpoint_id, dtype=np.int64),
+        x_m=np.ascontiguousarray(endpoint_x_m, dtype=np.float64),
+        y_m=np.ascontiguousarray(endpoint_y_m, dtype=np.float64),
+        elevation_m=np.zeros(node_id.shape, dtype=np.float64),
+        kind=kind,
+        pick_count=np.zeros(node_id.shape, dtype=np.int64),
+    )
+
+
+def _required_array(values: np.ndarray | None) -> np.ndarray:
+    assert values is not None
+    return values
+
+
+def _rms(values: np.ndarray) -> float:
+    return float(np.sqrt(np.mean(np.asarray(values, dtype=np.float64) ** 2)))
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))

--- a/app/tests/test_refraction_synthetic_fixtures.py
+++ b/app/tests/test_refraction_synthetic_fixtures.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from dataclasses import fields
+import subprocess
+import sys
+
+import numpy as np
+
+from app.tests.fixtures.refraction_synthetic import (
+    SyntheticRefractionCellDataset,
+    make_clean_2d_cell_refraction_dataset,
+    make_clean_3d_cell_refraction_dataset,
+    make_low_fold_empty_cell_refraction_dataset,
+    make_outlier_refraction_dataset,
+    make_rotated_2d_line_refraction_dataset,
+    make_v2_spike_smoothing_dataset,
+)
+
+
+def test_synthetic_clean_2d_builder_is_deterministic() -> None:
+    first = make_clean_2d_cell_refraction_dataset(seed=42, noise_std_s=0.001)
+    second = make_clean_2d_cell_refraction_dataset(seed=42, noise_std_s=0.001)
+
+    _assert_dataset_equal(first, second)
+
+
+def test_synthetic_clean_3d_builder_is_deterministic() -> None:
+    first = make_clean_3d_cell_refraction_dataset(seed=42, noise_std_s=0.001)
+    second = make_clean_3d_cell_refraction_dataset(seed=42, noise_std_s=0.001)
+
+    _assert_dataset_equal(first, second)
+
+
+def test_synthetic_fixture_pick_times_match_known_truth_without_noise() -> None:
+    dataset = make_clean_2d_cell_refraction_dataset(
+        seed=7,
+        noise_std_s=0.0,
+        outlier_fraction=0.0,
+    )
+
+    expected_pick_time_s = (
+        dataset.true_source_t1_s
+        + dataset.true_receiver_t1_s
+        + dataset.offset_m / dataset.true_midpoint_v2_m_s
+    )
+
+    np.testing.assert_allclose(dataset.pick_time_s, expected_pick_time_s, atol=1.0e-12)
+    np.testing.assert_allclose(dataset.true_noise_s, 0.0, atol=0.0)
+    assert not bool(np.any(dataset.outlier_mask))
+
+
+def test_synthetic_fixture_known_sh1_t1_wcor_are_consistent() -> None:
+    dataset = make_clean_3d_cell_refraction_dataset(seed=9)
+
+    source_sh1_m = _sh1_from_t1(
+        t1_s=dataset.true_source_endpoint_t1_s,
+        v1_m_s=dataset.true_v1_m_s,
+        v2_m_s=dataset.true_source_endpoint_v2_m_s,
+    )
+    receiver_sh1_m = _sh1_from_t1(
+        t1_s=dataset.true_receiver_endpoint_t1_s,
+        v1_m_s=dataset.true_v1_m_s,
+        v2_m_s=dataset.true_receiver_endpoint_v2_m_s,
+    )
+    source_wcor_s = _wcor_from_sh1(
+        sh1_m=dataset.true_source_endpoint_sh1_m,
+        v1_m_s=dataset.true_v1_m_s,
+        v2_m_s=dataset.true_source_endpoint_v2_m_s,
+    )
+    receiver_wcor_s = _wcor_from_sh1(
+        sh1_m=dataset.true_receiver_endpoint_sh1_m,
+        v1_m_s=dataset.true_v1_m_s,
+        v2_m_s=dataset.true_receiver_endpoint_v2_m_s,
+    )
+
+    np.testing.assert_allclose(source_sh1_m, dataset.true_source_endpoint_sh1_m)
+    np.testing.assert_allclose(receiver_sh1_m, dataset.true_receiver_endpoint_sh1_m)
+    np.testing.assert_allclose(source_wcor_s, dataset.true_source_endpoint_wcor_s)
+    np.testing.assert_allclose(receiver_wcor_s, dataset.true_receiver_endpoint_wcor_s)
+    np.testing.assert_allclose(
+        dataset.true_source_endpoint_static_s,
+        dataset.true_source_endpoint_wcor_s,
+    )
+    np.testing.assert_allclose(
+        dataset.true_receiver_endpoint_static_s,
+        dataset.true_receiver_endpoint_wcor_s,
+    )
+
+
+def test_synthetic_rotated_2d_builder_generates_projected_line_mode() -> None:
+    dataset = make_rotated_2d_line_refraction_dataset(
+        seed=11,
+        line_origin_x_m=1200.0,
+        line_origin_y_m=800.0,
+        line_azimuth_deg=42.0,
+    )
+
+    assert dataset.coordinate_mode == 'line_2d_projected'
+    assert dataset.source_inline_m is not None
+    assert dataset.receiver_inline_m is not None
+    projected_source_inline = _project_inline(
+        x_m=dataset.source_x_m,
+        y_m=dataset.source_y_m,
+        line_origin_x_m=dataset.line_origin_x_m,
+        line_origin_y_m=dataset.line_origin_y_m,
+        line_azimuth_deg=dataset.line_azimuth_deg,
+    )
+    projected_receiver_inline = _project_inline(
+        x_m=dataset.receiver_x_m,
+        y_m=dataset.receiver_y_m,
+        line_origin_x_m=dataset.line_origin_x_m,
+        line_origin_y_m=dataset.line_origin_y_m,
+        line_azimuth_deg=dataset.line_azimuth_deg,
+    )
+    expected_ix = np.floor(
+        0.5 * (dataset.source_inline_m + dataset.receiver_inline_m)
+        / dataset.cell_size_x_m
+    ).astype(np.int64)
+
+    np.testing.assert_allclose(projected_source_inline, dataset.source_inline_m)
+    np.testing.assert_allclose(projected_receiver_inline, dataset.receiver_inline_m)
+    np.testing.assert_array_equal(dataset.true_cell_ix_for_pick, expected_ix)
+    np.testing.assert_array_equal(dataset.true_cell_iy_for_pick, 0)
+
+
+def test_synthetic_required_special_builders_mark_expected_rows() -> None:
+    low_fold = make_low_fold_empty_cell_refraction_dataset(seed=3)
+    outlier = make_outlier_refraction_dataset(seed=3)
+    spike = make_v2_spike_smoothing_dataset(seed=3)
+
+    assert low_fold.cell_observation_count[1] == 2
+    assert low_fold.cell_observation_count[2] == 0
+    assert int(np.count_nonzero(outlier.outlier_mask)) > 0
+    assert spike.true_cell_v2_m_s[0, 2] > spike.true_cell_v2_m_s[0, 1]
+    assert spike.true_cell_v2_m_s[0, 2] > spike.true_cell_v2_m_s[0, 3]
+
+
+def test_synthetic_fixture_import_is_dependency_light() -> None:
+    script = """
+import sys
+import app.tests.fixtures.refraction_synthetic as fixture
+fixture.make_clean_2d_cell_refraction_dataset()
+forbidden_exact = {'app.main', 'segyio', 'torch'}
+forbidden_prefix = (
+    'app.api',
+    'app.services',
+    'app.trace_store',
+    'app.utils',
+    'app.web',
+)
+loaded = [
+    name for name in sys.modules
+    if name in forbidden_exact or name.startswith(forbidden_prefix)
+]
+if loaded:
+    raise SystemExit(','.join(sorted(loaded)))
+"""
+
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def _assert_dataset_equal(
+    first: SyntheticRefractionCellDataset,
+    second: SyntheticRefractionCellDataset,
+) -> None:
+    for field in fields(first):
+        first_value = getattr(first, field.name)
+        second_value = getattr(second, field.name)
+        if isinstance(first_value, np.ndarray):
+            np.testing.assert_array_equal(first_value, second_value)
+        elif first_value is None:
+            assert second_value is None
+        else:
+            assert first_value == second_value
+
+
+def _sh1_from_t1(
+    *,
+    t1_s: np.ndarray,
+    v1_m_s: float,
+    v2_m_s: np.ndarray,
+) -> np.ndarray:
+    return t1_s * v1_m_s * v2_m_s / np.sqrt(v2_m_s**2 - v1_m_s**2)
+
+
+def _wcor_from_sh1(
+    *,
+    sh1_m: np.ndarray,
+    v1_m_s: float,
+    v2_m_s: np.ndarray,
+) -> np.ndarray:
+    return sh1_m * ((1.0 / v2_m_s) - (1.0 / v1_m_s))
+
+
+def _project_inline(
+    *,
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+    line_origin_x_m: float | None,
+    line_origin_y_m: float | None,
+    line_azimuth_deg: float | None,
+) -> np.ndarray:
+    assert line_origin_x_m is not None
+    assert line_origin_y_m is not None
+    assert line_azimuth_deg is not None
+    azimuth_rad = np.deg2rad(float(line_azimuth_deg))
+    dx = x_m - float(line_origin_x_m)
+    dy = y_m - float(line_origin_y_m)
+    return np.round(dx * np.sin(azimuth_rad) + dy * np.cos(azimuth_rad), decimals=9)


### PR DESCRIPTION
Closes #430
Closes #431
Closes #432
Closes #433
Closes #434

## Issues
- #430 [statics][refraction][m2.5] Add synthetic fixture builders for 2D/3D cell-based refraction statics
- #431 [statics][refraction][m2.5] Add deterministic 2D clean synthetic tests for cell V2/T1 inversion
- #432 [statics][refraction][m2.5] Add rotated 2D line synthetic tests for line_2d_projected coordinate mode
- #433 [statics][refraction][m2.5] Add deterministic 3D grid synthetic tests for midpoint-cell V2 assignment
- #434 [statics][refraction][m2.5] Harden low-fold, empty-cell, and fallback behavior with synthetic tests

Batch range: #430-#434
