### PR TITLE
Batch: address issues #462-#465

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,11 @@ See:
 - `docs/time_term_static_correction.md`
 
 Refraction statics include the 1-layer V1/V2/T1 T1LSST workflow, cell-based
-local V2 support, and the public two-layer V3/T2
-`t1lsst_multilayer` workflow. Two-layer source/receiver outputs use the
-existing static table artifacts with added `t2`, `v3`, and `sh2` fields; the
-repo sign convention remains `corrected(t) = raw(t - shift_s)`.
+local V2 support, and the public two- and three-layer
+`t1lsst_multilayer` workflow. Multi-layer source/receiver outputs use the
+existing static table artifacts with added `t2`, `v3`, `sh2`, and, for
+three-layer runs, `t3`, `vsub`, and `sh3` fields; the repo sign convention
+remains `corrected(t) = raw(t - shift_s)`.
 
 ## Viewer benchmark
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -2592,8 +2592,16 @@ class RefractionStaticApplyRequest(BaseModel):
         if self.conversion.mode == 't1lsst_multilayer':
             enabled_count = self.model.enabled_refraction_layer_count
             if self.conversion.layer_count != enabled_count:
+                enabled_kinds = [
+                    layer.kind
+                    for layer in self.model.layers or []
+                    if layer.enabled
+                ]
+                enabled_text = ', '.join(enabled_kinds) if enabled_kinds else 'none'
                 raise ValueError(
-                    'conversion.layer_count must match enabled refraction layers'
+                    'conversion.layer_count must match enabled refraction layers; '
+                    f'conversion.layer_count={self.conversion.layer_count!r}, '
+                    f'enabled layer kinds={enabled_text}'
                 )
         return self
 

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -283,6 +283,33 @@ _NEAR_SURFACE_2LAYER_COLUMNS = (
     'residual_mad_ms',
 )
 
+_NEAR_SURFACE_3LAYER_COLUMNS = (
+    'node_id',
+    'node_kind',
+    'x_m',
+    'y_m',
+    'surface_elevation_m',
+    'floating_datum_elevation_m',
+    'refractor_elevation_m',
+    'weathering_thickness_m',
+    'sh1_weathering_thickness_m',
+    'sh2_weathering_thickness_m',
+    'sh3_weathering_thickness_m',
+    'layer1_base_elevation_m',
+    'layer2_base_elevation_m',
+    'final_refractor_elevation_m',
+    'half_intercept_time_ms',
+    'weathering_replacement_shift_ms',
+    'solution_status',
+    'weathering_status',
+    'datum_status',
+    'pick_count',
+    'used_pick_count',
+    'rejected_pick_count',
+    'residual_rms_ms',
+    'residual_mad_ms',
+)
+
 # Keep the legacy millisecond residual columns and append explicit seconds/cell
 # aliases so residual rows can be joined to refractor-cell QC artifacts.
 _RESIDUAL_COLUMNS = (
@@ -399,6 +426,48 @@ _SOURCE_STATIC_TABLE_2LAYER_COLUMNS = (
     'residual_mad_ms',
 )
 
+_SOURCE_STATIC_TABLE_3LAYER_COLUMNS = (
+    'endpoint_kind',
+    'source_endpoint_key',
+    'source_id',
+    'source_node_id',
+    'source_v2_cell_id',
+    'x_m',
+    'y_m',
+    'surface_elevation_m',
+    'floating_datum_elevation_m',
+    'flat_datum_elevation_m',
+    't1_ms',
+    't2_ms',
+    't3_ms',
+    'v1_m_s',
+    'v2_m_s',
+    'v2_status',
+    'v3_m_s',
+    'vsub_m_s',
+    'sh1_weathering_thickness_m',
+    'sh2_weathering_thickness_m',
+    'sh3_weathering_thickness_m',
+    'layer1_base_elevation_m',
+    'layer2_base_elevation_m',
+    'final_refractor_elevation_m',
+    'refractor_elevation_m',
+    'weathering_correction_ms',
+    'floating_datum_correction_ms',
+    'flat_datum_correction_ms',
+    'elevation_correction_ms',
+    'total_static_ms',
+    'total_applied_shift_ms',
+    'solution_status',
+    'weathering_status',
+    'datum_status',
+    'static_status',
+    'pick_count',
+    'used_pick_count',
+    'residual_rms_ms',
+    'residual_mad_ms',
+)
+
 _RECEIVER_STATIC_TABLE_COLUMNS = (
     'endpoint_kind',
     'receiver_endpoint_key',
@@ -452,6 +521,48 @@ _RECEIVER_STATIC_TABLE_2LAYER_COLUMNS = (
     'sh1_weathering_thickness_m',
     'sh2_weathering_thickness_m',
     'layer1_base_elevation_m',
+    'final_refractor_elevation_m',
+    'refractor_elevation_m',
+    'weathering_correction_ms',
+    'floating_datum_correction_ms',
+    'flat_datum_correction_ms',
+    'elevation_correction_ms',
+    'total_static_ms',
+    'total_applied_shift_ms',
+    'solution_status',
+    'weathering_status',
+    'datum_status',
+    'static_status',
+    'pick_count',
+    'used_pick_count',
+    'residual_rms_ms',
+    'residual_mad_ms',
+)
+
+_RECEIVER_STATIC_TABLE_3LAYER_COLUMNS = (
+    'endpoint_kind',
+    'receiver_endpoint_key',
+    'receiver_id',
+    'receiver_node_id',
+    'receiver_v2_cell_id',
+    'x_m',
+    'y_m',
+    'surface_elevation_m',
+    'floating_datum_elevation_m',
+    'flat_datum_elevation_m',
+    't1_ms',
+    't2_ms',
+    't3_ms',
+    'v1_m_s',
+    'v2_m_s',
+    'v2_status',
+    'v3_m_s',
+    'vsub_m_s',
+    'sh1_weathering_thickness_m',
+    'sh2_weathering_thickness_m',
+    'sh3_weathering_thickness_m',
+    'layer1_base_elevation_m',
+    'layer2_base_elevation_m',
     'final_refractor_elevation_m',
     'refractor_elevation_m',
     'weathering_correction_ms',
@@ -1499,6 +1610,7 @@ def build_source_receiver_static_table_arrays(
         assert r.source_t2_time_s is not None
         assert r.source_v3_m_s is not None
         assert r.source_sh2_weathering_thickness_m is not None
+        source_layer1_base = r.source_surface_elevation_m - source_sh1_m
         arrays.update(
             {
                 'source_t2_s': _float_array(r.source_t2_time_s),
@@ -1507,17 +1619,34 @@ def build_source_receiver_static_table_arrays(
                     r.source_sh2_weathering_thickness_m
                 ),
                 'source_layer1_base_elevation_m': _float_array(
-                    r.source_surface_elevation_m - source_sh1_m
+                    source_layer1_base
                 ),
                 'source_final_refractor_elevation_m': _float_array(
                     r.source_refractor_elevation_m
                 ),
             }
         )
+        if _has_source_3layer_static_fields(r):
+            assert r.source_t3_time_s is not None
+            assert r.source_vsub_m_s is not None
+            assert r.source_sh3_weathering_thickness_m is not None
+            arrays.update(
+                {
+                    'source_t3_s': _float_array(r.source_t3_time_s),
+                    'source_vsub_m_s': _float_array(r.source_vsub_m_s),
+                    'source_sh3_m': _float_array(
+                        r.source_sh3_weathering_thickness_m
+                    ),
+                    'source_layer2_base_elevation_m': _float_array(
+                        source_layer1_base - r.source_sh2_weathering_thickness_m
+                    ),
+                }
+            )
     if _has_receiver_2layer_static_fields(r):
         assert r.receiver_t2_time_s is not None
         assert r.receiver_v3_m_s is not None
         assert r.receiver_sh2_weathering_thickness_m is not None
+        receiver_layer1_base = r.receiver_surface_elevation_m - receiver_sh1_m
         arrays.update(
             {
                 'receiver_t2_s': _float_array(r.receiver_t2_time_s),
@@ -1526,13 +1655,29 @@ def build_source_receiver_static_table_arrays(
                     r.receiver_sh2_weathering_thickness_m
                 ),
                 'receiver_layer1_base_elevation_m': _float_array(
-                    r.receiver_surface_elevation_m - receiver_sh1_m
+                    receiver_layer1_base
                 ),
                 'receiver_final_refractor_elevation_m': _float_array(
                     r.receiver_refractor_elevation_m
                 ),
             }
         )
+        if _has_receiver_3layer_static_fields(r):
+            assert r.receiver_t3_time_s is not None
+            assert r.receiver_vsub_m_s is not None
+            assert r.receiver_sh3_weathering_thickness_m is not None
+            arrays.update(
+                {
+                    'receiver_t3_s': _float_array(r.receiver_t3_time_s),
+                    'receiver_vsub_m_s': _float_array(r.receiver_vsub_m_s),
+                    'receiver_sh3_m': _float_array(
+                        r.receiver_sh3_weathering_thickness_m
+                    ),
+                    'receiver_layer2_base_elevation_m': _float_array(
+                        receiver_layer1_base - r.receiver_sh2_weathering_thickness_m
+                    ),
+                }
+            )
     _validate_no_object_arrays(
         arrays,
         artifact_name=SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
@@ -1829,24 +1974,38 @@ def build_refraction_static_solution_arrays(
     if _has_node_2layer_static_fields(r):
         assert r.node_sh2_weathering_thickness_m is not None
         node_sh1_m = _node_sh1_weathering_thickness_m(r)
+        node_layer1_base = r.node_surface_elevation_m - node_sh1_m
         arrays.update(
             {
                 'node_sh2_weathering_thickness_m': _float_array(
                     r.node_sh2_weathering_thickness_m
                 ),
                 'node_layer1_base_elevation_m': _float_array(
-                    r.node_surface_elevation_m - node_sh1_m
+                    node_layer1_base
                 ),
                 'node_final_refractor_elevation_m': _float_array(
                     r.node_refractor_elevation_m
                 ),
             }
         )
+        if _has_node_3layer_static_fields(r):
+            assert r.node_sh3_weathering_thickness_m is not None
+            arrays.update(
+                {
+                    'node_sh3_weathering_thickness_m': _float_array(
+                        r.node_sh3_weathering_thickness_m
+                    ),
+                    'node_layer2_base_elevation_m': _float_array(
+                        node_layer1_base - r.node_sh2_weathering_thickness_m
+                    ),
+                }
+            )
     if _has_source_2layer_static_fields(r):
         assert r.source_t2_time_s is not None
         assert r.source_v3_m_s is not None
         assert r.source_sh2_weathering_thickness_m is not None
         source_sh1_m = _source_sh1_weathering_thickness_m(r)
+        source_layer1_base = r.source_surface_elevation_m - source_sh1_m
         arrays.update(
             {
                 'source_t2_time_s': _float_array(r.source_t2_time_s),
@@ -1856,18 +2015,35 @@ def build_refraction_static_solution_arrays(
                     r.source_sh2_weathering_thickness_m
                 ),
                 'source_layer1_base_elevation_m': _float_array(
-                    r.source_surface_elevation_m - source_sh1_m
+                    source_layer1_base
                 ),
                 'source_final_refractor_elevation_m': _float_array(
                     r.source_refractor_elevation_m
                 ),
             }
         )
+        if _has_source_3layer_static_fields(r):
+            assert r.source_t3_time_s is not None
+            assert r.source_vsub_m_s is not None
+            assert r.source_sh3_weathering_thickness_m is not None
+            arrays.update(
+                {
+                    'source_t3_time_s': _float_array(r.source_t3_time_s),
+                    'source_vsub_m_s': _float_array(r.source_vsub_m_s),
+                    'source_sh3_weathering_thickness_m': _float_array(
+                        r.source_sh3_weathering_thickness_m
+                    ),
+                    'source_layer2_base_elevation_m': _float_array(
+                        source_layer1_base - r.source_sh2_weathering_thickness_m
+                    ),
+                }
+            )
     if _has_receiver_2layer_static_fields(r):
         assert r.receiver_t2_time_s is not None
         assert r.receiver_v3_m_s is not None
         assert r.receiver_sh2_weathering_thickness_m is not None
         receiver_sh1_m = _receiver_sh1_weathering_thickness_m(r)
+        receiver_layer1_base = r.receiver_surface_elevation_m - receiver_sh1_m
         arrays.update(
             {
                 'receiver_t2_time_s': _float_array(r.receiver_t2_time_s),
@@ -1877,13 +2053,29 @@ def build_refraction_static_solution_arrays(
                     r.receiver_sh2_weathering_thickness_m
                 ),
                 'receiver_layer1_base_elevation_m': _float_array(
-                    r.receiver_surface_elevation_m - receiver_sh1_m
+                    receiver_layer1_base
                 ),
                 'receiver_final_refractor_elevation_m': _float_array(
                     r.receiver_refractor_elevation_m
                 ),
             }
         )
+        if _has_receiver_3layer_static_fields(r):
+            assert r.receiver_t3_time_s is not None
+            assert r.receiver_vsub_m_s is not None
+            assert r.receiver_sh3_weathering_thickness_m is not None
+            arrays.update(
+                {
+                    'receiver_t3_time_s': _float_array(r.receiver_t3_time_s),
+                    'receiver_vsub_m_s': _float_array(r.receiver_vsub_m_s),
+                    'receiver_sh3_weathering_thickness_m': _float_array(
+                        r.receiver_sh3_weathering_thickness_m
+                    ),
+                    'receiver_layer2_base_elevation_m': _float_array(
+                        receiver_layer1_base - r.receiver_sh2_weathering_thickness_m
+                    ),
+                }
+            )
     _validate_no_object_arrays(arrays, artifact_name=REFRACTION_STATIC_SOLUTION_NPZ_NAME)
     return arrays
 
@@ -2068,6 +2260,11 @@ def build_refraction_static_qc_payload(
     }
     if layer_count is not None:
         payload['layer_count'] = int(layer_count)
+    enabled_layer_kinds = r.qc.get('enabled_layer_kinds')
+    if isinstance(enabled_layer_kinds, (list, tuple)):
+        payload['enabled_layer_kinds'] = [
+            str(layer_kind) for layer_kind in enabled_layer_kinds
+        ]
     if _request_has_cell_velocity_layer(req):
         refractor_cell = req.model.refractor_cell
         if refractor_cell is None:
@@ -2425,6 +2622,12 @@ _NODE_2LAYER_STATIC_ARRAY_NAMES = (
     'node_sh2_weathering_thickness_m',
 )
 
+_NODE_3LAYER_STATIC_ARRAY_NAMES = (
+    'node_sh1_weathering_thickness_m',
+    'node_sh2_weathering_thickness_m',
+    'node_sh3_weathering_thickness_m',
+)
+
 _SOURCE_ARRAY_NAMES = (
     'source_id',
     'source_node_id',
@@ -2449,6 +2652,16 @@ _SOURCE_2LAYER_STATIC_ARRAY_NAMES = (
     'source_sh2_weathering_thickness_m',
 )
 
+_SOURCE_3LAYER_STATIC_ARRAY_NAMES = (
+    'source_t2_time_s',
+    'source_t3_time_s',
+    'source_v3_m_s',
+    'source_vsub_m_s',
+    'source_sh1_weathering_thickness_m',
+    'source_sh2_weathering_thickness_m',
+    'source_sh3_weathering_thickness_m',
+)
+
 _RECEIVER_ARRAY_NAMES = (
     'receiver_id',
     'receiver_node_id',
@@ -2471,6 +2684,16 @@ _RECEIVER_2LAYER_STATIC_ARRAY_NAMES = (
     'receiver_v3_m_s',
     'receiver_sh1_weathering_thickness_m',
     'receiver_sh2_weathering_thickness_m',
+)
+
+_RECEIVER_3LAYER_STATIC_ARRAY_NAMES = (
+    'receiver_t2_time_s',
+    'receiver_t3_time_s',
+    'receiver_v3_m_s',
+    'receiver_vsub_m_s',
+    'receiver_sh1_weathering_thickness_m',
+    'receiver_sh2_weathering_thickness_m',
+    'receiver_sh3_weathering_thickness_m',
 )
 
 _ROW_ARRAY_NAMES = (
@@ -2538,6 +2761,8 @@ def _near_surface_model_rows(result: RefractionDatumStaticsResult) -> list[dict[
     rows: list[dict[str, object]] = []
     node_sh1_m = _node_sh1_weathering_thickness_m(result)
     node_sh2_m = result.node_sh2_weathering_thickness_m
+    node_sh3_m = result.node_sh3_weathering_thickness_m
+    has_3layer_fields = _has_node_3layer_static_fields(result)
     has_2layer_fields = _has_node_2layer_static_fields(result)
     for index in range(int(result.node_id.shape[0])):
         row = {
@@ -2573,6 +2798,17 @@ def _near_surface_model_rows(result: RefractionDatumStaticsResult) -> list[dict[
                     ),
                 }
             )
+            if has_3layer_fields:
+                assert node_sh3_m is not None
+                layer2_base = layer1_base - node_sh2_m[index]
+                row.update(
+                    {
+                        'sh3_weathering_thickness_m': _csv_float(
+                            node_sh3_m[index]
+                        ),
+                        'layer2_base_elevation_m': _csv_float(layer2_base),
+                    }
+                )
         rows.append(row)
     return rows
 
@@ -2751,12 +2987,16 @@ def _component_rows(result: RefractionDatumStaticsResult) -> list[dict[str, obje
 def _source_static_table_columns(
     result: RefractionDatumStaticsResult,
 ) -> tuple[str, ...]:
+    if _has_source_3layer_static_fields(result):
+        return _SOURCE_STATIC_TABLE_3LAYER_COLUMNS
     if _has_source_2layer_static_fields(result):
         return _SOURCE_STATIC_TABLE_2LAYER_COLUMNS
     return _SOURCE_STATIC_TABLE_COLUMNS
 
 
 def _near_surface_columns(result: RefractionDatumStaticsResult) -> tuple[str, ...]:
+    if _has_node_3layer_static_fields(result):
+        return _NEAR_SURFACE_3LAYER_COLUMNS
     if _has_node_2layer_static_fields(result):
         return _NEAR_SURFACE_2LAYER_COLUMNS
     return _NEAR_SURFACE_COLUMNS
@@ -2765,9 +3005,17 @@ def _near_surface_columns(result: RefractionDatumStaticsResult) -> tuple[str, ..
 def _receiver_static_table_columns(
     result: RefractionDatumStaticsResult,
 ) -> tuple[str, ...]:
+    if _has_receiver_3layer_static_fields(result):
+        return _RECEIVER_STATIC_TABLE_3LAYER_COLUMNS
     if _has_receiver_2layer_static_fields(result):
         return _RECEIVER_STATIC_TABLE_2LAYER_COLUMNS
     return _RECEIVER_STATIC_TABLE_COLUMNS
+
+
+def _has_node_3layer_static_fields(result: RefractionDatumStaticsResult) -> bool:
+    return all(
+        getattr(result, name) is not None for name in _NODE_3LAYER_STATIC_ARRAY_NAMES
+    )
 
 
 def _has_node_2layer_static_fields(result: RefractionDatumStaticsResult) -> bool:
@@ -2776,9 +3024,22 @@ def _has_node_2layer_static_fields(result: RefractionDatumStaticsResult) -> bool
     )
 
 
+def _has_source_3layer_static_fields(result: RefractionDatumStaticsResult) -> bool:
+    return all(
+        getattr(result, name) is not None for name in _SOURCE_3LAYER_STATIC_ARRAY_NAMES
+    )
+
+
 def _has_source_2layer_static_fields(result: RefractionDatumStaticsResult) -> bool:
     return all(
         getattr(result, name) is not None for name in _SOURCE_2LAYER_STATIC_ARRAY_NAMES
+    )
+
+
+def _has_receiver_3layer_static_fields(result: RefractionDatumStaticsResult) -> bool:
+    return all(
+        getattr(result, name) is not None
+        for name in _RECEIVER_3LAYER_STATIC_ARRAY_NAMES
     )
 
 
@@ -2854,9 +3115,13 @@ def _source_static_table_rows(
         int(result.source_endpoint_key.shape[0]),
     )
     has_2layer_fields = _has_source_2layer_static_fields(result)
+    has_3layer_fields = _has_source_3layer_static_fields(result)
     source_t2_time_s = result.source_t2_time_s
+    source_t3_time_s = result.source_t3_time_s
     source_v3_m_s = result.source_v3_m_s
+    source_vsub_m_s = result.source_vsub_m_s
     source_sh2_m = result.source_sh2_weathering_thickness_m
+    source_sh3_m = result.source_sh3_weathering_thickness_m
     source_sh1_m = _source_sh1_weathering_thickness_m(result)
     rows: list[dict[str, object]] = []
     for index in range(int(result.source_endpoint_key.shape[0])):
@@ -2923,20 +3188,34 @@ def _source_static_table_rows(
             assert source_t2_time_s is not None
             assert source_v3_m_s is not None
             assert source_sh2_m is not None
+            layer1_base = result.source_surface_elevation_m[index] - source_sh1_m[index]
             rows[-1].update(
                 {
                     't2_ms': _csv_ms(source_t2_time_s[index]),
                     'v3_m_s': _csv_float(source_v3_m_s[index]),
                     'sh2_weathering_thickness_m': _csv_float(source_sh2_m[index]),
-                    'layer1_base_elevation_m': _csv_float(
-                        result.source_surface_elevation_m[index]
-                        - source_sh1_m[index]
-                    ),
+                    'layer1_base_elevation_m': _csv_float(layer1_base),
                     'final_refractor_elevation_m': _csv_float(
                         result.source_refractor_elevation_m[index]
                     ),
                 }
             )
+            if has_3layer_fields:
+                assert source_t3_time_s is not None
+                assert source_vsub_m_s is not None
+                assert source_sh3_m is not None
+                rows[-1].update(
+                    {
+                        't3_ms': _csv_ms(source_t3_time_s[index]),
+                        'vsub_m_s': _csv_float(source_vsub_m_s[index]),
+                        'sh3_weathering_thickness_m': _csv_float(
+                            source_sh3_m[index]
+                        ),
+                        'layer2_base_elevation_m': _csv_float(
+                            layer1_base - source_sh2_m[index]
+                        ),
+                    }
+                )
     return rows
 
 
@@ -2960,9 +3239,13 @@ def _receiver_static_table_rows(
         int(result.receiver_endpoint_key.shape[0]),
     )
     has_2layer_fields = _has_receiver_2layer_static_fields(result)
+    has_3layer_fields = _has_receiver_3layer_static_fields(result)
     receiver_t2_time_s = result.receiver_t2_time_s
+    receiver_t3_time_s = result.receiver_t3_time_s
     receiver_v3_m_s = result.receiver_v3_m_s
+    receiver_vsub_m_s = result.receiver_vsub_m_s
     receiver_sh2_m = result.receiver_sh2_weathering_thickness_m
+    receiver_sh3_m = result.receiver_sh3_weathering_thickness_m
     receiver_sh1_m = _receiver_sh1_weathering_thickness_m(result)
     rows: list[dict[str, object]] = []
     for index in range(int(result.receiver_endpoint_key.shape[0])):
@@ -3029,20 +3312,36 @@ def _receiver_static_table_rows(
             assert receiver_t2_time_s is not None
             assert receiver_v3_m_s is not None
             assert receiver_sh2_m is not None
+            layer1_base = (
+                result.receiver_surface_elevation_m[index] - receiver_sh1_m[index]
+            )
             rows[-1].update(
                 {
                     't2_ms': _csv_ms(receiver_t2_time_s[index]),
                     'v3_m_s': _csv_float(receiver_v3_m_s[index]),
                     'sh2_weathering_thickness_m': _csv_float(receiver_sh2_m[index]),
-                    'layer1_base_elevation_m': _csv_float(
-                        result.receiver_surface_elevation_m[index]
-                        - receiver_sh1_m[index]
-                    ),
+                    'layer1_base_elevation_m': _csv_float(layer1_base),
                     'final_refractor_elevation_m': _csv_float(
                         result.receiver_refractor_elevation_m[index]
                     ),
                 }
             )
+            if has_3layer_fields:
+                assert receiver_t3_time_s is not None
+                assert receiver_vsub_m_s is not None
+                assert receiver_sh3_m is not None
+                rows[-1].update(
+                    {
+                        't3_ms': _csv_ms(receiver_t3_time_s[index]),
+                        'vsub_m_s': _csv_float(receiver_vsub_m_s[index]),
+                        'sh3_weathering_thickness_m': _csv_float(
+                            receiver_sh3_m[index]
+                        ),
+                        'layer2_base_elevation_m': _csv_float(
+                            layer1_base - receiver_sh2_m[index]
+                        ),
+                    }
+                )
     return rows
 
 

--- a/app/services/refraction_static_datum.py
+++ b/app/services/refraction_static_datum.py
@@ -768,21 +768,34 @@ def build_refraction_datum_statics(
         node_sh2_weathering_thickness_m=(
             weathering_replacement_result.node_sh2_weathering_thickness_m
         ),
+        node_sh3_weathering_thickness_m=(
+            weathering_replacement_result.node_sh3_weathering_thickness_m
+        ),
         source_t2_time_s=weathering_replacement_result.source_t2_time_s,
+        source_t3_time_s=weathering_replacement_result.source_t3_time_s,
         source_v3_m_s=weathering_replacement_result.source_v3_m_s,
+        source_vsub_m_s=weathering_replacement_result.source_vsub_m_s,
         source_sh1_weathering_thickness_m=(
             weathering_replacement_result.source_sh1_weathering_thickness_m
         ),
         source_sh2_weathering_thickness_m=(
             weathering_replacement_result.source_sh2_weathering_thickness_m
         ),
+        source_sh3_weathering_thickness_m=(
+            weathering_replacement_result.source_sh3_weathering_thickness_m
+        ),
         receiver_t2_time_s=weathering_replacement_result.receiver_t2_time_s,
+        receiver_t3_time_s=weathering_replacement_result.receiver_t3_time_s,
         receiver_v3_m_s=weathering_replacement_result.receiver_v3_m_s,
+        receiver_vsub_m_s=weathering_replacement_result.receiver_vsub_m_s,
         receiver_sh1_weathering_thickness_m=(
             weathering_replacement_result.receiver_sh1_weathering_thickness_m
         ),
         receiver_sh2_weathering_thickness_m=(
             weathering_replacement_result.receiver_sh2_weathering_thickness_m
+        ),
+        receiver_sh3_weathering_thickness_m=(
+            weathering_replacement_result.receiver_sh3_weathering_thickness_m
         ),
     )
     if job_dir is not None:

--- a/app/services/refraction_static_multilayer_service.py
+++ b/app/services/refraction_static_multilayer_service.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import numpy as np
 
+import app.services.refraction_static_t1lsst as refraction_t1lsst
 from app.api.schemas import (
     RefractionStaticApplyOptions,
     RefractionStaticApplyRequest,
@@ -214,9 +215,10 @@ def compute_refraction_multilayer_datum_statics_from_input_model(
     key2_byte: int | None = None,
     floating_datum_artifact_path: Path | None = None,
 ) -> RefractionMultiLayerStaticsWorkflowResult:
-    """Run the implemented two-layer time-term, T1LSST, and datum workflow."""
+    """Run the implemented multi-layer time-term, T1LSST, and datum workflow."""
     normalized_layers = normalize_refraction_static_layers(model)
-    _require_two_layer_t1lsst_layers(normalized_layers)
+    _require_multilayer_t1lsst_layers(normalized_layers)
+    layer_count = len(normalized_layers)
     layer_masks = build_refraction_layer_observation_masks(
         input_model=input_model,
         model=model,
@@ -255,7 +257,8 @@ def compute_refraction_multilayer_datum_statics_from_input_model(
             **datum_result.qc,
             'method': 'multilayer_time_term',
             'conversion_mode': 't1lsst_multilayer',
-            'layer_count': 2,
+            'layer_count': layer_count,
+            'enabled_layer_kinds': list(solve_result.enabled_layer_kinds),
             'layers': solve_result.qc,
         },
         node_sh1_weathering_thickness_m=_required_result_array(
@@ -266,20 +269,29 @@ def compute_refraction_multilayer_datum_statics_from_input_model(
             weathering_replacement.node_sh2_weathering_thickness_m,
             name='node_sh2_weathering_thickness_m',
         ),
+        node_sh3_weathering_thickness_m=(
+            weathering_replacement.node_sh3_weathering_thickness_m
+        ),
         source_t2_time_s=components.source_t2_s,
+        source_t3_time_s=components.source_t3_s,
         source_v3_m_s=_required_result_array(
             weathering_replacement.source_v3_m_s,
             name='source_v3_m_s',
         ),
+        source_vsub_m_s=weathering_replacement.source_vsub_m_s,
         source_sh1_weathering_thickness_m=components.source_sh1_m,
         source_sh2_weathering_thickness_m=components.source_sh2_m,
+        source_sh3_weathering_thickness_m=components.source_sh3_m,
         receiver_t2_time_s=components.receiver_t2_s,
+        receiver_t3_time_s=components.receiver_t3_s,
         receiver_v3_m_s=_required_result_array(
             weathering_replacement.receiver_v3_m_s,
             name='receiver_v3_m_s',
         ),
+        receiver_vsub_m_s=weathering_replacement.receiver_vsub_m_s,
         receiver_sh1_weathering_thickness_m=components.receiver_sh1_m,
         receiver_sh2_weathering_thickness_m=components.receiver_sh2_m,
+        receiver_sh3_weathering_thickness_m=components.receiver_sh3_m,
     )
     if job_dir is not None:
         root = Path(job_dir)
@@ -327,7 +339,7 @@ def _artifact_request_for_multilayer_workflow(
         datum=datum,
         conversion=RefractionStaticConversionRequest(
             mode='t1lsst_multilayer',
-            layer_count=2,
+            layer_count=len(normalize_refraction_static_layers(model)),
         ),
         apply=apply_options or RefractionStaticApplyOptions(),
     )
@@ -349,15 +361,27 @@ def build_refraction_multilayer_weathering_replacement_statics(
     apply_options: RefractionStaticApplyOptions | None,
     resolved_first_layer: ResolvedRefractionFirstLayer,
 ) -> RefractionWeatheringReplacementStaticsResult:
-    """Build two-layer T1LSST replacement statics from production layer solves."""
-    _require_two_layer_t1lsst_layers(normalize_refraction_static_layers(model))
+    """Build T1LSST replacement statics from production layer solves."""
+    normalized_layers = normalize_refraction_static_layers(model)
+    _require_multilayer_t1lsst_layers(normalized_layers)
+    layer_count = len(normalized_layers)
     v2_layer = _required_layer_result(solve_result, 'v2_t1')
     v3_layer = _required_layer_result(solve_result, 'v3_t2')
+    vsub_layer = (
+        _required_layer_result(solve_result, 'vsub_t3')
+        if layer_count == 3
+        else None
+    )
     v1_m_s = _positive_float(
         resolved_first_layer.weathering_velocity_m_s,
         name='resolved_first_layer.weathering_velocity_m_s',
     )
     v3_m_s = _required_global_velocity(v3_layer)
+    vsub_m_s = None if vsub_layer is None else _required_global_velocity(vsub_layer)
+    replacement_velocity_m_s = v3_m_s if vsub_m_s is None else vsub_m_s
+    replacement_velocity_mode = (
+        v3_layer.velocity_mode if vsub_layer is None else vsub_layer.velocity_mode
+    )
     node_id = _input_node_id(input_model)
     source = _endpoint_metadata(input_model, endpoint='source')
     receiver = _endpoint_metadata(input_model, endpoint='receiver')
@@ -395,31 +419,79 @@ def build_refraction_multilayer_weathering_replacement_statics(
         receiver,
         name='receiver_t2',
     )
-
-    node_conversion = _compute_2layer_conversion(
-        t1_s=node_t1,
-        t2_s=node_t2,
-        v1_m_s=v1_m_s,
-        v2_m_s=v2.node_v2_m_s,
-        v3_m_s=v3_m_s,
-        v2_status=v2.node_v2_status,
-    )
-    source_conversion = _compute_2layer_conversion(
-        t1_s=source_t1,
-        t2_s=source_t2,
-        v1_m_s=v1_m_s,
-        v2_m_s=v2.source_v2_m_s,
-        v3_m_s=v3_m_s,
-        v2_status=v2.source_v2_status,
-    )
-    receiver_conversion = _compute_2layer_conversion(
-        t1_s=receiver_t1,
-        t2_s=receiver_t2,
-        v1_m_s=v1_m_s,
-        v2_m_s=v2.receiver_v2_m_s,
-        v3_m_s=v3_m_s,
-        v2_status=v2.receiver_v2_status,
-    )
+    if vsub_layer is None:
+        source_t3 = receiver_t3 = None
+        node_conversion = _compute_2layer_conversion(
+            t1_s=node_t1,
+            t2_s=node_t2,
+            v1_m_s=v1_m_s,
+            v2_m_s=v2.node_v2_m_s,
+            v3_m_s=v3_m_s,
+            v2_status=v2.node_v2_status,
+        )
+        source_conversion = _compute_2layer_conversion(
+            t1_s=source_t1,
+            t2_s=source_t2,
+            v1_m_s=v1_m_s,
+            v2_m_s=v2.source_v2_m_s,
+            v3_m_s=v3_m_s,
+            v2_status=v2.source_v2_status,
+        )
+        receiver_conversion = _compute_2layer_conversion(
+            t1_s=receiver_t1,
+            t2_s=receiver_t2,
+            v1_m_s=v1_m_s,
+            v2_m_s=v2.receiver_v2_m_s,
+            v3_m_s=v3_m_s,
+            v2_status=v2.receiver_v2_status,
+        )
+    else:
+        assert vsub_m_s is not None
+        node_t3 = _layer_node_terms(
+            vsub_layer,
+            shape=node_id.shape,
+            name='vsub_t3',
+        )
+        source_t3 = _endpoint_terms(
+            vsub_layer.source_time_term_s,
+            source,
+            name='source_t3',
+        )
+        receiver_t3 = _endpoint_terms(
+            vsub_layer.receiver_time_term_s,
+            receiver,
+            name='receiver_t3',
+        )
+        node_conversion = _compute_3layer_conversion(
+            t1_s=node_t1,
+            t2_s=node_t2,
+            t3_s=node_t3,
+            v1_m_s=v1_m_s,
+            v2_m_s=v2.node_v2_m_s,
+            v3_m_s=v3_m_s,
+            vsub_m_s=vsub_m_s,
+            v2_status=v2.node_v2_status,
+        )
+        source_conversion = _compute_3layer_conversion(
+            t1_s=source_t1,
+            t2_s=source_t2,
+            t3_s=source_t3,
+            v1_m_s=v1_m_s,
+            v2_m_s=v2.source_v2_m_s,
+            v3_m_s=v3_m_s,
+            vsub_m_s=vsub_m_s,
+            v2_status=v2.source_v2_status,
+        )
+        receiver_conversion = _compute_3layer_conversion(
+            t1_s=receiver_t1,
+            t2_s=receiver_t2,
+            t3_s=receiver_t3,
+            v1_m_s=v1_m_s,
+            v2_m_s=v2.receiver_v2_m_s,
+            v3_m_s=v3_m_s,
+            vsub_m_s=vsub_m_s,
+            v2_status=v2.receiver_v2_status,
+        )
 
     max_abs_shift_ms = (
         None if apply_options is None else float(apply_options.max_abs_shift_ms)
@@ -476,26 +548,51 @@ def build_refraction_multilayer_weathering_replacement_statics(
         endpoint_values=receiver_conversion.sh2_m,
         name='receiver_sh2_m_sorted',
     )
+    source_sh3_sorted = (
+        None
+        if source_conversion.sh3_m is None
+        else _map_endpoint_values_to_trace_order(
+            endpoint_key_sorted=input_model.source_endpoint_key_sorted,
+            endpoint_key=source.endpoint_key,
+            endpoint_values=source_conversion.sh3_m,
+            name='source_sh3_m_sorted',
+        )
+    )
+    receiver_sh3_sorted = (
+        None
+        if receiver_conversion.sh3_m is None
+        else _map_endpoint_values_to_trace_order(
+            endpoint_key_sorted=input_model.receiver_endpoint_key_sorted,
+            endpoint_key=receiver.endpoint_key,
+            endpoint_values=receiver_conversion.sh3_m,
+            name='receiver_sh3_m_sorted',
+        )
+    )
     node_surface = np.ascontiguousarray(input_model.node_elevation_m, dtype=np.float64)
     node_total_thickness = _total_weathering_thickness(
         node_conversion.sh1_m,
         node_conversion.sh2_m,
+        node_conversion.sh3_m,
     )
     source_total_thickness = _total_weathering_thickness(
         source_conversion.sh1_m,
         source_conversion.sh2_m,
+        source_conversion.sh3_m,
     )
     receiver_total_thickness = _total_weathering_thickness(
         receiver_conversion.sh1_m,
         receiver_conversion.sh2_m,
+        receiver_conversion.sh3_m,
     )
     source_total_thickness_sorted = _total_weathering_thickness(
         source_sh1_sorted,
         source_sh2_sorted,
+        source_sh3_sorted,
     )
     receiver_total_thickness_sorted = _total_weathering_thickness(
         receiver_sh1_sorted,
         receiver_sh2_sorted,
+        receiver_sh3_sorted,
     )
     source_wcor_sorted = _map_endpoint_values_to_trace_order(
         endpoint_key_sorted=input_model.source_endpoint_key_sorted,
@@ -550,9 +647,10 @@ def build_refraction_multilayer_weathering_replacement_statics(
         'method': 'multilayer_time_term',
         'static_component': 't1lsst_multilayer_weathering_replacement',
         'conversion_mode': 't1lsst_multilayer',
-        'layer_count': 2,
+        'layer_count': layer_count,
+        'enabled_layer_kinds': list(solve_result.enabled_layer_kinds),
         'sign_convention': _SIGN_CONVENTION_TEXT,
-        'bedrock_velocity_mode': v3_layer.velocity_mode,
+        'bedrock_velocity_mode': replacement_velocity_mode,
         'weathering_velocity_m_s': float(v1_m_s),
         'v2_velocity_mode': v2_layer.velocity_mode,
         'v3_velocity_mode': v3_layer.velocity_mode,
@@ -560,18 +658,37 @@ def build_refraction_multilayer_weathering_replacement_statics(
         'layers': solve_result.qc,
         **_cell_threshold_qc_from_layer(v2_layer),
     }
+    if vsub_layer is not None:
+        qc.update(
+            {
+                'vsub_velocity_mode': vsub_layer.velocity_mode,
+                'vsub_m_s': float(replacement_velocity_m_s),
+            }
+        )
     source_v3_m_s = np.full(source.endpoint_key.shape, v3_m_s, dtype=np.float64)
     receiver_v3_m_s = np.full(receiver.endpoint_key.shape, v3_m_s, dtype=np.float64)
+    source_vsub_m_s = (
+        None
+        if vsub_layer is None
+        else np.full(source.endpoint_key.shape, replacement_velocity_m_s, dtype=np.float64)
+    )
+    receiver_vsub_m_s = (
+        None
+        if vsub_layer is None
+        else np.full(receiver.endpoint_key.shape, replacement_velocity_m_s, dtype=np.float64)
+    )
     rejected_by_robust = _combined_rejected_by_robust_mask(
         solve_result,
         input_model.n_traces,
     )
     return RefractionWeatheringReplacementStaticsResult(
-        bedrock_velocity_mode=v3_layer.velocity_mode,
-        bedrock_slowness_s_per_m=1.0 / v3_m_s,
-        bedrock_velocity_m_s=v3_m_s,
+        bedrock_velocity_mode=replacement_velocity_mode,
+        bedrock_slowness_s_per_m=1.0 / replacement_velocity_m_s,
+        bedrock_velocity_m_s=replacement_velocity_m_s,
         weathering_velocity_m_s=v1_m_s,
-        replacement_slowness_delta_s_per_m=1.0 / v3_m_s - 1.0 / v1_m_s,
+        replacement_slowness_delta_s_per_m=(
+            1.0 / replacement_velocity_m_s - 1.0 / v1_m_s
+        ),
         node_id=node_id,
         node_x_m=np.ascontiguousarray(input_model.node_x_m, dtype=np.float64),
         node_y_m=np.ascontiguousarray(input_model.node_y_m, dtype=np.float64),
@@ -716,14 +833,21 @@ def build_refraction_multilayer_weathering_replacement_statics(
         receiver_v2_status_sorted=v2.receiver_v2_status_sorted,
         node_sh1_weathering_thickness_m=node_conversion.sh1_m,
         node_sh2_weathering_thickness_m=node_conversion.sh2_m,
+        node_sh3_weathering_thickness_m=node_conversion.sh3_m,
         source_t2_time_s=source_t2,
+        source_t3_time_s=source_t3,
         source_v3_m_s=source_v3_m_s,
+        source_vsub_m_s=source_vsub_m_s,
         source_sh1_weathering_thickness_m=source_conversion.sh1_m,
         source_sh2_weathering_thickness_m=source_conversion.sh2_m,
+        source_sh3_weathering_thickness_m=source_conversion.sh3_m,
         receiver_t2_time_s=receiver_t2,
+        receiver_t3_time_s=receiver_t3,
         receiver_v3_m_s=receiver_v3_m_s,
+        receiver_vsub_m_s=receiver_vsub_m_s,
         receiver_sh1_weathering_thickness_m=receiver_conversion.sh1_m,
         receiver_sh2_weathering_thickness_m=receiver_conversion.sh2_m,
+        receiver_sh3_weathering_thickness_m=receiver_conversion.sh3_m,
     )
 
 
@@ -763,26 +887,37 @@ class _V2StaticModel:
 
 
 @dataclass(frozen=True)
-class _TwoLayerConversion:
+class _T1LSSTMultilayerConversion:
     sh1_m: np.ndarray
     sh2_m: np.ndarray
     weathering_correction_s: np.ndarray
     status: np.ndarray
+    sh3_m: np.ndarray | None = None
 
 
-def _require_two_layer_t1lsst_layers(
+def _require_multilayer_t1lsst_layers(
     normalized_layers: tuple[RefractionStaticLayerConfig, ...],
 ) -> None:
     kinds = tuple(config.kind for config in normalized_layers)
-    if kinds != ('v2_t1', 'v3_t2'):
+    if kinds not in (('v2_t1', 'v3_t2'), ('v2_t1', 'v3_t2', 'vsub_t3')):
+        enabled_text = ', '.join(kinds) if kinds else 'none'
         raise RefractionMultiLayerSolveError(
-            'two-layer T1LSST statics requires enabled layers v2_t1 and v3_t2'
+            'multi-layer T1LSST statics requires enabled layers v2_t1 and '
+            'v3_t2 for layer_count=2 or v2_t1, v3_t2, and vsub_t3 for '
+            f'layer_count=3; enabled layer kinds={enabled_text}'
         )
     v3_mode = normalized_layers[1].velocity_mode
     if v3_mode not in ('solve_global', 'fixed_global'):
         raise RefractionMultiLayerSolveError(
-            'two-layer T1LSST statics currently requires global V3/T2 velocity'
+            'multi-layer T1LSST statics currently requires global V3/T2 velocity'
         )
+    if len(normalized_layers) == 3:
+        vsub_mode = normalized_layers[2].velocity_mode
+        if vsub_mode not in ('solve_global', 'fixed_global'):
+            raise RefractionMultiLayerSolveError(
+                'multi-layer T1LSST statics currently requires global '
+                'Vsub/T3 velocity'
+            )
 
 
 def _compute_2layer_conversion(
@@ -793,7 +928,7 @@ def _compute_2layer_conversion(
     v2_m_s: np.ndarray,
     v3_m_s: float,
     v2_status: np.ndarray | None,
-) -> _TwoLayerConversion:
+) -> _T1LSSTMultilayerConversion:
     v2 = np.asarray(v2_m_s, dtype=np.float64)
     if v2_status is None:
         thickness = compute_t1lsst_2layer_thicknesses_with_status(
@@ -804,8 +939,8 @@ def _compute_2layer_conversion(
             v3_m_s=v3_m_s,
             strict_velocity_order=True,
         )
-        wcor = _required_2layer_wcor(thickness.weathering_correction_s)
-        return _TwoLayerConversion(
+        wcor = _required_multilayer_wcor(thickness.weathering_correction_s)
+        return _T1LSSTMultilayerConversion(
             sh1_m=thickness.sh1_m,
             sh2_m=thickness.sh2_m,
             weathering_correction_s=wcor,
@@ -825,7 +960,7 @@ def _compute_2layer_conversion(
         v3_m_s=v3_m_s,
         strict_velocity_order=False,
     )
-    wcor = _required_2layer_wcor(thickness.weathering_correction_s)
+    wcor = _required_multilayer_wcor(thickness.weathering_correction_s)
 
     sh1 = np.array(thickness.sh1_m, dtype=np.float64, copy=True, order='C')
     sh2 = np.array(thickness.sh2_m, dtype=np.float64, copy=True, order='C')
@@ -835,7 +970,7 @@ def _compute_2layer_conversion(
     sh1[invalid_local_v2] = np.nan
     sh2[invalid_local_v2] = np.nan
     wcor[invalid_local_v2] = np.nan
-    return _TwoLayerConversion(
+    return _T1LSSTMultilayerConversion(
         sh1_m=sh1,
         sh2_m=sh2,
         weathering_correction_s=wcor,
@@ -843,11 +978,84 @@ def _compute_2layer_conversion(
     )
 
 
-def _total_weathering_thickness(sh1_m: np.ndarray, sh2_m: np.ndarray) -> np.ndarray:
-    return np.ascontiguousarray(
-        np.asarray(sh1_m, dtype=np.float64) + np.asarray(sh2_m, dtype=np.float64),
-        dtype=np.float64,
+def _compute_3layer_conversion(
+    *,
+    t1_s: np.ndarray,
+    t2_s: np.ndarray,
+    t3_s: np.ndarray,
+    v1_m_s: float,
+    v2_m_s: np.ndarray,
+    v3_m_s: float,
+    vsub_m_s: float,
+    v2_status: np.ndarray | None,
+) -> _T1LSSTMultilayerConversion:
+    v2 = np.asarray(v2_m_s, dtype=np.float64)
+    try:
+        compute_3layer = refraction_t1lsst.compute_t1lsst_3layer_thicknesses_with_status
+    except AttributeError as exc:
+        raise RefractionMultiLayerSolveError(
+            'three-layer T1LSST conversion dependency is not available'
+        ) from exc
+    thickness = compute_3layer(
+        t1_s=t1_s,
+        t2_s=t2_s,
+        t3_s=t3_s,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+        strict_velocity_order=v2_status is None,
     )
+    wcor = _required_multilayer_wcor(thickness.weathering_correction_s)
+    if v2_status is None:
+        return _T1LSSTMultilayerConversion(
+            sh1_m=thickness.sh1_m,
+            sh2_m=thickness.sh2_m,
+            sh3_m=thickness.sh3_m,
+            weathering_correction_s=wcor,
+            status=thickness.status,
+        )
+
+    status = np.asarray(v2_status).astype(_STATUS_DTYPE, copy=True)
+    if status.shape != v2.shape:
+        raise RefractionMultiLayerSolveError('local V2 status shape mismatch')
+    invalid_local_v2 = ~np.isin(status.astype(str), list(_LOCAL_V2_OK_STATUS))
+
+    sh1 = np.array(thickness.sh1_m, dtype=np.float64, copy=True, order='C')
+    sh2 = np.array(thickness.sh2_m, dtype=np.float64, copy=True, order='C')
+    sh3 = np.array(thickness.sh3_m, dtype=np.float64, copy=True, order='C')
+    wcor = np.array(wcor, dtype=np.float64, copy=True, order='C')
+    conversion_status = np.asarray(thickness.status).astype(_STATUS_DTYPE, copy=True)
+    conversion_status[invalid_local_v2] = status[invalid_local_v2]
+    sh1[invalid_local_v2] = np.nan
+    sh2[invalid_local_v2] = np.nan
+    sh3[invalid_local_v2] = np.nan
+    wcor[invalid_local_v2] = np.nan
+    return _T1LSSTMultilayerConversion(
+        sh1_m=sh1,
+        sh2_m=sh2,
+        sh3_m=sh3,
+        weathering_correction_s=wcor,
+        status=conversion_status,
+    )
+
+
+def _total_weathering_thickness(
+    *thicknesses_m: np.ndarray | None,
+) -> np.ndarray:
+    arrays = [
+        np.asarray(thickness, dtype=np.float64)
+        for thickness in thicknesses_m
+        if thickness is not None
+    ]
+    if not arrays:
+        raise RefractionMultiLayerSolveError(
+            'at least one weathering thickness array is required'
+        )
+    total = np.array(arrays[0], dtype=np.float64, copy=True, order='C')
+    for array in arrays[1:]:
+        total = total + array
+    return np.ascontiguousarray(total, dtype=np.float64)
 
 
 def _cell_threshold_qc_from_layer(
@@ -896,19 +1104,47 @@ def _components_from_replacement(
         result.receiver_sh1_weathering_thickness_m,
         name='receiver_sh1_m',
     )
+    has_3layer_components = any(
+        value is not None
+        for value in (
+            result.source_t3_time_s,
+            result.receiver_t3_time_s,
+            result.source_sh3_weathering_thickness_m,
+            result.receiver_sh3_weathering_thickness_m,
+        )
+    )
+    source_t3 = receiver_t3 = source_sh3 = receiver_sh3 = None
+    if has_3layer_components:
+        source_t3 = _required_result_array(
+            result.source_t3_time_s,
+            name='source_t3_s',
+        )
+        receiver_t3 = _required_result_array(
+            result.receiver_t3_time_s,
+            name='receiver_t3_s',
+        )
+        source_sh3 = _required_result_array(
+            result.source_sh3_weathering_thickness_m,
+            name='source_sh3_m',
+        )
+        receiver_sh3 = _required_result_array(
+            result.receiver_sh3_weathering_thickness_m,
+            name='receiver_sh3_m',
+        )
+    layer_count = 3 if has_3layer_components else 2
     return RefractionMultiLayerStaticComponents(
         source_t1_s=np.ascontiguousarray(result.source_half_intercept_time_s),
         source_t2_s=source_t2,
-        source_t3_s=None,
+        source_t3_s=source_t3,
         receiver_t1_s=np.ascontiguousarray(result.receiver_half_intercept_time_s),
         receiver_t2_s=receiver_t2,
-        receiver_t3_s=None,
+        receiver_t3_s=receiver_t3,
         source_sh1_m=source_sh1,
         source_sh2_m=source_sh2,
-        source_sh3_m=None,
+        source_sh3_m=source_sh3,
         receiver_sh1_m=receiver_sh1,
         receiver_sh2_m=receiver_sh2,
-        receiver_sh3_m=None,
+        receiver_sh3_m=receiver_sh3,
         source_weathering_correction_s=np.ascontiguousarray(
             result.source_weathering_replacement_shift_s
         ),
@@ -917,7 +1153,7 @@ def _components_from_replacement(
         ),
         qc={
             'conversion_mode': 't1lsst_multilayer',
-            'layer_count': 2,
+            'layer_count': layer_count,
             'sign_convention': _SIGN_CONVENTION_TEXT,
         },
     )
@@ -932,8 +1168,8 @@ def _required_result_array(value: object, *, name: str) -> np.ndarray:
     return np.ascontiguousarray(arr, dtype=np.float64)
 
 
-def _required_2layer_wcor(value: object) -> np.ndarray:
-    return _required_result_array(value, name='two-layer weathering_correction_s')
+def _required_multilayer_wcor(value: object) -> np.ndarray:
+    return _required_result_array(value, name='multilayer weathering_correction_s')
 
 
 def _required_layer_result(

--- a/app/services/refraction_static_multilayer_service.py
+++ b/app/services/refraction_static_multilayer_service.py
@@ -68,6 +68,10 @@ _LAYER_INDEX_BY_KIND: dict[RefractionLayerKind, int] = {
     'v3_t2': 2,
     'vsub_t3': 3,
 }
+_VELOCITY_SEQUENCE_REFERENCE_BY_KIND: dict[RefractionLayerKind, RefractionLayerKind] = {
+    'v3_t2': 'v2_t1',
+    'vsub_t3': 'v3_t2',
+}
 _STATUS_DTYPE = '<U32'
 _SIGN_CONVENTION_TEXT = 'corrected(t) = raw(t - shift_s)'
 _LOCAL_V2_OK_STATUS = {'ok', 'solved'}
@@ -1635,6 +1639,8 @@ def _effective_solver_dispatch(
         ('v2_t1', 'solve_cell'): _solve_existing_time_term_layer,
         ('v3_t2', 'fixed_global'): _solve_existing_time_term_layer,
         ('v3_t2', 'solve_global'): _solve_existing_time_term_layer,
+        ('vsub_t3', 'fixed_global'): _solve_existing_time_term_layer,
+        ('vsub_t3', 'solve_global'): _solve_existing_time_term_layer,
     }
     if overrides is not None:
         dispatch.update(dict(overrides))
@@ -2045,7 +2051,9 @@ def _layer_velocity_qc_aliases(
     if layer_kind == 'vsub_t3':
         return {
             'vsub_m_s': float(global_velocity_m_s),
+            'vsub_velocity_m_s': float(global_velocity_m_s),
             'slowness_sub_s_per_m': float(global_slowness_s_per_m),
+            'vsub_slowness_s_per_m': float(global_slowness_s_per_m),
         }
     return {}
 
@@ -2077,13 +2085,14 @@ def _validate_layer_velocity_sequence(
     previous_results: tuple[RefractionLayerSolveResult, ...],
     normalized_layers: tuple[RefractionStaticLayerConfig, ...],
 ) -> RefractionLayerSolveResult:
-    if result.layer_kind != 'v3_t2':
+    reference_layer_kind = _VELOCITY_SEQUENCE_REFERENCE_BY_KIND.get(result.layer_kind)
+    if reference_layer_kind is None:
         return result
     current_velocity = _summary_velocity_m_s(result)
     if current_velocity is None:
         return result
     reference = _prior_layer_velocity_reference(
-        layer_kind='v2_t1',
+        layer_kind=reference_layer_kind,
         previous_results=previous_results,
         normalized_layers=normalized_layers,
     )

--- a/app/services/refraction_static_service.py
+++ b/app/services/refraction_static_service.py
@@ -57,11 +57,12 @@ from app.services.refraction_static_weathering_replacement import (
 
 _REQUEST_JSON_NAME = 'refraction_static_request.json'
 _ARTIFACT_ONLY_DONE_MESSAGE = 'refraction_static_artifacts_written_artifact_only'
-_PUBLIC_TWO_LAYER_APPLY_CONTRACT = (
-    'public two-layer refraction apply requires '
+_PUBLIC_MULTILAYER_APPLY_CONTRACT = (
+    'public multi-layer refraction apply requires '
     'model.method=multilayer_time_term, '
-    'conversion.mode=t1lsst_multilayer, conversion.layer_count=2, '
-    'and exactly enabled layers v2_t1 and v3_t2'
+    'conversion.mode=t1lsst_multilayer, and exactly enabled layers '
+    'v2_t1 and v3_t2 for conversion.layer_count=2 or v2_t1, v3_t2, '
+    'and vsub_t3 for conversion.layer_count=3'
 )
 
 
@@ -173,13 +174,13 @@ def _reject_unsupported_multilayer_apply(req: RefractionStaticApplyRequest) -> N
         return
     raise RefractionMultiLayerApplyNotImplemented(
         'refraction static apply supports accepted multi-layer request fields '
-        'only for the M3 public two-layer contract. '
-        f'{_PUBLIC_TWO_LAYER_APPLY_CONTRACT}. Unsupported request fields: '
+        'only for the M3 public multi-layer contract. '
+        f'{_PUBLIC_MULTILAYER_APPLY_CONTRACT}. Unsupported request fields: '
         f'{", ".join(unsupported)}.'
     )
 
 
-def _is_public_two_layer_multilayer_apply(
+def _is_public_multilayer_apply(
     req: RefractionStaticApplyRequest,
 ) -> bool:
     if (
@@ -187,32 +188,49 @@ def _is_public_two_layer_multilayer_apply(
         or req.conversion.mode != 't1lsst_multilayer'
     ):
         return False
-    _require_public_two_layer_multilayer_apply(req)
+    _require_public_multilayer_apply(req)
     return True
 
 
-def _require_public_two_layer_multilayer_apply(
+def _require_public_multilayer_apply(
     req: RefractionStaticApplyRequest,
 ) -> None:
     normalized_layers = normalize_refraction_static_layers(req.model)
     enabled_kinds = tuple(config.kind for config in normalized_layers)
-    if req.conversion.layer_count != 2 or enabled_kinds != ('v2_t1', 'v3_t2'):
-        enabled_text = ', '.join(enabled_kinds) if enabled_kinds else 'none'
+    enabled_text = ', '.join(enabled_kinds) if enabled_kinds else 'none'
+    expected_by_count = {
+        2: ('v2_t1', 'v3_t2'),
+        3: ('v2_t1', 'v3_t2', 'vsub_t3'),
+    }
+    expected = expected_by_count.get(req.conversion.layer_count)
+    if expected is None or enabled_kinds != expected:
         raise RefractionMultiLayerApplyNotImplemented(
-            f'{_PUBLIC_TWO_LAYER_APPLY_CONTRACT}; got '
+            f'{_PUBLIC_MULTILAYER_APPLY_CONTRACT}; got '
             f'conversion.layer_count={req.conversion.layer_count!r}, '
-            f'enabled layers={enabled_text}. Public apply does not implement '
-            'vsub_t3 or three-layer T1LSST conversion.'
+            f'enabled layer kinds={enabled_text}.'
         )
 
     v3_config = normalized_layers[1]
     if v3_config.velocity_mode not in ('fixed_global', 'solve_global'):
         raise RefractionMultiLayerApplyNotImplemented(
-            f'{_PUBLIC_TWO_LAYER_APPLY_CONTRACT}; v3_t2 velocity_mode='
+            f'{_PUBLIC_MULTILAYER_APPLY_CONTRACT}; '
+            f'conversion.layer_count={req.conversion.layer_count!r}, '
+            f'enabled layer kinds={enabled_text}; v3_t2 velocity_mode='
             f'{v3_config.velocity_mode} is not supported. Public apply '
             'currently requires global V3/T2 velocity; cell V3 is not '
             'implemented.'
         )
+    if req.conversion.layer_count == 3:
+        vsub_config = normalized_layers[2]
+        if vsub_config.velocity_mode not in ('fixed_global', 'solve_global'):
+            raise RefractionMultiLayerApplyNotImplemented(
+                f'{_PUBLIC_MULTILAYER_APPLY_CONTRACT}; '
+                f'conversion.layer_count={req.conversion.layer_count!r}, '
+                f'enabled layer kinds={enabled_text}; vsub_t3 velocity_mode='
+                f'{vsub_config.velocity_mode} is not supported. Public apply '
+                'currently requires global Vsub/T3 velocity; cell Vsub is not '
+                'implemented.'
+            )
 
 
 def _solver_request_for_refraction_static_apply(
@@ -422,7 +440,7 @@ def _finish_refraction_static_apply_job(
     )
 
 
-def _run_public_two_layer_refraction_static_apply_job(
+def _run_public_multilayer_refraction_static_apply_job(
     *,
     job_id: str,
     req: RefractionStaticApplyRequest,
@@ -509,8 +527,8 @@ def _run_refraction_static_apply_job_body(
             'request': req.model_dump(mode='json'),
         },
     )
-    public_two_layer_apply = _is_public_two_layer_multilayer_apply(req)
-    if not public_two_layer_apply:
+    public_multilayer_apply = _is_public_multilayer_apply(req)
+    if not public_multilayer_apply:
         _reject_unsupported_multilayer_apply(req)
     _set_job_progress_message(
         state,
@@ -524,8 +542,8 @@ def _run_refraction_static_apply_job_body(
         job_dir=job_dir,
     )
     input_req = first_layer.req
-    if public_two_layer_apply:
-        return _run_public_two_layer_refraction_static_apply_job(
+    if public_multilayer_apply:
+        return _run_public_multilayer_refraction_static_apply_job(
             job_id=job_id,
             req=input_req,
             state=state,

--- a/app/services/refraction_static_t1lsst.py
+++ b/app/services/refraction_static_t1lsst.py
@@ -62,6 +62,17 @@ class RefractionT1LSST2LayerThicknessResult:
     weathering_correction_s: np.ndarray | None = None
 
 
+@dataclass(frozen=True)
+class RefractionT1LSST3LayerThicknessResult:
+    """Three-layer T1LSST thicknesses with endpoint conversion status."""
+
+    sh1_m: np.ndarray
+    sh2_m: np.ndarray
+    sh3_m: np.ndarray
+    status: np.ndarray
+    weathering_correction_s: np.ndarray | None = None
+
+
 def compute_t1lsst_1layer_thickness(
     t1_s: np.ndarray,
     v1_m_s: float,
@@ -221,6 +232,179 @@ def compute_t1lsst_2layer_weathering_correction(
     return np.array(
         sh1 * (1.0 / v3 - 1.0 / v1)
         + sh2 * (1.0 / v3 - 1.0 / v2),
+        dtype=np.float64,
+        copy=True,
+        order='C',
+    )
+
+
+def compute_t1lsst_3layer_thicknesses(
+    t1_s: np.ndarray,
+    t2_s: np.ndarray,
+    t3_s: np.ndarray,
+    v1_m_s: np.ndarray | float,
+    v2_m_s: np.ndarray | float,
+    v3_m_s: np.ndarray | float,
+    vsub_m_s: np.ndarray | float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute three-layer ``SH1``/``SH2``/``SH3`` thicknesses."""
+    result = compute_t1lsst_3layer_thicknesses_with_status(
+        t1_s=t1_s,
+        t2_s=t2_s,
+        t3_s=t3_s,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+        strict_velocity_order=True,
+    )
+    return result.sh1_m, result.sh2_m, result.sh3_m
+
+
+def compute_t1lsst_3layer_thicknesses_with_status(
+    t1_s: np.ndarray,
+    t2_s: np.ndarray,
+    t3_s: np.ndarray,
+    v1_m_s: np.ndarray | float,
+    v2_m_s: np.ndarray | float,
+    v3_m_s: np.ndarray | float,
+    vsub_m_s: np.ndarray | float,
+    *,
+    strict_velocity_order: bool = False,
+) -> RefractionT1LSST3LayerThicknessResult:
+    """Compute three-layer thicknesses and status-code invalid endpoints."""
+    if strict_velocity_order:
+        t1, t2, t3, v1, v2, v3, vsub = _coerce_3layer_inputs(
+            t1_s=t1_s,
+            t2_s=t2_s,
+            t3_s=t3_s,
+            v1_m_s=v1_m_s,
+            v2_m_s=v2_m_s,
+            v3_m_s=v3_m_s,
+            vsub_m_s=vsub_m_s,
+        )
+        invalid_nonfinite = np.zeros(t1.shape, dtype=bool)
+        invalid_velocity_order = np.zeros(t1.shape, dtype=bool)
+    else:
+        t1, t2, t3, v1, v2, v3, vsub = _coerce_3layer_status_inputs(
+            t1_s=t1_s,
+            t2_s=t2_s,
+            t3_s=t3_s,
+            v1_m_s=v1_m_s,
+            v2_m_s=v2_m_s,
+            v3_m_s=v3_m_s,
+            vsub_m_s=vsub_m_s,
+        )
+        invalid_nonfinite = ~(
+            np.isfinite(t1)
+            & np.isfinite(t2)
+            & np.isfinite(t3)
+            & np.isfinite(v1)
+            & np.isfinite(v2)
+            & np.isfinite(v3)
+            & np.isfinite(vsub)
+        )
+        invalid_velocity_order = (
+            ~invalid_nonfinite
+            & ((v1 <= 0.0) | (v2 <= v1) | (v3 <= v2) | (vsub <= v3))
+        )
+
+    status = np.full(t1.shape, 'ok', dtype='<U32')
+    status[invalid_nonfinite] = 'invalid_nonfinite_input'
+    status[invalid_velocity_order] = 'invalid_velocity_order'
+    valid = status == 'ok'
+    sh1 = np.full(t1.shape, np.nan, dtype=np.float64)
+    sh2 = np.full(t1.shape, np.nan, dtype=np.float64)
+    sh3 = np.full(t1.shape, np.nan, dtype=np.float64)
+    if np.any(valid):
+        valid_t1 = t1[valid]
+        valid_t2 = t2[valid]
+        valid_t3 = t3[valid]
+        valid_v1 = v1[valid]
+        valid_v2 = v2[valid]
+        valid_v3 = v3[valid]
+        valid_vsub = vsub[valid]
+        c12 = np.sqrt(1.0 - (valid_v1 / valid_v2) ** 2)
+        c13 = np.sqrt(1.0 - (valid_v1 / valid_v3) ** 2)
+        c23 = np.sqrt(1.0 - (valid_v2 / valid_v3) ** 2)
+        c1sub = np.sqrt(1.0 - (valid_v1 / valid_vsub) ** 2)
+        c2sub = np.sqrt(1.0 - (valid_v2 / valid_vsub) ** 2)
+        c3sub = np.sqrt(1.0 - (valid_v3 / valid_vsub) ** 2)
+        valid_sh1 = valid_t1 * valid_v1 / c12
+        valid_sh2 = (
+            (valid_t2 - valid_sh1 * c13 / valid_v1)
+            * valid_v2
+            / c23
+        )
+        valid_sh3 = (
+            valid_t3
+            - valid_sh1 * c1sub / valid_v1
+            - valid_sh2 * c2sub / valid_v2
+        ) * valid_v3 / c3sub
+        sh1[valid] = valid_sh1
+        sh2[valid] = valid_sh2
+        sh3[valid] = valid_sh3
+
+    invalid_negative = (
+        (np.isfinite(sh1) & (sh1 < 0.0))
+        | (np.isfinite(sh2) & (sh2 < 0.0))
+        | (np.isfinite(sh3) & (sh3 < 0.0))
+    )
+    status[invalid_negative] = 'invalid_negative_thickness'
+    sh1[invalid_negative] = np.nan
+    sh2[invalid_negative] = np.nan
+    sh3[invalid_negative] = np.nan
+    wcor = np.full(t1.shape, np.nan, dtype=np.float64)
+    wcor_valid = status == 'ok'
+    if np.any(wcor_valid):
+        wcor[wcor_valid] = (
+            sh1[wcor_valid] * (1.0 / vsub[wcor_valid] - 1.0 / v1[wcor_valid])
+            + sh2[wcor_valid] * (1.0 / vsub[wcor_valid] - 1.0 / v2[wcor_valid])
+            + sh3[wcor_valid] * (1.0 / vsub[wcor_valid] - 1.0 / v3[wcor_valid])
+        )
+    return RefractionT1LSST3LayerThicknessResult(
+        sh1_m=np.array(sh1, dtype=np.float64, copy=True, order='C'),
+        sh2_m=np.array(sh2, dtype=np.float64, copy=True, order='C'),
+        sh3_m=np.array(sh3, dtype=np.float64, copy=True, order='C'),
+        status=np.array(status, dtype='<U32', copy=True, order='C'),
+        weathering_correction_s=np.array(wcor, dtype=np.float64, copy=True, order='C'),
+    )
+
+
+def compute_t1lsst_3layer_weathering_correction(
+    sh1_m: np.ndarray,
+    sh2_m: np.ndarray,
+    sh3_m: np.ndarray,
+    v1_m_s: np.ndarray | float,
+    v2_m_s: np.ndarray | float,
+    v3_m_s: np.ndarray | float,
+    vsub_m_s: np.ndarray | float,
+) -> np.ndarray:
+    """Compute three-layer replacement ``WCOR`` to Vsub in seconds."""
+    sh1 = _coerce_float_array(sh1_m, name='sh1_m', allow_nonfinite=True)
+    sh2 = _coerce_float_array(sh2_m, name='sh2_m', allow_nonfinite=True)
+    sh3 = _coerce_float_array(sh3_m, name='sh3_m', allow_nonfinite=True)
+    v1 = _positive_finite_float_array(v1_m_s, name='v1_m_s')
+    v2 = _positive_finite_float_array(v2_m_s, name='v2_m_s')
+    v3 = _positive_finite_float_array(v3_m_s, name='v3_m_s')
+    vsub = _positive_finite_float_array(vsub_m_s, name='vsub_m_s')
+    sh1, sh2, sh3, v1, v2, v3, vsub = _broadcast_t1lsst_arrays(
+        (sh1, sh2, sh3, v1, v2, v3, vsub),
+        names=(
+            'sh1_m',
+            'sh2_m',
+            'sh3_m',
+            'v1_m_s',
+            'v2_m_s',
+            'v3_m_s',
+            'vsub_m_s',
+        ),
+    )
+    _validate_3layer_velocity_order(v1=v1, v2=v2, v3=v3, vsub=vsub)
+    return np.array(
+        sh1 * (1.0 / vsub - 1.0 / v1)
+        + sh2 * (1.0 / vsub - 1.0 / v2)
+        + sh3 * (1.0 / vsub - 1.0 / v3),
         dtype=np.float64,
         copy=True,
         order='C',
@@ -541,6 +725,86 @@ def _coerce_2layer_status_inputs(
     )
 
 
+def _coerce_3layer_inputs(
+    *,
+    t1_s: object,
+    t2_s: object,
+    t3_s: object,
+    v1_m_s: object,
+    v2_m_s: object,
+    v3_m_s: object,
+    vsub_m_s: object,
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+]:
+    t1 = _coerce_float_array(t1_s, name='t1_s')
+    t2 = _coerce_float_array(t2_s, name='t2_s')
+    t3 = _coerce_float_array(t3_s, name='t3_s')
+    v1 = _positive_finite_float_array(v1_m_s, name='v1_m_s')
+    v2 = _positive_finite_float_array(v2_m_s, name='v2_m_s')
+    v3 = _positive_finite_float_array(v3_m_s, name='v3_m_s')
+    vsub = _positive_finite_float_array(vsub_m_s, name='vsub_m_s')
+    t1, t2, t3, v1, v2, v3, vsub = _broadcast_t1lsst_arrays(
+        (t1, t2, t3, v1, v2, v3, vsub),
+        names=(
+            't1_s',
+            't2_s',
+            't3_s',
+            'v1_m_s',
+            'v2_m_s',
+            'v3_m_s',
+            'vsub_m_s',
+        ),
+    )
+    _validate_3layer_velocity_order(v1=v1, v2=v2, v3=v3, vsub=vsub)
+    return t1, t2, t3, v1, v2, v3, vsub
+
+
+def _coerce_3layer_status_inputs(
+    *,
+    t1_s: object,
+    t2_s: object,
+    t3_s: object,
+    v1_m_s: object,
+    v2_m_s: object,
+    v3_m_s: object,
+    vsub_m_s: object,
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+]:
+    t1 = _coerce_float_array(t1_s, name='t1_s', allow_nonfinite=True)
+    t2 = _coerce_float_array(t2_s, name='t2_s', allow_nonfinite=True)
+    t3 = _coerce_float_array(t3_s, name='t3_s', allow_nonfinite=True)
+    v1 = _coerce_float_array(v1_m_s, name='v1_m_s', allow_nonfinite=True)
+    v2 = _coerce_float_array(v2_m_s, name='v2_m_s', allow_nonfinite=True)
+    v3 = _coerce_float_array(v3_m_s, name='v3_m_s', allow_nonfinite=True)
+    vsub = _coerce_float_array(vsub_m_s, name='vsub_m_s', allow_nonfinite=True)
+    return _broadcast_t1lsst_arrays(
+        (t1, t2, t3, v1, v2, v3, vsub),
+        names=(
+            't1_s',
+            't2_s',
+            't3_s',
+            'v1_m_s',
+            'v2_m_s',
+            'v3_m_s',
+            'vsub_m_s',
+        ),
+    )
+
+
 def _broadcast_t1lsst_arrays(
     arrays: tuple[np.ndarray, ...],
     *,
@@ -569,6 +833,18 @@ def _validate_2layer_velocity_order(
         raise RefractionT1LSSTError('v2_m_s must be greater than v1_m_s')
     if np.any(v3 <= v2):
         raise RefractionT1LSSTError('v3_m_s must be greater than v2_m_s')
+
+
+def _validate_3layer_velocity_order(
+    *,
+    v1: np.ndarray,
+    v2: np.ndarray,
+    v3: np.ndarray,
+    vsub: np.ndarray,
+) -> None:
+    _validate_2layer_velocity_order(v1=v1, v2=v2, v3=v3)
+    if np.any(vsub <= v3):
+        raise RefractionT1LSSTError('vsub_m_s must be greater than v3_m_s')
 
 
 def _positive_finite(value: object, *, name: str) -> float:
@@ -643,12 +919,16 @@ __all__ = [
     'REFRACTION_T1LSST_1LAYER_COMPONENTS_CSV_NAME',
     'T1LSST_SIGN_CONVENTION',
     'RefractionT1LSST2LayerThicknessResult',
+    'RefractionT1LSST3LayerThicknessResult',
     'RefractionT1LSSTError',
     'compute_t1lsst_1layer_thickness',
     'compute_t1lsst_1layer_weathering_correction',
     'compute_t1lsst_2layer_thicknesses',
     'compute_t1lsst_2layer_thicknesses_with_status',
     'compute_t1lsst_2layer_weathering_correction',
+    'compute_t1lsst_3layer_thicknesses',
+    'compute_t1lsst_3layer_thicknesses_with_status',
+    'compute_t1lsst_3layer_weathering_correction',
     'compose_t1lsst_1layer_static_table_components',
     'write_refraction_t1lsst_1layer_components_csv',
 ]

--- a/app/services/refraction_static_types.py
+++ b/app/services/refraction_static_types.py
@@ -596,14 +596,21 @@ class RefractionWeatheringReplacementStaticsResult:
     receiver_v2_status_sorted: np.ndarray | None = None
     node_sh1_weathering_thickness_m: np.ndarray | None = None
     node_sh2_weathering_thickness_m: np.ndarray | None = None
+    node_sh3_weathering_thickness_m: np.ndarray | None = None
     source_t2_time_s: np.ndarray | None = None
+    source_t3_time_s: np.ndarray | None = None
     source_v3_m_s: np.ndarray | None = None
+    source_vsub_m_s: np.ndarray | None = None
     source_sh1_weathering_thickness_m: np.ndarray | None = None
     source_sh2_weathering_thickness_m: np.ndarray | None = None
+    source_sh3_weathering_thickness_m: np.ndarray | None = None
     receiver_t2_time_s: np.ndarray | None = None
+    receiver_t3_time_s: np.ndarray | None = None
     receiver_v3_m_s: np.ndarray | None = None
+    receiver_vsub_m_s: np.ndarray | None = None
     receiver_sh1_weathering_thickness_m: np.ndarray | None = None
     receiver_sh2_weathering_thickness_m: np.ndarray | None = None
+    receiver_sh3_weathering_thickness_m: np.ndarray | None = None
 
 
 @dataclass(frozen=True)
@@ -738,14 +745,21 @@ class RefractionDatumStaticsResult:
     receiver_v2_status_sorted: np.ndarray | None = None
     node_sh1_weathering_thickness_m: np.ndarray | None = None
     node_sh2_weathering_thickness_m: np.ndarray | None = None
+    node_sh3_weathering_thickness_m: np.ndarray | None = None
     source_t2_time_s: np.ndarray | None = None
+    source_t3_time_s: np.ndarray | None = None
     source_v3_m_s: np.ndarray | None = None
+    source_vsub_m_s: np.ndarray | None = None
     source_sh1_weathering_thickness_m: np.ndarray | None = None
     source_sh2_weathering_thickness_m: np.ndarray | None = None
+    source_sh3_weathering_thickness_m: np.ndarray | None = None
     receiver_t2_time_s: np.ndarray | None = None
+    receiver_t3_time_s: np.ndarray | None = None
     receiver_v3_m_s: np.ndarray | None = None
+    receiver_vsub_m_s: np.ndarray | None = None
     receiver_sh1_weathering_thickness_m: np.ndarray | None = None
     receiver_sh2_weathering_thickness_m: np.ndarray | None = None
+    receiver_sh3_weathering_thickness_m: np.ndarray | None = None
 
 
 @dataclass(frozen=True)

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -62,6 +62,12 @@ from app.tests._refraction_static_synthetic import (
     synthetic_refracted_arrival_input_model,
     synthetic_refraction_apply_request,
 )
+from app.tests._refraction_multilayer_synthetic import (
+    SYNTHETIC_MULTILAYER_V1_M_S,
+    SYNTHETIC_MULTILAYER_V2_M_S,
+    SYNTHETIC_MULTILAYER_V3_M_S,
+    SYNTHETIC_MULTILAYER_VSUB_M_S,
+)
 from app.tests.test_refraction_static_multilayer_2layer_e2e import (
     _CELL_VELOCITY_ARTIFACT_NAMES,
     _make_two_layer_fixture,
@@ -360,7 +366,7 @@ def test_run_refraction_static_apply_job_rejects_multilayer_conversion_explicitl
         job = dict(client.app.state.sv.jobs[job_id])
     assert job['status'] == 'error'
     assert 'conversion.mode=t1lsst_multilayer' in str(job['message'])
-    assert 'public two-layer refraction apply requires' in str(job['message'])
+    assert 'public multi-layer refraction apply requires' in str(job['message'])
     assert REQUEST_JSON_NAME in _job_file_names(job_dir)
     assert FINAL_REFRACTION_ARTIFACTS.isdisjoint(_job_file_names(job_dir))
 
@@ -462,13 +468,86 @@ def test_run_refraction_static_apply_job_completes_two_layer_cell_v2_global_v3(
     assert qc['velocity']['cell_velocity_component'] == 'v2'
 
 
-def test_run_refraction_static_apply_job_rejects_vsub_t3_until_implemented(
+def test_public_apply_accepts_three_layer_multilayer_request(
     client: TestClient,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     payload = _three_layer_apply_payload()
     req = RefractionStaticApplyRequest.model_validate(payload)
     job_id = 'refraction-vsub-t3-job-id'
+    job_dir = tmp_path / 'jobs' / job_id
+    _create_refraction_job(client, job_id=job_id, req=req, job_dir=job_dir)
+    input_model = object()
+    build_calls: list[dict[str, Any]] = []
+    workflow_calls: list[dict[str, Any]] = []
+
+    def _build_input_model(**kwargs: Any) -> object:
+        build_calls.append(kwargs)
+        return input_model
+
+    def _compute_workflow(**kwargs: Any) -> SimpleNamespace:
+        workflow_calls.append(kwargs)
+        return SimpleNamespace(datum_result=_three_layer_contract_datum_result())
+
+    monkeypatch.setattr(
+        refraction_service_module,
+        'build_refraction_static_input_model',
+        _build_input_model,
+    )
+    monkeypatch.setattr(
+        refraction_service_module,
+        'compute_refraction_multilayer_datum_statics_from_input_model',
+        _compute_workflow,
+    )
+
+    run_refraction_static_apply_job(job_id, req, client.app.state.sv)
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'done', job.get('message')
+    assert len(build_calls) == 1
+    assert build_calls[0]['req'] is req
+    assert len(workflow_calls) == 1
+    assert workflow_calls[0]['input_model'] is input_model
+    assert workflow_calls[0]['model'] is req.model
+    assert REQUEST_JSON_NAME in _job_file_names(job_dir)
+    assert FINAL_REFRACTION_ARTIFACTS.issubset(_job_file_names(job_dir))
+
+    qc = json.loads(
+        (job_dir / REFRACTION_STATIC_QC_JSON_NAME).read_text(encoding='utf-8')
+    )
+    assert qc['conversion_mode'] == 't1lsst_multilayer'
+    assert qc['layer_count'] == 3
+    assert qc['enabled_layer_kinds'] == ['v2_t1', 'v3_t2', 'vsub_t3']
+    _assert_three_layer_solution_arrays(job_dir)
+
+
+def test_public_apply_rejects_unsupported_vsub_cell_velocity_mode(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    payload = _three_layer_apply_payload()
+    payload['model']['refractor_cell'] = {
+        'number_of_cell_x': 5,
+        'size_of_cell_x_m': 500.0,
+        'x_coordinate_origin_m': 0.0,
+        'number_of_cell_y': 1,
+        'size_of_cell_y_m': None,
+        'y_coordinate_origin_m': 0.0,
+        'assignment_mode': 'midpoint',
+        'outside_grid_policy': 'reject',
+        'coordinate_mode': 'grid_3d',
+        'min_observations_per_cell': 1,
+        'velocity_smoothing_weight': 0.0,
+        'smoothing_reference_distance_m': None,
+    }
+    vsub_layer = payload['model']['layers'][2]
+    vsub_layer['velocity_mode'] = 'solve_cell'
+    vsub_layer['fixed_velocity_m_s'] = None
+    vsub_layer['initial_velocity_m_s'] = 5200.0
+    req = RefractionStaticApplyRequest.model_validate(payload)
+    job_id = 'refraction-vsub-cell-job-id'
     job_dir = tmp_path / 'jobs' / job_id
     _create_refraction_job(client, job_id=job_id, req=req, job_dir=job_dir)
 
@@ -477,10 +556,10 @@ def test_run_refraction_static_apply_job_rejects_vsub_t3_until_implemented(
     with client.app.state.sv.lock:
         job = dict(client.app.state.sv.jobs[job_id])
     assert job['status'] == 'error'
-    assert 'vsub_t3' in str(job['message'])
-    assert 'three-layer T1LSST conversion' in str(job['message'])
-    assert REQUEST_JSON_NAME in _job_file_names(job_dir)
-    assert FINAL_REFRACTION_ARTIFACTS.isdisjoint(_job_file_names(job_dir))
+    message = str(job['message'])
+    assert 'conversion.layer_count=3' in message
+    assert 'enabled layer kinds=v2_t1, v3_t2, vsub_t3' in message
+    assert 'vsub_t3 velocity_mode=solve_cell is not supported' in message
 
 
 def test_run_refraction_static_apply_job_rejects_cell_v3_until_implemented(
@@ -1626,40 +1705,48 @@ def _two_layer_apply_request(fixture: Any) -> RefractionStaticApplyRequest:
 
 def _three_layer_apply_payload() -> dict[str, Any]:
     payload = _payload()
+    layer_ranges = {
+        'v2_t1': (0.0, 1000.0),
+        'v3_t2': (1000.0, 2000.0),
+        'vsub_t3': (2000.0, None),
+    }
+    v2_min, v2_max = layer_ranges['v2_t1']
+    v3_min, v3_max = layer_ranges['v3_t2']
+    vsub_min, vsub_max = layer_ranges['vsub_t3']
     payload['model'] = {
         'method': 'multilayer_time_term',
         'first_layer': {
             'mode': 'constant',
-            'weathering_velocity_m_s': 800.0,
+            'weathering_velocity_m_s': SYNTHETIC_MULTILAYER_V1_M_S,
         },
         'layers': [
             {
                 'kind': 'v2_t1',
                 'enabled': True,
-                'min_offset_m': 0.0,
-                'max_offset_m': 1000.0,
-                'velocity_mode': 'solve_global',
-                'initial_velocity_m_s': 2400.0,
+                'min_offset_m': v2_min,
+                'max_offset_m': v2_max,
+                'velocity_mode': 'fixed_global',
+                'fixed_velocity_m_s': SYNTHETIC_MULTILAYER_V2_M_S,
                 'min_velocity_m_s': 1200.0,
                 'max_velocity_m_s': 3200.0,
             },
             {
                 'kind': 'v3_t2',
                 'enabled': True,
-                'min_offset_m': 1000.0,
-                'max_offset_m': 2000.0,
-                'velocity_mode': 'solve_global',
-                'initial_velocity_m_s': 3600.0,
+                'min_offset_m': v3_min,
+                'max_offset_m': v3_max,
+                'velocity_mode': 'fixed_global',
+                'fixed_velocity_m_s': SYNTHETIC_MULTILAYER_V3_M_S,
                 'min_velocity_m_s': 2600.0,
                 'max_velocity_m_s': 4800.0,
             },
             {
                 'kind': 'vsub_t3',
                 'enabled': True,
-                'min_offset_m': 2000.0,
-                'max_offset_m': None,
+                'min_offset_m': vsub_min,
+                'max_offset_m': vsub_max,
                 'velocity_mode': 'fixed_global',
-                'fixed_velocity_m_s': 5200.0,
+                'fixed_velocity_m_s': SYNTHETIC_MULTILAYER_VSUB_M_S,
                 'min_velocity_m_s': 3600.0,
                 'max_velocity_m_s': 7000.0,
             },
@@ -1694,6 +1781,134 @@ def _assert_two_layer_solution_arrays(job_dir: Path) -> None:
         assert expected_arrays <= set(data.files)
         for key in expected_arrays:
             assert data[key].dtype != object
+
+
+def _three_layer_contract_datum_result() -> Any:
+    result = _artifact_result()
+    node_sh1 = result.node_weathering_thickness_m
+    node_sh2 = np.asarray([4.0, 5.0, 6.0], dtype=np.float64)
+    node_sh3 = np.asarray([2.0, 3.0, 4.0], dtype=np.float64)
+    node_total = node_sh1 + node_sh2 + node_sh3
+
+    source_sh1 = result.source_weathering_thickness_m
+    source_sh2 = np.asarray([4.0, 5.0], dtype=np.float64)
+    source_sh3 = np.asarray([2.0, 3.0], dtype=np.float64)
+    source_total = source_sh1 + source_sh2 + source_sh3
+    source_sh2_sorted = np.asarray([4.0, 5.0, 4.0, 5.0], dtype=np.float64)
+    source_sh3_sorted = np.asarray([2.0, 3.0, 2.0, 3.0], dtype=np.float64)
+    source_total_sorted = (
+        result.source_weathering_thickness_m_sorted
+        + source_sh2_sorted
+        + source_sh3_sorted
+    )
+
+    receiver_sh1 = result.receiver_weathering_thickness_m
+    receiver_sh2 = np.asarray([5.0, 6.0], dtype=np.float64)
+    receiver_sh3 = np.asarray([3.0, 4.0], dtype=np.float64)
+    receiver_total = receiver_sh1 + receiver_sh2 + receiver_sh3
+    receiver_sh2_sorted = np.asarray([5.0, 6.0, 6.0, 5.0], dtype=np.float64)
+    receiver_sh3_sorted = np.asarray([3.0, 4.0, 4.0, 3.0], dtype=np.float64)
+    receiver_total_sorted = (
+        result.receiver_weathering_thickness_m_sorted
+        + receiver_sh2_sorted
+        + receiver_sh3_sorted
+    )
+
+    return replace(
+        result,
+        bedrock_velocity_mode='fixed_global',
+        bedrock_slowness_s_per_m=1.0 / SYNTHETIC_MULTILAYER_VSUB_M_S,
+        bedrock_velocity_m_s=SYNTHETIC_MULTILAYER_VSUB_M_S,
+        weathering_velocity_m_s=SYNTHETIC_MULTILAYER_V1_M_S,
+        replacement_slowness_delta_s_per_m=(
+            1.0 / SYNTHETIC_MULTILAYER_VSUB_M_S
+            - 1.0 / SYNTHETIC_MULTILAYER_V1_M_S
+        ),
+        qc={
+            **result.qc,
+            'method': 'multilayer_time_term',
+            'conversion_mode': 't1lsst_multilayer',
+            'layer_count': 3,
+            'enabled_layer_kinds': ['v2_t1', 'v3_t2', 'vsub_t3'],
+        },
+        node_weathering_thickness_m=node_total,
+        node_refractor_elevation_m=result.node_surface_elevation_m - node_total,
+        node_sh1_weathering_thickness_m=node_sh1,
+        node_sh2_weathering_thickness_m=node_sh2,
+        node_sh3_weathering_thickness_m=node_sh3,
+        source_weathering_thickness_m=source_total,
+        source_refractor_elevation_m=(
+            result.source_surface_elevation_m - source_total
+        ),
+        source_weathering_thickness_m_sorted=source_total_sorted,
+        source_refractor_elevation_m_sorted=(
+            result.source_surface_elevation_m_sorted - source_total_sorted
+        ),
+        source_t2_time_s=np.asarray([0.020, 0.022], dtype=np.float64),
+        source_t3_time_s=np.asarray([0.030, 0.033], dtype=np.float64),
+        source_v3_m_s=np.full(2, SYNTHETIC_MULTILAYER_V3_M_S, dtype=np.float64),
+        source_vsub_m_s=np.full(
+            2,
+            SYNTHETIC_MULTILAYER_VSUB_M_S,
+            dtype=np.float64,
+        ),
+        source_sh1_weathering_thickness_m=source_sh1,
+        source_sh2_weathering_thickness_m=source_sh2,
+        source_sh3_weathering_thickness_m=source_sh3,
+        receiver_weathering_thickness_m=receiver_total,
+        receiver_refractor_elevation_m=(
+            result.receiver_surface_elevation_m - receiver_total
+        ),
+        receiver_weathering_thickness_m_sorted=receiver_total_sorted,
+        receiver_refractor_elevation_m_sorted=(
+            result.receiver_surface_elevation_m_sorted - receiver_total_sorted
+        ),
+        receiver_t2_time_s=np.asarray([0.023, 0.025], dtype=np.float64),
+        receiver_t3_time_s=np.asarray([0.034, 0.037], dtype=np.float64),
+        receiver_v3_m_s=np.full(2, SYNTHETIC_MULTILAYER_V3_M_S, dtype=np.float64),
+        receiver_vsub_m_s=np.full(
+            2,
+            SYNTHETIC_MULTILAYER_VSUB_M_S,
+            dtype=np.float64,
+        ),
+        receiver_sh1_weathering_thickness_m=receiver_sh1,
+        receiver_sh2_weathering_thickness_m=receiver_sh2,
+        receiver_sh3_weathering_thickness_m=receiver_sh3,
+    )
+
+
+def _assert_three_layer_solution_arrays(job_dir: Path) -> None:
+    expected_arrays = {
+        'node_sh3_weathering_thickness_m',
+        'source_t3_time_s',
+        'source_vsub_m_s',
+        'source_sh3_weathering_thickness_m',
+        'receiver_t3_time_s',
+        'receiver_vsub_m_s',
+        'receiver_sh3_weathering_thickness_m',
+    }
+    with np.load(job_dir / REFRACTION_STATIC_SOLUTION_NPZ_NAME, allow_pickle=False) as data:
+        assert expected_arrays <= set(data.files)
+        for key in expected_arrays:
+            assert data[key].dtype != object
+        assert np.count_nonzero(np.isfinite(data['source_t3_time_s'])) > 0
+        assert np.count_nonzero(np.isfinite(data['receiver_t3_time_s'])) > 0
+        assert (
+            np.count_nonzero(
+                np.isfinite(data['source_sh3_weathering_thickness_m'])
+            )
+            > 0
+        )
+        np.testing.assert_allclose(
+            data['source_vsub_m_s'],
+            SYNTHETIC_MULTILAYER_VSUB_M_S,
+            rtol=1.0e-9,
+        )
+        np.testing.assert_allclose(
+            data['receiver_vsub_m_s'],
+            SYNTHETIC_MULTILAYER_VSUB_M_S,
+            rtol=1.0e-9,
+        )
 
 
 def _create_refraction_job(

--- a/app/tests/test_refraction_static_import_layers.py
+++ b/app/tests/test_refraction_static_import_layers.py
@@ -6,8 +6,10 @@ from pathlib import Path
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from types import ModuleType
+from typing import TextIO
 
 import pytest
 
@@ -54,6 +56,12 @@ def _subprocess_output_text(value: bytes | str | None) -> str:
     return value if value else '<empty>'
 
 
+def _read_tmp_text(file_obj: TextIO) -> str:
+    file_obj.flush()
+    file_obj.seek(0)
+    return file_obj.read()
+
+
 def _import_check_failure_message(
     title: str,
     *,
@@ -91,53 +99,60 @@ def _run_import_check_subprocess(
     forbidden_modules: set[str],
     forbidden_module_prefixes: tuple[str, ...],
 ) -> subprocess.CompletedProcess[str]:
-    proc = subprocess.Popen(
-        [sys.executable, '-c', code],
-        cwd=_REPO_ROOT,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-        env={**os.environ, **_IMPORT_LAYER_CHILD_ENV_OVERRIDES},
-    )
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout_s)
-    except subprocess.TimeoutExpired as exc:
-        try:
-            os.killpg(proc.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        try:
-            stdout, stderr = proc.communicate(timeout=1.0)
-        except subprocess.TimeoutExpired as drain_exc:
-            stdout = drain_exc.stdout or exc.stdout
-            stderr = drain_exc.stderr or exc.stderr
-        raise AssertionError(
-            _import_check_failure_message(
-                'Timed out while checking dependency-light import layer',
-                module_name=module_name,
-                forbidden_modules=forbidden_modules,
-                forbidden_module_prefixes=forbidden_module_prefixes,
-                timeout_s=timeout_s,
-                stdout=stdout,
-                stderr=stderr,
-            )
-        ) from exc
-
-    if proc.returncode != 0:
-        raise AssertionError(
-            _import_check_failure_message(
-                'Dependency-light import subprocess failed',
-                module_name=module_name,
-                forbidden_modules=forbidden_modules,
-                forbidden_module_prefixes=forbidden_module_prefixes,
-                timeout_s=timeout_s,
-                stdout=stdout,
-                stderr=stderr,
-                returncode=proc.returncode,
-            )
+    with (
+        tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as stdout_file,
+        tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as stderr_file,
+    ):
+        proc = subprocess.Popen(
+            [sys.executable, '-c', code],
+            cwd=_REPO_ROOT,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            text=True,
+            start_new_session=True,
+            env={**os.environ, **_IMPORT_LAYER_CHILD_ENV_OVERRIDES},
         )
-    return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
+        try:
+            returncode = proc.wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired as exc:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            try:
+                proc.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                pass
+            stdout = _read_tmp_text(stdout_file)
+            stderr = _read_tmp_text(stderr_file)
+            raise AssertionError(
+                _import_check_failure_message(
+                    'Timed out while checking dependency-light import layer',
+                    module_name=module_name,
+                    forbidden_modules=forbidden_modules,
+                    forbidden_module_prefixes=forbidden_module_prefixes,
+                    timeout_s=timeout_s,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            ) from exc
+
+        stdout = _read_tmp_text(stdout_file)
+        stderr = _read_tmp_text(stderr_file)
+        if returncode != 0:
+            raise AssertionError(
+                _import_check_failure_message(
+                    'Dependency-light import subprocess failed',
+                    module_name=module_name,
+                    forbidden_modules=forbidden_modules,
+                    forbidden_module_prefixes=forbidden_module_prefixes,
+                    timeout_s=timeout_s,
+                    stdout=stdout,
+                    stderr=stderr,
+                    returncode=returncode,
+                )
+            )
+        return subprocess.CompletedProcess(proc.args, returncode, stdout, stderr)
 
 
 def _forbidden_modules_imported_by(
@@ -191,10 +206,13 @@ def test_refraction_static_import_layer_checks_use_process_group_timeout(
             self.args = args
             self.pid = 12345
             self.returncode = 0
+            stdout = kwargs['stdout']
+            assert hasattr(stdout, 'write')
+            stdout.write('[]')
 
-        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+        def wait(self, timeout: float | None = None) -> int:
             captured['timeout'] = timeout
-            return '[]', ''
+            return self.returncode
 
     monkeypatch.setattr(subprocess, 'Popen', FakePopen)
 
@@ -202,8 +220,10 @@ def test_refraction_static_import_layer_checks_use_process_group_timeout(
 
     kwargs = captured['kwargs']
     assert kwargs['cwd'] == _REPO_ROOT
-    assert kwargs['stdout'] == subprocess.PIPE
-    assert kwargs['stderr'] == subprocess.PIPE
+    assert kwargs['stdout'] != subprocess.PIPE
+    assert kwargs['stderr'] != subprocess.PIPE
+    assert hasattr(kwargs['stdout'], 'write')
+    assert hasattr(kwargs['stderr'], 'write')
     assert kwargs['text'] is True
     assert kwargs['start_new_session'] is True
     assert captured['timeout'] == _IMPORT_LAYER_CHECK_TIMEOUT_S
@@ -270,18 +290,23 @@ def test_import_layer_timeout_failure_message_is_readable(
             self.args = args
             self.pid = 67890
             self.returncode = None
-            self.communicate_calls = 0
+            self.wait_calls = 0
+            stdout = kwargs['stdout']
+            stderr = kwargs['stderr']
+            assert hasattr(stdout, 'write')
+            assert hasattr(stderr, 'write')
+            stdout.write('partial stdout')
+            stderr.write('partial stderr')
 
-        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
-            self.communicate_calls += 1
-            if self.communicate_calls == 1:
+        def wait(self, timeout: float | None = None) -> int:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
                 raise subprocess.TimeoutExpired(
                     cmd=self.args,
                     timeout=timeout,
-                    output='partial stdout',
-                    stderr='partial stderr',
                 )
-            return 'partial stdout', 'partial stderr'
+            self.returncode = -signal.SIGKILL
+            return self.returncode
 
     def fake_killpg(pid: int, sig: int) -> None:
         captured['killpg'] = (pid, sig)

--- a/app/tests/test_refraction_static_multilayer_orchestration.py
+++ b/app/tests/test_refraction_static_multilayer_orchestration.py
@@ -217,7 +217,7 @@ def test_multilayer_orchestrator_applies_layer_cell_settings_to_layer_model() ->
     assert result.layer_results[0].velocity_mode == 'solve_cell'
 
 
-def test_multilayer_orchestrator_rejects_unimplemented_vsub_layer() -> None:
+def test_three_enabled_layers_are_solved_in_order_without_custom_dispatch() -> None:
     dataset = make_2d_straight_three_layer_refraction_dataset()
     model = _model(
         [
@@ -225,8 +225,8 @@ def test_multilayer_orchestrator_rejects_unimplemented_vsub_layer() -> None:
                 'v2_t1',
                 min_offset_m=300.0,
                 max_offset_m=800.0,
-                velocity_mode='solve_global',
-                initial_velocity_m_s=SYNTHETIC_MULTILAYER_V2_M_S,
+                velocity_mode='fixed_global',
+                fixed_velocity_m_s=SYNTHETIC_MULTILAYER_V2_M_S,
                 min_velocity_m_s=1600.0,
                 max_velocity_m_s=3200.0,
             ),
@@ -234,8 +234,8 @@ def test_multilayer_orchestrator_rejects_unimplemented_vsub_layer() -> None:
                 'v3_t2',
                 min_offset_m=1000.0,
                 max_offset_m=1900.0,
-                velocity_mode='solve_global',
-                initial_velocity_m_s=SYNTHETIC_MULTILAYER_V3_M_S,
+                velocity_mode='fixed_global',
+                fixed_velocity_m_s=SYNTHETIC_MULTILAYER_V3_M_S,
                 min_velocity_m_s=2600.0,
                 max_velocity_m_s=4800.0,
             ),
@@ -256,18 +256,29 @@ def test_multilayer_orchestrator_rejects_unimplemented_vsub_layer() -> None:
         model=model,
     )
 
-    with pytest.raises(
-        RefractionMultiLayerSolveError,
-        match='vsub_t3.*fixed_global.*not implemented',
-    ):
-        solve_refraction_multilayer_time_terms(
-            input_model=input_model,
-            resolved_first_layer=_resolved_first_layer(),
-            normalized_layers=normalize_refraction_static_layers(model),
-            layer_masks=masks,
-            model=model,
-            solver=RefractionStaticSolverRequest(),
-        )
+    result = solve_refraction_multilayer_time_terms(
+        input_model=input_model,
+        resolved_first_layer=_resolved_first_layer(),
+        normalized_layers=normalize_refraction_static_layers(model),
+        layer_masks=masks,
+        model=model,
+        solver=RefractionStaticSolverRequest(robust={'enabled': False}),
+    )
+
+    assert result.enabled_layer_kinds == ('v2_t1', 'v3_t2', 'vsub_t3')
+    assert [layer.layer_kind for layer in result.layer_results] == [
+        'v2_t1',
+        'v3_t2',
+        'vsub_t3',
+    ]
+    assert [layer.layer_index for layer in result.layer_results] == [1, 2, 3]
+    assert result.layer_results[2].global_velocity_m_s == pytest.approx(
+        SYNTHETIC_MULTILAYER_VSUB_M_S
+    )
+    assert 'vsub_t3' in result.qc['layers']
+    assert result.qc['observation_gates']['vsub_t3']['n_used_observations'] == int(
+        np.count_nonzero(masks.layer_used_mask_sorted['vsub_t3'])
+    )
 
 
 def test_multilayer_orchestrator_rejects_empty_layer_mask() -> None:

--- a/app/tests/test_refraction_static_multilayer_schema.py
+++ b/app/tests/test_refraction_static_multilayer_schema.py
@@ -256,5 +256,40 @@ def test_multilayer_conversion_requires_matching_enabled_layer_count() -> None:
 
     bad_payload = deepcopy(payload)
     bad_payload['conversion']['layer_count'] = 3
-    with pytest.raises(ValidationError, match='must match enabled refraction layers'):
+    with pytest.raises(
+        ValidationError,
+        match=(
+            'conversion.layer_count=3.*enabled layer kinds=v2_t1, v3_t2'
+        ),
+    ):
         RefractionStaticApplyRequest.model_validate(bad_payload)
+
+
+def test_multilayer_conversion_accepts_three_layer_contract() -> None:
+    payload = _apply_payload(
+        model=_multilayer_model([_v2_layer(), _v3_layer(), _vsub_layer()]),
+        conversion={'mode': 't1lsst_multilayer', 'layer_count': 3},
+    )
+    req = RefractionStaticApplyRequest.model_validate(payload)
+
+    assert req.conversion.mode == 't1lsst_multilayer'
+    assert req.conversion.layer_count == 3
+    assert [
+        layer.kind
+        for layer in normalize_refraction_static_layers(req.model)
+    ] == ['v2_t1', 'v3_t2', 'vsub_t3']
+
+
+def test_multilayer_conversion_rejects_layer_count_two_with_vsub_enabled() -> None:
+    payload = _apply_payload(
+        model=_multilayer_model([_v2_layer(), _v3_layer(), _vsub_layer()]),
+        conversion={'mode': 't1lsst_multilayer', 'layer_count': 2},
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match=(
+            'conversion.layer_count=2.*enabled layer kinds=v2_t1, v3_t2, vsub_t3'
+        ),
+    ):
+        RefractionStaticApplyRequest.model_validate(payload)

--- a/app/tests/test_refraction_static_multilayer_vsub_t3_solver.py
+++ b/app/tests/test_refraction_static_multilayer_vsub_t3_solver.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.api.schemas import RefractionStaticModelRequest, RefractionStaticSolverRequest
+from app.services.refraction_static_layer_config import (
+    normalize_refraction_static_layers,
+)
+from app.services.refraction_static_layer_observations import (
+    build_refraction_layer_observation_masks,
+)
+from app.services.refraction_static_multilayer_service import (
+    RefractionMultiLayerSolveError,
+    solve_refraction_multilayer_time_terms,
+)
+from app.services.refraction_static_types import (
+    RefractionEndpointTable,
+    RefractionLayerKind,
+    RefractionLayerSolveResult,
+    RefractionMultiLayerSolveResult,
+    RefractionStaticInputModel,
+    ResolvedRefractionFirstLayer,
+)
+
+V1_M_S = 800.0
+V2_M_S = 2400.0
+V3_M_S = 3600.0
+VSUB_M_S = 4800.0
+T1_S = np.asarray([0.008, 0.010, 0.012, 0.014, 0.016], dtype=np.float64)
+T2_S = np.asarray([0.020, 0.024, 0.022, 0.026, 0.028], dtype=np.float64)
+T3_S = np.asarray([0.036, 0.040, 0.038, 0.043, 0.046], dtype=np.float64)
+SOURCE_NODE = np.asarray([0, 0, 0, 1, 1, 2, 0, 1, 2, 3], dtype=np.int64)
+RECEIVER_NODE = np.asarray([1, 2, 3, 2, 4, 4, 0, 1, 2, 3], dtype=np.int64)
+V2_OFFSET_M = np.asarray(
+    [320.0, 450.0, 600.0, 380.0, 700.0, 520.0, 260.0, 300.0, 340.0, 480.0],
+    dtype=np.float64,
+)
+V3_OFFSET_M = np.asarray(
+    [1050.0, 1240.0, 1390.0, 1160.0, 1550.0, 1320.0, 1100.0, 1450.0, 1700.0, 1280.0],
+    dtype=np.float64,
+)
+VSUB_OFFSET_M = np.asarray(
+    [
+        2400.0,
+        2700.0,
+        3100.0,
+        2500.0,
+        3300.0,
+        2900.0,
+        2450.0,
+        2800.0,
+        3250.0,
+        3000.0,
+    ],
+    dtype=np.float64,
+)
+
+
+def test_vsub_t3_fixed_global_layer_solves_after_v3_t2() -> None:
+    result = _run_multilayer(
+        model=_model(vsub_velocity_mode='fixed_global'),
+        input_model=_input_model(),
+    )
+
+    assert result.enabled_layer_kinds == ('v2_t1', 'v3_t2', 'vsub_t3')
+    assert [layer.layer_kind for layer in result.layer_results] == [
+        'v2_t1',
+        'v3_t2',
+        'vsub_t3',
+    ]
+    layer = _layer(result, 'vsub_t3')
+    assert layer.velocity_mode == 'fixed_global'
+    assert layer.layer_index == 3
+    assert layer.global_velocity_m_s == pytest.approx(VSUB_M_S)
+    assert layer.global_slowness_s_per_m == pytest.approx(1.0 / VSUB_M_S)
+    assert layer.qc['velocity_sequence_reference_layer_kind'] == 'v3_t2'
+    assert layer.qc['velocity_sequence_reference_m_s'] == pytest.approx(V3_M_S)
+    assert result.qc['layers']['vsub_t3']['layer_kind'] == 'vsub_t3'
+    assert result.qc['observation_gates']['vsub_t3']['n_used_observations'] == (
+        VSUB_OFFSET_M.size
+    )
+
+
+def test_vsub_t3_solve_global_recovers_synthetic_vsub() -> None:
+    result = _run_multilayer(
+        model=_model(vsub_velocity_mode='solve_global'),
+        input_model=_input_model(),
+    )
+
+    layer = _layer(result, 'vsub_t3')
+
+    assert layer.velocity_mode == 'solve_global'
+    assert layer.global_velocity_m_s == pytest.approx(VSUB_M_S, rel=1.0e-8)
+    assert layer.global_slowness_s_per_m == pytest.approx(1.0 / VSUB_M_S, rel=1.0e-8)
+    assert layer.qc['vsub_velocity_m_s'] == pytest.approx(VSUB_M_S, rel=1.0e-8)
+    assert layer.qc['vsub_slowness_s_per_m'] == pytest.approx(
+        1.0 / VSUB_M_S,
+        rel=1.0e-8,
+    )
+    assert layer.qc['n_observations'] == VSUB_OFFSET_M.size
+    assert layer.qc['residual_rms_ms'] == pytest.approx(0.0, abs=1.0e-5)
+
+
+def test_vsub_t3_result_contains_t3_terms_and_layer_index_3() -> None:
+    result = _run_multilayer(
+        model=_model(vsub_velocity_mode='fixed_global'),
+        input_model=_input_model(),
+    )
+
+    layer = _layer(result, 'vsub_t3')
+
+    assert layer.layer_index == 3
+    np.testing.assert_allclose(layer.node_time_term_s, T3_S, atol=1.0e-9)
+    np.testing.assert_allclose(
+        layer.source_time_term_s,
+        _endpoint_terms(result.source_endpoint_key, T3_S),
+        atol=1.0e-9,
+    )
+    np.testing.assert_allclose(
+        layer.receiver_time_term_s,
+        _endpoint_terms(result.receiver_endpoint_key, T3_S),
+        atol=1.0e-9,
+    )
+
+
+def test_vsub_t3_rejects_velocity_not_greater_than_v3() -> None:
+    with pytest.raises(
+        RefractionMultiLayerSolveError,
+        match='vsub_t3 velocity must be greater than v3_t2 velocity',
+    ):
+        _run_multilayer(
+            model=_model(
+                vsub_velocity_mode='fixed_global',
+                vsub_fixed_velocity_m_s=V3_M_S,
+            ),
+            input_model=_input_model(),
+        )
+
+
+def _run_multilayer(
+    *,
+    model: RefractionStaticModelRequest,
+    input_model: RefractionStaticInputModel,
+) -> RefractionMultiLayerSolveResult:
+    masks = build_refraction_layer_observation_masks(
+        input_model=input_model,
+        model=model,
+    )
+    return solve_refraction_multilayer_time_terms(
+        input_model=input_model,
+        resolved_first_layer=_resolved_first_layer(),
+        normalized_layers=normalize_refraction_static_layers(model),
+        layer_masks=masks,
+        model=model,
+        solver=RefractionStaticSolverRequest(
+            damping=0.0,
+            robust={'enabled': False},
+        ),
+    )
+
+
+def _resolved_first_layer() -> ResolvedRefractionFirstLayer:
+    return ResolvedRefractionFirstLayer(
+        mode='constant',
+        weathering_velocity_m_s=V1_M_S,
+        status='constant',
+        qc={},
+    )
+
+
+def _layer(
+    result: RefractionMultiLayerSolveResult,
+    kind: RefractionLayerKind,
+) -> RefractionLayerSolveResult:
+    for layer in result.layer_results:
+        if layer.layer_kind == kind:
+            return layer
+    raise AssertionError(f'{kind} layer result was not returned')
+
+
+def _model(
+    *,
+    vsub_velocity_mode: str,
+    vsub_fixed_velocity_m_s: float = VSUB_M_S,
+) -> RefractionStaticModelRequest:
+    vsub_layer: dict[str, object] = {
+        'kind': 'vsub_t3',
+        'enabled': True,
+        'min_offset_m': 2200.0,
+        'max_offset_m': None,
+        'velocity_mode': vsub_velocity_mode,
+        'min_velocity_m_s': 3000.0,
+        'max_velocity_m_s': 6200.0,
+    }
+    if vsub_velocity_mode == 'fixed_global':
+        vsub_layer['fixed_velocity_m_s'] = vsub_fixed_velocity_m_s
+    else:
+        vsub_layer['initial_velocity_m_s'] = VSUB_M_S
+
+    return RefractionStaticModelRequest.model_validate(
+        {
+            'method': 'multilayer_time_term',
+            'first_layer': {
+                'mode': 'constant',
+                'weathering_velocity_m_s': V1_M_S,
+            },
+            'layers': [
+                {
+                    'kind': 'v2_t1',
+                    'enabled': True,
+                    'min_offset_m': 250.0,
+                    'max_offset_m': 800.0,
+                    'velocity_mode': 'fixed_global',
+                    'fixed_velocity_m_s': V2_M_S,
+                    'min_velocity_m_s': 1600.0,
+                    'max_velocity_m_s': 3200.0,
+                },
+                {
+                    'kind': 'v3_t2',
+                    'enabled': True,
+                    'min_offset_m': 1000.0,
+                    'max_offset_m': 1900.0,
+                    'velocity_mode': 'fixed_global',
+                    'fixed_velocity_m_s': V3_M_S,
+                    'min_velocity_m_s': 2600.0,
+                    'max_velocity_m_s': 4800.0,
+                },
+                vsub_layer,
+            ],
+        }
+    )
+
+
+def _input_model() -> RefractionStaticInputModel:
+    pick_time = np.concatenate(
+        (
+            T1_S[SOURCE_NODE] + T1_S[RECEIVER_NODE] + V2_OFFSET_M / V2_M_S,
+            T2_S[SOURCE_NODE] + T2_S[RECEIVER_NODE] + V3_OFFSET_M / V3_M_S,
+            T3_S[SOURCE_NODE] + T3_S[RECEIVER_NODE] + VSUB_OFFSET_M / VSUB_M_S,
+        )
+    )
+    source_node = np.concatenate((SOURCE_NODE, SOURCE_NODE, SOURCE_NODE)).astype(
+        np.int64
+    )
+    receiver_node = np.concatenate((RECEIVER_NODE, RECEIVER_NODE, RECEIVER_NODE)).astype(
+        np.int64
+    )
+    distance_m = np.concatenate((V2_OFFSET_M, V3_OFFSET_M, VSUB_OFFSET_M)).astype(
+        np.float64
+    )
+    n_traces = int(pick_time.shape[0])
+    trace_index = np.arange(n_traces, dtype=np.int64)
+    zeros = np.zeros(n_traces, dtype=np.float64)
+    endpoint_table = _endpoint_table(source_node, receiver_node)
+
+    return RefractionStaticInputModel(
+        file_id='synthetic-vsub-t3',
+        n_traces=n_traces,
+        sorted_trace_index=trace_index,
+        pick_time_s_sorted=np.ascontiguousarray(pick_time, dtype=np.float64),
+        valid_pick_mask_sorted=np.ones(n_traces, dtype=bool),
+        valid_observation_mask_sorted=np.ones(n_traces, dtype=bool),
+        source_id_sorted=source_node.copy(),
+        receiver_id_sorted=receiver_node.copy(),
+        source_x_m_sorted=zeros.copy(),
+        source_y_m_sorted=zeros.copy(),
+        receiver_x_m_sorted=distance_m.copy(),
+        receiver_y_m_sorted=zeros.copy(),
+        source_elevation_m_sorted=zeros.copy(),
+        receiver_elevation_m_sorted=zeros.copy(),
+        source_depth_m_sorted=None,
+        geometry_distance_m_sorted=distance_m.copy(),
+        offset_m_sorted=distance_m.copy(),
+        distance_m_sorted=np.ascontiguousarray(distance_m, dtype=np.float64),
+        source_endpoint_key_sorted=np.asarray(
+            [f's:{node}' for node in source_node.tolist()],
+            dtype=object,
+        ),
+        receiver_endpoint_key_sorted=np.asarray(
+            [f'r:{node}' for node in receiver_node.tolist()],
+            dtype=object,
+        ),
+        source_node_id_sorted=source_node.copy(),
+        receiver_node_id_sorted=receiver_node.copy(),
+        node_x_m=endpoint_table.x_m,
+        node_y_m=endpoint_table.y_m,
+        node_elevation_m=endpoint_table.elevation_m,
+        node_kind=endpoint_table.kind,
+        rejection_reason_sorted=np.full(n_traces, 'ok', dtype='<U32'),
+        qc={},
+        endpoint_table=endpoint_table,
+        metadata={},
+    )
+
+
+def _endpoint_table(
+    source_node: np.ndarray,
+    receiver_node: np.ndarray,
+) -> RefractionEndpointTable:
+    node_id = np.arange(T1_S.size, dtype=np.int64)
+    pick_count = np.zeros(node_id.shape, dtype=np.int64)
+    for node in np.concatenate((source_node, receiver_node)).tolist():
+        pick_count[int(node)] += 1
+    return RefractionEndpointTable(
+        node_id=node_id,
+        endpoint_id=node_id.copy(),
+        x_m=node_id.astype(np.float64),
+        y_m=np.zeros(node_id.shape, dtype=np.float64),
+        elevation_m=np.zeros(node_id.shape, dtype=np.float64),
+        kind=np.full(node_id.shape, 'linked', dtype='<U16'),
+        pick_count=pick_count,
+    )
+
+
+def _endpoint_terms(
+    endpoint_key: np.ndarray,
+    terms: np.ndarray,
+) -> np.ndarray:
+    return np.asarray(
+        [float(terms[int(str(key).split(':', maxsplit=1)[1])]) for key in endpoint_key],
+        dtype=np.float64,
+    )

--- a/app/tests/test_refraction_static_t1lsst_multilayer.py
+++ b/app/tests/test_refraction_static_t1lsst_multilayer.py
@@ -8,6 +8,9 @@ from app.services.refraction_static_t1lsst import (
     compute_t1lsst_2layer_thicknesses,
     compute_t1lsst_2layer_thicknesses_with_status,
     compute_t1lsst_2layer_weathering_correction,
+    compute_t1lsst_3layer_thicknesses,
+    compute_t1lsst_3layer_thicknesses_with_status,
+    compute_t1lsst_3layer_weathering_correction,
 )
 from app.tests._refraction_multilayer_synthetic import (
     SYNTHETIC_MULTILAYER_V1_M_S,
@@ -237,6 +240,174 @@ def test_t1lsst_2layer_negative_sh1_blanks_dependent_outputs() -> None:
     assert np.isnan(result.weathering_correction_s[0])
 
 
+def test_t1lsst_3layer_scalar_formula() -> None:
+    v1_m_s = 800.0
+    v2_m_s = 2400.0
+    v3_m_s = 3600.0
+    vsub_m_s = 5000.0
+    expected_sh1_m = 10.0
+    expected_sh2_m = 20.0
+    expected_sh3_m = 30.0
+    t1_s, t2_s, t3_s = _forward_t1_t2_t3_s(
+        sh1_m=expected_sh1_m,
+        sh2_m=expected_sh2_m,
+        sh3_m=expected_sh3_m,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+    )
+
+    sh1_m, sh2_m, sh3_m = compute_t1lsst_3layer_thicknesses(
+        t1_s=t1_s,
+        t2_s=t2_s,
+        t3_s=t3_s,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+    )
+
+    np.testing.assert_allclose(sh1_m, expected_sh1_m)
+    np.testing.assert_allclose(sh2_m, expected_sh2_m)
+    np.testing.assert_allclose(sh3_m, expected_sh3_m)
+
+
+def test_t1lsst_3layer_vector_formula() -> None:
+    v1_m_s = np.asarray([700.0, 800.0, 900.0], dtype=np.float64)
+    v2_m_s = np.asarray([2200.0, 2500.0, 2800.0], dtype=np.float64)
+    v3_m_s = np.asarray([3300.0, 3600.0, 4100.0], dtype=np.float64)
+    vsub_m_s = 5200.0
+    expected_sh1_m = np.asarray([8.0, 10.0, 12.0], dtype=np.float64)
+    expected_sh2_m = np.asarray([14.0, 18.0, 22.0], dtype=np.float64)
+    expected_sh3_m = np.asarray([24.0, 28.0, 32.0], dtype=np.float64)
+    t1_s, t2_s, t3_s = _forward_t1_t2_t3_s(
+        sh1_m=expected_sh1_m,
+        sh2_m=expected_sh2_m,
+        sh3_m=expected_sh3_m,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+    )
+
+    result = compute_t1lsst_3layer_thicknesses_with_status(
+        t1_s=t1_s,
+        t2_s=t2_s,
+        t3_s=t3_s,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+    )
+
+    assert result.status.tolist() == ['ok', 'ok', 'ok']
+    assert result.sh1_m.shape == expected_sh1_m.shape
+    np.testing.assert_allclose(result.sh1_m, expected_sh1_m)
+    np.testing.assert_allclose(result.sh2_m, expected_sh2_m)
+    np.testing.assert_allclose(result.sh3_m, expected_sh3_m)
+    assert result.weathering_correction_s is not None
+    np.testing.assert_allclose(
+        result.weathering_correction_s,
+        expected_sh1_m * (1.0 / vsub_m_s - 1.0 / v1_m_s)
+        + expected_sh2_m * (1.0 / vsub_m_s - 1.0 / v2_m_s)
+        + expected_sh3_m * (1.0 / vsub_m_s - 1.0 / v3_m_s),
+    )
+
+
+def test_t1lsst_3layer_weathering_correction_formula() -> None:
+    sh1_m = np.asarray([10.0, 12.0], dtype=np.float64)
+    sh2_m = np.asarray([20.0, 18.0], dtype=np.float64)
+    sh3_m = np.asarray([30.0, 26.0], dtype=np.float64)
+
+    wcor_s = compute_t1lsst_3layer_weathering_correction(
+        sh1_m=sh1_m,
+        sh2_m=sh2_m,
+        sh3_m=sh3_m,
+        v1_m_s=800.0,
+        v2_m_s=2400.0,
+        v3_m_s=3600.0,
+        vsub_m_s=5000.0,
+    )
+
+    expected = (
+        sh1_m * (1.0 / 5000.0 - 1.0 / 800.0)
+        + sh2_m * (1.0 / 5000.0 - 1.0 / 2400.0)
+        + sh3_m * (1.0 / 5000.0 - 1.0 / 3600.0)
+    )
+    np.testing.assert_allclose(wcor_s, expected)
+    assert np.all(wcor_s < 0.0)
+
+
+def test_t1lsst_3layer_status_invalid_velocity_order() -> None:
+    result = compute_t1lsst_3layer_thicknesses_with_status(
+        t1_s=np.asarray([0.01, 0.01], dtype=np.float64),
+        t2_s=np.asarray([0.02, 0.02], dtype=np.float64),
+        t3_s=np.asarray([0.03, 0.03], dtype=np.float64),
+        v1_m_s=800.0,
+        v2_m_s=np.asarray([2400.0, 3800.0], dtype=np.float64),
+        v3_m_s=3600.0,
+        vsub_m_s=5000.0,
+    )
+
+    assert result.status.tolist() == ['ok', 'invalid_velocity_order']
+    assert np.isfinite(result.sh1_m[0])
+    assert np.isfinite(result.sh2_m[0])
+    assert np.isfinite(result.sh3_m[0])
+    assert result.weathering_correction_s is not None
+    assert np.isfinite(result.weathering_correction_s[0])
+    assert np.isnan(result.sh1_m[1])
+    assert np.isnan(result.sh2_m[1])
+    assert np.isnan(result.sh3_m[1])
+    assert np.isnan(result.weathering_correction_s[1])
+
+
+def test_t1lsst_3layer_status_negative_sh3_sets_all_dependent_values_nan() -> None:
+    v1_m_s = 800.0
+    v2_m_s = 2400.0
+    v3_m_s = 3600.0
+    vsub_m_s = 5000.0
+    t1_s, t2_s, t3_s = _forward_t1_t2_t3_s(
+        sh1_m=np.asarray([10.0], dtype=np.float64),
+        sh2_m=np.asarray([20.0], dtype=np.float64),
+        sh3_m=np.asarray([0.0], dtype=np.float64),
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+    )
+
+    result = compute_t1lsst_3layer_thicknesses_with_status(
+        t1_s=t1_s,
+        t2_s=t2_s,
+        t3_s=t3_s - 0.001,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+    )
+
+    assert result.status.tolist() == ['invalid_negative_thickness']
+    assert np.isnan(result.sh1_m[0])
+    assert np.isnan(result.sh2_m[0])
+    assert np.isnan(result.sh3_m[0])
+    assert result.weathering_correction_s is not None
+    assert np.isnan(result.weathering_correction_s[0])
+
+
+def test_t1lsst_3layer_rejects_vsub_not_greater_than_v3_in_strict_mode() -> None:
+    with pytest.raises(RefractionT1LSSTError, match='vsub_m_s must be greater'):
+        compute_t1lsst_3layer_thicknesses(
+            t1_s=np.asarray([0.01]),
+            t2_s=np.asarray([0.02]),
+            t3_s=np.asarray([0.03]),
+            v1_m_s=800.0,
+            v2_m_s=2400.0,
+            v3_m_s=3600.0,
+            vsub_m_s=3600.0,
+        )
+
+
 def _forward_t1_t2_s(
     *,
     sh1_m: np.ndarray,
@@ -251,3 +422,33 @@ def _forward_t1_t2_s(
         + sh2_m * np.sqrt(v3_m_s**2 - v2_m_s**2) / (v2_m_s * v3_m_s)
     )
     return np.asarray(t1_s, dtype=np.float64), np.asarray(t2_s, dtype=np.float64)
+
+
+def _forward_t1_t2_t3_s(
+    *,
+    sh1_m: np.ndarray | float,
+    sh2_m: np.ndarray | float,
+    sh3_m: np.ndarray | float,
+    v1_m_s: np.ndarray | float,
+    v2_m_s: np.ndarray | float,
+    v3_m_s: np.ndarray | float,
+    vsub_m_s: np.ndarray | float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    c12 = np.sqrt(1.0 - (np.asarray(v1_m_s) / np.asarray(v2_m_s)) ** 2)
+    c13 = np.sqrt(1.0 - (np.asarray(v1_m_s) / np.asarray(v3_m_s)) ** 2)
+    c23 = np.sqrt(1.0 - (np.asarray(v2_m_s) / np.asarray(v3_m_s)) ** 2)
+    c1sub = np.sqrt(1.0 - (np.asarray(v1_m_s) / np.asarray(vsub_m_s)) ** 2)
+    c2sub = np.sqrt(1.0 - (np.asarray(v2_m_s) / np.asarray(vsub_m_s)) ** 2)
+    c3sub = np.sqrt(1.0 - (np.asarray(v3_m_s) / np.asarray(vsub_m_s)) ** 2)
+    t1_s = sh1_m * c12 / v1_m_s
+    t2_s = sh1_m * c13 / v1_m_s + sh2_m * c23 / v2_m_s
+    t3_s = (
+        sh1_m * c1sub / v1_m_s
+        + sh2_m * c2sub / v2_m_s
+        + sh3_m * c3sub / v3_m_s
+    )
+    return (
+        np.asarray(t1_s, dtype=np.float64),
+        np.asarray(t2_s, dtype=np.float64),
+        np.asarray(t3_s, dtype=np.float64),
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,10 +145,11 @@ See:
 - `time_term_static_correction.md`
 
 Refraction statics include the 1-layer V1/V2/T1 T1LSST workflow, cell-based
-local V2 support, and the public two-layer V3/T2
-`t1lsst_multilayer` workflow. Two-layer source/receiver outputs use the
-existing static table artifacts with added `t2`, `v3`, and `sh2` fields; the
-repo sign convention remains `corrected(t) = raw(t - shift_s)`.
+local V2 support, and the public two- and three-layer
+`t1lsst_multilayer` workflow. Multi-layer source/receiver outputs use the
+existing static table artifacts with added `t2`, `v3`, `sh2`, and, for
+three-layer runs, `t3`, `vsub`, and `sh3` fields; the repo sign convention
+remains `corrected(t) = raw(t - shift_s)`.
 
 ## Viewer benchmark
 

--- a/docs/refraction_static.md
+++ b/docs/refraction_static.md
@@ -17,16 +17,22 @@ first-break picks
   -> optionally apply trace shifts with the repo sign convention
 ```
 
-It also supports the M3 two-layer public contract for
+It also supports the M3 multi-layer public contract for
 `model.method="multilayer_time_term"` with `conversion.mode="t1lsst_multilayer"`
-and `conversion.layer_count=2`, when the enabled layers are exactly `v2_t1` and
-`v3_t2`. The `v2_t1` layer may use fixed, global solved, or cell solved V2; the
-`v3_t2` layer must use fixed or global solved V3. Cell V3, `vsub_t3`, and
-3-layer conversion remain out of scope.
+and either:
 
-`POST /statics/refraction/apply` is the public job entry point for both the
-1-layer workflow and this narrow two-layer workflow. It does not claim full IRAS
-compatibility.
+- `conversion.layer_count=2`, when the enabled layers are exactly `v2_t1` and
+  `v3_t2`
+- `conversion.layer_count=3`, when the enabled layers are exactly `v2_t1`,
+  `v3_t2`, and `vsub_t3`
+
+The `v2_t1` layer may use fixed, global solved, or cell solved V2; the `v3_t2`
+and `vsub_t3` layers must use fixed or global solved velocities. Cell V3 and
+cell Vsub remain out of scope.
+
+`POST /statics/refraction/apply` is the public job entry point for the
+1-layer workflow and the narrow two- and three-layer multi-layer workflows. It
+does not claim full IRAS compatibility.
 
 ## Terms
 
@@ -200,8 +206,9 @@ then `v3_t2`. Each layer solves:
 pick_time_s = Tn_source_s + Tn_receiver_s + offset_m / Vn_m_s
 ```
 
-For `v3_t2`, `velocity_mode` may be `solve_global` or `fixed_global`. Cell V3
-and Vsub/T3 are not implemented.
+For `v3_t2`, `velocity_mode` may be `solve_global` or `fixed_global`. For
+three-layer requests, `vsub_t3` is enabled after `v3_t2` and may also use
+`solve_global` or `fixed_global`. Cell V3 and cell Vsub are not implemented.
 
 For `conversion.mode="t1lsst_multilayer"` with `conversion.layer_count=2`, the
 two-layer conversion computes:
@@ -247,6 +254,26 @@ first-layer thickness.
 ```text
 conversion_mode = t1lsst_multilayer
 layer_count = 2
+```
+
+## Vsub/T3 Public Apply Contract
+
+The public three-layer apply contract uses
+`model.method="multilayer_time_term"` with enabled layers ordered as `v2_t1`,
+`v3_t2`, then `vsub_t3`.
+
+`conversion.mode="t1lsst_multilayer"` with `conversion.layer_count=3` requires
+global V3 and global Vsub velocities. Cell V3 and cell Vsub remain unsupported.
+The three-layer T1LSST formulas are supplied by the dependent multi-layer
+conversion implementation and are not defined by this public apply contract.
+
+`refraction_static_qc.json` and datum-result QC identify accepted three-layer
+jobs with:
+
+```text
+conversion_mode = t1lsst_multilayer
+layer_count = 3
+enabled_layer_kinds = v2_t1, v3_t2, vsub_t3
 ```
 
 ## Source and Receiver Static Tables
@@ -447,7 +474,9 @@ global V2
 cell V2
 T1 / SH1 / WCOR
 two-layer V3/T2 solve
+Vsub/T3 solve
 public 2-layer V3/T2 apply
+public 3-layer Vsub/T3 apply
 public 2-layer T1LSST conversion
 source static table
 receiver static table
@@ -460,9 +489,9 @@ Out of scope:
 full IRAS compatibility
 3-D refractor velocity grid
 spatially varying V1 map
-Vsub/T3
+cell V3
+cell Vsub
 GRM / plus-minus method
-3-layer T1LSST
 tomostatics
 SEG-Y header write-back
 UI documentation


### PR DESCRIPTION
Closes #462
Closes #463
Closes #464
Closes #465

## Issues
- #462 [tests][statics][refraction][m3] Make import-layer checks wait-based instead of PIPE/communicate-based
- #463 [statics][refraction][m3] Implement Vsub/T3 global layer solver and dispatch
- #464 [statics][refraction][m3] Extend public apply contract to three-layer T1LSST workflow
- #465 [statics][refraction][m3] Add T1LSST three-layer thickness and weathering-correction formulas

Batch range: #462-#465
