### PR TITLE
Batch: address issues #435-#439

### DIFF
--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -57,6 +57,7 @@ REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME = (
     'refraction_refractor_velocity_grid.npz'
 )
 REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME = 'refraction_refractor_velocity_qc.json'
+REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME = 'refraction_cell_solver_history.csv'
 REFRACTION_STATIC_ARTIFACTS_JSON_NAME = 'refraction_static_artifacts.json'
 REFRACTION_STATIC_REQUEST_JSON_NAME = 'refraction_static_request.json'
 
@@ -176,6 +177,12 @@ _REFRACTOR_CELL_VELOCITY_ARTIFACTS: tuple[dict[str, str | bool], ...] = (
         'kind': 'json',
         'required': True,
         'description': 'Refractor velocity cell QC summary',
+    },
+    {
+        'name': REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
+        'kind': 'csv',
+        'required': True,
+        'description': 'Cell V2/T1 solver convergence and history summary',
     },
 )
 
@@ -398,6 +405,29 @@ _REFRACTOR_VELOCITY_CELL_COLUMNS = (
     'smoothing_neighbor_count',
 )
 
+_CELL_SOLVER_HISTORY_COLUMNS = (
+    'iteration',
+    'stage',
+    'n_candidate_observations',
+    'n_used_observations',
+    'n_rejected_observations',
+    'n_active_cells',
+    'n_low_fold_cells',
+    'n_empty_cells',
+    'residual_rms_ms',
+    'residual_mad_ms',
+    'max_abs_residual_ms',
+    'median_v2_m_s',
+    'min_v2_m_s',
+    'max_v2_m_s',
+    'max_abs_v2_update_m_s',
+    'smoothing_weight',
+    'damping_weight',
+    'robust_threshold',
+    'converged',
+    'convergence_reason',
+)
+
 
 class RefractionStaticArtifactError(ValueError):
     """Raised when final refraction static artifacts cannot be written."""
@@ -411,6 +441,30 @@ class _ValidatedResult:
     n_source_endpoints: int
     n_receiver_endpoints: int
     n_rows: int
+
+
+@dataclass(frozen=True)
+class RefractionCellSolverHistoryRow:
+    iteration: int
+    stage: str
+    n_candidate_observations: int
+    n_used_observations: int
+    n_rejected_observations: int
+    n_active_cells: int
+    n_low_fold_cells: int
+    n_empty_cells: int
+    residual_rms_ms: float | None
+    residual_mad_ms: float | None
+    max_abs_residual_ms: float | None
+    median_v2_m_s: float | None
+    min_v2_m_s: float | None
+    max_v2_m_s: float | None
+    max_abs_v2_update_m_s: float | None
+    smoothing_weight: float
+    damping_weight: float
+    robust_threshold: float
+    converged: bool
+    convergence_reason: str
 
 
 def write_refraction_static_artifacts(
@@ -477,6 +531,11 @@ def write_refraction_static_artifacts(
         if cell_velocity_artifacts_enabled
         else None
     )
+    cell_solver_history_path = (
+        root / REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME
+        if cell_velocity_artifacts_enabled
+        else None
+    )
 
     paths = RefractionStaticArtifactSet(
         job_dir=root,
@@ -498,6 +557,7 @@ def write_refraction_static_artifacts(
         refraction_refractor_velocity_cells_csv=cell_velocity_cells_path,
         refraction_refractor_velocity_grid_npz=cell_velocity_grid_path,
         refraction_refractor_velocity_qc_json=cell_velocity_qc_path,
+        refraction_cell_solver_history_csv=cell_solver_history_path,
     )
 
     write_refraction_static_solution_npz(
@@ -540,6 +600,7 @@ def write_refraction_static_artifacts(
         paths.refraction_refractor_velocity_cells_csv is not None
         and paths.refraction_refractor_velocity_grid_npz is not None
         and paths.refraction_refractor_velocity_qc_json is not None
+        and paths.refraction_cell_solver_history_csv is not None
     ):
         write_refraction_refractor_velocity_cells_csv(
             result=values.result,
@@ -555,6 +616,11 @@ def write_refraction_static_artifacts(
             result=values.result,
             req=request,
             path=paths.refraction_refractor_velocity_qc_json,
+        )
+        write_refraction_cell_solver_history_csv(
+            result=values.result,
+            req=request,
+            path=paths.refraction_cell_solver_history_csv,
         )
     if paths.refraction_t1lsst_1layer_components_csv is not None:
         write_refraction_t1lsst_1layer_components_csv(
@@ -583,11 +649,13 @@ def write_refraction_static_artifacts(
         paths.refraction_refractor_velocity_cells_csv is not None
         and paths.refraction_refractor_velocity_grid_npz is not None
         and paths.refraction_refractor_velocity_qc_json is not None
+        and paths.refraction_cell_solver_history_csv is not None
     ):
         artifact_paths = artifact_paths + (
             paths.refraction_refractor_velocity_cells_csv,
             paths.refraction_refractor_velocity_grid_npz,
             paths.refraction_refractor_velocity_qc_json,
+            paths.refraction_cell_solver_history_csv,
         )
     for artifact_path in artifact_paths:
         if not artifact_path.is_file():
@@ -755,6 +823,17 @@ def write_refraction_refractor_velocity_qc_json(
     )
     _write_json_atomic(Path(path), payload)
     return payload
+
+
+def write_refraction_cell_solver_history_csv(
+    *,
+    result: RefractionDatumStaticsResult,
+    req: RefractionStaticApplyRequest,
+    path: Path,
+) -> None:
+    rows = build_refraction_cell_solver_history_rows(result=result, req=req)
+    csv_rows = [_cell_solver_history_csv_row(row) for row in rows]
+    _write_csv_atomic(Path(path), _CELL_SOLVER_HISTORY_COLUMNS, csv_rows)
 
 
 def build_refraction_refractor_velocity_grid_arrays(
@@ -1082,6 +1161,101 @@ def build_refraction_refractor_velocity_qc_payload(
         artifact_name=REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
     )
     return payload
+
+
+def build_refraction_cell_solver_history_rows(
+    *,
+    result: RefractionDatumStaticsResult,
+    req: RefractionStaticApplyRequest,
+) -> list[RefractionCellSolverHistoryRow]:
+    values = _validate_result(result)
+    request = RefractionStaticApplyRequest.model_validate(req)
+    if request.model.bedrock_velocity_mode != 'solve_cell':
+        raise RefractionStaticArtifactError(
+            'cell solver history artifact requires solve_cell request mode'
+        )
+    if values.result.bedrock_velocity_mode != 'solve_cell':
+        raise RefractionStaticArtifactError(
+            'cell solver history artifact requires solve_cell result mode'
+        )
+
+    arrays = build_refraction_refractor_velocity_grid_arrays(
+        result=values.result,
+        req=request,
+    )
+    cell_counts = _cell_solver_history_cell_counts(arrays)
+    initial_v2 = _initial_cell_v2_m_s(request)
+    final_velocity = np.asarray(arrays['v2_m_s'], dtype=np.float64)
+    active_mask = np.asarray(arrays['active_cell_mask'], dtype=bool)
+    active_final_v2 = final_velocity[active_mask & np.isfinite(final_velocity)]
+    update = np.asarray(
+        arrays['v2_update_from_initial_m_s'],
+        dtype=np.float64,
+    )
+    active_update = update[active_mask & np.isfinite(update)]
+
+    n_candidate = values.n_rows
+    n_used = int(np.count_nonzero(values.result.used_row_mask))
+    n_robust_rejected = int(np.count_nonzero(values.result.rejected_by_robust_mask))
+    smoothing_weight = _history_smoothing_weight(request)
+    damping_weight = float(request.solver.damping)
+    robust_threshold = float(request.solver.robust.threshold)
+    robust_iteration_count = _history_robust_iteration_count(
+        values.result,
+        request,
+    )
+    residual_stats = _history_residual_stats_ms(values.result)
+
+    return [
+        RefractionCellSolverHistoryRow(
+            iteration=0,
+            stage='initial',
+            n_candidate_observations=n_candidate,
+            n_used_observations=n_candidate,
+            n_rejected_observations=0,
+            n_active_cells=cell_counts['active'],
+            n_low_fold_cells=cell_counts['low_fold'],
+            n_empty_cells=cell_counts['empty'],
+            residual_rms_ms=None,
+            residual_mad_ms=None,
+            max_abs_residual_ms=None,
+            median_v2_m_s=initial_v2,
+            min_v2_m_s=initial_v2,
+            max_v2_m_s=initial_v2,
+            max_abs_v2_update_m_s=0.0,
+            smoothing_weight=smoothing_weight,
+            damping_weight=damping_weight,
+            robust_threshold=robust_threshold,
+            converged=False,
+            convergence_reason='initial_state',
+        ),
+        RefractionCellSolverHistoryRow(
+            iteration=max(1, robust_iteration_count),
+            stage='final',
+            n_candidate_observations=n_candidate,
+            n_used_observations=n_used,
+            n_rejected_observations=n_robust_rejected,
+            n_active_cells=cell_counts['active'],
+            n_low_fold_cells=cell_counts['low_fold'],
+            n_empty_cells=cell_counts['empty'],
+            residual_rms_ms=residual_stats['rms'],
+            residual_mad_ms=residual_stats['mad'],
+            max_abs_residual_ms=residual_stats['max_abs'],
+            median_v2_m_s=_stat(active_final_v2, 'median'),
+            min_v2_m_s=_stat(active_final_v2, 'min'),
+            max_v2_m_s=_stat(active_final_v2, 'max'),
+            max_abs_v2_update_m_s=_history_max_abs(active_update),
+            smoothing_weight=smoothing_weight,
+            damping_weight=damping_weight,
+            robust_threshold=robust_threshold,
+            converged=True,
+            convergence_reason=_history_convergence_reason(
+                robust_iteration_count=robust_iteration_count,
+                n_robust_rejected_observations=n_robust_rejected,
+                smoothing_weight=smoothing_weight,
+            ),
+        ),
+    ]
 
 
 def build_source_receiver_static_table_arrays(
@@ -1658,6 +1832,7 @@ def build_refraction_static_qc_payload(
             'cells_csv_artifact': REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME,
             'grid_npz_artifact': REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
             'qc_json_artifact': REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
+            'solver_history_csv_artifact': REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
         }
     _assert_strict_json(payload, artifact_name=REFRACTION_STATIC_QC_JSON_NAME)
     return payload
@@ -2752,6 +2927,113 @@ def _refractor_velocity_cell_rows(
     return rows
 
 
+def _cell_solver_history_csv_row(
+    row: RefractionCellSolverHistoryRow,
+) -> dict[str, object]:
+    return {
+        'iteration': int(row.iteration),
+        'stage': row.stage,
+        'n_candidate_observations': int(row.n_candidate_observations),
+        'n_used_observations': int(row.n_used_observations),
+        'n_rejected_observations': int(row.n_rejected_observations),
+        'n_active_cells': int(row.n_active_cells),
+        'n_low_fold_cells': int(row.n_low_fold_cells),
+        'n_empty_cells': int(row.n_empty_cells),
+        'residual_rms_ms': _csv_float(row.residual_rms_ms),
+        'residual_mad_ms': _csv_float(row.residual_mad_ms),
+        'max_abs_residual_ms': _csv_float(row.max_abs_residual_ms),
+        'median_v2_m_s': _csv_float(row.median_v2_m_s),
+        'min_v2_m_s': _csv_float(row.min_v2_m_s),
+        'max_v2_m_s': _csv_float(row.max_v2_m_s),
+        'max_abs_v2_update_m_s': _csv_float(row.max_abs_v2_update_m_s),
+        'smoothing_weight': _csv_float(row.smoothing_weight),
+        'damping_weight': _csv_float(row.damping_weight),
+        'robust_threshold': _csv_float(row.robust_threshold),
+        'converged': _csv_bool(row.converged),
+        'convergence_reason': row.convergence_reason,
+    }
+
+
+def _cell_solver_history_cell_counts(
+    arrays: dict[str, np.ndarray],
+) -> dict[str, int]:
+    active_mask = np.asarray(arrays['active_cell_mask'], dtype=bool)
+    velocity_status = np.asarray(arrays['velocity_status']).astype(str, copy=False)
+    n_observations = np.asarray(arrays['n_observations_per_cell'], dtype=np.int64)
+    return {
+        'active': int(np.count_nonzero(active_mask)),
+        'low_fold': int(
+            np.count_nonzero(velocity_status == LOW_FOLD_CELL_VELOCITY_STATUS)
+        ),
+        'empty': int(np.count_nonzero(n_observations == 0)),
+    }
+
+
+def _history_residual_stats_ms(
+    result: RefractionDatumStaticsResult,
+) -> dict[str, float | None]:
+    residual_ms = np.asarray(result.residual_time_s, dtype=np.float64)[
+        np.asarray(result.used_row_mask, dtype=bool)
+    ] * 1000.0
+    return {
+        'rms': _residual_stat(residual_ms, 'rms'),
+        'mad': _residual_stat(residual_ms, 'mad'),
+        'max_abs': _residual_stat(residual_ms, 'max_abs'),
+    }
+
+
+def _history_max_abs(values: np.ndarray) -> float | None:
+    finite = np.asarray(values, dtype=np.float64)
+    finite = finite[np.isfinite(finite)]
+    if finite.size == 0:
+        return None
+    return float(np.max(np.abs(finite)))
+
+
+def _initial_cell_v2_m_s(req: RefractionStaticApplyRequest) -> float:
+    value = req.model.initial_bedrock_velocity_m_s
+    if value is not None:
+        return float(value)
+    return 0.5 * (
+        float(req.model.min_bedrock_velocity_m_s)
+        + float(req.model.max_bedrock_velocity_m_s)
+    )
+
+
+def _history_smoothing_weight(req: RefractionStaticApplyRequest) -> float:
+    refractor_cell = req.model.refractor_cell
+    if refractor_cell is None:
+        raise RefractionStaticArtifactError(
+            'model.refractor_cell is required for cell solver history'
+        )
+    return float(refractor_cell.velocity_smoothing_weight)
+
+
+def _history_robust_iteration_count(
+    result: RefractionDatumStaticsResult,
+    req: RefractionStaticApplyRequest,
+) -> int:
+    raw = result.qc.get('robust_iteration_count')
+    if raw is not None:
+        return int(raw)
+    if req.solver.robust.enabled and np.count_nonzero(result.rejected_by_robust_mask):
+        return 1
+    return 0
+
+
+def _history_convergence_reason(
+    *,
+    robust_iteration_count: int,
+    n_robust_rejected_observations: int,
+    smoothing_weight: float,
+) -> str:
+    if robust_iteration_count > 0 or n_robust_rejected_observations > 0:
+        return 'robust_reweight_converged'
+    if smoothing_weight > 0.0:
+        return 'smoothed_least_squares_converged'
+    return 'least_squares_converged'
+
+
 def _refractor_cell_center_alias_arrays(
     *,
     x_center_m: np.ndarray,
@@ -3375,6 +3657,7 @@ def _assert_strict_json(payload: dict[str, Any], *, artifact_name: str) -> None:
 __all__ = [
     'FIRST_BREAK_RESIDUALS_CSV_NAME',
     'NEAR_SURFACE_MODEL_CSV_NAME',
+    'REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME',
     'REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME',
     'REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME',
     'REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME',
@@ -3391,8 +3674,10 @@ __all__ = [
     'RECEIVER_STATIC_TABLE_CSV_NAME',
     'SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME',
     'SOURCE_STATIC_TABLE_CSV_NAME',
+    'RefractionCellSolverHistoryRow',
     'RefractionStaticArtifactError',
     'RefractionStaticArtifactSet',
+    'build_refraction_cell_solver_history_rows',
     'build_refraction_refractor_velocity_grid_arrays',
     'build_refraction_refractor_velocity_qc_payload',
     'build_refraction_static_qc_payload',
@@ -3400,6 +3685,7 @@ __all__ = [
     'build_source_receiver_static_table_arrays',
     'write_first_break_residuals_csv',
     'write_near_surface_model_csv',
+    'write_refraction_cell_solver_history_csv',
     'write_refraction_refractor_velocity_cells_csv',
     'write_refraction_refractor_velocity_grid_npz',
     'write_refraction_refractor_velocity_qc_json',

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -258,6 +258,7 @@ _RESIDUAL_COLUMNS = (
     'residual_ms',
     'used',
     'rejected_by_robust',
+    'rejection_reason',
 )
 
 _COMPONENT_COLUMNS = (
@@ -1985,6 +1986,8 @@ def _near_surface_model_rows(result: RefractionDatumStaticsResult) -> list[dict[
 def _first_break_residual_rows(result: RefractionDatumStaticsResult) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
     for row_index in range(int(result.row_trace_index_sorted.shape[0])):
+        rejected_by_robust = bool(result.rejected_by_robust_mask[row_index])
+        used = bool(result.used_row_mask[row_index])
         rows.append(
             {
                 'row_index': row_index,
@@ -1995,11 +1998,27 @@ def _first_break_residual_rows(result: RefractionDatumStaticsResult) -> list[dic
                 'observed_pick_time_ms': _csv_ms(result.observed_pick_time_s[row_index]),
                 'modeled_pick_time_ms': _csv_ms(result.modeled_pick_time_s[row_index]),
                 'residual_ms': _csv_ms(result.residual_time_s[row_index]),
-                'used': _csv_bool(result.used_row_mask[row_index]),
-                'rejected_by_robust': _csv_bool(result.rejected_by_robust_mask[row_index]),
+                'used': _csv_bool(used),
+                'rejected_by_robust': _csv_bool(rejected_by_robust),
+                'rejection_reason': _residual_rejection_reason(
+                    used=used,
+                    rejected_by_robust=rejected_by_robust,
+                ),
             }
         )
     return rows
+
+
+def _residual_rejection_reason(
+    *,
+    used: bool,
+    rejected_by_robust: bool,
+) -> str:
+    if rejected_by_robust:
+        return 'robust_outlier'
+    if not used:
+        return 'not_used'
+    return 'ok'
 
 
 def _component_rows(result: RefractionDatumStaticsResult) -> list[dict[str, object]]:

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -247,18 +247,28 @@ _NEAR_SURFACE_COLUMNS = (
     'residual_mad_ms',
 )
 
+# Keep the legacy millisecond residual columns and append explicit seconds/cell
+# aliases so residual rows can be joined to refractor-cell QC artifacts.
 _RESIDUAL_COLUMNS = (
     'row_index',
+    'observation_index',
     'sorted_trace_index',
     'source_node_id',
     'receiver_node_id',
     'distance_m',
     'observed_pick_time_ms',
+    'observed_pick_time_s',
     'modeled_pick_time_ms',
+    'modeled_pick_time_s',
     'residual_ms',
+    'residual_s',
     'used',
+    'used_in_solve',
     'rejected_by_robust',
     'rejection_reason',
+    'cell_id',
+    'cell_ix',
+    'cell_iy',
 )
 
 _COMPONENT_COLUMNS = (
@@ -348,27 +358,43 @@ _RECEIVER_STATIC_TABLE_COLUMNS = (
     'residual_mad_ms',
 )
 
+# Keep the original Phase 2 cell columns and add self-describing aliases used
+# by downstream QC checks; existing artifact names and column meanings remain.
 _REFRACTOR_VELOCITY_CELL_COLUMNS = (
     'cell_id',
     'ix',
     'iy',
+    'cell_ix',
+    'cell_iy',
+    'coordinate_mode',
     'x_min_m',
     'x_max_m',
     'y_min_m',
     'y_max_m',
     'x_center_m',
     'y_center_m',
+    'cell_center_x_m',
+    'cell_center_y_m',
+    'cell_center_inline_m',
+    'cell_center_crossline_m',
     'active',
     'n_observations',
     'n_used_observations',
     'n_rejected_observations',
+    'n_sources',
+    'n_receivers',
     'v2_m_s',
     'slowness_s_per_m',
+    'initial_v2_m_s',
+    'v2_update_from_initial_m_s',
     'velocity_status',
+    'status_reason',
     'residual_rms_ms',
     'residual_mad_ms',
     'residual_mean_ms',
     'residual_p95_abs_ms',
+    'smoothing_enabled',
+    'smoothing_weight',
     'smoothing_neighbor_count',
 )
 
@@ -492,6 +518,7 @@ def write_refraction_static_artifacts(
     write_first_break_residuals_csv(
         result=values.result,
         path=paths.first_break_residuals_csv,
+        req=request,
     )
     write_refraction_static_components_csv(
         result=values.result,
@@ -638,9 +665,10 @@ def write_first_break_residuals_csv(
     *,
     result: RefractionDatumStaticsResult,
     path: Path,
+    req: RefractionStaticApplyRequest | None = None,
 ) -> None:
     values = _validate_result(result)
-    rows = _first_break_residual_rows(values.result)
+    rows = _first_break_residual_rows(values.result, req=req)
     _write_csv_atomic(Path(path), _RESIDUAL_COLUMNS, rows)
 
 
@@ -821,6 +849,24 @@ def build_refraction_refractor_velocity_grid_arrays(
     if low_fold_cell_id.size:
         velocity_status[low_fold_cell_id] = LOW_FOLD_CELL_VELOCITY_STATUS
 
+    coordinate_mode = str(refractor_cell.coordinate_mode)
+    center_aliases = _refractor_cell_center_alias_arrays(
+        x_center_m=grid.x_center_m,
+        y_center_m=grid.y_center_m,
+        coordinate_mode=coordinate_mode,
+        line_origin_x_m=refractor_cell.line_origin_x_m,
+        line_origin_y_m=refractor_cell.line_origin_y_m,
+        line_azimuth_deg=refractor_cell.line_azimuth_deg,
+    )
+    initial_v2 = np.full(n_total_cells, np.nan, dtype=np.float64)
+    if request.model.initial_bedrock_velocity_m_s is not None:
+        initial_v2.fill(float(request.model.initial_bedrock_velocity_m_s))
+    v2_update = np.full(n_total_cells, np.nan, dtype=np.float64)
+    finite_update = np.isfinite(v2_m_s) & np.isfinite(initial_v2)
+    v2_update[finite_update] = v2_m_s[finite_update] - initial_v2[finite_update]
+    smoothing_weight = float(refractor_cell.velocity_smoothing_weight)
+    smoothing_enabled = bool(smoothing_weight > 0.0)
+
     n_observations = np.zeros(n_total_cells, dtype=np.int64)
     n_used_observations = np.zeros(n_total_cells, dtype=np.int64)
     valid_row_cell = (
@@ -841,23 +887,46 @@ def build_refraction_refractor_velocity_grid_arrays(
         raise RefractionStaticArtifactError(
             'used observations per cell cannot exceed total observations per cell'
         )
+    n_sources = _unique_observation_endpoint_count_by_cell(
+        row_midpoint_cell_id=row_midpoint_cell_id,
+        endpoint_id=values.result.row_source_node_id,
+        n_total_cells=n_total_cells,
+    )
+    n_receivers = _unique_observation_endpoint_count_by_cell(
+        row_midpoint_cell_id=row_midpoint_cell_id,
+        endpoint_id=values.result.row_receiver_node_id,
+        n_total_cells=n_total_cells,
+    )
     residual_stats = _per_cell_residual_stats_ms(
         row_midpoint_cell_id=row_midpoint_cell_id,
         residual_time_s=values.result.residual_time_s,
         used_row_mask=values.result.used_row_mask,
         n_total_cells=n_total_cells,
     )
+    status_reason = _refractor_cell_status_reasons(
+        velocity_status=velocity_status,
+        n_observations=n_observations,
+    )
 
     arrays = {
         'cell_id': np.ascontiguousarray(grid.cell_id, dtype=np.int64),
         'ix': np.ascontiguousarray(grid.ix, dtype=np.int64),
         'iy': np.ascontiguousarray(grid.iy, dtype=np.int64),
+        'cell_ix': np.ascontiguousarray(grid.ix, dtype=np.int64),
+        'cell_iy': np.ascontiguousarray(grid.iy, dtype=np.int64),
+        'coordinate_mode': _string_array(
+            np.full(n_total_cells, coordinate_mode, dtype=f'<U{len(coordinate_mode)}')
+        ),
         'x_min_m': np.ascontiguousarray(grid.x_min_m, dtype=np.float64),
         'x_max_m': np.ascontiguousarray(grid.x_max_m, dtype=np.float64),
         'y_min_m': np.ascontiguousarray(grid.y_min_m, dtype=np.float64),
         'y_max_m': np.ascontiguousarray(grid.y_max_m, dtype=np.float64),
         'x_center_m': np.ascontiguousarray(grid.x_center_m, dtype=np.float64),
         'y_center_m': np.ascontiguousarray(grid.y_center_m, dtype=np.float64),
+        'cell_center_x_m': center_aliases['x_m'],
+        'cell_center_y_m': center_aliases['y_m'],
+        'cell_center_inline_m': center_aliases['inline_m'],
+        'cell_center_crossline_m': center_aliases['crossline_m'],
         'active_cell_mask': np.ascontiguousarray(active_cell_mask, dtype=bool),
         'n_observations_per_cell': np.ascontiguousarray(
             n_observations,
@@ -871,13 +940,27 @@ def build_refraction_refractor_velocity_grid_arrays(
             n_observations - n_used_observations,
             dtype=np.int64,
         ),
+        'n_sources_per_cell': np.ascontiguousarray(n_sources, dtype=np.int64),
+        'n_receivers_per_cell': np.ascontiguousarray(n_receivers, dtype=np.int64),
         'v2_m_s': np.ascontiguousarray(v2_m_s, dtype=np.float64),
         'slowness_s_per_m': np.ascontiguousarray(slowness_s_per_m, dtype=np.float64),
+        'initial_v2_m_s': np.ascontiguousarray(initial_v2, dtype=np.float64),
+        'v2_update_from_initial_m_s': np.ascontiguousarray(
+            v2_update,
+            dtype=np.float64,
+        ),
         'velocity_status': _string_array(velocity_status),
+        'status_reason': _string_array(status_reason),
         'residual_rms_ms': residual_stats['rms'],
         'residual_mad_ms': residual_stats['mad'],
         'residual_mean_ms': residual_stats['mean'],
         'residual_p95_abs_ms': residual_stats['p95_abs'],
+        'smoothing_enabled': np.full(n_total_cells, smoothing_enabled, dtype=bool),
+        'smoothing_weight': np.full(
+            n_total_cells,
+            smoothing_weight,
+            dtype=np.float64,
+        ),
         'smoothing_neighbor_count': np.ascontiguousarray(
             smoothing_neighbor_count,
             dtype=np.int64,
@@ -1983,30 +2066,102 @@ def _near_surface_model_rows(result: RefractionDatumStaticsResult) -> list[dict[
     return rows
 
 
-def _first_break_residual_rows(result: RefractionDatumStaticsResult) -> list[dict[str, object]]:
+def _first_break_residual_rows(
+    result: RefractionDatumStaticsResult,
+    *,
+    req: RefractionStaticApplyRequest | None = None,
+) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
+    cell_id_by_row, cell_ix_by_row, cell_iy_by_row = _residual_row_cell_context(
+        result,
+        req=req,
+    )
     for row_index in range(int(result.row_trace_index_sorted.shape[0])):
         rejected_by_robust = bool(result.rejected_by_robust_mask[row_index])
         used = bool(result.used_row_mask[row_index])
         rows.append(
             {
                 'row_index': row_index,
+                'observation_index': row_index,
                 'sorted_trace_index': int(result.row_trace_index_sorted[row_index]),
                 'source_node_id': int(result.row_source_node_id[row_index]),
                 'receiver_node_id': int(result.row_receiver_node_id[row_index]),
                 'distance_m': _csv_float(result.row_distance_m[row_index]),
                 'observed_pick_time_ms': _csv_ms(result.observed_pick_time_s[row_index]),
+                'observed_pick_time_s': _csv_float(result.observed_pick_time_s[row_index]),
                 'modeled_pick_time_ms': _csv_ms(result.modeled_pick_time_s[row_index]),
+                'modeled_pick_time_s': _csv_float(result.modeled_pick_time_s[row_index]),
                 'residual_ms': _csv_ms(result.residual_time_s[row_index]),
+                'residual_s': _csv_float(result.residual_time_s[row_index]),
                 'used': _csv_bool(used),
+                'used_in_solve': _csv_bool(used),
                 'rejected_by_robust': _csv_bool(rejected_by_robust),
                 'rejection_reason': _residual_rejection_reason(
                     used=used,
                     rejected_by_robust=rejected_by_robust,
                 ),
+                'cell_id': _csv_cell_id(cell_id_by_row[row_index]),
+                'cell_ix': _csv_cell_id(cell_ix_by_row[row_index]),
+                'cell_iy': _csv_cell_id(cell_iy_by_row[row_index]),
             }
         )
     return rows
+
+
+def _residual_row_cell_context(
+    result: RefractionDatumStaticsResult,
+    *,
+    req: RefractionStaticApplyRequest | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    n_rows = int(result.row_trace_index_sorted.shape[0])
+    empty = np.full(n_rows, -1, dtype=np.int64)
+    if result.bedrock_velocity_mode != 'solve_cell':
+        return empty, empty.copy(), empty.copy()
+
+    if result.row_midpoint_cell_id is None:
+        raise RefractionStaticArtifactError(
+            'solve_cell residual rows require row_midpoint_cell_id'
+        )
+    cell_id = np.ascontiguousarray(result.row_midpoint_cell_id, dtype=np.int64)
+    if cell_id.shape != (n_rows,):
+        raise RefractionStaticArtifactError(
+            'row_midpoint_cell_id length must match residual rows'
+        )
+    number_of_cell_x = _residual_cell_x_count(result=result, req=req)
+    cell_ix = np.full(n_rows, -1, dtype=np.int64)
+    cell_iy = np.full(n_rows, -1, dtype=np.int64)
+    if number_of_cell_x is not None:
+        valid = cell_id >= 0
+        cell_ix[valid] = cell_id[valid] % number_of_cell_x
+        cell_iy[valid] = cell_id[valid] // number_of_cell_x
+    return (
+        np.ascontiguousarray(cell_id, dtype=np.int64),
+        np.ascontiguousarray(cell_ix, dtype=np.int64),
+        np.ascontiguousarray(cell_iy, dtype=np.int64),
+    )
+
+
+def _residual_cell_x_count(
+    *,
+    result: RefractionDatumStaticsResult,
+    req: RefractionStaticApplyRequest | None,
+) -> int | None:
+    if req is not None:
+        request = RefractionStaticApplyRequest.model_validate(req)
+        refractor_cell = request.model.refractor_cell
+        if (
+            request.model.bedrock_velocity_mode == 'solve_cell'
+            and refractor_cell is not None
+        ):
+            return int(
+                effective_refraction_cell_grid_config(
+                    refractor_cell
+                ).number_of_cell_x
+            )
+    raw = result.qc.get('number_of_cell_x')
+    if raw is None:
+        return None
+    return _required_positive_qc_int(result.qc, 'number_of_cell_x')
 
 
 def _residual_rejection_reason(
@@ -2538,12 +2693,27 @@ def _refractor_velocity_cell_rows(
                 'cell_id': int(arrays['cell_id'][index]),
                 'ix': int(arrays['ix'][index]),
                 'iy': int(arrays['iy'][index]),
+                'cell_ix': int(arrays['cell_ix'][index]),
+                'cell_iy': int(arrays['cell_iy'][index]),
+                'coordinate_mode': str(arrays['coordinate_mode'][index]),
                 'x_min_m': _csv_grid_float(arrays['x_min_m'][index]),
                 'x_max_m': _csv_grid_float(arrays['x_max_m'][index]),
                 'y_min_m': _csv_grid_float(arrays['y_min_m'][index]),
                 'y_max_m': _csv_grid_float(arrays['y_max_m'][index]),
                 'x_center_m': _csv_grid_float(arrays['x_center_m'][index]),
                 'y_center_m': _csv_grid_float(arrays['y_center_m'][index]),
+                'cell_center_x_m': _csv_grid_float(
+                    arrays['cell_center_x_m'][index]
+                ),
+                'cell_center_y_m': _csv_grid_float(
+                    arrays['cell_center_y_m'][index]
+                ),
+                'cell_center_inline_m': _csv_grid_float(
+                    arrays['cell_center_inline_m'][index]
+                ),
+                'cell_center_crossline_m': _csv_grid_float(
+                    arrays['cell_center_crossline_m'][index]
+                ),
                 'active': _csv_bool(arrays['active_cell_mask'][index]),
                 'n_observations': int(
                     arrays['n_observations_per_cell'][index]
@@ -2554,23 +2724,129 @@ def _refractor_velocity_cell_rows(
                 'n_rejected_observations': int(
                     arrays['n_rejected_observations_per_cell'][index]
                 ),
+                'n_sources': int(arrays['n_sources_per_cell'][index]),
+                'n_receivers': int(arrays['n_receivers_per_cell'][index]),
                 'v2_m_s': _csv_float(arrays['v2_m_s'][index]),
                 'slowness_s_per_m': _csv_float(
                     arrays['slowness_s_per_m'][index]
                 ),
+                'initial_v2_m_s': _csv_float(arrays['initial_v2_m_s'][index]),
+                'v2_update_from_initial_m_s': _csv_float(
+                    arrays['v2_update_from_initial_m_s'][index]
+                ),
                 'velocity_status': str(arrays['velocity_status'][index]),
+                'status_reason': str(arrays['status_reason'][index]),
                 'residual_rms_ms': _csv_float(arrays['residual_rms_ms'][index]),
                 'residual_mad_ms': _csv_float(arrays['residual_mad_ms'][index]),
                 'residual_mean_ms': _csv_float(arrays['residual_mean_ms'][index]),
                 'residual_p95_abs_ms': _csv_float(
                     arrays['residual_p95_abs_ms'][index]
                 ),
+                'smoothing_enabled': _csv_bool(arrays['smoothing_enabled'][index]),
+                'smoothing_weight': _csv_float(arrays['smoothing_weight'][index]),
                 'smoothing_neighbor_count': int(
                     arrays['smoothing_neighbor_count'][index]
                 ),
             }
         )
     return rows
+
+
+def _refractor_cell_center_alias_arrays(
+    *,
+    x_center_m: np.ndarray,
+    y_center_m: np.ndarray,
+    coordinate_mode: str,
+    line_origin_x_m: float | None,
+    line_origin_y_m: float | None,
+    line_azimuth_deg: float | None,
+) -> dict[str, np.ndarray]:
+    x_center = np.asarray(x_center_m, dtype=np.float64)
+    y_center = np.asarray(y_center_m, dtype=np.float64)
+    if x_center.shape != y_center.shape:
+        raise RefractionStaticArtifactError(
+            'refractor cell center coordinate shape mismatch'
+        )
+
+    inline = np.full(x_center.shape, np.nan, dtype=np.float64)
+    crossline = np.full(x_center.shape, np.nan, dtype=np.float64)
+    center_x = np.ascontiguousarray(x_center, dtype=np.float64)
+    center_y = np.ascontiguousarray(y_center, dtype=np.float64)
+    if coordinate_mode == 'line_2d_projected':
+        origin_x = _required_finite_float(
+            line_origin_x_m,
+            name='model.refractor_cell.line_origin_x_m',
+        )
+        origin_y = _required_finite_float(
+            line_origin_y_m,
+            name='model.refractor_cell.line_origin_y_m',
+        )
+        azimuth_deg = _required_finite_float(
+            line_azimuth_deg,
+            name='model.refractor_cell.line_azimuth_deg',
+        )
+        inline = np.ascontiguousarray(x_center, dtype=np.float64)
+        crossline = np.ascontiguousarray(y_center, dtype=np.float64)
+        azimuth_rad = np.deg2rad(azimuth_deg)
+        inline_unit_x = float(np.sin(azimuth_rad))
+        inline_unit_y = float(np.cos(azimuth_rad))
+        center_x = np.ascontiguousarray(
+            origin_x + inline * inline_unit_x + crossline * inline_unit_y,
+            dtype=np.float64,
+        )
+        center_y = np.ascontiguousarray(
+            origin_y + inline * inline_unit_y - crossline * inline_unit_x,
+            dtype=np.float64,
+        )
+
+    return {
+        'x_m': center_x,
+        'y_m': center_y,
+        'inline_m': np.ascontiguousarray(inline, dtype=np.float64),
+        'crossline_m': np.ascontiguousarray(crossline, dtype=np.float64),
+    }
+
+
+def _unique_observation_endpoint_count_by_cell(
+    *,
+    row_midpoint_cell_id: np.ndarray,
+    endpoint_id: np.ndarray,
+    n_total_cells: int,
+) -> np.ndarray:
+    row_cell = np.asarray(row_midpoint_cell_id, dtype=np.int64)
+    endpoint = np.asarray(endpoint_id, dtype=np.int64)
+    if row_cell.shape != endpoint.shape:
+        raise RefractionStaticArtifactError(
+            'row endpoint arrays must match row_midpoint_cell_id shape'
+        )
+    counts = np.zeros(int(n_total_cells), dtype=np.int64)
+    for cell_id in range(int(n_total_cells)):
+        in_cell = row_cell == cell_id
+        if np.any(in_cell):
+            counts[cell_id] = int(np.unique(endpoint[in_cell]).shape[0])
+    return np.ascontiguousarray(counts, dtype=np.int64)
+
+
+def _refractor_cell_status_reasons(
+    *,
+    velocity_status: np.ndarray,
+    n_observations: np.ndarray,
+) -> np.ndarray:
+    status = np.asarray(velocity_status).astype(str, copy=False)
+    counts = np.asarray(n_observations, dtype=np.int64)
+    if status.shape != counts.shape:
+        raise RefractionStaticArtifactError(
+            'velocity_status and n_observations shape mismatch'
+        )
+    reasons: list[str] = []
+    for value, count in zip(status.tolist(), counts.tolist(), strict=True):
+        if value == LOW_FOLD_CELL_VELOCITY_STATUS:
+            reasons.append(LOW_FOLD_CELL_REJECTION_REASON)
+        elif value == 'inactive':
+            reasons.append('no_observations' if int(count) == 0 else 'inactive_cell')
+        else:
+            reasons.append(str(value))
+    return _string_array(reasons)
 
 
 def _required_cell_int_array(value: object, *, name: str) -> np.ndarray:
@@ -2712,6 +2988,23 @@ def _qc_int(qc: dict[str, Any], key: str, *, default: int) -> int:
         raise RefractionStaticArtifactError(
             f'QC field {key} must be an integer'
         ) from exc
+
+
+def _required_positive_qc_int(qc: dict[str, Any], key: str) -> int:
+    raw = qc.get(key)
+    if raw is None:
+        raise RefractionStaticArtifactError(f'QC field {key} is required')
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise RefractionStaticArtifactError(
+            f'QC field {key} must be an integer'
+        ) from exc
+    if value <= 0:
+        raise RefractionStaticArtifactError(
+            f'QC field {key} must be a positive integer'
+        )
+    return value
 
 
 def _qc_cell_id_array(
@@ -2886,6 +3179,16 @@ def _float_or_nan(value: object) -> float:
     except (TypeError, ValueError):
         return float('nan')
     return out if np.isfinite(out) else float('nan')
+
+
+def _required_finite_float(value: object, *, name: str) -> float:
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise RefractionStaticArtifactError(f'{name} must be finite') from exc
+    if not np.isfinite(out):
+        raise RefractionStaticArtifactError(f'{name} must be finite')
+    return out
 
 
 def _sum_correction_s(left: object, right: object) -> float:

--- a/app/services/refraction_static_types.py
+++ b/app/services/refraction_static_types.py
@@ -659,6 +659,7 @@ class RefractionStaticArtifactSet:
     refraction_refractor_velocity_cells_csv: Path | None = None
     refraction_refractor_velocity_grid_npz: Path | None = None
     refraction_refractor_velocity_qc_json: Path | None = None
+    refraction_cell_solver_history_csv: Path | None = None
 
 
 @dataclass(frozen=True)

--- a/app/tests/test_job_artifact_refs.py
+++ b/app/tests/test_job_artifact_refs.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.core.state import create_app_state
 from app.services.refraction_static_artifacts import (
+    REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
     REFRACTION_T1LSST_1LAYER_COMPONENTS_CSV_NAME,
     REFRACTION_V1_ESTIMATES_CSV_NAME,
     REFRACTION_V1_QC_JSON_NAME,
@@ -121,6 +122,7 @@ def test_resolve_job_artifact_path_rejects_wrong_statics_kind(
         REFRACTION_V1_QC_JSON_NAME,
         REFRACTION_V1_ESTIMATES_CSV_NAME,
         REFRACTION_T1LSST_1LAYER_COMPONENTS_CSV_NAME,
+        REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
         REFRACTION_STATIC_REQUEST_JSON_NAME,
         SOURCE_STATIC_TABLE_CSV_NAME,
         RECEIVER_STATIC_TABLE_CSV_NAME,

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -13,6 +13,7 @@ import app.services.refraction_static_artifacts as artifact_module
 from app.services.refraction_static_artifacts import (
     FIRST_BREAK_RESIDUALS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
+    REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
     REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
@@ -114,6 +115,7 @@ EXPECTED_FILENAMES = {
 }
 
 CELL_VELOCITY_FILENAMES = {
+    REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
     REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
@@ -459,6 +461,9 @@ def test_solve_cell_manifest_registers_cell_velocity_artifacts(
     )
     assert qc['refractor_velocity_cells']['grid_npz_artifact'] == (
         REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME
+    )
+    assert qc['refractor_velocity_cells']['solver_history_csv_artifact'] == (
+        REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME
     )
 
 

--- a/app/tests/test_refraction_static_cell_qc_artifacts.py
+++ b/app/tests/test_refraction_static_cell_qc_artifacts.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.services.refraction_static_artifacts import write_refraction_static_artifacts
+from app.tests._refraction_static_synthetic import (
+    SYNTHETIC_CELL_SIZE_X_M,
+    SYNTHETIC_CELL_V2_M_S,
+    run_synthetic_cell_refraction_statics,
+    synthetic_cell_midpoint_cell_id_sorted,
+    synthetic_cell_refracted_arrival_input_model,
+    synthetic_cell_refraction_apply_request,
+)
+from app.tests.test_refraction_static_cell_low_fold import (
+    EMPTY_CELL_ID,
+    LOW_FOLD_CELL_ID,
+    _low_fold_case,
+    _run_refraction_statics,
+)
+
+
+EXPECTED_CELL_COLUMNS = {
+    'cell_ix',
+    'cell_iy',
+    'cell_id',
+    'coordinate_mode',
+    'cell_center_x_m',
+    'cell_center_y_m',
+    'cell_center_inline_m',
+    'cell_center_crossline_m',
+    'n_observations',
+    'n_used_observations',
+    'n_rejected_observations',
+    'n_sources',
+    'n_receivers',
+    'v2_m_s',
+    'slowness_s_per_m',
+    'initial_v2_m_s',
+    'v2_update_from_initial_m_s',
+    'residual_rms_ms',
+    'residual_mad_ms',
+    'velocity_status',
+    'status_reason',
+    'smoothing_enabled',
+    'smoothing_weight',
+}
+
+EXPECTED_RESIDUAL_COLUMNS = {
+    'observation_index',
+    'cell_id',
+    'cell_ix',
+    'cell_iy',
+    'observed_pick_time_s',
+    'modeled_pick_time_s',
+    'residual_s',
+    'rejection_reason',
+    'used_in_solve',
+}
+
+
+def test_cell_velocity_artifact_contains_expected_columns(tmp_path: Path) -> None:
+    result, req, _ = _clean_result()
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    assert paths.refraction_refractor_velocity_cells_csv is not None
+    rows = _read_csv(paths.refraction_refractor_velocity_cells_csv)
+    assert EXPECTED_CELL_COLUMNS.issubset(rows[0].keys())
+
+    assert paths.first_break_residuals_csv is not None
+    residual_rows = _read_csv(paths.first_break_residuals_csv)
+    assert EXPECTED_RESIDUAL_COLUMNS.issubset(residual_rows[0].keys())
+
+
+def test_cell_velocity_artifact_counts_observations_correctly(
+    tmp_path: Path,
+) -> None:
+    result, req, input_model = _clean_result()
+    expected_cell_id = synthetic_cell_midpoint_cell_id_sorted(input_model)
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    assert paths.refraction_refractor_velocity_cells_csv is not None
+    rows = {
+        int(row['cell_id']): row
+        for row in _read_csv(paths.refraction_refractor_velocity_cells_csv)
+    }
+    for cell_id in range(SYNTHETIC_CELL_V2_M_S.shape[0]):
+        in_cell = expected_cell_id == cell_id
+        assert int(rows[cell_id]['n_observations']) == int(np.count_nonzero(in_cell))
+        assert int(rows[cell_id]['n_used_observations']) == int(
+            np.count_nonzero(in_cell)
+        )
+        assert int(rows[cell_id]['n_rejected_observations']) == 0
+        assert int(rows[cell_id]['n_sources']) == int(
+            np.unique(input_model.source_node_id_sorted[in_cell]).shape[0]
+        )
+        assert int(rows[cell_id]['n_receivers']) == int(
+            np.unique(input_model.receiver_node_id_sorted[in_cell]).shape[0]
+        )
+
+
+def test_cell_velocity_artifact_clean_synthetic_values_are_known_truth(
+    tmp_path: Path,
+) -> None:
+    result, req, _ = _clean_result()
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    assert paths.refraction_refractor_velocity_cells_csv is not None
+    rows = _read_csv(paths.refraction_refractor_velocity_cells_csv)
+    for row in rows:
+        cell_id = int(row['cell_id'])
+        true_v2 = float(SYNTHETIC_CELL_V2_M_S[cell_id])
+        center_x_m = (cell_id + 0.5) * SYNTHETIC_CELL_SIZE_X_M
+
+        assert int(row['cell_ix']) == cell_id
+        assert int(row['cell_iy']) == 0
+        assert row['coordinate_mode'] == 'grid_3d'
+        assert float(row['cell_center_x_m']) == pytest.approx(center_x_m)
+        assert float(row['cell_center_y_m']) == pytest.approx(0.0)
+        assert row['cell_center_inline_m'] == ''
+        assert row['cell_center_crossline_m'] == ''
+        assert float(row['v2_m_s']) == pytest.approx(true_v2, abs=1.0e-3)
+        assert float(row['slowness_s_per_m']) == pytest.approx(
+            1.0 / true_v2,
+            abs=1.0e-12,
+        )
+        assert float(row['initial_v2_m_s']) == pytest.approx(2600.0)
+        assert float(row['v2_update_from_initial_m_s']) == pytest.approx(
+            true_v2 - 2600.0,
+            abs=1.0e-3,
+        )
+        assert float(row['residual_rms_ms']) == pytest.approx(0.0, abs=1.0e-6)
+        assert float(row['residual_mad_ms']) == pytest.approx(0.0, abs=1.0e-6)
+        assert row['velocity_status'] == 'solved'
+        assert row['status_reason'] == 'solved'
+
+
+def test_cell_velocity_artifact_marks_low_fold_and_empty_cells(
+    tmp_path: Path,
+) -> None:
+    _, req, input_model = _low_fold_case()
+    result = _run_refraction_statics(req=req, input_model=input_model)
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    assert paths.refraction_refractor_velocity_cells_csv is not None
+    rows = {
+        int(row['cell_id']): row
+        for row in _read_csv(paths.refraction_refractor_velocity_cells_csv)
+    }
+    assert rows[LOW_FOLD_CELL_ID]['velocity_status'] == 'low_fold'
+    assert rows[LOW_FOLD_CELL_ID]['status_reason'] == (
+        'below_min_observations_per_cell'
+    )
+    assert rows[LOW_FOLD_CELL_ID]['n_observations'] == '19'
+    assert rows[LOW_FOLD_CELL_ID]['n_used_observations'] == '0'
+    assert rows[LOW_FOLD_CELL_ID]['n_rejected_observations'] == '19'
+
+    assert rows[EMPTY_CELL_ID]['velocity_status'] == 'inactive'
+    assert rows[EMPTY_CELL_ID]['status_reason'] == 'no_observations'
+    assert rows[EMPTY_CELL_ID]['n_observations'] == '0'
+    assert rows[EMPTY_CELL_ID]['v2_m_s'] == ''
+
+
+def test_observation_residual_artifact_includes_cell_ids_and_rejection_reason(
+    tmp_path: Path,
+) -> None:
+    result, req, input_model = _clean_result()
+    expected_cell_id = synthetic_cell_midpoint_cell_id_sorted(input_model)
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    assert paths.first_break_residuals_csv is not None
+    rows = _read_csv(paths.first_break_residuals_csv)
+    for row in rows:
+        observation_index = int(row['observation_index'])
+        trace_index = int(row['sorted_trace_index'])
+        cell_id = int(row['cell_id'])
+        assert observation_index == int(row['row_index'])
+        assert cell_id == int(expected_cell_id[trace_index])
+        assert int(row['cell_ix']) == cell_id
+        assert int(row['cell_iy']) == 0
+        assert float(row['observed_pick_time_s']) == pytest.approx(
+            float(input_model.pick_time_s_sorted[trace_index])
+        )
+        assert float(row['modeled_pick_time_s']) == pytest.approx(
+            float(input_model.pick_time_s_sorted[trace_index]),
+            abs=1.0e-8,
+        )
+        assert float(row['residual_s']) == pytest.approx(0.0, abs=1.0e-8)
+        assert row['used_in_solve'] == 'true'
+        assert row['rejection_reason'] == 'ok'
+
+
+def test_cell_velocity_artifact_records_smoothing_metadata(
+    tmp_path: Path,
+) -> None:
+    input_model = synthetic_cell_refracted_arrival_input_model()
+    req = synthetic_cell_refraction_apply_request(velocity_smoothing_weight=2.0)
+    result = run_synthetic_cell_refraction_statics(
+        req=req,
+        input_model=input_model,
+    )
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    assert paths.refraction_refractor_velocity_cells_csv is not None
+    for row in _read_csv(paths.refraction_refractor_velocity_cells_csv):
+        assert row['coordinate_mode'] == 'grid_3d'
+        assert row['smoothing_enabled'] == 'true'
+        assert float(row['smoothing_weight']) == pytest.approx(2.0)
+
+
+def _clean_result():
+    input_model = synthetic_cell_refracted_arrival_input_model()
+    req = synthetic_cell_refraction_apply_request()
+    result = run_synthetic_cell_refraction_statics(
+        req=req,
+        input_model=input_model,
+    )
+    return result, req, input_model
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))

--- a/app/tests/test_refraction_static_cell_robust_synthetic.py
+++ b/app/tests/test_refraction_static_cell_robust_synthetic.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.services.refraction_static_artifacts import write_refraction_static_artifacts
+from app.services.refraction_static_types import (
+    RefractionDatumStaticsResult,
+    RefractionStaticInputModel,
+)
+from app.tests._refraction_static_synthetic import (
+    SYNTHETIC_CELL_NODE_T1_S,
+    SYNTHETIC_CELL_V2_M_S,
+    SYNTHETIC_CELL_V2_TOLERANCE_M_S,
+    run_synthetic_cell_refraction_statics,
+    synthetic_cell_midpoint_cell_id_sorted,
+    synthetic_cell_refracted_arrival_input_model,
+    synthetic_cell_refraction_apply_request,
+)
+
+OUTLIER_SHIFT_PATTERN_S = np.asarray([0.050, -0.060, 0.100], dtype=np.float64)
+RANDOM_OUTLIER_SEED = 432
+
+
+def test_cell_v2_robust_solver_rejects_random_bad_picks() -> None:
+    input_model, outlier_indices = _random_sparse_outlier_input_model(
+        seed=RANDOM_OUTLIER_SEED
+    )
+
+    first_result = _run_cell_statics(input_model, robust_enabled=True)
+    second_result = _run_cell_statics(input_model, robust_enabled=True)
+
+    _assert_rejected_outliers(first_result, outlier_indices)
+    np.testing.assert_array_equal(
+        first_result.rejected_by_robust_mask,
+        second_result.rejected_by_robust_mask,
+    )
+    np.testing.assert_allclose(
+        _required_cell_v2(first_result),
+        _required_cell_v2(second_result),
+        atol=0.0,
+        rtol=0.0,
+    )
+    _assert_known_cell_v2(first_result)
+    _assert_used_t1_pair_sums_close(first_result)
+
+
+def test_cell_v2_robust_solver_handles_clustered_bad_picks_in_one_cell() -> None:
+    base = synthetic_cell_refracted_arrival_input_model()
+    outlier_indices = np.asarray([5, 6, 7, 13, 14, 15], dtype=np.int64)
+    midpoint_cell = synthetic_cell_midpoint_cell_id_sorted(base)
+    assert set(midpoint_cell[outlier_indices].tolist()) == {1}
+    input_model = _with_outlier_shifts(
+        base,
+        outlier_indices=outlier_indices,
+        shifts_s=_outlier_shifts(outlier_indices.shape[0]),
+    )
+
+    result = _run_cell_statics(input_model, robust_enabled=True)
+
+    _assert_rejected_outliers(result, outlier_indices)
+    _assert_known_cell_v2(result)
+    _assert_used_t1_pair_sums_close(result)
+    cell_v2 = _required_cell_v2(result)
+    cell_one_position = _cell_position(result, cell_id=1)
+    assert cell_v2[cell_one_position] == pytest.approx(
+        SYNTHETIC_CELL_V2_M_S[1],
+        abs=SYNTHETIC_CELL_V2_TOLERANCE_M_S,
+    )
+
+
+def test_cell_v2_robust_solver_handles_bad_source_group() -> None:
+    base = synthetic_cell_refracted_arrival_input_model()
+    outlier_indices = np.asarray([48, 49, 50, 51, 52], dtype=np.int64)
+    bad_source_node = int(base.source_node_id_sorted[outlier_indices[0]])
+    assert set(base.source_node_id_sorted[outlier_indices].tolist()) == {
+        bad_source_node
+    }
+    input_model = _with_outlier_shifts(
+        base,
+        outlier_indices=outlier_indices,
+        shifts_s=_outlier_shifts(outlier_indices.shape[0]),
+    )
+
+    result = _run_cell_statics(input_model, robust_enabled=True)
+
+    _assert_rejected_outliers(result, outlier_indices)
+    _assert_known_cell_v2(result)
+    _assert_used_t1_pair_sums_close(result)
+    node_position = _node_position(result, bad_source_node)
+    assert result.node_rejected_pick_count[node_position] >= outlier_indices.shape[0]
+
+
+def test_cell_v2_robust_qc_reports_rejected_outliers(tmp_path: Path) -> None:
+    input_model, outlier_indices = _random_sparse_outlier_input_model(
+        seed=RANDOM_OUTLIER_SEED
+    )
+    req = synthetic_cell_refraction_apply_request(robust_enabled=True)
+    result = run_synthetic_cell_refraction_statics(
+        req=req,
+        input_model=input_model,
+    )
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    rejected_count = int(np.count_nonzero(result.rejected_by_robust_mask))
+    qc = json.loads(paths.qc_json.read_text(encoding='utf-8'))
+    assert qc['observations']['n_rejected_by_robust'] == rejected_count
+    assert qc['observations']['n_used_observations'] == int(
+        np.count_nonzero(result.used_row_mask)
+    )
+    assert qc['first_break_fit']['robust_enabled'] is True
+    assert qc['first_break_fit']['robust_iteration_count'] >= 1
+
+    residual_by_trace = _rows_by_trace_index(paths.first_break_residuals_csv)
+    trace_by_trace = _rows_by_trace_index(paths.refraction_statics_csv)
+    for trace_index in outlier_indices.tolist():
+        residual_row = residual_by_trace[trace_index]
+        assert residual_row['used'] == 'false'
+        assert residual_row['rejected_by_robust'] == 'true'
+        assert residual_row['rejection_reason'] == 'robust_outlier'
+        assert trace_by_trace[trace_index]['used_observation'] == 'false'
+
+    clean_row = residual_by_trace[0]
+    assert clean_row['used'] == 'true'
+    assert clean_row['rejected_by_robust'] == 'false'
+    assert clean_row['rejection_reason'] == 'ok'
+
+
+def test_cell_v2_solution_degrades_without_robust_rejection_for_large_outliers() -> None:
+    input_model, _ = _random_sparse_outlier_input_model(seed=RANDOM_OUTLIER_SEED)
+
+    robust_result = _run_cell_statics(input_model, robust_enabled=True)
+    plain_result = _run_cell_statics(input_model, robust_enabled=False)
+
+    _assert_known_cell_v2(robust_result)
+    plain_cell_error_m_s = np.max(
+        np.abs(_required_cell_v2(plain_result) - SYNTHETIC_CELL_V2_M_S)
+    )
+    assert plain_cell_error_m_s > 250.0
+    assert _used_residual_rms_ms(robust_result) < 1.0e-6
+    assert _used_residual_mad_ms(robust_result) < 1.0e-6
+    assert _used_residual_rms_ms(plain_result) > 5.0
+    assert _used_residual_mad_ms(plain_result) > 1.0
+
+
+def _random_sparse_outlier_input_model(
+    *,
+    seed: int,
+) -> tuple[RefractionStaticInputModel, np.ndarray]:
+    base = synthetic_cell_refracted_arrival_input_model()
+    eligible = np.flatnonzero(base.pick_time_s_sorted > 0.061)
+    rng = np.random.default_rng(seed)
+    outlier_indices = np.sort(rng.choice(eligible, size=6, replace=False))
+    midpoint_cell = synthetic_cell_midpoint_cell_id_sorted(base)
+    assert {0, 1, 2}.issubset(set(midpoint_cell[outlier_indices].tolist()))
+    return (
+        _with_outlier_shifts(
+            base,
+            outlier_indices=outlier_indices,
+            shifts_s=_outlier_shifts(outlier_indices.shape[0]),
+        ),
+        outlier_indices,
+    )
+
+
+def _with_outlier_shifts(
+    input_model: RefractionStaticInputModel,
+    *,
+    outlier_indices: np.ndarray,
+    shifts_s: np.ndarray,
+) -> RefractionStaticInputModel:
+    pick_time_s = input_model.pick_time_s_sorted.copy()
+    pick_time_s[outlier_indices] += shifts_s
+    if np.any(pick_time_s[outlier_indices] < 0.0):
+        raise AssertionError('synthetic outlier shifts produced negative pick times')
+    return replace(
+        input_model,
+        pick_time_s_sorted=np.ascontiguousarray(pick_time_s, dtype=np.float64),
+    )
+
+
+def _outlier_shifts(count: int) -> np.ndarray:
+    return np.resize(OUTLIER_SHIFT_PATTERN_S, int(count)).astype(
+        np.float64,
+        copy=False,
+    )
+
+
+def _run_cell_statics(
+    input_model: RefractionStaticInputModel,
+    *,
+    robust_enabled: bool,
+) -> RefractionDatumStaticsResult:
+    return run_synthetic_cell_refraction_statics(
+        req=synthetic_cell_refraction_apply_request(
+            robust_enabled=robust_enabled,
+        ),
+        input_model=input_model,
+    )
+
+
+def _assert_rejected_outliers(
+    result: RefractionDatumStaticsResult,
+    outlier_indices: np.ndarray,
+) -> None:
+    rejected_trace_indices = set(
+        result.row_trace_index_sorted[result.rejected_by_robust_mask].tolist()
+    )
+    assert set(outlier_indices.tolist()).issubset(rejected_trace_indices)
+    assert int(np.count_nonzero(result.rejected_by_robust_mask)) >= int(
+        outlier_indices.shape[0]
+    )
+    for trace_index in outlier_indices.tolist():
+        row_position = np.flatnonzero(result.row_trace_index_sorted == trace_index)
+        assert row_position.shape == (1,)
+        assert not bool(result.used_row_mask[int(row_position[0])])
+
+
+def _assert_known_cell_v2(result: RefractionDatumStaticsResult) -> None:
+    np.testing.assert_allclose(
+        _required_cell_v2(result),
+        SYNTHETIC_CELL_V2_M_S,
+        atol=SYNTHETIC_CELL_V2_TOLERANCE_M_S,
+        rtol=0.0,
+    )
+
+
+def _assert_used_t1_pair_sums_close(result: RefractionDatumStaticsResult) -> None:
+    node_t1_by_id = {
+        int(node_id): float(result.node_half_intercept_time_s[index])
+        for index, node_id in enumerate(result.node_id.tolist())
+    }
+    solved_pair_sums: list[float] = []
+    true_pair_sums: list[float] = []
+    for row_index in np.flatnonzero(result.used_row_mask).tolist():
+        source = int(result.row_source_node_id[row_index])
+        receiver = int(result.row_receiver_node_id[row_index])
+        solved_pair_sums.append(node_t1_by_id[source] + node_t1_by_id[receiver])
+        true_pair_sums.append(
+            float(SYNTHETIC_CELL_NODE_T1_S[source])
+            + float(SYNTHETIC_CELL_NODE_T1_S[receiver])
+        )
+    np.testing.assert_allclose(
+        solved_pair_sums,
+        true_pair_sums,
+        atol=1.0e-8,
+        rtol=0.0,
+    )
+
+
+def _required_cell_v2(result: RefractionDatumStaticsResult) -> np.ndarray:
+    assert result.cell_bedrock_velocity_m_s is not None
+    return result.cell_bedrock_velocity_m_s
+
+
+def _cell_position(result: RefractionDatumStaticsResult, *, cell_id: int) -> int:
+    assert result.active_cell_id is not None
+    matches = np.flatnonzero(result.active_cell_id == cell_id)
+    assert matches.shape == (1,)
+    return int(matches[0])
+
+
+def _node_position(result: RefractionDatumStaticsResult, node_id: int) -> int:
+    matches = np.flatnonzero(result.node_id == node_id)
+    assert matches.shape == (1,)
+    return int(matches[0])
+
+
+def _used_residual_rms_ms(result: RefractionDatumStaticsResult) -> float:
+    residual_ms = result.residual_time_s[result.used_row_mask] * 1000.0
+    return float(np.sqrt(np.mean(residual_ms * residual_ms)))
+
+
+def _used_residual_mad_ms(result: RefractionDatumStaticsResult) -> float:
+    residual_ms = result.residual_time_s[result.used_row_mask] * 1000.0
+    median = float(np.median(residual_ms))
+    return float(1.4826 * np.median(np.abs(residual_ms - median)))
+
+
+def _rows_by_trace_index(path: Path) -> dict[int, dict[str, str]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return {
+            int(row['sorted_trace_index']): row
+            for row in csv.DictReader(handle)
+        }

--- a/app/tests/test_refraction_static_cell_smoothing_synthetic.py
+++ b/app/tests/test_refraction_static_cell_smoothing_synthetic.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.api.schemas import (
+    RefractionStaticApplyRequest,
+    RefractionStaticModelRequest,
+    RefractionStaticSolverRequest,
+)
+from app.services.refraction_static_artifacts import (
+    REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
+    write_refraction_static_artifacts,
+)
+from app.services.refraction_static_cell_regularization import (
+    build_cell_slowness_smoothing_rows,
+)
+from app.services.refraction_static_datum import build_refraction_datum_statics
+from app.services.refraction_static_design_matrix import (
+    build_refraction_static_design_matrix,
+)
+from app.services.refraction_static_solver import solve_refraction_static_bounded_ls
+from app.services.refraction_static_types import (
+    RefractionDatumStaticsResult,
+    RefractionEndpointTable,
+    RefractionStaticInputModel,
+    RefractionStaticSolverResult,
+)
+from app.services.refraction_static_weathering_replacement import (
+    compute_weathering_replacement_statics_from_first_breaks,
+)
+from app.tests.fixtures.refraction_synthetic import (
+    SyntheticRefractionCellDataset,
+    make_clean_2d_cell_refraction_dataset,
+    make_clean_3d_cell_refraction_dataset,
+    make_rotated_2d_line_refraction_dataset,
+)
+
+SMOOTH_2D_V2_M_S = np.asarray(
+    [2200.0, 2300.0, 2400.0, 2500.0, 2600.0],
+    dtype=np.float64,
+)
+SMOOTH_3D_V2_M_S = np.asarray(
+    [
+        [2200.0, 2300.0, 2400.0],
+        [2250.0, 2350.0, 2450.0],
+        [2300.0, 2400.0, 2500.0],
+    ],
+    dtype=np.float64,
+)
+MIN_OBSERVATIONS_PER_CELL = 5
+
+
+def test_cell_v2_smoothing_reduces_synthetic_velocity_spike() -> None:
+    dataset = make_clean_2d_cell_refraction_dataset(
+        seed=436,
+        cell_v2_m_s=SMOOTH_2D_V2_M_S,
+        n_sources=20,
+        n_receivers=20,
+        noise_std_s=0.0,
+        outlier_fraction=0.0,
+    )
+    center_cell_id = 2
+    perturbation_s = np.where(
+        dataset.true_cell_id_for_pick == center_cell_id,
+        -0.012,
+        0.0,
+    )
+    spiky_dataset = replace(
+        dataset,
+        pick_time_s=np.ascontiguousarray(
+            dataset.pick_time_s + perturbation_s,
+            dtype=np.float64,
+        ),
+    )
+
+    unsmoothed = _solve_cell_dataset(spiky_dataset, velocity_smoothing_weight=0.0)
+    smoothed = _solve_cell_dataset(spiky_dataset, velocity_smoothing_weight=4.0)
+
+    unsmoothed_v2 = _required_array(unsmoothed.cell_bedrock_velocity_m_s)
+    smoothed_v2 = _required_array(smoothed.cell_bedrock_velocity_m_s)
+    np.testing.assert_array_equal(unsmoothed.active_cell_id, np.arange(5))
+    np.testing.assert_array_equal(smoothed.active_cell_id, np.arange(5))
+
+    unsmoothed_spike = _center_spike_amplitude(unsmoothed_v2, center_cell_id)
+    smoothed_spike = _center_spike_amplitude(smoothed_v2, center_cell_id)
+    assert smoothed_spike < unsmoothed_spike
+    assert abs(smoothed_v2[center_cell_id] - SMOOTH_2D_V2_M_S[center_cell_id]) < abs(
+        unsmoothed_v2[center_cell_id] - SMOOTH_2D_V2_M_S[center_cell_id]
+    )
+
+    neighbor_cell_id = np.asarray([0, 1, 3, 4], dtype=np.int64)
+    neighbor_deviation_m_s = np.abs(
+        smoothed_v2[neighbor_cell_id] - SMOOTH_2D_V2_M_S[neighbor_cell_id]
+    )
+    assert float(np.max(neighbor_deviation_m_s)) < 150.0
+    assert smoothed.qc['velocity_smoothing_weight'] == pytest.approx(4.0)
+    assert smoothed.qc['n_cell_smoothing_rows'] == 4
+
+
+def test_cell_v2_smoothing_preserves_smooth_velocity_trend() -> None:
+    dataset = make_clean_2d_cell_refraction_dataset(
+        seed=437,
+        cell_v2_m_s=SMOOTH_2D_V2_M_S,
+        n_sources=20,
+        n_receivers=20,
+        noise_std_s=0.0,
+        outlier_fraction=0.0,
+    )
+
+    unsmoothed = _solve_cell_dataset(dataset, velocity_smoothing_weight=0.0)
+    smoothed = _solve_cell_dataset(dataset, velocity_smoothing_weight=2.0)
+
+    np.testing.assert_allclose(
+        _required_array(unsmoothed.cell_bedrock_velocity_m_s),
+        SMOOTH_2D_V2_M_S,
+        atol=1.0e-5,
+        rtol=0.0,
+    )
+    smoothed_v2 = _required_array(smoothed.cell_bedrock_velocity_m_s)
+    assert bool(np.all(np.diff(smoothed_v2) > 0.0))
+    assert float(np.max(np.abs(smoothed_v2 - SMOOTH_2D_V2_M_S))) < 60.0
+    assert smoothed.qc['n_cell_smoothing_rows'] == 4
+
+
+def test_cell_v2_smoothing_line_2d_uses_inline_neighbors_only() -> None:
+    dataset = make_rotated_2d_line_refraction_dataset(
+        seed=438,
+        cell_v2_m_s=SMOOTH_2D_V2_M_S,
+        n_sources=20,
+        n_receivers=20,
+        noise_std_s=0.0,
+        outlier_fraction=0.0,
+        line_origin_x_m=1000.0,
+        line_origin_y_m=2000.0,
+        line_azimuth_deg=37.0,
+    )
+    dataset = _with_valid_observations_by_cell(
+        dataset,
+        {
+            1: MIN_OBSERVATIONS_PER_CELL - 1,
+            4: 0,
+        },
+    )
+
+    result = _solve_cell_dataset(dataset, velocity_smoothing_weight=1.0)
+    active_cell_id = _required_array(result.active_cell_id)
+    rows = build_cell_slowness_smoothing_rows(
+        active_cell_id=active_cell_id,
+        velocity_smoothing_weight=1.0,
+        smoothing_reference_distance_m=dataset.cell_size_x_m,
+        n_total_cells=int(dataset.true_cell_v2_m_s.size),
+        number_of_cell_x=int(dataset.true_cell_v2_m_s.shape[1]),
+        number_of_cell_y=1,
+        n_parameters=int(active_cell_id.shape[0]),
+    )
+
+    np.testing.assert_array_equal(active_cell_id, [0, 2, 3])
+    np.testing.assert_array_equal(result.inactive_cell_id, [1, 4])
+    np.testing.assert_array_equal(
+        rows.edge_cell_id,
+        [[2, 3]],
+    )
+    np.testing.assert_array_equal(rows.active_cell_neighbor_count, [0, 1, 1])
+    assert result.qc['low_fold_cell_id'] == [1]
+    assert result.qc['n_low_fold_cells'] == 1
+    assert result.qc['n_cell_smoothing_rows'] == 1
+    assert result.qc['active_cell_neighbor_count_min'] == 0
+    assert result.qc['active_cell_neighbor_count_median'] == pytest.approx(1.0)
+    assert result.qc['active_cell_neighbor_count_max'] == 1
+
+
+def test_cell_v2_smoothing_grid_3d_uses_expected_cardinal_neighbors() -> None:
+    dataset = make_clean_3d_cell_refraction_dataset(
+        seed=439,
+        cell_v2_m_s=SMOOTH_3D_V2_M_S,
+        n_sources=24,
+        n_receivers=24,
+        cell_size_x_m=100.0,
+        cell_size_y_m=120.0,
+        noise_std_s=0.0,
+        outlier_fraction=0.0,
+    )
+    dataset = _with_valid_observations_by_cell(
+        dataset,
+        {
+            2: MIN_OBSERVATIONS_PER_CELL - 1,
+            6: 0,
+        },
+    )
+
+    result = _solve_cell_dataset(dataset, velocity_smoothing_weight=1.0)
+    active_cell_id = _required_array(result.active_cell_id)
+    rows = build_cell_slowness_smoothing_rows(
+        active_cell_id=active_cell_id,
+        velocity_smoothing_weight=1.0,
+        smoothing_reference_distance_m=dataset.cell_size_x_m,
+        n_total_cells=int(dataset.true_cell_v2_m_s.size),
+        number_of_cell_x=int(dataset.true_cell_v2_m_s.shape[1]),
+        number_of_cell_y=int(dataset.true_cell_v2_m_s.shape[0]),
+        n_parameters=int(active_cell_id.shape[0]),
+    )
+
+    np.testing.assert_array_equal(active_cell_id, [0, 1, 3, 4, 5, 7, 8])
+    np.testing.assert_array_equal(result.inactive_cell_id, [2, 6])
+    np.testing.assert_array_equal(
+        rows.edge_cell_id,
+        [
+            [0, 1],
+            [0, 3],
+            [1, 4],
+            [3, 4],
+            [4, 5],
+            [4, 7],
+            [5, 8],
+            [7, 8],
+        ],
+    )
+    np.testing.assert_array_equal(
+        rows.active_cell_neighbor_count,
+        [2, 2, 2, 4, 2, 2, 2],
+    )
+    assert result.qc['low_fold_cell_id'] == [2]
+    assert result.qc['n_low_fold_cells'] == 1
+    assert result.qc['n_cell_smoothing_rows'] == 8
+    assert result.qc['active_cell_neighbor_count_min'] == 2
+    assert result.qc['active_cell_neighbor_count_median'] == pytest.approx(2.0)
+    assert result.qc['active_cell_neighbor_count_max'] == 4
+
+
+def test_cell_v2_smoothing_qc_records_weight_and_row_count(
+    tmp_path: Path,
+) -> None:
+    dataset = make_clean_2d_cell_refraction_dataset(
+        seed=440,
+        cell_v2_m_s=SMOOTH_2D_V2_M_S,
+        n_sources=20,
+        n_receivers=20,
+        noise_std_s=0.0,
+        outlier_fraction=0.0,
+    )
+    req = _apply_request_from_dataset(dataset, velocity_smoothing_weight=3.0)
+    result = _run_cell_refraction_statics(dataset, req=req)
+
+    write_refraction_static_artifacts(result=result, req=req, job_dir=tmp_path)
+    cell_qc = json.loads(
+        (tmp_path / REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME).read_text(
+            encoding='utf-8'
+        )
+    )
+    assert cell_qc['velocity_smoothing_weight'] == pytest.approx(3.0)
+    assert cell_qc['smoothing_reference_distance_m'] == pytest.approx(
+        dataset.cell_size_x_m
+    )
+    assert cell_qc['n_cell_smoothing_rows'] == 4
+
+
+def _solve_cell_dataset(
+    dataset: SyntheticRefractionCellDataset,
+    *,
+    velocity_smoothing_weight: float,
+) -> RefractionStaticSolverResult:
+    model = _model_from_dataset(
+        dataset,
+        velocity_smoothing_weight=velocity_smoothing_weight,
+    )
+    design = build_refraction_static_design_matrix(
+        input_model=_input_model_from_dataset(dataset),
+        model=model,
+    )
+    return solve_refraction_static_bounded_ls(
+        design_matrix=design,
+        model=model,
+        solver=_solver(),
+    )
+
+
+def _run_cell_refraction_statics(
+    dataset: SyntheticRefractionCellDataset,
+    *,
+    req: RefractionStaticApplyRequest,
+) -> RefractionDatumStaticsResult:
+    replacement = compute_weathering_replacement_statics_from_first_breaks(
+        req=req,
+        state=None,
+        input_model=_input_model_from_dataset(dataset),
+    )
+    return build_refraction_datum_statics(
+        weathering_replacement_result=replacement,
+        datum=req.datum,
+        apply_options=req.apply,
+        state=None,
+        file_id=req.file_id,
+        key1_byte=req.key1_byte,
+        key2_byte=req.key2_byte,
+    )
+
+
+def _apply_request_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+    *,
+    velocity_smoothing_weight: float,
+) -> RefractionStaticApplyRequest:
+    return RefractionStaticApplyRequest.model_validate(
+        {
+            'file_id': 'synthetic-cell-smoothing',
+            'key1_byte': 189,
+            'key2_byte': 193,
+            'pick_source': {
+                'kind': 'batch_predicted_npz',
+                'job_id': 'synthetic-cell-smoothing-first-breaks',
+                'artifact_name': 'predicted_picks_time_s.npz',
+            },
+            'linkage': {'mode': 'none'},
+            'model': _model_from_dataset(
+                dataset,
+                velocity_smoothing_weight=velocity_smoothing_weight,
+            ).model_dump(mode='json'),
+            'moveout': {
+                'model': 'head_wave_linear_offset',
+                'distance_source': 'geometry',
+                'offset_byte': None,
+                'min_offset_m': None,
+                'max_offset_m': None,
+                'allow_missing_offset': False,
+                'max_geometry_offset_mismatch_m': None,
+            },
+            'solver': _solver().model_dump(mode='json'),
+            'datum': {'mode': 'none'},
+            'conversion': {'mode': 't1lsst_1layer'},
+            'apply': {
+                'mode': 'refraction_from_raw',
+                'interpolation': 'linear',
+                'fill_value': 0.0,
+                'max_abs_shift_ms': 250.0,
+                'output_dtype': 'float32',
+                'register_corrected_file': False,
+            },
+        }
+    )
+
+
+def _model_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+    *,
+    velocity_smoothing_weight: float,
+) -> RefractionStaticModelRequest:
+    return RefractionStaticModelRequest.model_validate(
+        {
+            'method': 'gli_variable_thickness',
+            'weathering_velocity_m_s': dataset.true_v1_m_s,
+            'bedrock_velocity_mode': 'solve_cell',
+            'bedrock_velocity_m_s': None,
+            'initial_bedrock_velocity_m_s': 2400.0,
+            'min_bedrock_velocity_m_s': 1200.0,
+            'max_bedrock_velocity_m_s': 6000.0,
+            'max_weathering_thickness_m': None,
+            'refractor_cell': {
+                'number_of_cell_x': int(dataset.true_cell_v2_m_s.shape[1]),
+                'size_of_cell_x_m': dataset.cell_size_x_m,
+                'x_coordinate_origin_m': dataset.x_coordinate_origin_m,
+                'number_of_cell_y': int(dataset.true_cell_v2_m_s.shape[0]),
+                'size_of_cell_y_m': dataset.cell_size_y_m,
+                'y_coordinate_origin_m': dataset.y_coordinate_origin_m,
+                'assignment_mode': 'midpoint',
+                'outside_grid_policy': 'reject',
+                'coordinate_mode': dataset.coordinate_mode,
+                'line_origin_x_m': dataset.line_origin_x_m,
+                'line_origin_y_m': dataset.line_origin_y_m,
+                'line_azimuth_deg': dataset.line_azimuth_deg,
+                'min_observations_per_cell': MIN_OBSERVATIONS_PER_CELL,
+                'velocity_smoothing_weight': velocity_smoothing_weight,
+                'smoothing_reference_distance_m': (
+                    dataset.cell_size_x_m
+                    if velocity_smoothing_weight > 0.0
+                    else None
+                ),
+            },
+        }
+    )
+
+
+def _solver() -> RefractionStaticSolverRequest:
+    return RefractionStaticSolverRequest.model_validate(
+        {
+            'damping': 0.0,
+            'min_picks_per_node': 1,
+            'max_abs_half_intercept_time_ms': 500.0,
+            'robust': {
+                'enabled': False,
+                'method': 'mad',
+                'threshold': 3.5,
+                'max_iterations': 5,
+                'min_used_fraction': 0.5,
+                'min_used_observations': 1,
+            },
+        }
+    )
+
+
+def _input_model_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionStaticInputModel:
+    n_traces = int(dataset.pick_time_s.shape[0])
+    endpoint_table = _endpoint_table_from_dataset(dataset)
+    node_x_m = np.concatenate(
+        (dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)
+    )
+    node_y_m = np.concatenate(
+        (dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)
+    )
+    node_kind = np.concatenate(
+        (
+            np.full(dataset.source_endpoint_id.shape, 'source', dtype='<U16'),
+            np.full(dataset.receiver_endpoint_id.shape, 'receiver', dtype='<U16'),
+        )
+    )
+    return RefractionStaticInputModel(
+        file_id='synthetic-cell-smoothing',
+        n_traces=n_traces,
+        sorted_trace_index=np.arange(n_traces, dtype=np.int64),
+        pick_time_s_sorted=np.ascontiguousarray(dataset.pick_time_s, dtype=np.float64),
+        valid_pick_mask_sorted=np.ones(n_traces, dtype=bool),
+        valid_observation_mask_sorted=np.ascontiguousarray(
+            dataset.valid_mask,
+            dtype=bool,
+        ),
+        source_id_sorted=np.ascontiguousarray(dataset.source_id, dtype=np.int64),
+        receiver_id_sorted=np.ascontiguousarray(dataset.receiver_id, dtype=np.int64),
+        source_x_m_sorted=np.ascontiguousarray(dataset.source_x_m, dtype=np.float64),
+        source_y_m_sorted=np.ascontiguousarray(dataset.source_y_m, dtype=np.float64),
+        receiver_x_m_sorted=np.ascontiguousarray(
+            dataset.receiver_x_m,
+            dtype=np.float64,
+        ),
+        receiver_y_m_sorted=np.ascontiguousarray(
+            dataset.receiver_y_m,
+            dtype=np.float64,
+        ),
+        source_elevation_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        receiver_elevation_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        source_depth_m_sorted=None,
+        geometry_distance_m_sorted=np.ascontiguousarray(
+            dataset.offset_m,
+            dtype=np.float64,
+        ),
+        offset_m_sorted=None,
+        distance_m_sorted=np.ascontiguousarray(dataset.offset_m, dtype=np.float64),
+        source_endpoint_key_sorted=np.asarray(
+            [f'source:{int(value)}' for value in dataset.source_id],
+            dtype='<U32',
+        ),
+        receiver_endpoint_key_sorted=np.asarray(
+            [f'receiver:{int(value)}' for value in dataset.receiver_id],
+            dtype='<U32',
+        ),
+        source_node_id_sorted=np.ascontiguousarray(
+            dataset.source_node_id,
+            dtype=np.int64,
+        ),
+        receiver_node_id_sorted=np.ascontiguousarray(
+            dataset.receiver_node_id,
+            dtype=np.int64,
+        ),
+        node_x_m=np.ascontiguousarray(node_x_m, dtype=np.float64),
+        node_y_m=np.ascontiguousarray(node_y_m, dtype=np.float64),
+        node_elevation_m=np.zeros(endpoint_table.node_id.shape, dtype=np.float64),
+        node_kind=node_kind,
+        rejection_reason_sorted=np.full(n_traces, 'ok', dtype='<U32'),
+        qc={},
+        endpoint_table=endpoint_table,
+        metadata={'synthetic_model': 'cell_v2_smoothing'},
+    )
+
+
+def _with_valid_observations_by_cell(
+    dataset: SyntheticRefractionCellDataset,
+    valid_observations_by_cell: dict[int, int],
+) -> SyntheticRefractionCellDataset:
+    valid_mask = np.ones(dataset.valid_mask.shape, dtype=bool)
+    for raw_cell_id, raw_count in valid_observations_by_cell.items():
+        cell_id = int(raw_cell_id)
+        count = int(raw_count)
+        row_index = np.flatnonzero(dataset.true_cell_id_for_pick == cell_id)
+        if count < 0 or count > int(row_index.shape[0]):
+            raise ValueError('valid observation count must fit available cell rows')
+        valid_mask[row_index] = False
+        valid_mask[row_index[:count]] = True
+    return replace(
+        dataset,
+        valid_mask=np.ascontiguousarray(valid_mask, dtype=bool),
+    )
+
+
+def _endpoint_table_from_dataset(
+    dataset: SyntheticRefractionCellDataset,
+) -> RefractionEndpointTable:
+    node_id = np.concatenate(
+        (dataset.source_endpoint_node_id, dataset.receiver_endpoint_node_id)
+    )
+    endpoint_id = np.concatenate(
+        (dataset.source_endpoint_id, dataset.receiver_endpoint_id)
+    )
+    endpoint_x_m = np.concatenate(
+        (dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)
+    )
+    endpoint_y_m = np.concatenate(
+        (dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)
+    )
+    kind = np.concatenate(
+        (
+            np.full(dataset.source_endpoint_id.shape, 'source', dtype='<U16'),
+            np.full(dataset.receiver_endpoint_id.shape, 'receiver', dtype='<U16'),
+        )
+    )
+    return RefractionEndpointTable(
+        node_id=np.ascontiguousarray(node_id, dtype=np.int64),
+        endpoint_id=np.ascontiguousarray(endpoint_id, dtype=np.int64),
+        x_m=np.ascontiguousarray(endpoint_x_m, dtype=np.float64),
+        y_m=np.ascontiguousarray(endpoint_y_m, dtype=np.float64),
+        elevation_m=np.zeros(node_id.shape, dtype=np.float64),
+        kind=kind,
+        pick_count=np.zeros(node_id.shape, dtype=np.int64),
+    )
+
+
+def _center_spike_amplitude(velocity_m_s: np.ndarray, center_cell_id: int) -> float:
+    neighbor_average = 0.5 * (
+        float(velocity_m_s[center_cell_id - 1])
+        + float(velocity_m_s[center_cell_id + 1])
+    )
+    return abs(float(velocity_m_s[center_cell_id]) - neighbor_average)
+
+
+def _required_array(value: np.ndarray | None) -> np.ndarray:
+    assert value is not None
+    return value

--- a/app/tests/test_refraction_static_cell_solver_history.py
+++ b/app/tests/test_refraction_static_cell_solver_history.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.services.refraction_static_artifacts import (
+    REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
+    write_refraction_static_artifacts,
+)
+from app.tests._refraction_static_synthetic import (
+    run_synthetic_cell_refraction_statics,
+    synthetic_cell_refracted_arrival_input_model,
+    synthetic_cell_refraction_apply_request,
+)
+from app.tests.test_refraction_static_cell_low_fold import (
+    _low_fold_case,
+    _run_refraction_statics,
+)
+
+
+def test_cell_solver_history_artifact_exists_for_solve_cell(
+    tmp_path: Path,
+) -> None:
+    result, req = _clean_cell_result()
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    assert paths.refraction_cell_solver_history_csv is not None
+    assert paths.refraction_cell_solver_history_csv.name == (
+        REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME
+    )
+    rows = _read_csv(paths.refraction_cell_solver_history_csv)
+    assert [row['stage'] for row in rows] == ['initial', 'final']
+    assert rows[0]['converged'] == 'false'
+    assert rows[-1]['converged'] == 'true'
+
+    manifest = json.loads(paths.manifest_json.read_text(encoding='utf-8'))
+    artifact_names = {item['name'] for item in manifest['artifacts']}
+    assert REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME in artifact_names
+
+
+def test_cell_solver_history_final_row_matches_qc_summary(
+    tmp_path: Path,
+) -> None:
+    result, req = _clean_cell_result()
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    qc = json.loads(paths.qc_json.read_text(encoding='utf-8'))
+    final = _read_csv(paths.refraction_cell_solver_history_csv)[-1]
+    assert int(final['n_candidate_observations']) == (
+        qc['observations']['n_valid_observations']
+    )
+    assert int(final['n_used_observations']) == (
+        qc['observations']['n_used_observations']
+    )
+    assert int(final['n_rejected_observations']) == (
+        qc['observations']['n_rejected_by_robust']
+    )
+    assert float(final['residual_rms_ms']) == pytest.approx(
+        qc['first_break_fit']['residual_rms_ms'],
+        abs=1.0e-12,
+    )
+    assert float(final['residual_mad_ms']) == pytest.approx(
+        qc['first_break_fit']['residual_mad_ms'],
+        abs=1.0e-12,
+    )
+    assert float(final['max_abs_residual_ms']) == pytest.approx(
+        qc['first_break_fit']['residual_max_abs_ms'],
+        abs=1.0e-12,
+    )
+    assert float(final['residual_rms_ms']) == pytest.approx(0.0, abs=1.0e-6)
+
+
+def test_cell_solver_history_records_robust_rejections(
+    tmp_path: Path,
+) -> None:
+    input_model = _outlier_input_model()
+    req = synthetic_cell_refraction_apply_request(robust_enabled=True)
+    result = run_synthetic_cell_refraction_statics(
+        req=req,
+        input_model=input_model,
+    )
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    final = _read_csv(paths.refraction_cell_solver_history_csv)[-1]
+    rejected_count = int(np.count_nonzero(result.rejected_by_robust_mask))
+    assert rejected_count > 0
+    assert int(final['n_rejected_observations']) == rejected_count
+    assert float(final['robust_threshold']) == pytest.approx(
+        req.solver.robust.threshold
+    )
+    assert final['convergence_reason'] == 'robust_reweight_converged'
+
+
+def test_cell_solver_history_records_smoothing_settings(
+    tmp_path: Path,
+) -> None:
+    req = synthetic_cell_refraction_apply_request(velocity_smoothing_weight=2.0)
+    result = run_synthetic_cell_refraction_statics(req=req)
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    final = _read_csv(paths.refraction_cell_solver_history_csv)[-1]
+    assert float(final['smoothing_weight']) == pytest.approx(2.0)
+    assert float(final['damping_weight']) == pytest.approx(0.0)
+    assert float(final['robust_threshold']) == pytest.approx(
+        req.solver.robust.threshold
+    )
+    assert final['convergence_reason'] == 'smoothed_least_squares_converged'
+
+
+def test_cell_solver_history_records_low_fold_and_empty_cell_counts(
+    tmp_path: Path,
+) -> None:
+    dataset, req, input_model = _low_fold_case()
+    result = _run_refraction_statics(req=req, input_model=input_model)
+
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    final = _read_csv(paths.refraction_cell_solver_history_csv)[-1]
+    assert int(final['n_active_cells']) == int(result.active_cell_id.shape[0])
+    assert int(final['n_low_fold_cells']) == 1
+    assert int(final['n_empty_cells']) == int(
+        np.count_nonzero(dataset.cell_observation_count == 0)
+    )
+    assert int(final['n_rejected_observations']) == 0
+    assert final['convergence_reason'] == 'least_squares_converged'
+
+
+def _clean_cell_result():
+    req = synthetic_cell_refraction_apply_request()
+    result = run_synthetic_cell_refraction_statics(req=req)
+    return result, req
+
+
+def _outlier_input_model():
+    input_model = synthetic_cell_refracted_arrival_input_model()
+    outlier_indices = np.asarray([5, 6, 7, 13, 14, 15], dtype=np.int64)
+    outlier_shift_s = np.asarray([0.050, -0.060, 0.100], dtype=np.float64)
+    pick_time_s = input_model.pick_time_s_sorted.copy()
+    pick_time_s[outlier_indices] += np.resize(
+        outlier_shift_s,
+        outlier_indices.shape[0],
+    )
+    return replace(
+        input_model,
+        pick_time_s_sorted=np.ascontiguousarray(pick_time_s, dtype=np.float64),
+    )
+
+
+def _read_csv(path: Path | None) -> list[dict[str, str]]:
+    assert path is not None
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))

--- a/app/tests/test_refraction_static_static_tables_synthetic.py
+++ b/app/tests/test_refraction_static_static_tables_synthetic.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from app.services.refraction_static_artifacts import write_refraction_static_artifacts
+from app.tests._refraction_static_synthetic import (
+    SYNTHETIC_CELL_NODE_CELL_ID,
+    SYNTHETIC_CELL_V2_M_S,
+    SYNTHETIC_CELL_V2_TOLERANCE_M_S,
+    SYNTHETIC_SH1_TOLERANCE_M,
+    SYNTHETIC_T1_TOLERANCE_MS,
+    SYNTHETIC_V1_M_S,
+    SYNTHETIC_WCOR_TOLERANCE_MS,
+    expected_cell_sh1_m_for_node,
+    expected_cell_t1_s_for_node,
+    expected_cell_wcor_s_for_node,
+    run_synthetic_cell_refraction_statics,
+    synthetic_cell_refraction_apply_request,
+)
+
+
+@pytest.fixture(scope='module')
+def synthetic_static_table_artifacts(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> dict[str, Any]:
+    req = synthetic_cell_refraction_apply_request(conversion_mode='t1lsst_1layer')
+    result = run_synthetic_cell_refraction_statics(req=req)
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path_factory.mktemp('refraction-static-tables-synthetic'),
+    )
+
+    with np.load(paths.source_receiver_static_table_npz, allow_pickle=False) as data:
+        table_arrays = {name: data[name].copy() for name in data.files}
+
+    return {
+        'result': result,
+        'source_rows': _read_csv(paths.source_static_table_csv),
+        'receiver_rows': _read_csv(paths.receiver_static_table_csv),
+        'trace_rows': _read_csv(paths.refraction_statics_csv),
+        'table_arrays': table_arrays,
+    }
+
+
+def test_source_static_table_uses_local_cell_v2_for_t1lsst(
+    synthetic_static_table_artifacts: dict[str, Any],
+) -> None:
+    result = synthetic_static_table_artifacts['result']
+    source_rows = synthetic_static_table_artifacts['source_rows']
+
+    for node_id in (0, 6):
+        row = _row_by_node(source_rows, node_column='source_node_id', node_id=node_id)
+        _assert_endpoint_uses_direct_cell_v2(row, node_id, result.bedrock_velocity_m_s)
+        _assert_endpoint_row_matches_known_truth(row, node_id)
+
+
+def test_receiver_static_table_uses_local_cell_v2_for_t1lsst(
+    synthetic_static_table_artifacts: dict[str, Any],
+) -> None:
+    result = synthetic_static_table_artifacts['result']
+    receiver_rows = synthetic_static_table_artifacts['receiver_rows']
+
+    for node_id in (0, 6):
+        row = _row_by_node(
+            receiver_rows,
+            node_column='receiver_node_id',
+            node_id=node_id,
+        )
+        _assert_endpoint_uses_direct_cell_v2(row, node_id, result.bedrock_velocity_m_s)
+        _assert_endpoint_row_matches_known_truth(row, node_id)
+
+
+def test_static_table_sh1_matches_known_truth_with_local_v2(
+    synthetic_static_table_artifacts: dict[str, Any],
+) -> None:
+    for row, node_id in _all_endpoint_rows(synthetic_static_table_artifacts):
+        assert float(row['t1_ms']) == pytest.approx(
+            expected_cell_t1_s_for_node(node_id) * 1000.0,
+            abs=SYNTHETIC_T1_TOLERANCE_MS,
+        )
+        assert float(row['sh1_weathering_thickness_m']) == pytest.approx(
+            expected_cell_sh1_m_for_node(node_id),
+            abs=SYNTHETIC_SH1_TOLERANCE_M,
+        )
+
+
+def test_static_table_wcor_matches_known_truth_and_sign_convention(
+    synthetic_static_table_artifacts: dict[str, Any],
+) -> None:
+    for row, node_id in _all_endpoint_rows(synthetic_static_table_artifacts):
+        expected_wcor_ms = expected_cell_wcor_s_for_node(node_id) * 1000.0
+
+        assert float(row['weathering_correction_ms']) == pytest.approx(
+            expected_wcor_ms,
+            abs=SYNTHETIC_WCOR_TOLERANCE_MS,
+        )
+        assert float(row['weathering_correction_ms']) < 0.0
+        assert float(row['total_static_ms']) == pytest.approx(
+            expected_wcor_ms,
+            abs=SYNTHETIC_WCOR_TOLERANCE_MS,
+        )
+        assert float(row['total_applied_shift_ms']) == pytest.approx(
+            float(row['total_static_ms'])
+        )
+        assert row['static_status'] == 'ok'
+
+
+def test_source_receiver_static_table_csv_and_npz_are_consistent(
+    synthetic_static_table_artifacts: dict[str, Any],
+) -> None:
+    source_rows = synthetic_static_table_artifacts['source_rows']
+    receiver_rows = synthetic_static_table_artifacts['receiver_rows']
+    table = synthetic_static_table_artifacts['table_arrays']
+
+    for index, row in enumerate(source_rows):
+        _assert_npz_endpoint_matches_csv(table, 'source', row, index)
+
+    for index, row in enumerate(receiver_rows):
+        _assert_npz_endpoint_matches_csv(table, 'receiver', row, index)
+
+
+def test_trace_shift_equals_source_plus_receiver_components_for_synthetic_case(
+    synthetic_static_table_artifacts: dict[str, Any],
+) -> None:
+    for row in synthetic_static_table_artifacts['trace_rows']:
+        source_node_id = int(row['source_node_id'])
+        receiver_node_id = int(row['receiver_node_id'])
+        expected_source_ms = expected_cell_wcor_s_for_node(source_node_id) * 1000.0
+        expected_receiver_ms = expected_cell_wcor_s_for_node(receiver_node_id) * 1000.0
+        expected_trace_ms = expected_source_ms + expected_receiver_ms
+
+        assert float(row['source_refraction_shift_ms']) == pytest.approx(
+            expected_source_ms,
+            abs=SYNTHETIC_WCOR_TOLERANCE_MS,
+        )
+        assert float(row['receiver_refraction_shift_ms']) == pytest.approx(
+            expected_receiver_ms,
+            abs=SYNTHETIC_WCOR_TOLERANCE_MS,
+        )
+        assert float(row['refraction_trace_shift_ms']) == pytest.approx(
+            expected_trace_ms,
+            abs=2.0 * SYNTHETIC_WCOR_TOLERANCE_MS,
+        )
+        assert float(row['refraction_trace_shift_ms']) == pytest.approx(
+            float(row['source_refraction_shift_ms'])
+            + float(row['receiver_refraction_shift_ms'])
+        )
+        assert float(row['weathering_replacement_trace_shift_ms']) == pytest.approx(
+            expected_trace_ms,
+            abs=2.0 * SYNTHETIC_WCOR_TOLERANCE_MS,
+        )
+
+
+def _assert_endpoint_uses_direct_cell_v2(
+    row: dict[str, str],
+    node_id: int,
+    summary_v2_m_s: float,
+) -> None:
+    # Phase 2 projects endpoint-local V2 by direct endpoint-coordinate cell assignment.
+    expected_cell_id = _expected_endpoint_cell_id(node_id)
+    expected_v2_m_s = _expected_endpoint_v2_m_s(node_id)
+
+    assert int(row[_cell_id_column(row)]) == expected_cell_id
+    assert float(row['v2_m_s']) == pytest.approx(
+        expected_v2_m_s,
+        abs=SYNTHETIC_CELL_V2_TOLERANCE_M_S,
+    )
+    assert float(row['v2_m_s']) != pytest.approx(
+        summary_v2_m_s,
+        abs=SYNTHETIC_CELL_V2_TOLERANCE_M_S,
+    )
+
+
+def _assert_endpoint_row_matches_known_truth(
+    row: dict[str, str],
+    node_id: int,
+) -> None:
+    expected_wcor_ms = expected_cell_wcor_s_for_node(node_id) * 1000.0
+
+    assert float(row['t1_ms']) == pytest.approx(
+        expected_cell_t1_s_for_node(node_id) * 1000.0,
+        abs=SYNTHETIC_T1_TOLERANCE_MS,
+    )
+    assert float(row['v1_m_s']) == pytest.approx(SYNTHETIC_V1_M_S)
+    assert float(row['sh1_weathering_thickness_m']) == pytest.approx(
+        expected_cell_sh1_m_for_node(node_id),
+        abs=SYNTHETIC_SH1_TOLERANCE_M,
+    )
+    assert float(row['weathering_correction_ms']) == pytest.approx(
+        expected_wcor_ms,
+        abs=SYNTHETIC_WCOR_TOLERANCE_MS,
+    )
+    assert float(row['total_static_ms']) == pytest.approx(
+        expected_wcor_ms,
+        abs=SYNTHETIC_WCOR_TOLERANCE_MS,
+    )
+    assert float(row['total_applied_shift_ms']) == pytest.approx(
+        expected_wcor_ms,
+        abs=SYNTHETIC_WCOR_TOLERANCE_MS,
+    )
+    assert row['static_status'] == 'ok'
+
+
+def _assert_npz_endpoint_matches_csv(
+    table: dict[str, np.ndarray],
+    prefix: str,
+    row: dict[str, str],
+    index: int,
+) -> None:
+    node_column = f'{prefix}_node_id'
+    cell_column = f'{prefix}_v2_cell_id'
+
+    assert str(table[f'{prefix}_endpoint_key'][index]) == row[f'{prefix}_endpoint_key']
+    assert int(table[f'{prefix}_id'][index]) == int(row[f'{prefix}_id'])
+    assert int(table[node_column][index]) == int(row[node_column])
+    assert int(table[cell_column][index]) == int(row[cell_column])
+    assert str(table[f'{prefix}_v2_status'][index]) == row['v2_status']
+    assert float(table[f'{prefix}_t1_s'][index]) * 1000.0 == pytest.approx(
+        float(row['t1_ms'])
+    )
+    assert float(table[f'{prefix}_v1_m_s'][index]) == pytest.approx(
+        float(row['v1_m_s'])
+    )
+    assert float(table[f'{prefix}_v2_m_s'][index]) == pytest.approx(
+        float(row['v2_m_s'])
+    )
+    assert float(table[f'{prefix}_sh1_m'][index]) == pytest.approx(
+        float(row['sh1_weathering_thickness_m'])
+    )
+    assert (
+        float(table[f'{prefix}_weathering_correction_s'][index]) * 1000.0
+    ) == pytest.approx(float(row['weathering_correction_ms']))
+    assert float(table[f'{prefix}_total_static_s'][index]) * 1000.0 == pytest.approx(
+        float(row['total_static_ms'])
+    )
+    assert (
+        float(table[f'{prefix}_total_applied_shift_s'][index]) * 1000.0
+    ) == pytest.approx(float(row['total_applied_shift_ms']))
+    assert str(table[f'{prefix}_static_status'][index]) == row['static_status']
+
+
+def _all_endpoint_rows(
+    artifacts: dict[str, Any],
+) -> list[tuple[dict[str, str], int]]:
+    source = [
+        (row, int(row['source_node_id']))
+        for row in artifacts['source_rows']
+    ]
+    receiver = [
+        (row, int(row['receiver_node_id']))
+        for row in artifacts['receiver_rows']
+    ]
+    return source + receiver
+
+
+def _row_by_node(
+    rows: list[dict[str, str]],
+    *,
+    node_column: str,
+    node_id: int,
+) -> dict[str, str]:
+    matches = [row for row in rows if int(row[node_column]) == node_id]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _cell_id_column(row: dict[str, str]) -> str:
+    if 'source_v2_cell_id' in row:
+        return 'source_v2_cell_id'
+    return 'receiver_v2_cell_id'
+
+
+def _expected_endpoint_cell_id(node_id: int) -> int:
+    return int(SYNTHETIC_CELL_NODE_CELL_ID[int(node_id)])
+
+
+def _expected_endpoint_v2_m_s(node_id: int) -> float:
+    return float(SYNTHETIC_CELL_V2_M_S[_expected_endpoint_cell_id(node_id)])
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))


### PR DESCRIPTION
Closes #435
Closes #436
Closes #437
Closes #438
Closes #439

## Issues
- #435 [statics][refraction][m2.5] Add synthetic outlier and bad-pick tests for robust cell V2/T1 solving
- #436 [statics][refraction][m2.5] Add synthetic smoothing tests for cell V2 spike suppression
- #437 [statics][refraction][m2.5] Extend cell velocity QC artifacts using synthetic known-truth validation
- #438 [statics][refraction][m2.5] Add synthetic static-table validation for local V2, SH1, WCOR, and sign convention
- #439 [statics][refraction][m2.5] Add convergence and iteration-history artifacts for cell V2/T1 solving

Batch range: #435-#439
