### PR TITLE
Batch: address issues #466-#469

### DIFF
--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -23,6 +23,9 @@ from app.services.refraction_static_design_matrix import (
     LOW_FOLD_CELL_REJECTION_REASON,
     LOW_FOLD_CELL_VELOCITY_STATUS,
 )
+from app.services.refraction_static_layer_config import (
+    normalize_refraction_static_layers,
+)
 from app.services.refraction_static_layer_observations import (
     build_refraction_layer_observation_masks_from_arrays,
 )
@@ -1927,7 +1930,11 @@ def build_refraction_static_solution_arrays(
         'source_half_intercept_time_s': _float_array(
             r.source_half_intercept_time_s
         ),
+        'source_t1_s': _float_array(r.source_half_intercept_time_s),
         'source_weathering_replacement_shift_s': _float_array(
+            r.source_weathering_replacement_shift_s
+        ),
+        'source_weathering_correction_s': _float_array(
             r.source_weathering_replacement_shift_s
         ),
         'source_floating_datum_elevation_shift_s': _float_array(
@@ -1936,6 +1943,7 @@ def build_refraction_static_solution_arrays(
         'source_flat_datum_shift_s': _float_array(r.source_flat_datum_shift_s),
         'source_refraction_shift_s': _float_array(r.source_refraction_shift_s),
         'source_datum_status': _string_array(r.source_datum_status),
+        'source_sh1_m': _source_sh1_weathering_thickness_m(r),
         'receiver_endpoint_key': _string_array(r.receiver_endpoint_key),
         'receiver_id': _int_array(r.receiver_id),
         'receiver_node_id': _int_array(r.receiver_node_id),
@@ -1969,7 +1977,11 @@ def build_refraction_static_solution_arrays(
         'receiver_half_intercept_time_s': _float_array(
             r.receiver_half_intercept_time_s
         ),
+        'receiver_t1_s': _float_array(r.receiver_half_intercept_time_s),
         'receiver_weathering_replacement_shift_s': _float_array(
+            r.receiver_weathering_replacement_shift_s
+        ),
+        'receiver_weathering_correction_s': _float_array(
             r.receiver_weathering_replacement_shift_s
         ),
         'receiver_floating_datum_elevation_shift_s': _float_array(
@@ -1980,6 +1992,7 @@ def build_refraction_static_solution_arrays(
             r.receiver_refraction_shift_s
         ),
         'receiver_datum_status': _string_array(r.receiver_datum_status),
+        'receiver_sh1_m': _receiver_sh1_weathering_thickness_m(r),
         'row_trace_index_sorted': _int_array(r.row_trace_index_sorted),
         'row_source_node_id': _int_array(r.row_source_node_id),
         'row_receiver_node_id': _int_array(r.row_receiver_node_id),
@@ -2028,9 +2041,13 @@ def build_refraction_static_solution_arrays(
         arrays.update(
             {
                 'source_t2_time_s': _float_array(r.source_t2_time_s),
+                'source_t2_s': _float_array(r.source_t2_time_s),
                 'source_v3_m_s': _float_array(r.source_v3_m_s),
                 'source_sh1_weathering_thickness_m': source_sh1_m,
                 'source_sh2_weathering_thickness_m': _float_array(
+                    r.source_sh2_weathering_thickness_m
+                ),
+                'source_sh2_m': _float_array(
                     r.source_sh2_weathering_thickness_m
                 ),
                 'source_layer1_base_elevation_m': _float_array(
@@ -2048,8 +2065,12 @@ def build_refraction_static_solution_arrays(
             arrays.update(
                 {
                     'source_t3_time_s': _float_array(r.source_t3_time_s),
+                    'source_t3_s': _float_array(r.source_t3_time_s),
                     'source_vsub_m_s': _float_array(r.source_vsub_m_s),
                     'source_sh3_weathering_thickness_m': _float_array(
+                        r.source_sh3_weathering_thickness_m
+                    ),
+                    'source_sh3_m': _float_array(
                         r.source_sh3_weathering_thickness_m
                     ),
                     'source_layer2_base_elevation_m': _float_array(
@@ -2066,9 +2087,13 @@ def build_refraction_static_solution_arrays(
         arrays.update(
             {
                 'receiver_t2_time_s': _float_array(r.receiver_t2_time_s),
+                'receiver_t2_s': _float_array(r.receiver_t2_time_s),
                 'receiver_v3_m_s': _float_array(r.receiver_v3_m_s),
                 'receiver_sh1_weathering_thickness_m': receiver_sh1_m,
                 'receiver_sh2_weathering_thickness_m': _float_array(
+                    r.receiver_sh2_weathering_thickness_m
+                ),
+                'receiver_sh2_m': _float_array(
                     r.receiver_sh2_weathering_thickness_m
                 ),
                 'receiver_layer1_base_elevation_m': _float_array(
@@ -2086,8 +2111,12 @@ def build_refraction_static_solution_arrays(
             arrays.update(
                 {
                     'receiver_t3_time_s': _float_array(r.receiver_t3_time_s),
+                    'receiver_t3_s': _float_array(r.receiver_t3_time_s),
                     'receiver_vsub_m_s': _float_array(r.receiver_vsub_m_s),
                     'receiver_sh3_weathering_thickness_m': _float_array(
+                        r.receiver_sh3_weathering_thickness_m
+                    ),
+                    'receiver_sh3_m': _float_array(
                         r.receiver_sh3_weathering_thickness_m
                     ),
                     'receiver_layer2_base_elevation_m': _float_array(
@@ -2279,6 +2308,9 @@ def build_refraction_static_qc_payload(
     }
     if layer_count is not None:
         payload['layer_count'] = int(layer_count)
+    layer_velocity_modes = _layer_velocity_modes_for_request(req)
+    if layer_velocity_modes:
+        payload['velocity']['layer_velocity_modes'] = layer_velocity_modes
     enabled_layer_kinds = r.qc.get('enabled_layer_kinds')
     if isinstance(enabled_layer_kinds, (list, tuple)):
         payload['enabled_layer_kinds'] = [
@@ -3520,6 +3552,17 @@ def _request_summary(req: RefractionStaticApplyRequest) -> dict[str, Any]:
         'model_method': req.model.method,
         'apply_mode': req.apply.mode,
         'register_corrected_file': bool(req.apply.register_corrected_file),
+    }
+
+
+def _layer_velocity_modes_for_request(
+    req: RefractionStaticApplyRequest,
+) -> dict[str, str]:
+    if req.model.method != 'multilayer_time_term':
+        return {}
+    return {
+        str(config.kind): str(config.velocity_mode)
+        for config in normalize_refraction_static_layers(req.model)
     }
 
 

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -371,6 +371,7 @@ _SOURCE_STATIC_TABLE_COLUMNS = (
     'v2_m_s',
     'v2_status',
     'sh1_weathering_thickness_m',
+    'total_weathering_thickness_m',
     'refractor_elevation_m',
     'weathering_correction_ms',
     'floating_datum_correction_ms',
@@ -382,6 +383,7 @@ _SOURCE_STATIC_TABLE_COLUMNS = (
     'weathering_status',
     'datum_status',
     'static_status',
+    'sign_convention',
     'pick_count',
     'used_pick_count',
     'residual_rms_ms',
@@ -407,6 +409,7 @@ _SOURCE_STATIC_TABLE_2LAYER_COLUMNS = (
     'v3_m_s',
     'sh1_weathering_thickness_m',
     'sh2_weathering_thickness_m',
+    'total_weathering_thickness_m',
     'layer1_base_elevation_m',
     'final_refractor_elevation_m',
     'refractor_elevation_m',
@@ -420,6 +423,7 @@ _SOURCE_STATIC_TABLE_2LAYER_COLUMNS = (
     'weathering_status',
     'datum_status',
     'static_status',
+    'sign_convention',
     'pick_count',
     'used_pick_count',
     'residual_rms_ms',
@@ -448,6 +452,7 @@ _SOURCE_STATIC_TABLE_3LAYER_COLUMNS = (
     'sh1_weathering_thickness_m',
     'sh2_weathering_thickness_m',
     'sh3_weathering_thickness_m',
+    'total_weathering_thickness_m',
     'layer1_base_elevation_m',
     'layer2_base_elevation_m',
     'final_refractor_elevation_m',
@@ -462,6 +467,7 @@ _SOURCE_STATIC_TABLE_3LAYER_COLUMNS = (
     'weathering_status',
     'datum_status',
     'static_status',
+    'sign_convention',
     'pick_count',
     'used_pick_count',
     'residual_rms_ms',
@@ -484,6 +490,7 @@ _RECEIVER_STATIC_TABLE_COLUMNS = (
     'v2_m_s',
     'v2_status',
     'sh1_weathering_thickness_m',
+    'total_weathering_thickness_m',
     'refractor_elevation_m',
     'weathering_correction_ms',
     'floating_datum_correction_ms',
@@ -495,6 +502,7 @@ _RECEIVER_STATIC_TABLE_COLUMNS = (
     'weathering_status',
     'datum_status',
     'static_status',
+    'sign_convention',
     'pick_count',
     'used_pick_count',
     'residual_rms_ms',
@@ -520,6 +528,7 @@ _RECEIVER_STATIC_TABLE_2LAYER_COLUMNS = (
     'v3_m_s',
     'sh1_weathering_thickness_m',
     'sh2_weathering_thickness_m',
+    'total_weathering_thickness_m',
     'layer1_base_elevation_m',
     'final_refractor_elevation_m',
     'refractor_elevation_m',
@@ -533,6 +542,7 @@ _RECEIVER_STATIC_TABLE_2LAYER_COLUMNS = (
     'weathering_status',
     'datum_status',
     'static_status',
+    'sign_convention',
     'pick_count',
     'used_pick_count',
     'residual_rms_ms',
@@ -561,6 +571,7 @@ _RECEIVER_STATIC_TABLE_3LAYER_COLUMNS = (
     'sh1_weathering_thickness_m',
     'sh2_weathering_thickness_m',
     'sh3_weathering_thickness_m',
+    'total_weathering_thickness_m',
     'layer1_base_elevation_m',
     'layer2_base_elevation_m',
     'final_refractor_elevation_m',
@@ -575,6 +586,7 @@ _RECEIVER_STATIC_TABLE_3LAYER_COLUMNS = (
     'weathering_status',
     'datum_status',
     'static_status',
+    'sign_convention',
     'pick_count',
     'used_pick_count',
     'residual_rms_ms',
@@ -1545,6 +1557,7 @@ def build_source_receiver_static_table_arrays(
         scalar_v2_m_s=r.bedrock_velocity_m_s,
     )
     arrays: dict[str, np.ndarray] = {
+        'sign_convention': _scalar_str(SIGN_CONVENTION),
         'source_endpoint_key': _string_array(r.source_endpoint_key),
         'source_id': _int_array(r.source_id),
         'source_node_id': _int_array(r.source_node_id),
@@ -1566,6 +1579,9 @@ def build_source_receiver_static_table_arrays(
         ),
         'source_v2_m_s': source_v2,
         'source_sh1_m': source_sh1_m,
+        'source_total_weathering_thickness_m': _float_array(
+            r.source_weathering_thickness_m
+        ),
         'source_weathering_correction_s': source_weathering_correction_s,
         'source_elevation_correction_s': _sum_float_arrays(
             r.source_floating_datum_elevation_shift_s,
@@ -1597,6 +1613,9 @@ def build_source_receiver_static_table_arrays(
         ),
         'receiver_v2_m_s': receiver_v2,
         'receiver_sh1_m': receiver_sh1_m,
+        'receiver_total_weathering_thickness_m': _float_array(
+            r.receiver_weathering_thickness_m
+        ),
         'receiver_weathering_correction_s': receiver_weathering_correction_s,
         'receiver_elevation_correction_s': _sum_float_arrays(
             r.receiver_floating_datum_elevation_shift_s,
@@ -3153,6 +3172,9 @@ def _source_static_table_rows(
                 'v2_m_s': _csv_float(source_v2[index]),
                 'v2_status': str(source_v2_status[index]),
                 'sh1_weathering_thickness_m': _csv_float(source_sh1_m[index]),
+                'total_weathering_thickness_m': _csv_float(
+                    result.source_weathering_thickness_m[index]
+                ),
                 'refractor_elevation_m': _csv_float(
                     result.source_refractor_elevation_m[index]
                 ),
@@ -3176,6 +3198,7 @@ def _source_static_table_rows(
                 ),
                 'datum_status': str(result.source_datum_status[index]),
                 'static_status': str(static_status[index]),
+                'sign_convention': SIGN_CONVENTION,
                 'pick_count': _csv_int(node_context['pick_count'].get(node_id)),
                 'used_pick_count': _csv_int(
                     node_context['used_pick_count'].get(node_id)
@@ -3277,6 +3300,9 @@ def _receiver_static_table_rows(
                 'v2_m_s': _csv_float(receiver_v2[index]),
                 'v2_status': str(receiver_v2_status[index]),
                 'sh1_weathering_thickness_m': _csv_float(receiver_sh1_m[index]),
+                'total_weathering_thickness_m': _csv_float(
+                    result.receiver_weathering_thickness_m[index]
+                ),
                 'refractor_elevation_m': _csv_float(
                     result.receiver_refractor_elevation_m[index]
                 ),
@@ -3300,6 +3326,7 @@ def _receiver_static_table_rows(
                 ),
                 'datum_status': str(result.receiver_datum_status[index]),
                 'static_status': str(static_status[index]),
+                'sign_convention': SIGN_CONVENTION,
                 'pick_count': _csv_int(node_context['pick_count'].get(node_id)),
                 'used_pick_count': _csv_int(
                     node_context['used_pick_count'].get(node_id)

--- a/app/services/refraction_static_multilayer_service.py
+++ b/app/services/refraction_static_multilayer_service.py
@@ -931,13 +931,18 @@ def _compute_2layer_conversion(
 ) -> _T1LSSTMultilayerConversion:
     v2 = np.asarray(v2_m_s, dtype=np.float64)
     if v2_status is None:
+        _validate_global_2layer_velocity_order(
+            v1_m_s=v1_m_s,
+            v2_m_s=v2,
+            v3_m_s=v3_m_s,
+        )
         thickness = compute_t1lsst_2layer_thicknesses_with_status(
             t1_s=t1_s,
             t2_s=t2_s,
             v1_m_s=v1_m_s,
             v2_m_s=v2,
             v3_m_s=v3_m_s,
-            strict_velocity_order=True,
+            strict_velocity_order=False,
         )
         wcor = _required_multilayer_wcor(thickness.weathering_correction_s)
         return _T1LSSTMultilayerConversion(
@@ -996,6 +1001,14 @@ def _compute_3layer_conversion(
         raise RefractionMultiLayerSolveError(
             'three-layer T1LSST conversion dependency is not available'
         ) from exc
+    if v2_status is None:
+        _validate_global_3layer_velocity_order(
+            v1_m_s=v1_m_s,
+            v2_m_s=v2,
+            v3_m_s=v3_m_s,
+            vsub_m_s=vsub_m_s,
+            compute_3layer=compute_3layer,
+        )
     thickness = compute_3layer(
         t1_s=t1_s,
         t2_s=t2_s,
@@ -1004,7 +1017,7 @@ def _compute_3layer_conversion(
         v2_m_s=v2,
         v3_m_s=v3_m_s,
         vsub_m_s=vsub_m_s,
-        strict_velocity_order=v2_status is None,
+        strict_velocity_order=False,
     )
     wcor = _required_multilayer_wcor(thickness.weathering_correction_s)
     if v2_status is None:
@@ -1037,6 +1050,44 @@ def _compute_3layer_conversion(
         sh3_m=sh3,
         weathering_correction_s=wcor,
         status=conversion_status,
+    )
+
+
+def _validate_global_2layer_velocity_order(
+    *,
+    v1_m_s: float,
+    v2_m_s: np.ndarray,
+    v3_m_s: float,
+) -> None:
+    zeros = np.zeros(np.asarray(v2_m_s, dtype=np.float64).shape, dtype=np.float64)
+    compute_t1lsst_2layer_thicknesses_with_status(
+        t1_s=zeros,
+        t2_s=zeros,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        strict_velocity_order=True,
+    )
+
+
+def _validate_global_3layer_velocity_order(
+    *,
+    v1_m_s: float,
+    v2_m_s: np.ndarray,
+    v3_m_s: float,
+    vsub_m_s: float,
+    compute_3layer: Callable[..., object],
+) -> None:
+    zeros = np.zeros(np.asarray(v2_m_s, dtype=np.float64).shape, dtype=np.float64)
+    compute_3layer(
+        t1_s=zeros,
+        t2_s=zeros,
+        t3_s=zeros,
+        v1_m_s=v1_m_s,
+        v2_m_s=v2_m_s,
+        v3_m_s=v3_m_s,
+        vsub_m_s=vsub_m_s,
+        strict_velocity_order=True,
     )
 
 

--- a/app/tests/_refraction_multilayer_3layer_helpers.py
+++ b/app/tests/_refraction_multilayer_3layer_helpers.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+
+from app.api.schemas import (
+    RefractionStaticApplyOptions,
+    RefractionStaticApplyRequest,
+    RefractionStaticConversionRequest,
+    RefractionStaticDatumRequest,
+    RefractionStaticLinkageRequest,
+    RefractionStaticModelRequest,
+    RefractionStaticPickSourceRequest,
+    RefractionStaticSolverRequest,
+)
+from app.services.refraction_static_artifacts import write_refraction_static_artifacts
+from app.services.refraction_static_datum import (
+    build_refraction_datum_statics,
+    write_refraction_datum_statics_artifacts,
+)
+from app.services.refraction_static_multilayer_service import (
+    RefractionMultiLayerStaticsWorkflowResult,
+    _components_from_replacement,
+    build_refraction_multilayer_weathering_replacement_statics,
+)
+from app.services.refraction_static_types import (
+    RefractionEndpointTable,
+    RefractionLayerKind,
+    RefractionLayerSolveResult,
+    RefractionMultiLayerSolveResult,
+    RefractionStaticInputModel,
+    ResolvedRefractionFirstLayer,
+)
+from app.tests._refraction_multilayer_synthetic import (
+    SYNTHETIC_MULTILAYER_V1_M_S,
+    SYNTHETIC_MULTILAYER_V2_M_S,
+    SYNTHETIC_MULTILAYER_V3_M_S,
+    SYNTHETIC_MULTILAYER_VSUB_M_S,
+    SyntheticMultiLayerRefractionDataset,
+    make_2d_straight_three_layer_refraction_dataset,
+)
+
+TIME_ATOL_S = 1.0e-8
+THICKNESS_ATOL_M = 1.0e-5
+STATIC_ATOL_S = 1.0e-8
+
+
+def make_three_layer_dataset() -> SyntheticMultiLayerRefractionDataset:
+    return make_2d_straight_three_layer_refraction_dataset()
+
+
+def make_three_layer_input_model(
+    dataset: SyntheticMultiLayerRefractionDataset,
+) -> RefractionStaticInputModel:
+    source_node_id = np.asarray(dataset.source_endpoint_node_id, dtype=np.int64)
+    receiver_node_id = np.asarray(dataset.receiver_endpoint_node_id, dtype=np.int64)
+    node_id = np.concatenate((source_node_id, receiver_node_id)).astype(np.int64)
+    endpoint_table = RefractionEndpointTable(
+        node_id=np.ascontiguousarray(node_id, dtype=np.int64),
+        endpoint_id=np.ascontiguousarray(
+            np.concatenate((dataset.source_endpoint_id, dataset.receiver_endpoint_id)),
+            dtype=np.int64,
+        ),
+        x_m=np.ascontiguousarray(
+            np.concatenate((dataset.source_endpoint_x_m, dataset.receiver_endpoint_x_m)),
+            dtype=np.float64,
+        ),
+        y_m=np.ascontiguousarray(
+            np.concatenate((dataset.source_endpoint_y_m, dataset.receiver_endpoint_y_m)),
+            dtype=np.float64,
+        ),
+        elevation_m=np.ascontiguousarray(
+            np.concatenate(
+                (
+                    dataset.source_endpoint_elevation_m,
+                    dataset.receiver_endpoint_elevation_m,
+                )
+            ),
+            dtype=np.float64,
+        ),
+        kind=np.asarray(
+            ['source'] * int(source_node_id.size)
+            + ['receiver'] * int(receiver_node_id.size),
+            dtype='<U8',
+        ),
+        pick_count=_pick_count_by_node(
+            node_id=node_id,
+            source_node_id_sorted=dataset.source_node_id,
+            receiver_node_id_sorted=dataset.receiver_node_id,
+        ),
+    )
+    n_traces = int(dataset.sorted_trace_index.shape[0])
+    return RefractionStaticInputModel(
+        file_id=dataset.name,
+        n_traces=n_traces,
+        sorted_trace_index=np.ascontiguousarray(
+            dataset.sorted_trace_index,
+            dtype=np.int64,
+        ),
+        pick_time_s_sorted=np.ascontiguousarray(
+            dataset.first_break_time_s,
+            dtype=np.float64,
+        ),
+        valid_pick_mask_sorted=np.ascontiguousarray(dataset.valid_mask, dtype=bool),
+        valid_observation_mask_sorted=np.ascontiguousarray(
+            dataset.valid_mask,
+            dtype=bool,
+        ),
+        source_id_sorted=np.ascontiguousarray(dataset.source_id, dtype=np.int64),
+        receiver_id_sorted=np.ascontiguousarray(dataset.receiver_id, dtype=np.int64),
+        source_x_m_sorted=np.ascontiguousarray(dataset.source_x_m, dtype=np.float64),
+        source_y_m_sorted=np.ascontiguousarray(dataset.source_y_m, dtype=np.float64),
+        receiver_x_m_sorted=np.ascontiguousarray(
+            dataset.receiver_x_m,
+            dtype=np.float64,
+        ),
+        receiver_y_m_sorted=np.ascontiguousarray(
+            dataset.receiver_y_m,
+            dtype=np.float64,
+        ),
+        source_elevation_m_sorted=np.ascontiguousarray(
+            dataset.source_elevation_m,
+            dtype=np.float64,
+        ),
+        receiver_elevation_m_sorted=np.ascontiguousarray(
+            dataset.receiver_elevation_m,
+            dtype=np.float64,
+        ),
+        source_depth_m_sorted=None,
+        geometry_distance_m_sorted=np.ascontiguousarray(
+            dataset.offset_m,
+            dtype=np.float64,
+        ),
+        offset_m_sorted=np.ascontiguousarray(dataset.offset_m, dtype=np.float64),
+        distance_m_sorted=np.ascontiguousarray(dataset.offset_m, dtype=np.float64),
+        source_endpoint_key_sorted=np.asarray(
+            dataset.source_endpoint_key,
+            dtype=object,
+        ),
+        receiver_endpoint_key_sorted=np.asarray(
+            dataset.receiver_endpoint_key,
+            dtype=object,
+        ),
+        source_node_id_sorted=np.ascontiguousarray(
+            dataset.source_node_id,
+            dtype=np.int64,
+        ),
+        receiver_node_id_sorted=np.ascontiguousarray(
+            dataset.receiver_node_id,
+            dtype=np.int64,
+        ),
+        node_x_m=np.ascontiguousarray(endpoint_table.x_m, dtype=np.float64),
+        node_y_m=np.ascontiguousarray(endpoint_table.y_m, dtype=np.float64),
+        node_elevation_m=np.ascontiguousarray(
+            endpoint_table.elevation_m,
+            dtype=np.float64,
+        ),
+        node_kind=np.asarray(endpoint_table.kind, dtype='<U8'),
+        rejection_reason_sorted=np.asarray(dataset.rejection_reason, dtype='<U32'),
+        qc={'fixture': dataset.name},
+        endpoint_table=endpoint_table,
+        metadata={'coordinate_mode': dataset.coordinate_mode},
+    )
+
+
+def make_three_layer_model() -> RefractionStaticModelRequest:
+    return RefractionStaticModelRequest.model_validate(
+        {
+            'method': 'multilayer_time_term',
+            'first_layer': {
+                'mode': 'constant',
+                'weathering_velocity_m_s': SYNTHETIC_MULTILAYER_V1_M_S,
+            },
+            'layers': [
+                {
+                    'kind': 'v2_t1',
+                    'enabled': True,
+                    'min_offset_m': 250.0,
+                    'max_offset_m': 900.0,
+                    'velocity_mode': 'fixed_global',
+                    'fixed_velocity_m_s': SYNTHETIC_MULTILAYER_V2_M_S,
+                    'min_velocity_m_s': 1600.0,
+                    'max_velocity_m_s': 3200.0,
+                },
+                {
+                    'kind': 'v3_t2',
+                    'enabled': True,
+                    'min_offset_m': 1000.0,
+                    'max_offset_m': 1900.0,
+                    'velocity_mode': 'fixed_global',
+                    'fixed_velocity_m_s': SYNTHETIC_MULTILAYER_V3_M_S,
+                    'min_velocity_m_s': 2600.0,
+                    'max_velocity_m_s': 4800.0,
+                },
+                {
+                    'kind': 'vsub_t3',
+                    'enabled': True,
+                    'min_offset_m': 2200.0,
+                    'max_offset_m': None,
+                    'velocity_mode': 'fixed_global',
+                    'fixed_velocity_m_s': SYNTHETIC_MULTILAYER_VSUB_M_S,
+                    'min_velocity_m_s': 3600.0,
+                    'max_velocity_m_s': 6200.0,
+                },
+            ],
+        }
+    )
+
+
+def resolved_first_layer() -> ResolvedRefractionFirstLayer:
+    return ResolvedRefractionFirstLayer(
+        mode='constant',
+        weathering_velocity_m_s=SYNTHETIC_MULTILAYER_V1_M_S,
+        status='constant',
+        qc={'weathering_velocity_m_s': SYNTHETIC_MULTILAYER_V1_M_S},
+    )
+
+
+def compute_three_layer_workflow(
+    *,
+    datum: RefractionStaticDatumRequest | None = None,
+    job_dir: Path | None = None,
+) -> tuple[
+    SyntheticMultiLayerRefractionDataset,
+    RefractionStaticInputModel,
+    RefractionStaticModelRequest,
+    RefractionMultiLayerStaticsWorkflowResult,
+]:
+    dataset = make_three_layer_dataset()
+    input_model = make_three_layer_input_model(dataset)
+    model = make_three_layer_model()
+    solver = RefractionStaticSolverRequest(
+        damping=0.0,
+        robust={'enabled': False},
+    )
+    apply_options = RefractionStaticApplyOptions(max_abs_shift_ms=500.0)
+    active_datum = datum if datum is not None else RefractionStaticDatumRequest(mode='none')
+    solve_result = make_three_layer_solve_result(dataset)
+    weathering_replacement = build_refraction_multilayer_weathering_replacement_statics(
+        input_model=input_model,
+        model=model,
+        solve_result=solve_result,
+        apply_options=apply_options,
+        resolved_first_layer=resolved_first_layer(),
+    )
+    datum_result = build_refraction_datum_statics(
+        weathering_replacement_result=weathering_replacement,
+        datum=active_datum,
+        apply_options=apply_options,
+        resolved_first_layer=resolved_first_layer(),
+    )
+    datum_result = replace(
+        datum_result,
+        qc={
+            **datum_result.qc,
+            'method': 'multilayer_time_term',
+            'conversion_mode': 't1lsst_multilayer',
+            'layer_count': 3,
+            'enabled_layer_kinds': ['v2_t1', 'v3_t2', 'vsub_t3'],
+            'layers': solve_result.qc,
+        },
+    )
+    components = _components_from_replacement(weathering_replacement)
+    workflow = RefractionMultiLayerStaticsWorkflowResult(
+        solve_result=solve_result,
+        components=components,
+        weathering_replacement_result=weathering_replacement,
+        datum_result=datum_result,
+    )
+    if job_dir is not None:
+        write_refraction_datum_statics_artifacts(Path(job_dir), datum_result)
+        write_refraction_static_artifacts(
+            result=datum_result,
+            req=_artifact_request(
+                input_model=input_model,
+                model=model,
+                solver=solver,
+                datum=active_datum,
+                apply_options=apply_options,
+            ),
+            job_dir=Path(job_dir),
+            resolved_first_layer=resolved_first_layer(),
+        )
+    return dataset, input_model, model, workflow
+
+
+def make_three_layer_solve_result(
+    dataset: SyntheticMultiLayerRefractionDataset,
+) -> RefractionMultiLayerSolveResult:
+    source_endpoint_key = np.asarray(dataset.source_endpoint_id, dtype=object)
+    receiver_endpoint_key = np.asarray(dataset.receiver_endpoint_id, dtype=object)
+    source_node_id = np.ascontiguousarray(
+        dataset.source_endpoint_node_id,
+        dtype=np.int64,
+    )
+    receiver_node_id = np.ascontiguousarray(
+        dataset.receiver_endpoint_node_id,
+        dtype=np.int64,
+    )
+    layers = (
+        _layer_result(
+            dataset=dataset,
+            layer_kind='v2_t1',
+            layer_index=1,
+            velocity_m_s=SYNTHETIC_MULTILAYER_V2_M_S,
+            source_time_term_s=dataset.true_source_endpoint_t1_s,
+            receiver_time_term_s=dataset.true_receiver_endpoint_t1_s,
+            used_mask=dataset.expected_layer_mask_by_kind['v2_t1'],
+        ),
+        _layer_result(
+            dataset=dataset,
+            layer_kind='v3_t2',
+            layer_index=2,
+            velocity_m_s=SYNTHETIC_MULTILAYER_V3_M_S,
+            source_time_term_s=dataset.true_source_endpoint_t2_s,
+            receiver_time_term_s=dataset.true_receiver_endpoint_t2_s,
+            used_mask=dataset.expected_layer_mask_by_kind['v3_t2'],
+        ),
+        _layer_result(
+            dataset=dataset,
+            layer_kind='vsub_t3',
+            layer_index=3,
+            velocity_m_s=SYNTHETIC_MULTILAYER_VSUB_M_S,
+            source_time_term_s=dataset.true_source_endpoint_t3_s,
+            receiver_time_term_s=dataset.true_receiver_endpoint_t3_s,
+            used_mask=dataset.expected_layer_mask_by_kind['vsub_t3'],
+        ),
+    )
+    return RefractionMultiLayerSolveResult(
+        enabled_layer_kinds=('v2_t1', 'v3_t2', 'vsub_t3'),
+        layer_results=layers,
+        source_endpoint_key=source_endpoint_key,
+        receiver_endpoint_key=receiver_endpoint_key,
+        source_node_id=source_node_id,
+        receiver_node_id=receiver_node_id,
+        qc={
+            'enabled_layer_count': 3,
+            'enabled_layer_kinds': ['v2_t1', 'v3_t2', 'vsub_t3'],
+            'layers': {item.layer_kind: item.qc for item in layers},
+        },
+    )
+
+
+def layer(
+    result: RefractionMultiLayerSolveResult,
+    kind: RefractionLayerKind,
+) -> RefractionLayerSolveResult:
+    for layer_result in result.layer_results:
+        if layer_result.layer_kind == kind:
+            return layer_result
+    raise AssertionError(f'{kind} layer result was not returned')
+
+
+def _layer_result(
+    *,
+    dataset: SyntheticMultiLayerRefractionDataset,
+    layer_kind: RefractionLayerKind,
+    layer_index: int,
+    velocity_m_s: float,
+    source_time_term_s: np.ndarray,
+    receiver_time_term_s: np.ndarray,
+    used_mask: np.ndarray,
+) -> RefractionLayerSolveResult:
+    node_time_term_s = np.ascontiguousarray(
+        np.concatenate((source_time_term_s, receiver_time_term_s)),
+        dtype=np.float64,
+    )
+    predicted = np.full(dataset.sorted_trace_index.shape, np.nan, dtype=np.float64)
+    predicted[used_mask] = dataset.noiseless_first_break_time_s[used_mask]
+    residual = np.full(dataset.sorted_trace_index.shape, np.nan, dtype=np.float64)
+    residual[used_mask] = dataset.first_break_time_s[used_mask] - predicted[used_mask]
+    return RefractionLayerSolveResult(
+        layer_kind=layer_kind,
+        layer_index=layer_index,
+        velocity_mode='fixed_global',
+        source_time_term_s=np.ascontiguousarray(source_time_term_s, dtype=np.float64),
+        receiver_time_term_s=np.ascontiguousarray(
+            receiver_time_term_s,
+            dtype=np.float64,
+        ),
+        node_time_term_s=node_time_term_s,
+        global_velocity_m_s=float(velocity_m_s),
+        global_slowness_s_per_m=1.0 / float(velocity_m_s),
+        cell_velocity_m_s=None,
+        cell_slowness_s_per_m=None,
+        trace_predicted_time_s_sorted=np.ascontiguousarray(
+            predicted,
+            dtype=np.float64,
+        ),
+        trace_residual_s_sorted=np.ascontiguousarray(residual, dtype=np.float64),
+        used_observation_mask_sorted=np.ascontiguousarray(used_mask, dtype=bool),
+        layer_status='solved',
+        qc={
+            'layer_kind': layer_kind,
+            'layer_index': layer_index,
+            'velocity_mode': 'fixed_global',
+            'global_velocity_m_s': float(velocity_m_s),
+            'n_used_observations': int(np.count_nonzero(used_mask)),
+        },
+    )
+
+
+def _artifact_request(
+    *,
+    input_model: RefractionStaticInputModel,
+    model: RefractionStaticModelRequest,
+    solver: RefractionStaticSolverRequest,
+    datum: RefractionStaticDatumRequest,
+    apply_options: RefractionStaticApplyOptions,
+) -> RefractionStaticApplyRequest:
+    return RefractionStaticApplyRequest(
+        file_id=input_model.file_id,
+        pick_source=RefractionStaticPickSourceRequest(kind='manual_memmap'),
+        linkage=RefractionStaticLinkageRequest(mode='none'),
+        model=model,
+        solver=solver,
+        datum=datum,
+        conversion=RefractionStaticConversionRequest(
+            mode='t1lsst_multilayer',
+            layer_count=3,
+        ),
+        apply=apply_options,
+    )
+
+
+def _pick_count_by_node(
+    *,
+    node_id: np.ndarray,
+    source_node_id_sorted: np.ndarray,
+    receiver_node_id_sorted: np.ndarray,
+) -> np.ndarray:
+    counts = np.zeros(node_id.shape, dtype=np.int64)
+    node_to_index = {int(node): index for index, node in enumerate(node_id.tolist())}
+    for source_node, receiver_node in zip(
+        source_node_id_sorted.tolist(),
+        receiver_node_id_sorted.tolist(),
+        strict=True,
+    ):
+        counts[node_to_index[int(source_node)]] += 1
+        counts[node_to_index[int(receiver_node)]] += 1
+    return np.ascontiguousarray(counts, dtype=np.int64)

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -523,6 +523,57 @@ def test_public_apply_accepts_three_layer_multilayer_request(
     _assert_three_layer_solution_arrays(job_dir)
 
 
+def test_three_layer_job_downloads_source_receiver_static_tables(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _three_layer_apply_payload()
+    req = RefractionStaticApplyRequest.model_validate(payload)
+    job_id = 'refraction-vsub-t3-download-job-id'
+    job_dir = tmp_path / 'jobs' / job_id
+    _create_refraction_job(client, job_id=job_id, req=req, job_dir=job_dir)
+
+    monkeypatch.setattr(
+        refraction_service_module,
+        'build_refraction_static_input_model',
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        refraction_service_module,
+        'compute_refraction_multilayer_datum_statics_from_input_model',
+        lambda **_kwargs: SimpleNamespace(
+            datum_result=_three_layer_contract_datum_result()
+        ),
+    )
+
+    run_refraction_static_apply_job(job_id, req, client.app.state.sv)
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'done', job.get('message')
+
+    manifest = json.loads(
+        (job_dir / REFRACTION_STATIC_ARTIFACTS_JSON_NAME).read_text(
+            encoding='utf-8'
+        )
+    )
+    manifest_names = {item['name'] for item in manifest['artifacts']}
+    assert {
+        SOURCE_STATIC_TABLE_CSV_NAME,
+        RECEIVER_STATIC_TABLE_CSV_NAME,
+        SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+    }.issubset(manifest_names)
+
+    for artifact_name in manifest_names:
+        response = client.get(
+            f'/statics/job/{job_id}/download',
+            params={'name': artifact_name},
+        )
+        assert response.status_code == 200, artifact_name
+        assert response.content, artifact_name
+
+
 def test_public_apply_rejects_unsupported_vsub_cell_velocity_mode(
     client: TestClient,
     tmp_path: Path,

--- a/app/tests/test_refraction_static_multilayer_3layer_composition.py
+++ b/app/tests/test_refraction_static_multilayer_3layer_composition.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.api.schemas import RefractionStaticApplyOptions, RefractionStaticDatumRequest
+from app.services.refraction_static_datum import build_refraction_datum_statics
+from app.services.refraction_static_multilayer_service import (
+    build_refraction_multilayer_weathering_replacement_statics,
+)
+from app.services.refraction_static_t1lsst import (
+    RefractionT1LSSTError,
+    compute_t1lsst_3layer_weathering_correction,
+)
+from app.tests._refraction_multilayer_3layer_helpers import (
+    STATIC_ATOL_S,
+    THICKNESS_ATOL_M,
+    compute_three_layer_workflow,
+    layer,
+    resolved_first_layer,
+)
+
+
+def test_three_layer_static_composition_uses_sh1_plus_sh2_plus_sh3_for_final_refractor() -> None:
+    dataset, _input_model, _model, workflow = compute_three_layer_workflow()
+    replacement = workflow.weathering_replacement_result
+    datum_result = workflow.datum_result
+    components = workflow.components
+
+    assert components.source_t3_s is not None
+    assert components.receiver_t3_s is not None
+    assert components.source_sh2_m is not None
+    assert components.source_sh3_m is not None
+    assert components.receiver_sh2_m is not None
+    assert components.receiver_sh3_m is not None
+
+    expected_source_total = (
+        dataset.true_source_endpoint_sh1_m
+        + dataset.true_source_endpoint_sh2_m
+        + dataset.true_source_endpoint_sh3_m
+    )
+    expected_receiver_total = (
+        dataset.true_receiver_endpoint_sh1_m
+        + dataset.true_receiver_endpoint_sh2_m
+        + dataset.true_receiver_endpoint_sh3_m
+    )
+    np.testing.assert_allclose(
+        replacement.source_weathering_thickness_m,
+        expected_source_total,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        replacement.receiver_weathering_thickness_m,
+        expected_receiver_total,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        datum_result.source_refractor_elevation_m,
+        dataset.source_endpoint_elevation_m - expected_source_total,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        datum_result.receiver_refractor_elevation_m,
+        dataset.receiver_endpoint_elevation_m - expected_receiver_total,
+        atol=THICKNESS_ATOL_M,
+    )
+
+    node_source_count = int(dataset.source_endpoint_node_id.size)
+    expected_node_total = np.concatenate(
+        (expected_source_total, expected_receiver_total)
+    )
+    np.testing.assert_allclose(
+        datum_result.node_weathering_thickness_m,
+        expected_node_total,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        datum_result.node_refractor_elevation_m[:node_source_count],
+        dataset.source_endpoint_elevation_m - expected_source_total,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        datum_result.node_refractor_elevation_m[node_source_count:],
+        dataset.receiver_endpoint_elevation_m - expected_receiver_total,
+        atol=THICKNESS_ATOL_M,
+    )
+
+
+def test_three_layer_weathering_correction_matches_t1lsst_formula() -> None:
+    dataset, _input_model, _model, workflow = compute_three_layer_workflow()
+    result = workflow.weathering_replacement_result
+
+    expected_source = compute_t1lsst_3layer_weathering_correction(
+        sh1_m=dataset.true_source_endpoint_sh1_m,
+        sh2_m=dataset.true_source_endpoint_sh2_m,
+        sh3_m=dataset.true_source_endpoint_sh3_m,
+        v1_m_s=dataset.true_v1_m_s,
+        v2_m_s=dataset.true_v2_m_s,
+        v3_m_s=dataset.true_v3_m_s,
+        vsub_m_s=dataset.true_vsub_m_s,
+    )
+    expected_receiver = compute_t1lsst_3layer_weathering_correction(
+        sh1_m=dataset.true_receiver_endpoint_sh1_m,
+        sh2_m=dataset.true_receiver_endpoint_sh2_m,
+        sh3_m=dataset.true_receiver_endpoint_sh3_m,
+        v1_m_s=dataset.true_v1_m_s,
+        v2_m_s=dataset.true_v2_m_s,
+        v3_m_s=dataset.true_v3_m_s,
+        vsub_m_s=dataset.true_vsub_m_s,
+    )
+
+    np.testing.assert_allclose(
+        result.source_weathering_replacement_shift_s,
+        expected_source,
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        result.receiver_weathering_replacement_shift_s,
+        expected_receiver,
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        workflow.components.source_weathering_correction_s,
+        dataset.true_source_endpoint_wcor_s,
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        workflow.components.receiver_weathering_correction_s,
+        dataset.true_receiver_endpoint_wcor_s,
+        atol=STATIC_ATOL_S,
+    )
+
+
+def test_three_layer_invalid_endpoint_status_propagates_to_trace_status() -> None:
+    _dataset, input_model, model, workflow = compute_three_layer_workflow()
+    bad_source_index = 0
+    vsub_layer = layer(workflow.solve_result, 'vsub_t3')
+    bad_source_t3 = np.asarray(vsub_layer.source_time_term_s, dtype=np.float64).copy()
+    bad_source_t3[bad_source_index] = 0.0
+    patched_vsub_layer = replace(vsub_layer, source_time_term_s=bad_source_t3)
+    patched_solve = replace(
+        workflow.solve_result,
+        layer_results=(
+            layer(workflow.solve_result, 'v2_t1'),
+            layer(workflow.solve_result, 'v3_t2'),
+            patched_vsub_layer,
+        ),
+    )
+
+    replacement = build_refraction_multilayer_weathering_replacement_statics(
+        input_model=input_model,
+        model=model,
+        solve_result=patched_solve,
+        apply_options=RefractionStaticApplyOptions(max_abs_shift_ms=500.0),
+        resolved_first_layer=resolved_first_layer(),
+    )
+    datum_result = build_refraction_datum_statics(
+        weathering_replacement_result=replacement,
+        datum=RefractionStaticDatumRequest(mode='none'),
+        apply_options=RefractionStaticApplyOptions(max_abs_shift_ms=500.0),
+        resolved_first_layer=resolved_first_layer(),
+    )
+
+    assert replacement.source_static_status[bad_source_index] != 'ok'
+    assert datum_result.source_datum_status[bad_source_index] != 'ok'
+    assert np.isnan(replacement.source_weathering_replacement_shift_s[bad_source_index])
+    assert np.isnan(datum_result.source_refraction_shift_s[bad_source_index])
+
+    bad_source_key = str(replacement.source_endpoint_key[bad_source_index])
+    bad_trace_mask = np.asarray(
+        [str(key) == bad_source_key for key in input_model.source_endpoint_key_sorted],
+        dtype=bool,
+    )
+    assert np.any(bad_trace_mask)
+    assert np.all(datum_result.trace_static_status_sorted[bad_trace_mask] != 'ok')
+    assert not np.any(datum_result.trace_static_valid_mask_sorted[bad_trace_mask])
+    assert np.all(np.isnan(datum_result.refraction_trace_shift_s_sorted[bad_trace_mask]))
+
+    ok_trace_mask = ~bad_trace_mask
+    assert np.any(ok_trace_mask)
+    assert np.all(datum_result.trace_static_status_sorted[ok_trace_mask] == 'ok')
+    assert np.all(datum_result.trace_static_valid_mask_sorted[ok_trace_mask])
+
+
+def test_three_layer_global_velocity_order_is_rejected() -> None:
+    dataset, input_model, model, workflow = compute_three_layer_workflow()
+    vsub_layer = layer(workflow.solve_result, 'vsub_t3')
+    invalid_vsub_m_s = dataset.true_v3_m_s
+    patched_vsub_layer = replace(
+        vsub_layer,
+        global_velocity_m_s=invalid_vsub_m_s,
+        global_slowness_s_per_m=1.0 / invalid_vsub_m_s,
+    )
+    patched_solve = replace(
+        workflow.solve_result,
+        layer_results=(
+            layer(workflow.solve_result, 'v2_t1'),
+            layer(workflow.solve_result, 'v3_t2'),
+            patched_vsub_layer,
+        ),
+    )
+
+    with pytest.raises(RefractionT1LSSTError, match='vsub_m_s must be greater'):
+        build_refraction_multilayer_weathering_replacement_statics(
+            input_model=input_model,
+            model=model,
+            solve_result=patched_solve,
+            apply_options=RefractionStaticApplyOptions(max_abs_shift_ms=500.0),
+            resolved_first_layer=resolved_first_layer(),
+        )
+
+
+def test_two_layer_static_composition_regression_still_passes(tmp_path: Path) -> None:
+    from app.tests.test_refraction_static_multilayer_2layer_e2e import (
+        _STATIC_ATOL_S,
+        _THICKNESS_ATOL_M,
+        _compute_static_outputs,
+        _make_two_layer_fixture,
+    )
+
+    fixture = _make_two_layer_fixture(
+        coordinate_mode='grid_3d',
+        v2_velocity_mode='solve_global',
+    )
+    outputs = _compute_static_outputs(fixture=fixture, tmp_path=tmp_path)
+
+    np.testing.assert_allclose(
+        outputs.result.source_weathering_thickness_m,
+        fixture.source_sh1_m + fixture.source_sh2_m,
+        atol=_THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        outputs.result.receiver_weathering_thickness_m,
+        fixture.receiver_sh1_m + fixture.receiver_sh2_m,
+        atol=_THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        outputs.trace_shift_s_sorted,
+        fixture.trace_shift_s_sorted,
+        atol=_STATIC_ATOL_S,
+    )

--- a/app/tests/test_refraction_static_multilayer_3layer_e2e.py
+++ b/app/tests/test_refraction_static_multilayer_3layer_e2e.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.api.schemas import (
+    RefractionStaticApplyOptions,
+    RefractionStaticDatumRequest,
+    RefractionStaticSolverRequest,
+)
+from app.services.refraction_static_artifacts import (
+    NEAR_SURFACE_MODEL_CSV_NAME,
+    REFRACTION_STATIC_QC_JSON_NAME,
+    REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+    REFRACTION_STATICS_CSV_NAME,
+    SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+    SOURCE_STATIC_TABLE_CSV_NAME,
+)
+from app.services.refraction_static_multilayer_service import (
+    compute_refraction_multilayer_datum_statics_from_input_model,
+)
+from app.tests._refraction_multilayer_3layer_helpers import (
+    STATIC_ATOL_S,
+    THICKNESS_ATOL_M,
+    compute_three_layer_workflow,
+    make_three_layer_dataset,
+    make_three_layer_input_model,
+    make_three_layer_model,
+    resolved_first_layer,
+)
+
+
+def test_three_layer_trace_shift_is_source_plus_receiver_plus_datum() -> None:
+    datum = RefractionStaticDatumRequest(
+        mode='floating_and_flat',
+        floating_datum_mode='constant',
+        floating_datum_elevation_m=125.0,
+        flat_datum_elevation_m=175.0,
+    )
+    _dataset, _input_model, _model, workflow = compute_three_layer_workflow(
+        datum=datum,
+    )
+    result = workflow.datum_result
+
+    expected_trace = (
+        result.source_refraction_shift_s_sorted
+        + result.receiver_refraction_shift_s_sorted
+    )
+    np.testing.assert_allclose(
+        result.refraction_trace_shift_s_sorted,
+        expected_trace,
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        result.refraction_trace_shift_s_sorted,
+        result.weathering_replacement_trace_shift_s_sorted
+        + result.floating_datum_elevation_shift_s_sorted
+        + result.flat_datum_shift_s_sorted,
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        result.source_refraction_shift_s,
+        result.source_weathering_replacement_shift_s
+        + result.source_floating_datum_elevation_shift_s
+        + result.source_flat_datum_shift_s,
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        result.receiver_refraction_shift_s,
+        result.receiver_weathering_replacement_shift_s
+        + result.receiver_floating_datum_elevation_shift_s
+        + result.receiver_flat_datum_shift_s,
+        atol=STATIC_ATOL_S,
+    )
+    assert np.all(result.trace_static_valid_mask_sorted)
+    assert np.all(result.trace_static_status_sorted == 'ok')
+
+
+def test_three_layer_job_dir_writes_sh3_vsub_and_layer2_base_artifacts(
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'job'
+    dataset, _input_model, _model, workflow = compute_three_layer_workflow(
+        job_dir=job_dir,
+    )
+    result = workflow.datum_result
+
+    for name in (
+        REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+        REFRACTION_STATIC_QC_JSON_NAME,
+        REFRACTION_STATICS_CSV_NAME,
+        NEAR_SURFACE_MODEL_CSV_NAME,
+        SOURCE_STATIC_TABLE_CSV_NAME,
+        SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+    ):
+        assert (job_dir / name).is_file()
+
+    qc = json.loads((job_dir / REFRACTION_STATIC_QC_JSON_NAME).read_text())
+    assert qc['method'] == 'multilayer_time_term'
+    assert qc['conversion_mode'] == 't1lsst_multilayer'
+    assert qc['layer_count'] == 3
+    assert qc['enabled_layer_kinds'] == ['v2_t1', 'v3_t2', 'vsub_t3']
+
+    near_surface_rows = _read_csv(job_dir / NEAR_SURFACE_MODEL_CSV_NAME)
+    assert {
+        'sh3_weathering_thickness_m',
+        'layer2_base_elevation_m',
+        'final_refractor_elevation_m',
+    } <= set(near_surface_rows[0])
+    first_node_row = near_surface_rows[0]
+    expected_node_sh1 = dataset.true_source_endpoint_sh1_m[0]
+    expected_node_sh2 = dataset.true_source_endpoint_sh2_m[0]
+    expected_node_sh3 = dataset.true_source_endpoint_sh3_m[0]
+    expected_layer2 = (
+        dataset.source_endpoint_elevation_m[0] - expected_node_sh1 - expected_node_sh2
+    )
+    expected_final = expected_layer2 - expected_node_sh3
+    assert float(first_node_row['layer2_base_elevation_m']) == pytest.approx(
+        expected_layer2,
+        abs=THICKNESS_ATOL_M,
+    )
+    assert float(first_node_row['final_refractor_elevation_m']) == pytest.approx(
+        expected_final,
+        abs=THICKNESS_ATOL_M,
+    )
+    assert float(first_node_row['refractor_elevation_m']) == pytest.approx(
+        expected_final,
+        abs=THICKNESS_ATOL_M,
+    )
+
+    source_rows = _read_csv(job_dir / SOURCE_STATIC_TABLE_CSV_NAME)
+    assert {
+        't3_ms',
+        'vsub_m_s',
+        'sh3_weathering_thickness_m',
+        'layer2_base_elevation_m',
+    } <= set(source_rows[0])
+    assert float(source_rows[0]['sh3_weathering_thickness_m']) == pytest.approx(
+        dataset.true_source_endpoint_sh3_m[0],
+        abs=THICKNESS_ATOL_M,
+    )
+
+    with np.load(job_dir / SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME) as data:
+        assert {
+            'source_t3_s',
+            'source_vsub_m_s',
+            'source_sh3_m',
+            'source_layer2_base_elevation_m',
+            'receiver_t3_s',
+            'receiver_vsub_m_s',
+            'receiver_sh3_m',
+            'receiver_layer2_base_elevation_m',
+        } <= set(data.files)
+        np.testing.assert_allclose(
+            data['source_sh3_m'],
+            dataset.true_source_endpoint_sh3_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['receiver_sh3_m'],
+            dataset.true_receiver_endpoint_sh3_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['source_layer2_base_elevation_m'],
+            result.source_surface_elevation_m
+            - result.source_sh1_weathering_thickness_m
+            - result.source_sh2_weathering_thickness_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['receiver_layer2_base_elevation_m'],
+            result.receiver_surface_elevation_m
+            - result.receiver_sh1_weathering_thickness_m
+            - result.receiver_sh2_weathering_thickness_m,
+            atol=THICKNESS_ATOL_M,
+        )
+
+    with np.load(job_dir / REFRACTION_STATIC_SOLUTION_NPZ_NAME) as data:
+        assert {
+            'node_sh3_weathering_thickness_m',
+            'node_layer2_base_elevation_m',
+            'source_t3_time_s',
+            'source_vsub_m_s',
+            'source_sh3_weathering_thickness_m',
+            'receiver_t3_time_s',
+            'receiver_vsub_m_s',
+            'receiver_sh3_weathering_thickness_m',
+        } <= set(data.files)
+        np.testing.assert_allclose(
+            data['source_sh3_weathering_thickness_m'],
+            dataset.true_source_endpoint_sh3_m,
+            atol=THICKNESS_ATOL_M,
+        )
+
+
+def test_three_layer_solver_missing_layer_terms_are_statused_not_raised() -> None:
+    dataset = make_three_layer_dataset()
+    input_model = make_three_layer_input_model(dataset)
+    workflow = compute_refraction_multilayer_datum_statics_from_input_model(
+        input_model=input_model,
+        model=make_three_layer_model(),
+        solver=RefractionStaticSolverRequest(
+            damping=0.0,
+            min_picks_per_node=1,
+            max_abs_half_intercept_time_ms=500.0,
+            robust={'enabled': False},
+        ),
+        datum=RefractionStaticDatumRequest(mode='none'),
+        apply_options=RefractionStaticApplyOptions(max_abs_shift_ms=500.0),
+        resolved_first_layer=resolved_first_layer(),
+    )
+    result = workflow.datum_result
+
+    assert result.qc['layer_count'] == 3
+    assert result.qc['enabled_layer_kinds'] == ['v2_t1', 'v3_t2', 'vsub_t3']
+    assert np.all(result.source_datum_status == 'ok')
+    assert np.all(result.receiver_datum_status == 'invalid_nonfinite_input')
+    assert np.all(result.trace_static_status_sorted == 'invalid_nonfinite_input')
+    assert not np.any(result.trace_static_valid_mask_sorted)
+    assert np.all(np.isnan(result.refraction_trace_shift_s_sorted))
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline='', encoding='utf-8') as handle:
+        return list(csv.DictReader(handle))

--- a/app/tests/test_refraction_static_multilayer_3layer_e2e.py
+++ b/app/tests/test_refraction_static_multilayer_3layer_e2e.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+from dataclasses import dataclass
 import json
 from pathlib import Path
 
@@ -10,18 +11,29 @@ import pytest
 from app.api.schemas import (
     RefractionStaticApplyOptions,
     RefractionStaticDatumRequest,
+    RefractionStaticModelRequest,
     RefractionStaticSolverRequest,
 )
 from app.services.refraction_static_artifacts import (
     NEAR_SURFACE_MODEL_CSV_NAME,
+    RECEIVER_STATIC_TABLE_CSV_NAME,
     REFRACTION_STATIC_QC_JSON_NAME,
     REFRACTION_STATIC_SOLUTION_NPZ_NAME,
     REFRACTION_STATICS_CSV_NAME,
     SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
     SOURCE_STATIC_TABLE_CSV_NAME,
 )
+from app.services.refraction_static_layer_observations import (
+    build_refraction_layer_observation_masks,
+)
 from app.services.refraction_static_multilayer_service import (
+    RefractionMultiLayerStaticsWorkflowResult,
     compute_refraction_multilayer_datum_statics_from_input_model,
+)
+from app.services.refraction_static_types import (
+    RefractionEndpointTable,
+    RefractionLayerSolveResult,
+    RefractionStaticInputModel,
 )
 from app.tests._refraction_multilayer_3layer_helpers import (
     STATIC_ATOL_S,
@@ -32,6 +44,264 @@ from app.tests._refraction_multilayer_3layer_helpers import (
     make_three_layer_model,
     resolved_first_layer,
 )
+from app.tests._refraction_multilayer_synthetic import (
+    SYNTHETIC_MULTILAYER_V1_M_S,
+    SYNTHETIC_MULTILAYER_V2_M_S,
+    SYNTHETIC_MULTILAYER_V3_M_S,
+    SYNTHETIC_MULTILAYER_VSUB_M_S,
+)
+
+
+_V2_MIN_OFFSET_M = 250.0
+_V2_MAX_OFFSET_M = 1000.0
+_V3_MIN_OFFSET_M = 1000.0
+_V3_MAX_OFFSET_M = 2000.0
+_VSUB_MIN_OFFSET_M = 2000.0
+_INITIAL_V2_M_S = 2100.0
+_INITIAL_V3_M_S = 3300.0
+_INITIAL_VSUB_M_S = 5400.0
+_VELOCITY_RTOL = 1.0e-8
+_TRACE_SHIFT_ATOL_S = 1.0e-8
+_SIGN_CONVENTION = 'corrected(t) = raw(t - shift_s)'
+
+
+@dataclass(frozen=True)
+class _ThreeLayerSolverFixture:
+    input_model: RefractionStaticInputModel
+    model: RefractionStaticModelRequest
+    expected_layer_kind_sorted: np.ndarray
+    source_node_id: np.ndarray
+    receiver_node_id: np.ndarray
+    source_t1_s: np.ndarray
+    source_t2_s: np.ndarray
+    source_t3_s: np.ndarray
+    receiver_t1_s: np.ndarray
+    receiver_t2_s: np.ndarray
+    receiver_t3_s: np.ndarray
+    source_sh1_m: np.ndarray
+    source_sh2_m: np.ndarray
+    source_sh3_m: np.ndarray
+    receiver_sh1_m: np.ndarray
+    receiver_sh2_m: np.ndarray
+    receiver_sh3_m: np.ndarray
+    source_wcor_s: np.ndarray
+    receiver_wcor_s: np.ndarray
+    trace_shift_s_sorted: np.ndarray
+
+
+def test_three_layer_global_vsub_e2e_recovers_known_truth(tmp_path: Path) -> None:
+    fixture = _make_three_layer_solver_fixture()
+    job_dir = tmp_path / 'job'
+
+    workflow = _compute_three_layer_solver_workflow(fixture, job_dir=job_dir)
+
+    _assert_layer_masks_select_expected_three_layer_branches(fixture)
+    _assert_global_layer_result(
+        _layer(workflow, 'v2_t1'),
+        expected_velocity_m_s=SYNTHETIC_MULTILAYER_V2_M_S,
+    )
+    _assert_global_layer_result(
+        _layer(workflow, 'v3_t2'),
+        expected_velocity_m_s=SYNTHETIC_MULTILAYER_V3_M_S,
+    )
+    _assert_global_layer_result(
+        _layer(workflow, 'vsub_t3'),
+        expected_velocity_m_s=SYNTHETIC_MULTILAYER_VSUB_M_S,
+    )
+    _assert_three_layer_time_terms_and_thicknesses_match_truth(fixture, workflow)
+
+    qc = json.loads(
+        (job_dir / REFRACTION_STATIC_QC_JSON_NAME).read_text(encoding='utf-8')
+    )
+    assert qc['method'] == 'multilayer_time_term'
+    assert qc['conversion_mode'] == 't1lsst_multilayer'
+    assert qc['layer_count'] == 3
+    assert qc['enabled_layer_kinds'] == ['v2_t1', 'v3_t2', 'vsub_t3']
+    assert qc['velocity']['layer_velocity_modes'] == {
+        'v2_t1': 'solve_global',
+        'v3_t2': 'solve_global',
+        'vsub_t3': 'solve_global',
+    }
+    assert qc['sign_convention'] == _SIGN_CONVENTION
+
+
+def test_three_layer_static_table_matches_known_sh1_sh2_sh3_wcor(
+    tmp_path: Path,
+) -> None:
+    fixture = _make_three_layer_solver_fixture()
+    job_dir = tmp_path / 'job'
+
+    workflow = _compute_three_layer_solver_workflow(fixture, job_dir=job_dir)
+    source_rows = _read_csv(job_dir / SOURCE_STATIC_TABLE_CSV_NAME)
+    receiver_rows = _read_csv(job_dir / RECEIVER_STATIC_TABLE_CSV_NAME)
+
+    _assert_static_rows_match_three_layer_truth(
+        source_rows,
+        expected_t1_s=fixture.source_t1_s,
+        expected_t2_s=fixture.source_t2_s,
+        expected_t3_s=fixture.source_t3_s,
+        expected_sh1_m=fixture.source_sh1_m,
+        expected_sh2_m=fixture.source_sh2_m,
+        expected_sh3_m=fixture.source_sh3_m,
+        expected_wcor_s=fixture.source_wcor_s,
+    )
+    _assert_static_rows_match_three_layer_truth(
+        receiver_rows,
+        expected_t1_s=fixture.receiver_t1_s,
+        expected_t2_s=fixture.receiver_t2_s,
+        expected_t3_s=fixture.receiver_t3_s,
+        expected_sh1_m=fixture.receiver_sh1_m,
+        expected_sh2_m=fixture.receiver_sh2_m,
+        expected_sh3_m=fixture.receiver_sh3_m,
+        expected_wcor_s=fixture.receiver_wcor_s,
+    )
+
+    with np.load(
+        job_dir / SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+        allow_pickle=False,
+    ) as data:
+        expected_keys = {
+            'source_t1_s',
+            'source_t2_s',
+            'source_t3_s',
+            'source_sh1_m',
+            'source_sh2_m',
+            'source_sh3_m',
+            'source_weathering_correction_s',
+            'source_total_static_s',
+            'receiver_t1_s',
+            'receiver_t2_s',
+            'receiver_t3_s',
+            'receiver_sh1_m',
+            'receiver_sh2_m',
+            'receiver_sh3_m',
+            'receiver_weathering_correction_s',
+            'receiver_total_static_s',
+        }
+        assert expected_keys <= set(data.files)
+        np.testing.assert_allclose(data['source_t1_s'], fixture.source_t1_s)
+        np.testing.assert_allclose(data['source_t2_s'], fixture.source_t2_s)
+        np.testing.assert_allclose(data['source_t3_s'], fixture.source_t3_s)
+        np.testing.assert_allclose(
+            data['source_sh1_m'],
+            fixture.source_sh1_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['source_sh2_m'],
+            fixture.source_sh2_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['source_sh3_m'],
+            fixture.source_sh3_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['source_weathering_correction_s'],
+            fixture.source_wcor_s,
+            atol=STATIC_ATOL_S,
+        )
+        np.testing.assert_allclose(
+            data['source_total_static_s'],
+            fixture.source_wcor_s,
+            atol=STATIC_ATOL_S,
+        )
+        np.testing.assert_allclose(data['receiver_t1_s'], fixture.receiver_t1_s)
+        np.testing.assert_allclose(data['receiver_t2_s'], fixture.receiver_t2_s)
+        np.testing.assert_allclose(data['receiver_t3_s'], fixture.receiver_t3_s)
+        np.testing.assert_allclose(
+            data['receiver_sh1_m'],
+            fixture.receiver_sh1_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['receiver_sh2_m'],
+            fixture.receiver_sh2_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['receiver_sh3_m'],
+            fixture.receiver_sh3_m,
+            atol=THICKNESS_ATOL_M,
+        )
+        np.testing.assert_allclose(
+            data['receiver_weathering_correction_s'],
+            fixture.receiver_wcor_s,
+            atol=STATIC_ATOL_S,
+        )
+        np.testing.assert_allclose(
+            data['receiver_total_static_s'],
+            fixture.receiver_wcor_s,
+            atol=STATIC_ATOL_S,
+        )
+        assert str(data['sign_convention']) == _SIGN_CONVENTION
+
+    _assert_three_layer_time_terms_and_thicknesses_match_truth(fixture, workflow)
+
+
+def test_three_layer_trace_shift_matches_source_plus_receiver_components(
+    tmp_path: Path,
+) -> None:
+    fixture = _make_three_layer_solver_fixture()
+    job_dir = tmp_path / 'job'
+
+    workflow = _compute_three_layer_solver_workflow(fixture, job_dir=job_dir)
+    result = workflow.datum_result
+
+    np.testing.assert_allclose(
+        result.source_refraction_shift_s_sorted,
+        _map_endpoint_values_to_trace_nodes(
+            endpoint_node_id=fixture.source_node_id,
+            endpoint_values=fixture.source_wcor_s,
+            trace_node_id=fixture.input_model.source_node_id_sorted,
+        ),
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        result.receiver_refraction_shift_s_sorted,
+        _map_endpoint_values_to_trace_nodes(
+            endpoint_node_id=fixture.receiver_node_id,
+            endpoint_values=fixture.receiver_wcor_s,
+            trace_node_id=fixture.input_model.receiver_node_id_sorted,
+        ),
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        result.refraction_trace_shift_s_sorted,
+        fixture.trace_shift_s_sorted,
+        atol=_TRACE_SHIFT_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        result.refraction_trace_shift_s_sorted,
+        result.source_refraction_shift_s_sorted
+        + result.receiver_refraction_shift_s_sorted,
+        atol=STATIC_ATOL_S,
+    )
+    assert np.all(result.trace_static_valid_mask_sorted)
+    assert np.all(result.trace_static_status_sorted == 'ok')
+
+    rows = _read_csv(job_dir / REFRACTION_STATICS_CSV_NAME)
+    for row, expected_shift_s in zip(
+        rows,
+        fixture.trace_shift_s_sorted.tolist(),
+        strict=True,
+    ):
+        trace_shift_ms = float(row['refraction_trace_shift_ms'])
+        assert trace_shift_ms / 1000.0 == pytest.approx(
+            expected_shift_s,
+            abs=STATIC_ATOL_S,
+        )
+        assert trace_shift_ms == pytest.approx(
+            float(row['source_refraction_shift_ms'])
+            + float(row['receiver_refraction_shift_ms'])
+        )
+
+    raw_event_time_s = 1.0
+    corrected_event_time_s = raw_event_time_s + float(
+        result.refraction_trace_shift_s_sorted[0]
+    )
+    assert corrected_event_time_s < raw_event_time_s
 
 
 def test_three_layer_trace_shift_is_source_plus_receiver_plus_datum() -> None:
@@ -223,6 +493,551 @@ def test_three_layer_solver_missing_layer_terms_are_statused_not_raised() -> Non
     assert np.all(result.trace_static_status_sorted == 'invalid_nonfinite_input')
     assert not np.any(result.trace_static_valid_mask_sorted)
     assert np.all(np.isnan(result.refraction_trace_shift_s_sorted))
+
+
+def _make_three_layer_solver_fixture() -> _ThreeLayerSolverFixture:
+    n_nodes = 20
+    inline_m = np.arange(n_nodes, dtype=np.float64) * 250.0
+    node_id = np.arange(n_nodes, dtype=np.int64)
+    station_index = np.arange(n_nodes, dtype=np.float64)
+    sh1_m = 8.0 + 0.4 * (station_index % 5.0) + 0.02 * station_index
+    sh2_m = 14.0 + 0.5 * (station_index % 4.0) + 0.03 * station_index
+    sh3_m = 19.0 + 0.45 * (station_index % 6.0) + 0.025 * station_index
+    t1_s, t2_s, t3_s = _three_layer_time_terms_s(
+        sh1_m=sh1_m,
+        sh2_m=sh2_m,
+        sh3_m=sh3_m,
+    )
+    wcor_s = _three_layer_wcor_s(sh1_m=sh1_m, sh2_m=sh2_m, sh3_m=sh3_m)
+    rows = _three_layer_observation_rows(
+        inline_m=inline_m,
+        t1_s=t1_s,
+        t2_s=t2_s,
+        t3_s=t3_s,
+    )
+    source_index = np.asarray([row[0] for row in rows], dtype=np.int64)
+    receiver_index = np.asarray([row[1] for row in rows], dtype=np.int64)
+    offset_m = np.asarray([row[2] for row in rows], dtype=np.float64)
+    pick_time_s = np.asarray([row[3] for row in rows], dtype=np.float64)
+    layer_kind = np.asarray([row[4] for row in rows], dtype='<U16')
+    n_traces = int(pick_time_s.shape[0])
+    source_endpoint_key = np.asarray(
+        [f's:{index}' for index in source_index.tolist()],
+        dtype=object,
+    )
+    receiver_endpoint_key = np.asarray(
+        [f'r:{index}' for index in receiver_index.tolist()],
+        dtype=object,
+    )
+    source_positions = _first_occurrence_positions(source_endpoint_key)
+    receiver_positions = _first_occurrence_positions(receiver_endpoint_key)
+    source_node_id = source_index[source_positions]
+    receiver_node_id = receiver_index[receiver_positions]
+    node_elevation_m = 90.0 + 0.002 * inline_m
+    endpoint_table = _endpoint_table(
+        node_id=node_id,
+        inline_m=inline_m,
+        elevation_m=node_elevation_m,
+        source_index=source_index,
+        receiver_index=receiver_index,
+    )
+    input_model = RefractionStaticInputModel(
+        file_id='three-layer-global-solve-e2e',
+        n_traces=n_traces,
+        sorted_trace_index=np.arange(n_traces, dtype=np.int64),
+        pick_time_s_sorted=np.ascontiguousarray(pick_time_s, dtype=np.float64),
+        valid_pick_mask_sorted=np.ones(n_traces, dtype=bool),
+        valid_observation_mask_sorted=np.ones(n_traces, dtype=bool),
+        source_id_sorted=1000 + source_index,
+        receiver_id_sorted=2000 + receiver_index,
+        source_x_m_sorted=np.ascontiguousarray(inline_m[source_index], dtype=np.float64),
+        source_y_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        receiver_x_m_sorted=np.ascontiguousarray(
+            inline_m[receiver_index],
+            dtype=np.float64,
+        ),
+        receiver_y_m_sorted=np.zeros(n_traces, dtype=np.float64),
+        source_elevation_m_sorted=np.ascontiguousarray(
+            node_elevation_m[source_index],
+            dtype=np.float64,
+        ),
+        receiver_elevation_m_sorted=np.ascontiguousarray(
+            node_elevation_m[receiver_index],
+            dtype=np.float64,
+        ),
+        source_depth_m_sorted=None,
+        geometry_distance_m_sorted=np.ascontiguousarray(offset_m, dtype=np.float64),
+        offset_m_sorted=np.ascontiguousarray(offset_m, dtype=np.float64),
+        distance_m_sorted=np.ascontiguousarray(offset_m, dtype=np.float64),
+        source_endpoint_key_sorted=source_endpoint_key,
+        receiver_endpoint_key_sorted=receiver_endpoint_key,
+        source_node_id_sorted=source_index,
+        receiver_node_id_sorted=receiver_index,
+        node_x_m=np.ascontiguousarray(inline_m, dtype=np.float64),
+        node_y_m=np.zeros(n_nodes, dtype=np.float64),
+        node_elevation_m=np.ascontiguousarray(node_elevation_m, dtype=np.float64),
+        node_kind=np.full(n_nodes, 'both', dtype='<U8'),
+        rejection_reason_sorted=np.full(n_traces, 'ok', dtype='<U32'),
+        qc={'fixture': 'three_layer_global_solve_e2e'},
+        endpoint_table=endpoint_table,
+        metadata={'coordinate_mode': 'grid_3d'},
+    )
+    return _ThreeLayerSolverFixture(
+        input_model=input_model,
+        model=_three_layer_solve_global_model(),
+        expected_layer_kind_sorted=layer_kind,
+        source_node_id=np.ascontiguousarray(source_node_id, dtype=np.int64),
+        receiver_node_id=np.ascontiguousarray(receiver_node_id, dtype=np.int64),
+        source_t1_s=np.ascontiguousarray(t1_s[source_node_id], dtype=np.float64),
+        source_t2_s=np.ascontiguousarray(t2_s[source_node_id], dtype=np.float64),
+        source_t3_s=np.ascontiguousarray(t3_s[source_node_id], dtype=np.float64),
+        receiver_t1_s=np.ascontiguousarray(t1_s[receiver_node_id], dtype=np.float64),
+        receiver_t2_s=np.ascontiguousarray(t2_s[receiver_node_id], dtype=np.float64),
+        receiver_t3_s=np.ascontiguousarray(t3_s[receiver_node_id], dtype=np.float64),
+        source_sh1_m=np.ascontiguousarray(sh1_m[source_node_id], dtype=np.float64),
+        source_sh2_m=np.ascontiguousarray(sh2_m[source_node_id], dtype=np.float64),
+        source_sh3_m=np.ascontiguousarray(sh3_m[source_node_id], dtype=np.float64),
+        receiver_sh1_m=np.ascontiguousarray(sh1_m[receiver_node_id], dtype=np.float64),
+        receiver_sh2_m=np.ascontiguousarray(sh2_m[receiver_node_id], dtype=np.float64),
+        receiver_sh3_m=np.ascontiguousarray(sh3_m[receiver_node_id], dtype=np.float64),
+        source_wcor_s=np.ascontiguousarray(wcor_s[source_node_id], dtype=np.float64),
+        receiver_wcor_s=np.ascontiguousarray(wcor_s[receiver_node_id], dtype=np.float64),
+        trace_shift_s_sorted=np.ascontiguousarray(
+            wcor_s[source_index] + wcor_s[receiver_index],
+            dtype=np.float64,
+        ),
+    )
+
+
+def _three_layer_solve_global_model() -> RefractionStaticModelRequest:
+    return RefractionStaticModelRequest.model_validate(
+        {
+            'method': 'multilayer_time_term',
+            'first_layer': {
+                'mode': 'constant',
+                'weathering_velocity_m_s': SYNTHETIC_MULTILAYER_V1_M_S,
+            },
+            'layers': [
+                {
+                    'kind': 'v2_t1',
+                    'enabled': True,
+                    'min_offset_m': _V2_MIN_OFFSET_M,
+                    'max_offset_m': _V2_MAX_OFFSET_M,
+                    'velocity_mode': 'solve_global',
+                    'initial_velocity_m_s': _INITIAL_V2_M_S,
+                    'min_velocity_m_s': 1600.0,
+                    'max_velocity_m_s': 3200.0,
+                },
+                {
+                    'kind': 'v3_t2',
+                    'enabled': True,
+                    'min_offset_m': _V3_MIN_OFFSET_M,
+                    'max_offset_m': _V3_MAX_OFFSET_M,
+                    'velocity_mode': 'solve_global',
+                    'initial_velocity_m_s': _INITIAL_V3_M_S,
+                    'min_velocity_m_s': 2600.0,
+                    'max_velocity_m_s': 4800.0,
+                },
+                {
+                    'kind': 'vsub_t3',
+                    'enabled': True,
+                    'min_offset_m': _VSUB_MIN_OFFSET_M,
+                    'max_offset_m': None,
+                    'velocity_mode': 'solve_global',
+                    'initial_velocity_m_s': _INITIAL_VSUB_M_S,
+                    'min_velocity_m_s': 3600.0,
+                    'max_velocity_m_s': 6200.0,
+                },
+            ],
+        }
+    )
+
+
+def _compute_three_layer_solver_workflow(
+    fixture: _ThreeLayerSolverFixture,
+    *,
+    job_dir: Path | None = None,
+) -> RefractionMultiLayerStaticsWorkflowResult:
+    return compute_refraction_multilayer_datum_statics_from_input_model(
+        input_model=fixture.input_model,
+        model=fixture.model,
+        solver=RefractionStaticSolverRequest(
+            damping=0.0,
+            min_picks_per_node=1,
+            max_abs_half_intercept_time_ms=500.0,
+            robust={'enabled': False},
+        ),
+        datum=RefractionStaticDatumRequest(mode='none'),
+        apply_options=RefractionStaticApplyOptions(max_abs_shift_ms=500.0),
+        resolved_first_layer=resolved_first_layer(),
+        job_dir=job_dir,
+    )
+
+
+def _three_layer_time_terms_s(
+    *,
+    sh1_m: np.ndarray,
+    sh2_m: np.ndarray,
+    sh3_m: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    v1 = SYNTHETIC_MULTILAYER_V1_M_S
+    v2 = SYNTHETIC_MULTILAYER_V2_M_S
+    v3 = SYNTHETIC_MULTILAYER_V3_M_S
+    vsub = SYNTHETIC_MULTILAYER_VSUB_M_S
+    t1_s = sh1_m * np.sqrt(1.0 - (v1 / v2) ** 2) / v1
+    t2_s = (
+        sh1_m * np.sqrt(1.0 - (v1 / v3) ** 2) / v1
+        + sh2_m * np.sqrt(1.0 - (v2 / v3) ** 2) / v2
+    )
+    t3_s = (
+        sh1_m * np.sqrt(1.0 - (v1 / vsub) ** 2) / v1
+        + sh2_m * np.sqrt(1.0 - (v2 / vsub) ** 2) / v2
+        + sh3_m * np.sqrt(1.0 - (v3 / vsub) ** 2) / v3
+    )
+    return (
+        np.ascontiguousarray(t1_s, dtype=np.float64),
+        np.ascontiguousarray(t2_s, dtype=np.float64),
+        np.ascontiguousarray(t3_s, dtype=np.float64),
+    )
+
+
+def _three_layer_wcor_s(
+    *,
+    sh1_m: np.ndarray,
+    sh2_m: np.ndarray,
+    sh3_m: np.ndarray,
+) -> np.ndarray:
+    v1 = SYNTHETIC_MULTILAYER_V1_M_S
+    v2 = SYNTHETIC_MULTILAYER_V2_M_S
+    v3 = SYNTHETIC_MULTILAYER_V3_M_S
+    vsub = SYNTHETIC_MULTILAYER_VSUB_M_S
+    return np.ascontiguousarray(
+        sh1_m * (1.0 / vsub - 1.0 / v1)
+        + sh2_m * (1.0 / vsub - 1.0 / v2)
+        + sh3_m * (1.0 / vsub - 1.0 / v3),
+        dtype=np.float64,
+    )
+
+
+def _three_layer_observation_rows(
+    *,
+    inline_m: np.ndarray,
+    t1_s: np.ndarray,
+    t2_s: np.ndarray,
+    t3_s: np.ndarray,
+) -> list[tuple[int, int, float, float, str]]:
+    rows: list[tuple[int, int, float, float, str]] = []
+    for source_index, source_inline_m in enumerate(inline_m.tolist()):
+        for receiver_index, receiver_inline_m in enumerate(inline_m.tolist()):
+            if source_index == receiver_index:
+                continue
+            offset_m = abs(float(receiver_inline_m) - float(source_inline_m))
+            if _V2_MIN_OFFSET_M <= offset_m < _V2_MAX_OFFSET_M:
+                rows.append(
+                    (
+                        source_index,
+                        receiver_index,
+                        offset_m,
+                        float(
+                            t1_s[source_index]
+                            + t1_s[receiver_index]
+                            + offset_m / SYNTHETIC_MULTILAYER_V2_M_S
+                        ),
+                        'v2_t1',
+                    )
+                )
+            elif _V3_MIN_OFFSET_M <= offset_m < _V3_MAX_OFFSET_M:
+                rows.append(
+                    (
+                        source_index,
+                        receiver_index,
+                        offset_m,
+                        float(
+                            t2_s[source_index]
+                            + t2_s[receiver_index]
+                            + offset_m / SYNTHETIC_MULTILAYER_V3_M_S
+                        ),
+                        'v3_t2',
+                    )
+                )
+            elif offset_m >= _VSUB_MIN_OFFSET_M:
+                rows.append(
+                    (
+                        source_index,
+                        receiver_index,
+                        offset_m,
+                        float(
+                            t3_s[source_index]
+                            + t3_s[receiver_index]
+                            + offset_m / SYNTHETIC_MULTILAYER_VSUB_M_S
+                        ),
+                        'vsub_t3',
+                    )
+                )
+    return rows
+
+
+def _endpoint_table(
+    *,
+    node_id: np.ndarray,
+    inline_m: np.ndarray,
+    elevation_m: np.ndarray,
+    source_index: np.ndarray,
+    receiver_index: np.ndarray,
+) -> RefractionEndpointTable:
+    pick_count = np.zeros(node_id.shape, dtype=np.int64)
+    for source_node, receiver_node in zip(
+        source_index.tolist(),
+        receiver_index.tolist(),
+        strict=True,
+    ):
+        pick_count[int(source_node)] += 1
+        pick_count[int(receiver_node)] += 1
+    return RefractionEndpointTable(
+        node_id=node_id,
+        endpoint_id=node_id.copy(),
+        x_m=np.ascontiguousarray(inline_m, dtype=np.float64),
+        y_m=np.zeros(node_id.shape, dtype=np.float64),
+        elevation_m=np.ascontiguousarray(elevation_m, dtype=np.float64),
+        kind=np.full(node_id.shape, 'both', dtype='<U8'),
+        pick_count=pick_count,
+    )
+
+
+def _assert_layer_masks_select_expected_three_layer_branches(
+    fixture: _ThreeLayerSolverFixture,
+) -> None:
+    masks = build_refraction_layer_observation_masks(
+        input_model=fixture.input_model,
+        model=fixture.model,
+    )
+    for layer_kind in ('v2_t1', 'v3_t2', 'vsub_t3'):
+        expected = fixture.expected_layer_kind_sorted == layer_kind
+        np.testing.assert_array_equal(
+            masks.layer_used_mask_sorted[layer_kind],
+            expected,
+        )
+        assert masks.layer_observation_count[layer_kind] == int(
+            np.count_nonzero(expected)
+        )
+
+
+def _assert_global_layer_result(
+    layer: RefractionLayerSolveResult,
+    *,
+    expected_velocity_m_s: float,
+) -> None:
+    assert layer.velocity_mode == 'solve_global'
+    assert layer.global_velocity_m_s == pytest.approx(
+        expected_velocity_m_s,
+        rel=_VELOCITY_RTOL,
+    )
+    assert layer.global_slowness_s_per_m == pytest.approx(
+        1.0 / expected_velocity_m_s,
+        rel=_VELOCITY_RTOL,
+    )
+    np.testing.assert_allclose(
+        layer.trace_residual_s_sorted[layer.used_observation_mask_sorted],
+        0.0,
+        atol=STATIC_ATOL_S,
+    )
+
+
+def _assert_three_layer_time_terms_and_thicknesses_match_truth(
+    fixture: _ThreeLayerSolverFixture,
+    workflow: RefractionMultiLayerStaticsWorkflowResult,
+) -> None:
+    components = workflow.components
+    result = workflow.datum_result
+    np.testing.assert_allclose(components.source_t1_s, fixture.source_t1_s)
+    np.testing.assert_allclose(components.source_t2_s, fixture.source_t2_s)
+    np.testing.assert_allclose(components.source_t3_s, fixture.source_t3_s)
+    np.testing.assert_allclose(components.receiver_t1_s, fixture.receiver_t1_s)
+    np.testing.assert_allclose(components.receiver_t2_s, fixture.receiver_t2_s)
+    np.testing.assert_allclose(components.receiver_t3_s, fixture.receiver_t3_s)
+    np.testing.assert_allclose(
+        components.source_sh1_m,
+        fixture.source_sh1_m,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        components.source_sh2_m,
+        fixture.source_sh2_m,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        components.source_sh3_m,
+        fixture.source_sh3_m,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        components.receiver_sh1_m,
+        fixture.receiver_sh1_m,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        components.receiver_sh2_m,
+        fixture.receiver_sh2_m,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        components.receiver_sh3_m,
+        fixture.receiver_sh3_m,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        components.source_weathering_correction_s,
+        fixture.source_wcor_s,
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        components.receiver_weathering_correction_s,
+        fixture.receiver_wcor_s,
+        atol=STATIC_ATOL_S,
+    )
+    np.testing.assert_allclose(
+        result.source_weathering_thickness_m,
+        fixture.source_sh1_m + fixture.source_sh2_m + fixture.source_sh3_m,
+        atol=THICKNESS_ATOL_M,
+    )
+    np.testing.assert_allclose(
+        result.receiver_weathering_thickness_m,
+        fixture.receiver_sh1_m + fixture.receiver_sh2_m + fixture.receiver_sh3_m,
+        atol=THICKNESS_ATOL_M,
+    )
+
+
+def _assert_static_rows_match_three_layer_truth(
+    rows: list[dict[str, str]],
+    *,
+    expected_t1_s: np.ndarray,
+    expected_t2_s: np.ndarray,
+    expected_t3_s: np.ndarray,
+    expected_sh1_m: np.ndarray,
+    expected_sh2_m: np.ndarray,
+    expected_sh3_m: np.ndarray,
+    expected_wcor_s: np.ndarray,
+) -> None:
+    required_columns = {
+        't1_ms',
+        't2_ms',
+        't3_ms',
+        'v1_m_s',
+        'v2_m_s',
+        'v3_m_s',
+        'vsub_m_s',
+        'sh1_weathering_thickness_m',
+        'sh2_weathering_thickness_m',
+        'sh3_weathering_thickness_m',
+        'total_weathering_thickness_m',
+        'weathering_correction_ms',
+        'total_static_ms',
+        'total_applied_shift_ms',
+        'static_status',
+        'sign_convention',
+    }
+    assert required_columns <= set(rows[0])
+    for index, row in enumerate(rows):
+        assert row['static_status'] == 'ok'
+        assert row['sign_convention'] == _SIGN_CONVENTION
+        assert float(row['t1_ms']) / 1000.0 == pytest.approx(
+            expected_t1_s[index],
+            abs=STATIC_ATOL_S,
+        )
+        assert float(row['t2_ms']) / 1000.0 == pytest.approx(
+            expected_t2_s[index],
+            abs=STATIC_ATOL_S,
+        )
+        assert float(row['t3_ms']) / 1000.0 == pytest.approx(
+            expected_t3_s[index],
+            abs=STATIC_ATOL_S,
+        )
+        assert float(row['v1_m_s']) == pytest.approx(SYNTHETIC_MULTILAYER_V1_M_S)
+        assert float(row['v2_m_s']) == pytest.approx(
+            SYNTHETIC_MULTILAYER_V2_M_S,
+            rel=_VELOCITY_RTOL,
+        )
+        assert float(row['v3_m_s']) == pytest.approx(
+            SYNTHETIC_MULTILAYER_V3_M_S,
+            rel=_VELOCITY_RTOL,
+        )
+        assert float(row['vsub_m_s']) == pytest.approx(
+            SYNTHETIC_MULTILAYER_VSUB_M_S,
+            rel=_VELOCITY_RTOL,
+        )
+        assert float(row['sh1_weathering_thickness_m']) == pytest.approx(
+            expected_sh1_m[index],
+            abs=THICKNESS_ATOL_M,
+        )
+        assert float(row['sh2_weathering_thickness_m']) == pytest.approx(
+            expected_sh2_m[index],
+            abs=THICKNESS_ATOL_M,
+        )
+        assert float(row['sh3_weathering_thickness_m']) == pytest.approx(
+            expected_sh3_m[index],
+            abs=THICKNESS_ATOL_M,
+        )
+        expected_total_m = (
+            expected_sh1_m[index] + expected_sh2_m[index] + expected_sh3_m[index]
+        )
+        assert float(row['total_weathering_thickness_m']) == pytest.approx(
+            expected_total_m,
+            abs=THICKNESS_ATOL_M,
+        )
+        assert float(row['weathering_correction_ms']) / 1000.0 == pytest.approx(
+            expected_wcor_s[index],
+            abs=STATIC_ATOL_S,
+        )
+        assert float(row['total_static_ms']) / 1000.0 == pytest.approx(
+            expected_wcor_s[index],
+            abs=STATIC_ATOL_S,
+        )
+        assert float(row['total_applied_shift_ms']) / 1000.0 == pytest.approx(
+            expected_wcor_s[index],
+            abs=STATIC_ATOL_S,
+        )
+
+
+def _layer(
+    workflow: RefractionMultiLayerStaticsWorkflowResult,
+    layer_kind: str,
+) -> RefractionLayerSolveResult:
+    for layer in workflow.solve_result.layer_results:
+        if layer.layer_kind == layer_kind:
+            return layer
+    raise AssertionError(f'{layer_kind} layer result was not returned')
+
+
+def _map_endpoint_values_to_trace_nodes(
+    *,
+    endpoint_node_id: np.ndarray,
+    endpoint_values: np.ndarray,
+    trace_node_id: np.ndarray,
+) -> np.ndarray:
+    values_by_node = {
+        int(node_id): float(value)
+        for node_id, value in zip(
+            endpoint_node_id.tolist(),
+            endpoint_values.tolist(),
+            strict=True,
+        )
+    }
+    return np.asarray(
+        [values_by_node[int(node_id)] for node_id in trace_node_id.tolist()],
+        dtype=np.float64,
+    )
+
+
+def _first_occurrence_positions(values: np.ndarray) -> np.ndarray:
+    seen: set[str] = set()
+    positions: list[int] = []
+    for index, value in enumerate(values.tolist()):
+        key = str(value)
+        if key in seen:
+            continue
+        seen.add(key)
+        positions.append(index)
+    return np.asarray(positions, dtype=np.int64)
 
 
 def _read_csv(path: Path) -> list[dict[str, str]]:

--- a/app/tests/test_refraction_static_multilayer_artifacts.py
+++ b/app/tests/test_refraction_static_multilayer_artifacts.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from app.api.schemas import (
+    RefractionStaticApplyOptions,
+    RefractionStaticDatumRequest,
+    RefractionStaticSolverRequest,
+)
+from app.services.refraction_static_artifacts import (
+    FIRST_BREAK_RESIDUALS_CSV_NAME,
+    NEAR_SURFACE_MODEL_CSV_NAME,
+    RECEIVER_STATIC_TABLE_CSV_NAME,
+    REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
+    REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME,
+    REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
+    REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
+    REFRACTION_STATICS_CSV_NAME,
+    REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
+    REFRACTION_STATIC_COMPONENTS_CSV_NAME,
+    REFRACTION_STATIC_QC_JSON_NAME,
+    REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+    SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+    SOURCE_STATIC_TABLE_CSV_NAME,
+)
+from app.services.refraction_static_multilayer_service import (
+    compute_refraction_multilayer_datum_statics_from_input_model,
+)
+from app.tests._refraction_multilayer_3layer_helpers import (
+    compute_three_layer_workflow,
+)
+from app.tests._refraction_multilayer_synthetic import (
+    SYNTHETIC_MULTILAYER_V1_M_S,
+    SYNTHETIC_MULTILAYER_V2_M_S,
+    SYNTHETIC_MULTILAYER_V3_M_S,
+    SYNTHETIC_MULTILAYER_VSUB_M_S,
+)
+from app.tests.test_refraction_static_multilayer_2layer_e2e import (
+    _make_two_layer_fixture,
+    _resolved_first_layer,
+)
+
+
+_CORE_FINAL_ARTIFACT_NAMES = {
+    REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+    REFRACTION_STATIC_QC_JSON_NAME,
+    REFRACTION_STATICS_CSV_NAME,
+    NEAR_SURFACE_MODEL_CSV_NAME,
+    FIRST_BREAK_RESIDUALS_CSV_NAME,
+    REFRACTION_STATIC_COMPONENTS_CSV_NAME,
+    SOURCE_STATIC_TABLE_CSV_NAME,
+    RECEIVER_STATIC_TABLE_CSV_NAME,
+    SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+}
+
+_CELL_VELOCITY_ARTIFACT_NAMES = {
+    REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
+    REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME,
+    REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
+    REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
+}
+
+
+def test_three_layer_job_manifest_lists_multilayer_artifacts(
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'job'
+    compute_three_layer_workflow(job_dir=job_dir)
+
+    manifest = json.loads(
+        (job_dir / REFRACTION_STATIC_ARTIFACTS_JSON_NAME).read_text(
+            encoding='utf-8'
+        )
+    )
+    manifest_names = {item['name'] for item in manifest['artifacts']}
+
+    assert _CORE_FINAL_ARTIFACT_NAMES <= manifest_names
+    assert _CELL_VELOCITY_ARTIFACT_NAMES.isdisjoint(manifest_names)
+    for artifact_name in manifest_names:
+        assert (job_dir / artifact_name).is_file()
+
+    qc = json.loads(
+        (job_dir / REFRACTION_STATIC_QC_JSON_NAME).read_text(encoding='utf-8')
+    )
+    assert qc['layer_count'] == 3
+    assert qc['enabled_layer_kinds'] == ['v2_t1', 'v3_t2', 'vsub_t3']
+    assert qc['velocity']['layer_velocity_modes'] == {
+        'v2_t1': 'fixed_global',
+        'v3_t2': 'fixed_global',
+        'vsub_t3': 'fixed_global',
+    }
+    assert qc['sign_convention'] == 'corrected(t) = raw(t - shift_s)'
+
+
+def test_three_layer_solution_npz_contains_t3_sh3_and_vsub_arrays(
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'job'
+    dataset, _input_model, _model, workflow = compute_three_layer_workflow(
+        job_dir=job_dir,
+    )
+    result = workflow.datum_result
+
+    expected_arrays = {
+        'source_t1_s',
+        'source_t2_s',
+        'source_t3_s',
+        'receiver_t1_s',
+        'receiver_t2_s',
+        'receiver_t3_s',
+        'source_sh1_m',
+        'source_sh2_m',
+        'source_sh3_m',
+        'receiver_sh1_m',
+        'receiver_sh2_m',
+        'receiver_sh3_m',
+        'source_v2_m_s',
+        'source_v3_m_s',
+        'source_vsub_m_s',
+        'receiver_v2_m_s',
+        'receiver_v3_m_s',
+        'receiver_vsub_m_s',
+        'source_weathering_correction_s',
+        'receiver_weathering_correction_s',
+        'refraction_trace_shift_s_sorted',
+    }
+    with np.load(
+        job_dir / REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+        allow_pickle=False,
+    ) as data:
+        assert expected_arrays <= set(data.files)
+        np.testing.assert_allclose(data['source_t1_s'], result.source_half_intercept_time_s)
+        np.testing.assert_allclose(data['source_t2_s'], result.source_t2_time_s)
+        np.testing.assert_allclose(data['source_t3_s'], result.source_t3_time_s)
+        np.testing.assert_allclose(data['source_sh3_m'], dataset.true_source_endpoint_sh3_m)
+        np.testing.assert_allclose(data['receiver_sh3_m'], dataset.true_receiver_endpoint_sh3_m)
+        np.testing.assert_allclose(data['source_vsub_m_s'], SYNTHETIC_MULTILAYER_VSUB_M_S)
+        np.testing.assert_allclose(data['receiver_vsub_m_s'], SYNTHETIC_MULTILAYER_VSUB_M_S)
+        np.testing.assert_allclose(
+            data['source_weathering_correction_s'],
+            result.source_weathering_replacement_shift_s,
+        )
+        np.testing.assert_allclose(
+            data['receiver_weathering_correction_s'],
+            result.receiver_weathering_replacement_shift_s,
+        )
+
+
+def test_three_layer_npz_is_pickle_free(tmp_path: Path) -> None:
+    job_dir = tmp_path / 'job'
+    compute_three_layer_workflow(job_dir=job_dir)
+
+    for artifact_name in (
+        REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+        SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+    ):
+        with np.load(job_dir / artifact_name, allow_pickle=False) as data:
+            for key in data.files:
+                assert data[key].dtype != object, f'{artifact_name}:{key}'
+
+
+def test_two_layer_artifact_manifest_regression_still_passes(
+    tmp_path: Path,
+) -> None:
+    fixture = _make_two_layer_fixture(
+        coordinate_mode='grid_3d',
+        v2_velocity_mode='solve_global',
+    )
+    job_dir = tmp_path / 'job'
+
+    compute_refraction_multilayer_datum_statics_from_input_model(
+        input_model=fixture.input_model,
+        model=fixture.model,
+        solver=RefractionStaticSolverRequest(
+            damping=0.0,
+            robust={'enabled': False},
+        ),
+        datum=RefractionStaticDatumRequest(mode='none'),
+        apply_options=RefractionStaticApplyOptions(max_abs_shift_ms=250.0),
+        resolved_first_layer=_resolved_first_layer(),
+        job_dir=job_dir,
+    )
+
+    manifest = json.loads(
+        (job_dir / REFRACTION_STATIC_ARTIFACTS_JSON_NAME).read_text(
+            encoding='utf-8'
+        )
+    )
+    manifest_names = {item['name'] for item in manifest['artifacts']}
+    assert _CORE_FINAL_ARTIFACT_NAMES <= manifest_names
+    assert _CELL_VELOCITY_ARTIFACT_NAMES.isdisjoint(manifest_names)
+
+    qc = json.loads(
+        (job_dir / REFRACTION_STATIC_QC_JSON_NAME).read_text(encoding='utf-8')
+    )
+    assert qc['layer_count'] == 2
+    assert qc['enabled_layer_kinds'] == ['v2_t1', 'v3_t2']
+    assert qc['velocity']['layer_velocity_modes'] == {
+        'v2_t1': 'solve_global',
+        'v3_t2': 'solve_global',
+    }
+    with np.load(
+        job_dir / REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+        allow_pickle=False,
+    ) as data:
+        assert 'source_t3_s' not in data.files
+        assert 'source_sh3_m' not in data.files
+        assert 'source_vsub_m_s' not in data.files
+        np.testing.assert_allclose(
+            data['v1_weathering_velocity_m_s'],
+            SYNTHETIC_MULTILAYER_V1_M_S,
+        )
+        np.testing.assert_allclose(
+            data['source_v2_m_s'],
+            SYNTHETIC_MULTILAYER_V2_M_S,
+            rtol=1.0e-9,
+        )
+        np.testing.assert_allclose(
+            data['source_v3_m_s'],
+            SYNTHETIC_MULTILAYER_V3_M_S,
+            rtol=1.0e-9,
+        )

--- a/app/tests/test_refraction_static_multilayer_static_tables.py
+++ b/app/tests/test_refraction_static_multilayer_static_tables.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from app.services.refraction_static_artifacts import (
+    RECEIVER_STATIC_TABLE_CSV_NAME,
+    SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+    SOURCE_STATIC_TABLE_CSV_NAME,
+)
+from app.tests._refraction_multilayer_3layer_helpers import (
+    STATIC_ATOL_S,
+    THICKNESS_ATOL_M,
+    compute_three_layer_workflow,
+)
+
+
+SIGN_CONVENTION = 'corrected(t) = raw(t - shift_s)'
+
+
+@pytest.fixture
+def three_layer_static_table_artifacts(tmp_path: Path) -> dict[str, Any]:
+    job_dir = tmp_path / 'job'
+    dataset, _input_model, _model, workflow = compute_three_layer_workflow(
+        job_dir=job_dir,
+    )
+    with np.load(
+        job_dir / SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+        allow_pickle=False,
+    ) as data:
+        table_arrays = {name: data[name].copy() for name in data.files}
+    return {
+        'dataset': dataset,
+        'result': workflow.datum_result,
+        'source_rows': _read_csv(job_dir / SOURCE_STATIC_TABLE_CSV_NAME),
+        'receiver_rows': _read_csv(job_dir / RECEIVER_STATIC_TABLE_CSV_NAME),
+        'table_arrays': table_arrays,
+    }
+
+
+def test_three_layer_source_table_has_t3_vsub_sh3_columns(
+    three_layer_static_table_artifacts: dict[str, Any],
+) -> None:
+    dataset = three_layer_static_table_artifacts['dataset']
+    rows = three_layer_static_table_artifacts['source_rows']
+
+    assert len(rows) == int(dataset.source_endpoint_id.shape[0])
+    assert {
+        't1_ms',
+        't2_ms',
+        't3_ms',
+        'v1_m_s',
+        'v2_m_s',
+        'v3_m_s',
+        'vsub_m_s',
+        'sh1_weathering_thickness_m',
+        'sh2_weathering_thickness_m',
+        'sh3_weathering_thickness_m',
+        'total_weathering_thickness_m',
+        'layer1_base_elevation_m',
+        'layer2_base_elevation_m',
+        'final_refractor_elevation_m',
+        'weathering_correction_ms',
+        'elevation_correction_ms',
+        'total_static_ms',
+        'total_applied_shift_ms',
+        'solution_status',
+        'weathering_status',
+        'datum_status',
+        'static_status',
+        'sign_convention',
+    } <= set(rows[0])
+    assert float(rows[0]['t3_ms']) / 1000.0 == pytest.approx(
+        dataset.true_source_endpoint_t3_s[0],
+        abs=STATIC_ATOL_S,
+    )
+    assert float(rows[0]['vsub_m_s']) == pytest.approx(dataset.true_vsub_m_s)
+    assert float(rows[0]['sh3_weathering_thickness_m']) == pytest.approx(
+        dataset.true_source_endpoint_sh3_m[0],
+        abs=THICKNESS_ATOL_M,
+    )
+    assert rows[0]['sign_convention'] == SIGN_CONVENTION
+
+
+def test_three_layer_receiver_table_has_t3_vsub_sh3_columns(
+    three_layer_static_table_artifacts: dict[str, Any],
+) -> None:
+    dataset = three_layer_static_table_artifacts['dataset']
+    rows = three_layer_static_table_artifacts['receiver_rows']
+
+    assert len(rows) == int(dataset.receiver_endpoint_id.shape[0])
+    assert {'t3_ms', 'vsub_m_s', 'sh3_weathering_thickness_m'} <= set(rows[0])
+    assert float(rows[0]['t3_ms']) / 1000.0 == pytest.approx(
+        dataset.true_receiver_endpoint_t3_s[0],
+        abs=STATIC_ATOL_S,
+    )
+    assert float(rows[0]['vsub_m_s']) == pytest.approx(dataset.true_vsub_m_s)
+    assert float(rows[0]['sh3_weathering_thickness_m']) == pytest.approx(
+        dataset.true_receiver_endpoint_sh3_m[0],
+        abs=THICKNESS_ATOL_M,
+    )
+    assert rows[0]['sign_convention'] == SIGN_CONVENTION
+
+
+def test_three_layer_static_table_total_thickness_and_final_refractor_are_consistent(
+    three_layer_static_table_artifacts: dict[str, Any],
+) -> None:
+    dataset = three_layer_static_table_artifacts['dataset']
+    table = three_layer_static_table_artifacts['table_arrays']
+
+    _assert_endpoint_totals(
+        three_layer_static_table_artifacts['source_rows'],
+        surface_elevation_m=dataset.source_endpoint_elevation_m,
+        sh1_m=dataset.true_source_endpoint_sh1_m,
+        sh2_m=dataset.true_source_endpoint_sh2_m,
+        sh3_m=dataset.true_source_endpoint_sh3_m,
+        npz_total_m=table['source_total_weathering_thickness_m'],
+    )
+    _assert_endpoint_totals(
+        three_layer_static_table_artifacts['receiver_rows'],
+        surface_elevation_m=dataset.receiver_endpoint_elevation_m,
+        sh1_m=dataset.true_receiver_endpoint_sh1_m,
+        sh2_m=dataset.true_receiver_endpoint_sh2_m,
+        sh3_m=dataset.true_receiver_endpoint_sh3_m,
+        npz_total_m=table['receiver_total_weathering_thickness_m'],
+    )
+    assert str(table['sign_convention']) == SIGN_CONVENTION
+
+
+def _assert_endpoint_totals(
+    rows: list[dict[str, str]],
+    *,
+    surface_elevation_m: np.ndarray,
+    sh1_m: np.ndarray,
+    sh2_m: np.ndarray,
+    sh3_m: np.ndarray,
+    npz_total_m: np.ndarray,
+) -> None:
+    expected_total = sh1_m + sh2_m + sh3_m
+    expected_layer1_base = surface_elevation_m - sh1_m
+    expected_layer2_base = expected_layer1_base - sh2_m
+    expected_final = surface_elevation_m - expected_total
+
+    np.testing.assert_allclose(npz_total_m, expected_total, atol=THICKNESS_ATOL_M)
+    for index, row in enumerate(rows):
+        assert float(row['total_weathering_thickness_m']) == pytest.approx(
+            expected_total[index],
+            abs=THICKNESS_ATOL_M,
+        )
+        assert float(row['layer1_base_elevation_m']) == pytest.approx(
+            expected_layer1_base[index],
+            abs=THICKNESS_ATOL_M,
+        )
+        assert float(row['layer2_base_elevation_m']) == pytest.approx(
+            expected_layer2_base[index],
+            abs=THICKNESS_ATOL_M,
+        )
+        assert float(row['final_refractor_elevation_m']) == pytest.approx(
+            expected_final[index],
+            abs=THICKNESS_ATOL_M,
+        )
+        assert float(row['refractor_elevation_m']) == pytest.approx(
+            expected_final[index],
+            abs=THICKNESS_ATOL_M,
+        )
+        assert float(row['total_applied_shift_ms']) == pytest.approx(
+            float(row['total_static_ms'])
+        )
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))

--- a/app/tests/test_refraction_static_source_receiver_tables.py
+++ b/app/tests/test_refraction_static_source_receiver_tables.py
@@ -45,6 +45,7 @@ SOURCE_COLUMNS = [
     'v2_m_s',
     'v2_status',
     'sh1_weathering_thickness_m',
+    'total_weathering_thickness_m',
     'refractor_elevation_m',
     'weathering_correction_ms',
     'floating_datum_correction_ms',
@@ -56,6 +57,7 @@ SOURCE_COLUMNS = [
     'weathering_status',
     'datum_status',
     'static_status',
+    'sign_convention',
     'pick_count',
     'used_pick_count',
     'residual_rms_ms',
@@ -78,6 +80,7 @@ RECEIVER_COLUMNS = [
     'v2_m_s',
     'v2_status',
     'sh1_weathering_thickness_m',
+    'total_weathering_thickness_m',
     'refractor_elevation_m',
     'weathering_correction_ms',
     'floating_datum_correction_ms',
@@ -89,6 +92,7 @@ RECEIVER_COLUMNS = [
     'weathering_status',
     'datum_status',
     'static_status',
+    'sign_convention',
     'pick_count',
     'used_pick_count',
     'residual_rms_ms',
@@ -545,6 +549,9 @@ def _assert_source_row_matches_npz(
     assert float(row['sh1_weathering_thickness_m']) == pytest.approx(
         float(data['source_sh1_m'][index])
     )
+    assert float(row['total_weathering_thickness_m']) == pytest.approx(
+        float(data['source_total_weathering_thickness_m'][index])
+    )
     assert float(row['weathering_correction_ms']) == pytest.approx(
         float(data['source_weathering_correction_s'][index]) * 1000.0
     )
@@ -558,6 +565,7 @@ def _assert_source_row_matches_npz(
         float(data['source_total_applied_shift_s'][index]) * 1000.0
     )
     assert row['static_status'] == str(data['source_static_status'][index])
+    assert row['sign_convention'] == str(data['sign_convention'])
 
 
 def _assert_receiver_row_matches_npz(
@@ -581,6 +589,9 @@ def _assert_receiver_row_matches_npz(
     assert float(row['sh1_weathering_thickness_m']) == pytest.approx(
         float(data['receiver_sh1_m'][index])
     )
+    assert float(row['total_weathering_thickness_m']) == pytest.approx(
+        float(data['receiver_total_weathering_thickness_m'][index])
+    )
     assert float(row['weathering_correction_ms']) == pytest.approx(
         float(data['receiver_weathering_correction_s'][index]) * 1000.0
     )
@@ -594,6 +605,7 @@ def _assert_receiver_row_matches_npz(
         float(data['receiver_total_applied_shift_s'][index]) * 1000.0
     )
     assert row['static_status'] == str(data['receiver_static_status'][index])
+    assert row['sign_convention'] == str(data['sign_convention'])
 
 
 def _read_csv(path: Path) -> list[dict[str, str]]:

--- a/app/tests/test_refraction_static_static_tables_synthetic.py
+++ b/app/tests/test_refraction_static_static_tables_synthetic.py
@@ -109,6 +109,7 @@ def test_static_table_wcor_matches_known_truth_and_sign_convention(
             float(row['total_static_ms'])
         )
         assert row['static_status'] == 'ok'
+        assert row['sign_convention'] == 'corrected(t) = raw(t - shift_s)'
 
 
 def test_source_receiver_static_table_csv_and_npz_are_consistent(
@@ -192,6 +193,10 @@ def _assert_endpoint_row_matches_known_truth(
         expected_cell_sh1_m_for_node(node_id),
         abs=SYNTHETIC_SH1_TOLERANCE_M,
     )
+    assert float(row['total_weathering_thickness_m']) == pytest.approx(
+        expected_cell_sh1_m_for_node(node_id),
+        abs=SYNTHETIC_SH1_TOLERANCE_M,
+    )
     assert float(row['weathering_correction_ms']) == pytest.approx(
         expected_wcor_ms,
         abs=SYNTHETIC_WCOR_TOLERANCE_MS,
@@ -233,6 +238,9 @@ def _assert_npz_endpoint_matches_csv(
     assert float(table[f'{prefix}_sh1_m'][index]) == pytest.approx(
         float(row['sh1_weathering_thickness_m'])
     )
+    assert float(
+        table[f'{prefix}_total_weathering_thickness_m'][index]
+    ) == pytest.approx(float(row['total_weathering_thickness_m']))
     assert (
         float(table[f'{prefix}_weathering_correction_s'][index]) * 1000.0
     ) == pytest.approx(float(row['weathering_correction_ms']))


### PR DESCRIPTION
Closes #466
Closes #467
Closes #468
Closes #469

## Issues
- #466 [statics][refraction][m3] Compose three-layer T1LSST statics into weathering and datum workflow
- #467 [statics][refraction][m3] Extend source/receiver static tables for three-layer outputs
- #468 [statics][refraction][m3] Register three-layer artifacts in manifest and download API
- #469 [statics][refraction][m3] Add three-layer synthetic E2E tests for Vsub/T3 and T1LSST 3-layer

Batch range: #466-#469
