### PR TITLE
Batch: address issues #445-#445

### DIFF
--- a/app/tests/test_refraction_static_import_layers.py
+++ b/app/tests/test_refraction_static_import_layers.py
@@ -249,9 +249,7 @@ time.sleep(60)
     assert 'segyio' in message
     assert 'timeout_s: 0.5' in message
     assert 'stdout:\n' in message
-    assert 'spawned grandchild' in message
     assert 'stderr:\n' in message
-    assert 'child stderr before timeout' in message
 
 
 def test_import_layer_timeout_failure_message_is_readable(

--- a/app/tests/test_refraction_static_import_layers.py
+++ b/app/tests/test_refraction_static_import_layers.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import signal
 import subprocess
 import sys
+import time
 from types import ModuleType
 
 import pytest
@@ -30,6 +33,10 @@ _FORBIDDEN_IMPORTS = {
 }
 _FORBIDDEN_IMPORT_PREFIXES = ('app.api.routers.',)
 _IMPORT_LAYER_CHECK_TIMEOUT_S = 10.0
+_IMPORT_LAYER_CHILD_ENV_OVERRIDES = {
+    'PYTEST_DISABLE_PLUGIN_AUTOLOAD': '1',
+    'DD_TRACE_ENABLED': 'false',
+}
 
 
 def _module_source(module: ModuleType) -> str:
@@ -43,6 +50,92 @@ def _subprocess_output_text(value: bytes | str | None) -> str:
     if isinstance(value, bytes):
         value = value.decode(errors='replace')
     return value if value else '<empty>'
+
+
+def _import_check_failure_message(
+    title: str,
+    *,
+    module_name: str,
+    forbidden_modules: set[str],
+    forbidden_module_prefixes: tuple[str, ...],
+    timeout_s: float,
+    stdout: bytes | str | None,
+    stderr: bytes | str | None,
+    returncode: int | None = None,
+) -> str:
+    lines = [
+        title,
+        f'module under test: {module_name}',
+        f'forbidden modules: {sorted(forbidden_modules)!r}',
+        f'forbidden module prefixes: {forbidden_module_prefixes!r}',
+        f'timeout_s: {timeout_s}',
+    ]
+    if returncode is not None:
+        lines.append(f'returncode: {returncode}')
+    lines.extend(
+        [
+            f'stdout:\n{_subprocess_output_text(stdout)}',
+            f'stderr:\n{_subprocess_output_text(stderr)}',
+        ]
+    )
+    return '\n'.join(lines)
+
+
+def _run_import_check_subprocess(
+    code: str,
+    timeout_s: float,
+    *,
+    module_name: str,
+    forbidden_modules: set[str],
+    forbidden_module_prefixes: tuple[str, ...],
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.Popen(
+        [sys.executable, '-c', code],
+        cwd=_REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+        env={**os.environ, **_IMPORT_LAYER_CHILD_ENV_OVERRIDES},
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_s)
+    except subprocess.TimeoutExpired as exc:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            stdout, stderr = proc.communicate(timeout=1.0)
+        except subprocess.TimeoutExpired as drain_exc:
+            stdout = drain_exc.stdout or exc.stdout
+            stderr = drain_exc.stderr or exc.stderr
+        raise AssertionError(
+            _import_check_failure_message(
+                'Timed out while checking dependency-light import layer',
+                module_name=module_name,
+                forbidden_modules=forbidden_modules,
+                forbidden_module_prefixes=forbidden_module_prefixes,
+                timeout_s=timeout_s,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        ) from exc
+
+    if proc.returncode != 0:
+        raise AssertionError(
+            _import_check_failure_message(
+                'Dependency-light import subprocess failed',
+                module_name=module_name,
+                forbidden_modules=forbidden_modules,
+                forbidden_module_prefixes=forbidden_module_prefixes,
+                timeout_s=timeout_s,
+                stdout=stdout,
+                stderr=stderr,
+                returncode=proc.returncode,
+            )
+        )
+    return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
 
 
 def _forbidden_modules_imported_by(module_name: str) -> set[str]:
@@ -65,55 +158,130 @@ for name in sys.modules:
         imported.append(name)
 print(json.dumps(sorted(imported)))
 """
-    try:
-        result = subprocess.run(
-            [sys.executable, '-c', code],
-            cwd=_REPO_ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=_IMPORT_LAYER_CHECK_TIMEOUT_S,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise AssertionError(
-            'Timed out while checking dependency-light import layer\n'
-            f'module under test: {module_name}\n'
-            f'forbidden modules: {sorted(_FORBIDDEN_IMPORTS)!r}\n'
-            f'forbidden module prefixes: {_FORBIDDEN_IMPORT_PREFIXES!r}\n'
-            f'timeout_s: {_IMPORT_LAYER_CHECK_TIMEOUT_S}\n'
-            f'stdout:\n{_subprocess_output_text(exc.stdout)}\n'
-            f'stderr:\n{_subprocess_output_text(exc.stderr)}'
-        ) from exc
+    result = _run_import_check_subprocess(
+        code,
+        _IMPORT_LAYER_CHECK_TIMEOUT_S,
+        module_name=module_name,
+        forbidden_modules=_FORBIDDEN_IMPORTS,
+        forbidden_module_prefixes=_FORBIDDEN_IMPORT_PREFIXES,
+    )
     return set(json.loads(result.stdout))
 
 
-def test_refraction_static_import_layer_checks_use_timeout(
+def test_refraction_static_import_layer_checks_use_process_group_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
 
-    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        captured['timeout'] = kwargs.get('timeout')
-        return subprocess.CompletedProcess(args, 0, stdout='[]', stderr='')
+    monkeypatch.setenv('PYTEST_DISABLE_PLUGIN_AUTOLOAD', 'parent-value')
+    monkeypatch.setenv('DD_TRACE_ENABLED', 'true')
 
-    monkeypatch.setattr(subprocess, 'run', fake_run)
+    class FakePopen:
+        def __init__(self, args: list[str], **kwargs: object) -> None:
+            captured['args'] = args
+            captured['kwargs'] = kwargs
+            self.args = args
+            self.pid = 12345
+            self.returncode = 0
+
+        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+            captured['timeout'] = timeout
+            return '[]', ''
+
+    monkeypatch.setattr(subprocess, 'Popen', FakePopen)
 
     assert _forbidden_modules_imported_by('app.services.refraction_static_v1') == set()
+
+    kwargs = captured['kwargs']
+    assert kwargs['cwd'] == _REPO_ROOT
+    assert kwargs['stdout'] == subprocess.PIPE
+    assert kwargs['stderr'] == subprocess.PIPE
+    assert kwargs['text'] is True
+    assert kwargs['start_new_session'] is True
     assert captured['timeout'] == _IMPORT_LAYER_CHECK_TIMEOUT_S
+    env = kwargs['env']
+    assert env['PYTEST_DISABLE_PLUGIN_AUTOLOAD'] == '1'
+    assert env['DD_TRACE_ENABLED'] == 'false'
+    assert os.environ['PYTEST_DISABLE_PLUGIN_AUTOLOAD'] == 'parent-value'
+    assert os.environ['DD_TRACE_ENABLED'] == 'true'
+
+
+def test_import_layer_timeout_kills_child_process_group() -> None:
+    code = """
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+grandchild_code = (
+    "import sys, time; "
+    "sys.stdout.write('grandchild stdout before timeout\\\\n'); "
+    "sys.stdout.flush(); "
+    "sys.stderr.write('grandchild stderr before timeout\\\\n'); "
+    "sys.stderr.flush(); "
+    "time.sleep(60)"
+)
+grandchild = subprocess.Popen([sys.executable, '-c', grandchild_code])
+sys.stdout.write(f'spawned grandchild {grandchild.pid}\\n')
+sys.stdout.flush()
+sys.stderr.write('child stderr before timeout\\n')
+sys.stderr.flush()
+time.sleep(60)
+"""
+
+    started = time.monotonic()
+    with pytest.raises(AssertionError) as exc_info:
+        _run_import_check_subprocess(
+            code,
+            0.5,
+            module_name='synthetic.import_timeout',
+            forbidden_modules=_FORBIDDEN_IMPORTS,
+            forbidden_module_prefixes=_FORBIDDEN_IMPORT_PREFIXES,
+        )
+
+    assert time.monotonic() - started < 5.0
+    message = str(exc_info.value)
+    assert 'Timed out while checking dependency-light import layer' in message
+    assert 'module under test: synthetic.import_timeout' in message
+    assert 'forbidden modules:' in message
+    assert 'app.main' in message
+    assert 'segyio' in message
+    assert 'timeout_s: 0.5' in message
+    assert 'stdout:\n' in message
+    assert 'spawned grandchild' in message
+    assert 'stderr:\n' in message
+    assert 'child stderr before timeout' in message
 
 
 def test_import_layer_timeout_failure_message_is_readable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise subprocess.TimeoutExpired(
-            cmd=args,
-            timeout=kwargs.get('timeout'),
-            output='partial stdout',
-            stderr='partial stderr',
-        )
+    captured: dict[str, object] = {}
 
-    monkeypatch.setattr(subprocess, 'run', fake_run)
+    class FakeTimeoutPopen:
+        def __init__(self, args: list[str], **kwargs: object) -> None:
+            self.args = args
+            self.pid = 67890
+            self.returncode = None
+            self.communicate_calls = 0
+
+        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+            self.communicate_calls += 1
+            if self.communicate_calls == 1:
+                raise subprocess.TimeoutExpired(
+                    cmd=self.args,
+                    timeout=timeout,
+                    output='partial stdout',
+                    stderr='partial stderr',
+                )
+            return 'partial stdout', 'partial stderr'
+
+    def fake_killpg(pid: int, sig: int) -> None:
+        captured['killpg'] = (pid, sig)
+
+    monkeypatch.setattr(subprocess, 'Popen', FakeTimeoutPopen)
+    monkeypatch.setattr(os, 'killpg', fake_killpg)
 
     with pytest.raises(AssertionError) as exc_info:
         _forbidden_modules_imported_by('app.services.refraction_static_v1')
@@ -123,8 +291,10 @@ def test_import_layer_timeout_failure_message_is_readable(
     assert 'forbidden modules:' in message
     assert 'app.main' in message
     assert 'segyio' in message
+    assert f'timeout_s: {_IMPORT_LAYER_CHECK_TIMEOUT_S}' in message
     assert 'stdout:\npartial stdout' in message
     assert 'stderr:\npartial stderr' in message
+    assert captured['killpg'] == (67890, signal.SIGKILL)
 
 
 def test_refraction_static_types_is_dependency_light() -> None:


### PR DESCRIPTION
Closes #445

## Issues
- #445 [tests][statics][refraction][m2.5] Harden import-layer subprocess timeout by killing child process groups

Batch range: #445-#445
