### PR TITLE
Batch: address issues #506-#509

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -19,6 +19,8 @@ from app.api.schemas import (
     RefractionStaticApplyResponse,
     RefractionStaticExportJobRequest,
     RefractionStaticExportJobResponse,
+    RefractionStaticTableApplyRequest,
+    RefractionStaticTableApplyResponse,
     ResidualStaticApplyRequest,
     ResidualStaticApplyResponse,
     StaticLinkageBuildRequest,
@@ -45,6 +47,9 @@ from app.services.refraction_static_export_service import (
     validate_refraction_static_export_source_job,
 )
 from app.services.refraction_static_service import run_refraction_static_apply_job
+from app.services.refraction_static_table_apply_service import (
+    run_refraction_static_table_apply_job,
+)
 from app.services.residual_static_service import run_residual_static_apply_job
 from app.services.time_term_static_service import run_time_term_static_apply_job
 
@@ -280,6 +285,39 @@ def refraction_static_apply(
     if req.export.enabled:
         response['requested_formats'] = list(requested_formats)
     return response
+
+
+@router.post(
+    '/statics/refraction/static-table/apply',
+    response_model=RefractionStaticTableApplyResponse,
+)
+def refraction_static_table_apply(
+    req: RefractionStaticTableApplyRequest,
+    request: Request,
+) -> RefractionStaticTableApplyResponse:
+    state = get_state(request.app)
+    cleanup_in_memory_state(state)
+    maybe_cleanup_expired_jobs()
+
+    job_id = str(uuid4())
+    with state.lock:
+        job_state = state.jobs.create_static_job(
+            job_id,
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            statics_kind='refraction_static_table_apply',
+            artifacts_dir=str(get_job_dir(job_id)),
+        )
+        status = job_state['status']
+
+    start_job_thread(
+        thread_factory=threading.Thread,
+        target=run_refraction_static_table_apply_job,
+        args=(job_id, req, state),
+    )
+
+    return {'job_id': job_id, 'state': status}
 
 
 @router.post(

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -2926,7 +2926,7 @@ class RefractionStaticTableApplyRequest(BaseModel):
     allow_missing_source_static: bool = False
     allow_missing_receiver_static: bool = False
     missing_static_policy: Literal['fail', 'zero'] = 'fail'
-    double_application_policy: Literal['warn', 'fail', 'allow'] = 'warn'
+    double_application_policy: Literal['warn', 'fail', 'allow'] = 'fail'
     allow_reapply_same_static_table: bool = False
     fill_value: float = 0.0
     max_abs_shift_ms: float = 250.0

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -2905,6 +2905,121 @@ class RefractionStaticApplyResponse(BaseModel):
     requested_formats: list[RefractionStaticExportFormat] | None = None
 
 
+class RefractionStaticTableApplyRequest(BaseModel):
+    """Request model for standalone M5 static-table TraceStore apply jobs."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    file_id: str
+    key1_byte: int = 189
+    key2_byte: int = 193
+    geometry: RefractionStaticGeometryRequest = Field(
+        default_factory=RefractionStaticGeometryRequest,
+    )
+    source_table_artifact_id: str | None = None
+    receiver_table_artifact_id: str | None = None
+    combined_table_artifact_id: str | None = None
+    source_key_header: Literal['endpoint_key', 'endpoint_id'] | None = None
+    receiver_key_header: Literal['endpoint_key', 'endpoint_id'] | None = None
+    register_corrected_file: bool = True
+    output_name: str | None = None
+    allow_missing_source_static: bool = False
+    allow_missing_receiver_static: bool = False
+    missing_static_policy: Literal['fail', 'zero'] = 'fail'
+    double_application_policy: Literal['warn', 'fail', 'allow'] = 'warn'
+    fill_value: float = 0.0
+    max_abs_shift_ms: float = 250.0
+
+    @field_validator('file_id', mode='before')
+    @classmethod
+    def _check_file_id(cls, value: object) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError('file_id must be a non-empty string')
+        return value
+
+    @field_validator('key1_byte', 'key2_byte', mode='before')
+    @classmethod
+    def _check_key_header_byte(cls, value: object, info: Any) -> int:
+        return require_trace_header_byte(value, info.field_name)
+
+    @field_validator(
+        'source_table_artifact_id',
+        'receiver_table_artifact_id',
+        'combined_table_artifact_id',
+        mode='before',
+    )
+    @classmethod
+    def _check_artifact_id(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value:
+            raise ValueError('static table artifact id must be a non-empty string')
+        return value
+
+    @field_validator('register_corrected_file', mode='before')
+    @classmethod
+    def _check_register_corrected_file_bool(cls, value: object) -> bool:
+        return _require_bool(value, 'register_corrected_file')
+
+    @field_validator(
+        'allow_missing_source_static',
+        'allow_missing_receiver_static',
+        mode='before',
+    )
+    @classmethod
+    def _check_allow_missing_bool(cls, value: object, info: Any) -> bool:
+        return _require_bool(value, info.field_name)
+
+    @field_validator('output_name', mode='before')
+    @classmethod
+    def _check_output_name(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError('output_name must be a plain file name')
+        return _validate_artifact_basename(value, 'output_name')
+
+    @field_validator('fill_value', mode='before')
+    @classmethod
+    def _check_fill_value(cls, value: object) -> float:
+        return _require_finite_float(value, 'fill_value')
+
+    @field_validator('max_abs_shift_ms', mode='before')
+    @classmethod
+    def _check_max_abs_shift_ms(cls, value: object) -> float:
+        return _require_positive_finite_float(value, 'max_abs_shift_ms')
+
+    @model_validator(mode='after')
+    def _check_table_artifacts(self) -> 'RefractionStaticTableApplyRequest':
+        has_combined = self.combined_table_artifact_id is not None
+        has_separate = (
+            self.source_table_artifact_id is not None
+            or self.receiver_table_artifact_id is not None
+        )
+        if has_combined and has_separate:
+            raise ValueError(
+                'provide either combined_table_artifact_id or separate '
+                'source/receiver table artifact ids'
+            )
+        if has_combined:
+            return self
+        if self.source_table_artifact_id is None or self.receiver_table_artifact_id is None:
+            raise ValueError(
+                'source_table_artifact_id and receiver_table_artifact_id are '
+                'required when combined_table_artifact_id is omitted'
+            )
+        return self
+
+
+class RefractionStaticTableApplyResponse(BaseModel):
+    """Response model for creating a standalone static-table apply job."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    job_id: str
+    state: str
+
+
 class RefractionStaticExportJobRequest(BaseModel):
     """Request model for ``/statics/refraction/export`` jobs."""
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -2927,6 +2927,7 @@ class RefractionStaticTableApplyRequest(BaseModel):
     allow_missing_receiver_static: bool = False
     missing_static_policy: Literal['fail', 'zero'] = 'fail'
     double_application_policy: Literal['warn', 'fail', 'allow'] = 'warn'
+    allow_reapply_same_static_table: bool = False
     fill_value: float = 0.0
     max_abs_shift_ms: float = 250.0
 
@@ -2964,6 +2965,7 @@ class RefractionStaticTableApplyRequest(BaseModel):
     @field_validator(
         'allow_missing_source_static',
         'allow_missing_receiver_static',
+        'allow_reapply_same_static_table',
         mode='before',
     )
     @classmethod

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -216,7 +216,7 @@ TIME_TERM_SPREADSHEET_FORMAT_VERSION = 1
 TIME_TERM_SPREADSHEET_SCHEMA_VERSION = 1
 FIRST_BREAK_TIME_EXPORT_SCHEMA_VERSION = 1
 FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION = (
-    'residual_ms = observed_pick_time_ms - modeled_pick_time_ms'
+    'residual_ms = observed_first_break_time_ms - modeled_first_break_time_ms'
 )
 
 _ARTIFACTS: tuple[dict[str, str | bool], ...] = (
@@ -537,28 +537,22 @@ _RESIDUAL_COLUMNS = (
 )
 
 _FIRST_BREAK_TIME_EXPORT_COLUMNS = (
-    'schema_version',
-    'trace_index_sorted',
+    'format_name',
+    'format_version',
+    'source_job_id',
+    'observation_index',
+    'sorted_trace_index',
     'source_endpoint_key',
     'receiver_endpoint_key',
-    'source_node_id',
-    'receiver_node_id',
+    'source_id',
+    'receiver_id',
     'offset_m',
-    'midpoint_x_m',
-    'midpoint_y_m',
-    'cell_ix',
-    'cell_iy',
     'layer_kind',
-    'used_for_layer',
-    'observed_pick_time_ms',
-    'modeled_pick_time_ms',
+    'observed_first_break_time_ms',
+    'modeled_first_break_time_ms',
     'residual_ms',
-    'moveout_time_ms',
-    'source_time_term_ms',
-    'receiver_time_term_ms',
-    'velocity_m_s',
-    'rejection_reason',
-    'observation_status',
+    'used_in_solve',
+    'reject_reason',
     'sign_convention',
 )
 
@@ -1135,6 +1129,7 @@ def write_refraction_static_artifacts(
         result=values.result,
         path=paths.refraction_first_break_time_export_csv,
         req=request,
+        source_job_id=source_job_id,
     )
     write_refraction_static_components_csv(
         result=values.result,
@@ -1327,9 +1322,14 @@ def write_refraction_first_break_time_export_csv(
     result: RefractionDatumStaticsResult,
     path: Path,
     req: RefractionStaticApplyRequest | None = None,
+    source_job_id: str | None = None,
 ) -> None:
     values = _validate_result(result)
-    rows = _first_break_time_export_rows(values.result, req=req)
+    rows = _first_break_time_export_rows(
+        values.result,
+        req=req,
+        source_job_id=source_job_id,
+    )
     _write_csv_atomic(Path(path), _FIRST_BREAK_TIME_EXPORT_COLUMNS, rows)
 
 
@@ -4138,12 +4138,9 @@ def _first_break_time_export_rows(
     result: RefractionDatumStaticsResult,
     *,
     req: RefractionStaticApplyRequest | None = None,
+    source_job_id: str | None = None,
 ) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
-    _cell_id_by_row, cell_ix_by_row, cell_iy_by_row = _residual_row_cell_context(
-        result,
-        req=req,
-    )
     layer_kind_by_row, _layer_index_by_row = _first_break_export_layer_context(
         result,
     )
@@ -4159,44 +4156,19 @@ def _first_break_time_export_rows(
         result,
         'row_rejection_reason',
     )
-    row_velocity_m_s = _residual_row_velocity_context(result)
-    source_x_by_row = _row_endpoint_float_context(
+    source_id_by_row = _row_endpoint_id_context(
         result,
         endpoint='source',
         row_endpoint_key=source_key_by_row,
-        value_field='source_x_m',
+        value_field='source_id',
     )
-    source_y_by_row = _row_endpoint_float_context(
-        result,
-        endpoint='source',
-        row_endpoint_key=source_key_by_row,
-        value_field='source_y_m',
-    )
-    receiver_x_by_row = _row_endpoint_float_context(
+    receiver_id_by_row = _row_endpoint_id_context(
         result,
         endpoint='receiver',
         row_endpoint_key=receiver_key_by_row,
-        value_field='receiver_x_m',
+        value_field='receiver_id',
     )
-    receiver_y_by_row = _row_endpoint_float_context(
-        result,
-        endpoint='receiver',
-        row_endpoint_key=receiver_key_by_row,
-        value_field='receiver_y_m',
-    )
-    source_time_term_s, receiver_time_term_s = _first_break_row_time_terms(
-        result,
-        layer_kind_by_row=layer_kind_by_row,
-        source_key_by_row=source_key_by_row,
-        receiver_key_by_row=receiver_key_by_row,
-    )
-    moveout_time_s = _first_break_moveout_time_s(
-        modeled_pick_time_s=result.modeled_pick_time_s,
-        source_time_term_s=source_time_term_s,
-        receiver_time_term_s=receiver_time_term_s,
-    )
-    midpoint_x_m = _midpoint_coordinate(source_x_by_row, receiver_x_by_row)
-    midpoint_y_m = _midpoint_coordinate(source_y_by_row, receiver_y_by_row)
+    source_job_id_text = _source_job_id(source_job_id, req)
 
     for row_index in range(int(result.row_trace_index_sorted.shape[0])):
         rejected_by_robust = bool(result.rejected_by_robust_mask[row_index])
@@ -4208,40 +4180,76 @@ def _first_break_time_export_rows(
         )
         rows.append(
             {
-                'schema_version': FIRST_BREAK_TIME_EXPORT_SCHEMA_VERSION,
-                'trace_index_sorted': int(result.row_trace_index_sorted[row_index]),
+                'format_name': 'first_break_time',
+                'format_version': FIRST_BREAK_TIME_EXPORT_SCHEMA_VERSION,
+                'source_job_id': source_job_id_text,
+                'observation_index': row_index,
+                'sorted_trace_index': int(result.row_trace_index_sorted[row_index]),
                 'source_endpoint_key': str(source_key_by_row[row_index]),
                 'receiver_endpoint_key': str(receiver_key_by_row[row_index]),
-                'source_node_id': int(result.row_source_node_id[row_index]),
-                'receiver_node_id': int(result.row_receiver_node_id[row_index]),
+                'source_id': _csv_int(source_id_by_row[row_index]),
+                'receiver_id': _csv_int(receiver_id_by_row[row_index]),
                 'offset_m': _csv_float(result.row_distance_m[row_index]),
-                'midpoint_x_m': _csv_float(midpoint_x_m[row_index]),
-                'midpoint_y_m': _csv_float(midpoint_y_m[row_index]),
-                'cell_ix': _csv_cell_id(cell_ix_by_row[row_index]),
-                'cell_iy': _csv_cell_id(cell_iy_by_row[row_index]),
                 'layer_kind': str(layer_kind_by_row[row_index]),
-                'used_for_layer': _csv_bool(used),
-                'observed_pick_time_ms': _csv_ms(
+                'observed_first_break_time_ms': _csv_ms(
                     result.observed_pick_time_s[row_index]
                 ),
-                'modeled_pick_time_ms': _csv_ms(result.modeled_pick_time_s[row_index]),
+                'modeled_first_break_time_ms': _csv_ms(
+                    result.modeled_pick_time_s[row_index]
+                ),
                 'residual_ms': _csv_ms(result.residual_time_s[row_index]),
-                'moveout_time_ms': _csv_ms(moveout_time_s[row_index]),
-                'source_time_term_ms': _csv_ms(source_time_term_s[row_index]),
-                'receiver_time_term_ms': _csv_ms(receiver_time_term_s[row_index]),
-                'velocity_m_s': _csv_float(row_velocity_m_s[row_index]),
-                'rejection_reason': rejection_reason,
-                'observation_status': 'used' if used else 'rejected',
+                'used_in_solve': _csv_bool(used),
+                'reject_reason': rejection_reason,
                 'sign_convention': FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION,
             }
         )
     return rows
 
 
+def _source_job_id(
+    source_job_id: str | None,
+    req: RefractionStaticApplyRequest | None,
+) -> str:
+    raw = source_job_id
+    if raw is None and req is not None:
+        raw = getattr(req, 'source_job_id', None)
+    return '' if raw is None else str(raw)
+
+
 def _first_break_export_layer_context(
     result: RefractionDatumStaticsResult,
 ) -> tuple[np.ndarray, np.ndarray]:
     return _residual_row_layer_context(result)
+
+
+def _row_endpoint_id_context(
+    result: RefractionDatumStaticsResult,
+    *,
+    endpoint: str,
+    row_endpoint_key: np.ndarray,
+    value_field: str,
+) -> np.ndarray:
+    n_rows = int(result.row_trace_index_sorted.shape[0])
+    keys = (
+        result.source_endpoint_key
+        if endpoint == 'source'
+        else result.receiver_endpoint_key
+    )
+    values = getattr(result, value_field)
+    lookup = {
+        str(key): value
+        for key, value in zip(
+            np.asarray(keys).tolist(),
+            np.asarray(values).tolist(),
+            strict=True,
+        )
+    }
+    out = np.full(n_rows, '', dtype=object)
+    for index, raw_key in enumerate(row_endpoint_key.tolist()):
+        value = lookup.get(str(raw_key))
+        if value is not None:
+            out[index] = value
+    return np.ascontiguousarray(out, dtype=object)
 
 
 def _row_endpoint_float_context(

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -68,6 +68,7 @@ REFRACTION_STATIC_QC_JSON_NAME = 'refraction_static_qc.json'
 REFRACTION_STATICS_CSV_NAME = 'refraction_statics.csv'
 NEAR_SURFACE_MODEL_CSV_NAME = 'near_surface_model.csv'
 FIRST_BREAK_RESIDUALS_CSV_NAME = 'first_break_residuals.csv'
+REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME = 'refraction_first_break_time_export.csv'
 REFRACTION_STATIC_COMPONENTS_CSV_NAME = 'refraction_static_components.csv'
 SOURCE_STATIC_TABLE_CSV_NAME = 'source_static_table.csv'
 RECEIVER_STATIC_TABLE_CSV_NAME = 'receiver_static_table.csv'
@@ -213,6 +214,10 @@ NEGATIVE_SHIFT_DESCRIPTION = 'event appears earlier in corrected data'
 TIME_TERM_SPREADSHEET_FORMAT_NAME = 'time_term_spreadsheet'
 TIME_TERM_SPREADSHEET_FORMAT_VERSION = 1
 TIME_TERM_SPREADSHEET_SCHEMA_VERSION = 1
+FIRST_BREAK_TIME_EXPORT_SCHEMA_VERSION = 1
+FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION = (
+    'residual_ms = observed_pick_time_ms - modeled_pick_time_ms'
+)
 
 _ARTIFACTS: tuple[dict[str, str | bool], ...] = (
     {
@@ -250,6 +255,12 @@ _ARTIFACTS: tuple[dict[str, str | bool], ...] = (
         'kind': 'csv',
         'required': True,
         'description': 'GLI first-break residual table',
+    },
+    {
+        'name': REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
+        'kind': 'csv',
+        'required': True,
+        'description': 'Observation-level first-break time QC export',
     },
     {
         'name': REFRACTION_STATIC_COMPONENTS_CSV_NAME,
@@ -523,6 +534,32 @@ _RESIDUAL_COLUMNS = (
     'residual_time_s',
     'midpoint_cell_id',
     'row_velocity_m_s',
+)
+
+_FIRST_BREAK_TIME_EXPORT_COLUMNS = (
+    'schema_version',
+    'trace_index_sorted',
+    'source_endpoint_key',
+    'receiver_endpoint_key',
+    'source_node_id',
+    'receiver_node_id',
+    'offset_m',
+    'midpoint_x_m',
+    'midpoint_y_m',
+    'cell_ix',
+    'cell_iy',
+    'layer_kind',
+    'used_for_layer',
+    'observed_pick_time_ms',
+    'modeled_pick_time_ms',
+    'residual_ms',
+    'moveout_time_ms',
+    'source_time_term_ms',
+    'receiver_time_term_ms',
+    'velocity_m_s',
+    'rejection_reason',
+    'observation_status',
+    'sign_convention',
 )
 
 _COMPONENT_COLUMNS = (
@@ -1035,6 +1072,9 @@ def write_refraction_static_artifacts(
         refraction_statics_csv=root / REFRACTION_STATICS_CSV_NAME,
         near_surface_model_csv=root / NEAR_SURFACE_MODEL_CSV_NAME,
         first_break_residuals_csv=root / FIRST_BREAK_RESIDUALS_CSV_NAME,
+        refraction_first_break_time_export_csv=(
+            root / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME
+        ),
         refraction_static_components_csv=root / REFRACTION_STATIC_COMPONENTS_CSV_NAME,
         source_static_table_csv=root / SOURCE_STATIC_TABLE_CSV_NAME,
         receiver_static_table_csv=root / RECEIVER_STATIC_TABLE_CSV_NAME,
@@ -1089,6 +1129,11 @@ def write_refraction_static_artifacts(
     write_first_break_residuals_csv(
         result=values.result,
         path=paths.first_break_residuals_csv,
+        req=request,
+    )
+    write_refraction_first_break_time_export_csv(
+        result=values.result,
+        path=paths.refraction_first_break_time_export_csv,
         req=request,
     )
     write_refraction_static_components_csv(
@@ -1155,6 +1200,7 @@ def write_refraction_static_artifacts(
         paths.refraction_statics_csv,
         paths.near_surface_model_csv,
         paths.first_break_residuals_csv,
+        paths.refraction_first_break_time_export_csv,
         paths.refraction_static_components_csv,
         paths.source_static_table_csv,
         paths.receiver_static_table_csv,
@@ -1274,6 +1320,17 @@ def write_first_break_residuals_csv(
     values = _validate_result(result)
     rows = _first_break_residual_rows(values.result, req=req)
     _write_csv_atomic(Path(path), _RESIDUAL_COLUMNS, rows)
+
+
+def write_refraction_first_break_time_export_csv(
+    *,
+    result: RefractionDatumStaticsResult,
+    path: Path,
+    req: RefractionStaticApplyRequest | None = None,
+) -> None:
+    values = _validate_result(result)
+    rows = _first_break_time_export_rows(values.result, req=req)
+    _write_csv_atomic(Path(path), _FIRST_BREAK_TIME_EXPORT_COLUMNS, rows)
 
 
 def write_refraction_static_components_csv(
@@ -4050,6 +4107,248 @@ def _first_break_residual_rows(
             }
         )
     return rows
+
+
+def _first_break_time_export_rows(
+    result: RefractionDatumStaticsResult,
+    *,
+    req: RefractionStaticApplyRequest | None = None,
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    _cell_id_by_row, cell_ix_by_row, cell_iy_by_row = _residual_row_cell_context(
+        result,
+        req=req,
+    )
+    layer_kind_by_row, _layer_index_by_row = _first_break_export_layer_context(
+        result,
+    )
+    source_key_by_row = _residual_row_string_context(
+        result,
+        'row_source_endpoint_key',
+    )
+    receiver_key_by_row = _residual_row_string_context(
+        result,
+        'row_receiver_endpoint_key',
+    )
+    rejection_reason_by_row = _residual_row_string_context(
+        result,
+        'row_rejection_reason',
+    )
+    row_velocity_m_s = _residual_row_velocity_context(result)
+    source_x_by_row = _row_endpoint_float_context(
+        result,
+        endpoint='source',
+        row_endpoint_key=source_key_by_row,
+        value_field='source_x_m',
+    )
+    source_y_by_row = _row_endpoint_float_context(
+        result,
+        endpoint='source',
+        row_endpoint_key=source_key_by_row,
+        value_field='source_y_m',
+    )
+    receiver_x_by_row = _row_endpoint_float_context(
+        result,
+        endpoint='receiver',
+        row_endpoint_key=receiver_key_by_row,
+        value_field='receiver_x_m',
+    )
+    receiver_y_by_row = _row_endpoint_float_context(
+        result,
+        endpoint='receiver',
+        row_endpoint_key=receiver_key_by_row,
+        value_field='receiver_y_m',
+    )
+    source_time_term_s, receiver_time_term_s = _first_break_row_time_terms(
+        result,
+        layer_kind_by_row=layer_kind_by_row,
+        source_key_by_row=source_key_by_row,
+        receiver_key_by_row=receiver_key_by_row,
+    )
+    moveout_time_s = _first_break_moveout_time_s(
+        modeled_pick_time_s=result.modeled_pick_time_s,
+        source_time_term_s=source_time_term_s,
+        receiver_time_term_s=receiver_time_term_s,
+    )
+    midpoint_x_m = _midpoint_coordinate(source_x_by_row, receiver_x_by_row)
+    midpoint_y_m = _midpoint_coordinate(source_y_by_row, receiver_y_by_row)
+
+    for row_index in range(int(result.row_trace_index_sorted.shape[0])):
+        rejected_by_robust = bool(result.rejected_by_robust_mask[row_index])
+        used = bool(result.used_row_mask[row_index])
+        rejection_reason = _residual_rejection_reason(
+            used=used,
+            rejected_by_robust=rejected_by_robust,
+            explicit_reason=rejection_reason_by_row[row_index],
+        )
+        rows.append(
+            {
+                'schema_version': FIRST_BREAK_TIME_EXPORT_SCHEMA_VERSION,
+                'trace_index_sorted': int(result.row_trace_index_sorted[row_index]),
+                'source_endpoint_key': str(source_key_by_row[row_index]),
+                'receiver_endpoint_key': str(receiver_key_by_row[row_index]),
+                'source_node_id': int(result.row_source_node_id[row_index]),
+                'receiver_node_id': int(result.row_receiver_node_id[row_index]),
+                'offset_m': _csv_float(result.row_distance_m[row_index]),
+                'midpoint_x_m': _csv_float(midpoint_x_m[row_index]),
+                'midpoint_y_m': _csv_float(midpoint_y_m[row_index]),
+                'cell_ix': _csv_cell_id(cell_ix_by_row[row_index]),
+                'cell_iy': _csv_cell_id(cell_iy_by_row[row_index]),
+                'layer_kind': str(layer_kind_by_row[row_index]),
+                'used_for_layer': _csv_bool(used),
+                'observed_pick_time_ms': _csv_ms(
+                    result.observed_pick_time_s[row_index]
+                ),
+                'modeled_pick_time_ms': _csv_ms(result.modeled_pick_time_s[row_index]),
+                'residual_ms': _csv_ms(result.residual_time_s[row_index]),
+                'moveout_time_ms': _csv_ms(moveout_time_s[row_index]),
+                'source_time_term_ms': _csv_ms(source_time_term_s[row_index]),
+                'receiver_time_term_ms': _csv_ms(receiver_time_term_s[row_index]),
+                'velocity_m_s': _csv_float(row_velocity_m_s[row_index]),
+                'rejection_reason': rejection_reason,
+                'observation_status': 'used' if used else 'rejected',
+                'sign_convention': FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION,
+            }
+        )
+    return rows
+
+
+def _first_break_export_layer_context(
+    result: RefractionDatumStaticsResult,
+) -> tuple[np.ndarray, np.ndarray]:
+    return _residual_row_layer_context(result)
+
+
+def _row_endpoint_float_context(
+    result: RefractionDatumStaticsResult,
+    *,
+    endpoint: str,
+    row_endpoint_key: np.ndarray,
+    value_field: str,
+) -> np.ndarray:
+    n_rows = int(result.row_trace_index_sorted.shape[0])
+    keys = (
+        result.source_endpoint_key
+        if endpoint == 'source'
+        else result.receiver_endpoint_key
+    )
+    values = getattr(result, value_field)
+    lookup = {
+        str(key): float(value)
+        for key, value in zip(
+            np.asarray(keys).tolist(),
+            np.asarray(values).tolist(),
+            strict=True,
+        )
+    }
+    out = np.full(n_rows, np.nan, dtype=np.float64)
+    for index, raw_key in enumerate(row_endpoint_key.tolist()):
+        value = lookup.get(str(raw_key))
+        if value is not None:
+            out[index] = value
+    return np.ascontiguousarray(out, dtype=np.float64)
+
+
+def _first_break_row_time_terms(
+    result: RefractionDatumStaticsResult,
+    *,
+    layer_kind_by_row: np.ndarray,
+    source_key_by_row: np.ndarray,
+    receiver_key_by_row: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    n_rows = int(result.row_trace_index_sorted.shape[0])
+    source = np.full(n_rows, np.nan, dtype=np.float64)
+    receiver = np.full(n_rows, np.nan, dtype=np.float64)
+    source_t1_sorted = np.asarray(
+        result.source_half_intercept_time_s_sorted,
+        dtype=np.float64,
+    )
+    receiver_t1_sorted = np.asarray(
+        result.receiver_half_intercept_time_s_sorted,
+        dtype=np.float64,
+    )
+    source_t2 = _endpoint_time_lookup(
+        result.source_endpoint_key,
+        result.source_t2_time_s,
+    )
+    receiver_t2 = _endpoint_time_lookup(
+        result.receiver_endpoint_key,
+        result.receiver_t2_time_s,
+    )
+    source_t3 = _endpoint_time_lookup(
+        result.source_endpoint_key,
+        result.source_t3_time_s,
+    )
+    receiver_t3 = _endpoint_time_lookup(
+        result.receiver_endpoint_key,
+        result.receiver_t3_time_s,
+    )
+    for row_index, trace_index in enumerate(result.row_trace_index_sorted.tolist()):
+        kind = str(layer_kind_by_row[row_index])
+        if kind == 'v3_t2':
+            source[row_index] = source_t2.get(
+                str(source_key_by_row[row_index]),
+                np.nan,
+            )
+            receiver[row_index] = receiver_t2.get(
+                str(receiver_key_by_row[row_index]),
+                np.nan,
+            )
+        elif kind == 'vsub_t3':
+            source[row_index] = source_t3.get(
+                str(source_key_by_row[row_index]),
+                np.nan,
+            )
+            receiver[row_index] = receiver_t3.get(
+                str(receiver_key_by_row[row_index]),
+                np.nan,
+            )
+        elif kind == 'v2_t1':
+            source[row_index] = source_t1_sorted[int(trace_index)]
+            receiver[row_index] = receiver_t1_sorted[int(trace_index)]
+    return (
+        np.ascontiguousarray(source, dtype=np.float64),
+        np.ascontiguousarray(receiver, dtype=np.float64),
+    )
+
+
+def _endpoint_time_lookup(
+    endpoint_key: np.ndarray,
+    values: np.ndarray | None,
+) -> dict[str, float]:
+    if values is None:
+        return {}
+    return {
+        str(key): float(value)
+        for key, value in zip(
+            np.asarray(endpoint_key).tolist(),
+            np.asarray(values, dtype=np.float64).tolist(),
+            strict=True,
+        )
+    }
+
+
+def _first_break_moveout_time_s(
+    *,
+    modeled_pick_time_s: np.ndarray,
+    source_time_term_s: np.ndarray,
+    receiver_time_term_s: np.ndarray,
+) -> np.ndarray:
+    modeled = np.asarray(modeled_pick_time_s, dtype=np.float64)
+    source = np.asarray(source_time_term_s, dtype=np.float64)
+    receiver = np.asarray(receiver_time_term_s, dtype=np.float64)
+    out = modeled - source - receiver
+    invalid = ~np.isfinite(modeled) | ~np.isfinite(source) | ~np.isfinite(receiver)
+    out[invalid] = np.nan
+    return np.ascontiguousarray(out, dtype=np.float64)
+
+
+def _midpoint_coordinate(left: np.ndarray, right: np.ndarray) -> np.ndarray:
+    left_arr = np.asarray(left, dtype=np.float64)
+    right_arr = np.asarray(right, dtype=np.float64)
+    out = 0.5 * (left_arr + right_arr)
+    out[~np.isfinite(left_arr) | ~np.isfinite(right_arr)] = np.nan
+    return np.ascontiguousarray(out, dtype=np.float64)
 
 
 def _residual_row_layer_context(
@@ -7287,6 +7586,7 @@ def _assert_strict_json(payload: dict[str, Any], *, artifact_name: str) -> None:
 
 __all__ = [
     'FIRST_BREAK_RESIDUALS_CSV_NAME',
+    'REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME',
     'NEAR_SURFACE_MODEL_CSV_NAME',
     'REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME',
     'REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME',
@@ -7329,6 +7629,7 @@ __all__ = [
     'refraction_static_trace_shift_component_names',
     'write_first_break_residuals_csv',
     'write_near_surface_model_csv',
+    'write_refraction_first_break_time_export_csv',
     'write_refraction_cell_solver_history_csv',
     'write_refraction_refractor_velocity_cells_csv',
     'write_refraction_refractor_velocity_grid_npz',

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -3170,8 +3170,29 @@ def refraction_static_double_application_qc(
     source_meta: Mapping[str, object],
 ) -> dict[str, Any]:
     request = RefractionStaticApplyRequest.model_validate(req)
-    policy = request.field_corrections.composition.double_application_policy
-    requested = set(refraction_static_trace_shift_component_names(request))
+    return static_history_double_application_qc(
+        input_file_id=request.file_id,
+        policy=request.field_corrections.composition.double_application_policy,
+        requested_components=refraction_static_trace_shift_component_names(request),
+        source_meta=source_meta,
+    )
+
+
+def static_history_double_application_qc(
+    *,
+    input_file_id: str,
+    policy: str,
+    requested_components: Iterable[str],
+    source_meta: Mapping[str, object],
+) -> dict[str, Any]:
+    requested = {
+        canonical
+        for canonical in (
+            _canonical_static_history_component(component)
+            for component in requested_components
+        )
+        if canonical is not None
+    }
     existing, suspected = _lineage_component_names(source_meta)
     duplicate_components = sorted(requested.intersection(existing))
     suspected_components = sorted(
@@ -3185,7 +3206,7 @@ def refraction_static_double_application_qc(
             'duplicate_allowed' if policy == 'allow' else 'duplicate_warned'
         )
         message = _double_application_message(
-            input_file_id=request.file_id,
+            input_file_id=input_file_id,
             duplicate_components=duplicate_components,
             suspected_components=suspected_components,
             policy=policy,
@@ -3400,6 +3421,10 @@ def _canonical_static_history_component(value: object) -> str | None:
         'refraction_t1lsst',
         'refraction_static',
         'refraction_static_correction',
+        'refraction_static_table_apply',
+        'static_table_apply',
+        'source_static_table',
+        'receiver_static_table',
     }:
         return 'refraction'
     if name in {'source_depth', 'source_depth_shift_s'}:
@@ -7627,6 +7652,7 @@ __all__ = [
     'build_source_receiver_static_table_arrays',
     'refraction_static_double_application_qc',
     'refraction_static_trace_shift_component_names',
+    'static_history_double_application_qc',
     'write_first_break_residuals_csv',
     'write_near_surface_model_csv',
     'write_refraction_first_break_time_export_csv',

--- a/app/services/refraction_static_artifacts.py
+++ b/app/services/refraction_static_artifacts.py
@@ -216,7 +216,7 @@ TIME_TERM_SPREADSHEET_FORMAT_VERSION = 1
 TIME_TERM_SPREADSHEET_SCHEMA_VERSION = 1
 FIRST_BREAK_TIME_EXPORT_SCHEMA_VERSION = 1
 FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION = (
-    'residual_ms = observed_first_break_time_ms - modeled_first_break_time_ms'
+    'residual_ms = observed_pick_time_ms - modeled_pick_time_ms'
 )
 
 _ARTIFACTS: tuple[dict[str, str | bool], ...] = (
@@ -537,22 +537,28 @@ _RESIDUAL_COLUMNS = (
 )
 
 _FIRST_BREAK_TIME_EXPORT_COLUMNS = (
-    'format_name',
-    'format_version',
-    'source_job_id',
-    'observation_index',
-    'sorted_trace_index',
+    'schema_version',
+    'trace_index_sorted',
     'source_endpoint_key',
     'receiver_endpoint_key',
-    'source_id',
-    'receiver_id',
+    'source_node_id',
+    'receiver_node_id',
     'offset_m',
+    'midpoint_x_m',
+    'midpoint_y_m',
+    'cell_ix',
+    'cell_iy',
     'layer_kind',
-    'observed_first_break_time_ms',
-    'modeled_first_break_time_ms',
+    'used_for_layer',
+    'observed_pick_time_ms',
+    'modeled_pick_time_ms',
     'residual_ms',
-    'used_in_solve',
-    'reject_reason',
+    'moveout_time_ms',
+    'source_time_term_ms',
+    'receiver_time_term_ms',
+    'velocity_m_s',
+    'rejection_reason',
+    'observation_status',
     'sign_convention',
 )
 
@@ -4141,6 +4147,11 @@ def _first_break_time_export_rows(
     source_job_id: str | None = None,
 ) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
+    cell_id_by_row, cell_ix_by_row, cell_iy_by_row = _residual_row_cell_context(
+        result,
+        req=req,
+    )
+    _ = cell_id_by_row
     layer_kind_by_row, _layer_index_by_row = _first_break_export_layer_context(
         result,
     )
@@ -4156,19 +4167,45 @@ def _first_break_time_export_rows(
         result,
         'row_rejection_reason',
     )
-    source_id_by_row = _row_endpoint_id_context(
+    source_x_by_row = _row_endpoint_float_context(
         result,
         endpoint='source',
         row_endpoint_key=source_key_by_row,
-        value_field='source_id',
+        value_field='source_x_m',
     )
-    receiver_id_by_row = _row_endpoint_id_context(
+    source_y_by_row = _row_endpoint_float_context(
+        result,
+        endpoint='source',
+        row_endpoint_key=source_key_by_row,
+        value_field='source_y_m',
+    )
+    receiver_x_by_row = _row_endpoint_float_context(
         result,
         endpoint='receiver',
         row_endpoint_key=receiver_key_by_row,
-        value_field='receiver_id',
+        value_field='receiver_x_m',
     )
-    source_job_id_text = _source_job_id(source_job_id, req)
+    receiver_y_by_row = _row_endpoint_float_context(
+        result,
+        endpoint='receiver',
+        row_endpoint_key=receiver_key_by_row,
+        value_field='receiver_y_m',
+    )
+    midpoint_x_m = _midpoint_coordinate(source_x_by_row, receiver_x_by_row)
+    midpoint_y_m = _midpoint_coordinate(source_y_by_row, receiver_y_by_row)
+    source_time_term_s, receiver_time_term_s = _first_break_row_time_terms(
+        result,
+        layer_kind_by_row=layer_kind_by_row,
+        source_key_by_row=source_key_by_row,
+        receiver_key_by_row=receiver_key_by_row,
+    )
+    moveout_time_s = _first_break_moveout_time_s(
+        modeled_pick_time_s=result.modeled_pick_time_s,
+        source_time_term_s=source_time_term_s,
+        receiver_time_term_s=receiver_time_term_s,
+    )
+    row_velocity_m_s = _residual_row_velocity_context(result)
+    _ = _source_job_id(source_job_id, req)
 
     for row_index in range(int(result.row_trace_index_sorted.shape[0])):
         rejected_by_robust = bool(result.rejected_by_robust_mask[row_index])
@@ -4180,26 +4217,28 @@ def _first_break_time_export_rows(
         )
         rows.append(
             {
-                'format_name': 'first_break_time',
-                'format_version': FIRST_BREAK_TIME_EXPORT_SCHEMA_VERSION,
-                'source_job_id': source_job_id_text,
-                'observation_index': row_index,
-                'sorted_trace_index': int(result.row_trace_index_sorted[row_index]),
+                'schema_version': FIRST_BREAK_TIME_EXPORT_SCHEMA_VERSION,
+                'trace_index_sorted': int(result.row_trace_index_sorted[row_index]),
                 'source_endpoint_key': str(source_key_by_row[row_index]),
                 'receiver_endpoint_key': str(receiver_key_by_row[row_index]),
-                'source_id': _csv_int(source_id_by_row[row_index]),
-                'receiver_id': _csv_int(receiver_id_by_row[row_index]),
+                'source_node_id': int(result.row_source_node_id[row_index]),
+                'receiver_node_id': int(result.row_receiver_node_id[row_index]),
                 'offset_m': _csv_float(result.row_distance_m[row_index]),
+                'midpoint_x_m': _csv_float(midpoint_x_m[row_index]),
+                'midpoint_y_m': _csv_float(midpoint_y_m[row_index]),
+                'cell_ix': _csv_cell_id(cell_ix_by_row[row_index]),
+                'cell_iy': _csv_cell_id(cell_iy_by_row[row_index]),
                 'layer_kind': str(layer_kind_by_row[row_index]),
-                'observed_first_break_time_ms': _csv_ms(
-                    result.observed_pick_time_s[row_index]
-                ),
-                'modeled_first_break_time_ms': _csv_ms(
-                    result.modeled_pick_time_s[row_index]
-                ),
+                'used_for_layer': _csv_bool(used),
+                'observed_pick_time_ms': _csv_ms(result.observed_pick_time_s[row_index]),
+                'modeled_pick_time_ms': _csv_ms(result.modeled_pick_time_s[row_index]),
                 'residual_ms': _csv_ms(result.residual_time_s[row_index]),
-                'used_in_solve': _csv_bool(used),
-                'reject_reason': rejection_reason,
+                'moveout_time_ms': _csv_ms(moveout_time_s[row_index]),
+                'source_time_term_ms': _csv_ms(source_time_term_s[row_index]),
+                'receiver_time_term_ms': _csv_ms(receiver_time_term_s[row_index]),
+                'velocity_m_s': _csv_float(row_velocity_m_s[row_index]),
+                'rejection_reason': rejection_reason,
+                'observation_status': 'used' if used else 'rejected',
                 'sign_convention': FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION,
             }
         )

--- a/app/services/refraction_static_datum.py
+++ b/app/services/refraction_static_datum.py
@@ -809,10 +809,26 @@ def build_refraction_datum_statics(
         receiver_sh3_weathering_thickness_m=(
             weathering_replacement_result.receiver_sh3_weathering_thickness_m
         ),
-        row_layer_kind=data.row_layer_kind,
-        row_layer_index=data.row_layer_index,
-        row_source_endpoint_key=data.row_source_endpoint_key,
-        row_receiver_endpoint_key=data.row_receiver_endpoint_key,
+        row_layer_kind=(
+            data.row_layer_kind
+            if data.row_layer_kind is not None
+            else np.full(data.row_trace_index_sorted.shape, 'v2_t1', dtype='<U32')
+        ),
+        row_layer_index=(
+            data.row_layer_index
+            if data.row_layer_index is not None
+            else np.ones(data.row_trace_index_sorted.shape, dtype=np.int64)
+        ),
+        row_source_endpoint_key=(
+            data.row_source_endpoint_key
+            if data.row_source_endpoint_key is not None
+            else data.source_endpoint_key_sorted[data.row_trace_index_sorted]
+        ),
+        row_receiver_endpoint_key=(
+            data.row_receiver_endpoint_key
+            if data.row_receiver_endpoint_key is not None
+            else data.receiver_endpoint_key_sorted[data.row_trace_index_sorted]
+        ),
         row_rejection_reason=data.row_rejection_reason,
         row_velocity_m_s=data.row_velocity_m_s,
     )

--- a/app/services/refraction_static_export_service.py
+++ b/app/services/refraction_static_export_service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import csv
 import json
-import shutil
 from dataclasses import dataclass
 from pathlib import Path
 import time
@@ -393,7 +392,20 @@ def _copy_first_break_time_export(
     dest_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = dest_path.with_name(f'{dest_path.name}.{uuid4().hex}.tmp')
     try:
-        shutil.copyfile(source_path, tmp_path)
+        with source_path.open('r', encoding='utf-8', newline='') as handle:
+            reader = csv.DictReader(handle)
+            fieldnames = list(reader.fieldnames or [])
+            rows = list(reader)
+        if 'source_job_id' not in fieldnames:
+            raise ValueError(
+                f'{REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME} missing source_job_id'
+            )
+        for row in rows:
+            row['source_job_id'] = source.source_job_id
+        with tmp_path.open('w', encoding='utf-8', newline='') as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
         tmp_path.replace(dest_path)
     except Exception:
         tmp_path.unlink(missing_ok=True)

--- a/app/services/refraction_static_export_service.py
+++ b/app/services/refraction_static_export_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 import time
@@ -20,8 +21,8 @@ from app.core.state import AppState
 from app.services.job_manager import JobManager
 from app.services.job_runner import JobCompletion, JobFailure, run_job_with_lifecycle
 from app.services.refraction_static_artifacts import (
-    FIRST_BREAK_RESIDUALS_CSV_NAME,
     RECEIVER_STATIC_TABLE_CSV_NAME,
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
     REFRACTION_STATIC_REQUEST_JSON_NAME,
     REFRACTION_STATIC_SOLUTION_NPZ_NAME,
@@ -77,8 +78,7 @@ _FORMAT_SOURCE_ARTIFACTS: dict[
         REFRACTION_STATIC_SOLUTION_NPZ_NAME,
     ),
     'first_break_time': (
-        FIRST_BREAK_RESIDUALS_CSV_NAME,
-        REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+        REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     ),
 }
 
@@ -317,6 +317,8 @@ def _generated_refraction_static_export_artifacts(
         names.append(REFRACTION_LSST_CSV_NAME)
     if 'lsst_plus' in requested_formats:
         names.append(REFRACTION_LSST_PLUS_CSV_NAME)
+    if 'first_break_time' in requested_formats:
+        names.append(REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME)
     return tuple(names)
 
 
@@ -332,6 +334,8 @@ def _write_requested_export_artifacts(
             job_dir=job_dir,
             include_inactive_endpoints=bool(req.export.include_inactive_endpoints),
         )
+    if 'first_break_time' in source.requested_formats:
+        _copy_first_break_time_export(source=source, job_dir=job_dir)
     if (
         'lsst' not in source.requested_formats
         and 'lsst_plus' not in source.requested_formats
@@ -375,6 +379,25 @@ def _write_time_term_spreadsheet_export(
         source_job_id=source.source_job_id,
         include_inactive_endpoints=include_inactive_endpoints,
     )
+
+
+def _copy_first_break_time_export(
+    *,
+    source: ResolvedRefractionStaticExportSourceJob,
+    job_dir: Path,
+) -> None:
+    source_path = (
+        source.source_artifacts_dir / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME
+    )
+    dest_path = job_dir / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = dest_path.with_name(f'{dest_path.name}.{uuid4().hex}.tmp')
+    try:
+        shutil.copyfile(source_path, tmp_path)
+        tmp_path.replace(dest_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def _load_lsst_export_bundle(

--- a/app/services/refraction_static_export_service.py
+++ b/app/services/refraction_static_export_service.py
@@ -396,12 +396,6 @@ def _copy_first_break_time_export(
             reader = csv.DictReader(handle)
             fieldnames = list(reader.fieldnames or [])
             rows = list(reader)
-        if 'source_job_id' not in fieldnames:
-            raise ValueError(
-                f'{REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME} missing source_job_id'
-            )
-        for row in rows:
-            row['source_job_id'] = source.source_job_id
         with tmp_path.open('w', encoding='utf-8', newline='') as handle:
             writer = csv.DictWriter(handle, fieldnames=fieldnames)
             writer.writeheader()

--- a/app/services/refraction_static_table_apply_service.py
+++ b/app/services/refraction_static_table_apply_service.py
@@ -117,7 +117,9 @@ class _StaticTableApplyLineage:
     trace_shift_s_sorted_digest: str
     applied_component_name: str
     created_from_refraction_job_id: str | None
+    created_from_refraction_job_ids: tuple[str, ...]
     created_from_export_job_id: str | None
+    created_from_export_job_ids: tuple[str, ...]
 
 
 def run_refraction_static_table_apply_job(
@@ -1233,17 +1235,29 @@ def _static_table_apply_lineage(
                 'receiver_table_digest': receiver_digest,
             }
         )
+    created_from_refraction_job_ids = _imported_source_job_ids(imported)
+    created_from_export_job_ids = _created_from_export_job_ids(
+        state=state,
+        table_paths=table_paths,
+    )
     return _StaticTableApplyLineage(
         source_table_digest=source_digest,
         receiver_table_digest=receiver_digest,
         combined_table_digest=combined_digest,
         trace_shift_s_sorted_digest=_array_sha256(trace_shift.trace_shift_s_sorted),
         applied_component_name='refraction',
-        created_from_refraction_job_id=_first_source_job_id(imported),
-        created_from_export_job_id=_created_from_export_job_id(
-            state=state,
-            table_paths=table_paths,
+        created_from_refraction_job_id=(
+            created_from_refraction_job_ids[0]
+            if created_from_refraction_job_ids
+            else None
         ),
+        created_from_refraction_job_ids=created_from_refraction_job_ids,
+        created_from_export_job_id=(
+            created_from_export_job_ids[0]
+            if len(created_from_export_job_ids) == 1
+            else None
+        ),
+        created_from_export_job_ids=created_from_export_job_ids,
     )
 
 
@@ -1274,14 +1288,8 @@ def _static_table_reapply_qc(
         )
 
     duplicate_table_digests = sorted(current_digests.intersection(existing_digests))
-    current_source_jobs = {
-        job_id
-        for job_id in (
-            table_lineage.created_from_refraction_job_id,
-            table_lineage.created_from_export_job_id,
-        )
-        if job_id
-    }
+    current_source_jobs = set(table_lineage.created_from_refraction_job_ids)
+    current_source_jobs.update(table_lineage.created_from_export_job_ids)
     duplicate_source_jobs = current_source_jobs.intersection(existing_source_jobs)
 
     duplicate_reasons: list[str] = []
@@ -1329,9 +1337,10 @@ def _double_application_qc(
     state: AppState,
 ) -> dict[str, Any]:
     source_meta = _source_trace_store_meta(req=req, state=state)
+    policy = 'allow' if req.allow_reapply_same_static_table else 'fail'
     return static_history_double_application_qc(
         input_file_id=req.file_id,
-        policy=req.double_application_policy,
+        policy=policy,
         requested_components=('refraction',),
         source_meta=source_meta,
     )
@@ -1393,11 +1402,11 @@ def _digest_json(payload: Mapping[str, object]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _created_from_export_job_id(
+def _created_from_export_job_ids(
     *,
     state: AppState,
     table_paths: _ResolvedTablePaths,
-) -> str | None:
+) -> tuple[str, ...]:
     export_job_ids: list[str] = []
     with state.lock:
         for job_id in table_paths.artifact_job_ids:
@@ -1406,8 +1415,7 @@ def _created_from_export_job_id(
                 continue
             if job.get('statics_kind') == 'refraction_export':
                 export_job_ids.append(str(job_id))
-    unique = tuple(dict.fromkeys(export_job_ids))
-    return unique[0] if len(unique) == 1 else None
+    return tuple(dict.fromkeys(export_job_ids))
 
 
 def _static_table_history_records(
@@ -1472,7 +1480,7 @@ def _history_table_digests(history: Mapping[str, object]) -> set[str]:
 
 
 def _history_source_job_ids(history: Mapping[str, object]) -> set[str]:
-    return {
+    ids = {
         job_id
         for job_id in (
             _history_text(history.get('created_from_refraction_job_id')),
@@ -1481,6 +1489,10 @@ def _history_source_job_ids(history: Mapping[str, object]) -> set[str]:
         )
         if job_id
     }
+    ids.update(_history_text_items(history.get('created_from_refraction_job_ids')))
+    ids.update(_history_text_items(history.get('created_from_export_job_ids')))
+    ids.update(_history_text_items(history.get('source_job_ids')))
+    return ids
 
 
 def _history_duplicate_component_digests(
@@ -1519,6 +1531,15 @@ def _history_text(value: object) -> str | None:
         return None
     text = value.strip()
     return text or None
+
+
+def _history_text_items(value: object) -> set[str]:
+    if isinstance(value, str):
+        item = _history_text(value)
+        return {item} if item else set()
+    if not isinstance(value, (list, tuple)):
+        return set()
+    return {text for item in value if (text := _history_text(item))}
 
 
 def _solution_arrays(
@@ -1612,7 +1633,11 @@ def _qc_payload(
         'created_from_refraction_job_id': (
             table_lineage.created_from_refraction_job_id
         ),
+        'created_from_refraction_job_ids': list(
+            table_lineage.created_from_refraction_job_ids
+        ),
         'created_from_export_job_id': table_lineage.created_from_export_job_id,
+        'created_from_export_job_ids': list(table_lineage.created_from_export_job_ids),
         'missing_static_policy': req.missing_static_policy,
         'allow_missing_source_static': bool(req.allow_missing_source_static),
         'allow_missing_receiver_static': bool(req.allow_missing_receiver_static),
@@ -1716,7 +1741,11 @@ def _static_table_apply_history_payload(
         'created_from_refraction_job_id': (
             table_lineage.created_from_refraction_job_id
         ),
+        'created_from_refraction_job_ids': list(
+            table_lineage.created_from_refraction_job_ids
+        ),
         'created_from_export_job_id': table_lineage.created_from_export_job_id,
+        'created_from_export_job_ids': list(table_lineage.created_from_export_job_ids),
         'input_file_id': req.file_id,
         'output_file_id': corrected_file_id,
         'source_file_id': req.file_id,
@@ -1847,7 +1876,11 @@ def _corrected_file_payload(
         'created_from_refraction_job_id': (
             table_lineage.created_from_refraction_job_id
         ),
+        'created_from_refraction_job_ids': list(
+            table_lineage.created_from_refraction_job_ids
+        ),
         'created_from_export_job_id': table_lineage.created_from_export_job_id,
+        'created_from_export_job_ids': list(table_lineage.created_from_export_job_ids),
         'shift_field': 'trace_shift_s_sorted',
         'static_components_applied': ['refraction'],
         'interpolation': 'linear',
@@ -1904,8 +1937,14 @@ def _derived_metadata(
         'created_from_refraction_job_id': history_metadata.get(
             'created_from_refraction_job_id'
         ),
+        'created_from_refraction_job_ids': history_metadata.get(
+            'created_from_refraction_job_ids'
+        ),
         'created_from_export_job_id': history_metadata.get(
             'created_from_export_job_id'
+        ),
+        'created_from_export_job_ids': history_metadata.get(
+            'created_from_export_job_ids'
         ),
         'components': [
             {
@@ -2084,17 +2123,6 @@ def _endpoint_key_array(
 def _unique_missing(values: np.ndarray, missing_mask: np.ndarray) -> tuple[str, ...]:
     missing = [str(value) for value in np.asarray(values, dtype=str)[missing_mask]]
     return tuple(dict.fromkeys(missing))
-
-
-def _first_source_job_id(imported: RefractionStaticTableImportResult) -> str | None:
-    rows = [
-        *imported.source_static_by_endpoint_key.values(),
-        *imported.receiver_static_by_endpoint_key.values(),
-    ]
-    if not rows:
-        return None
-    source_job_id = str(rows[0].source_job_id).strip()
-    return source_job_id or None
 
 
 def _status_counts(statuses: np.ndarray) -> dict[str, int]:

--- a/app/services/refraction_static_table_apply_service.py
+++ b/app/services/refraction_static_table_apply_service.py
@@ -410,14 +410,29 @@ def _import_static_tables(
     else:
         assert table_paths.source_table_path is not None
         assert table_paths.receiver_table_path is not None
+        source_job_id = _artifact_job_id(
+            table_paths.artifact_ids.get('source_table_artifact_id')
+        )
+        receiver_job_id = _artifact_job_id(
+            table_paths.artifact_ids.get('receiver_table_artifact_id')
+        )
         imported = import_refraction_static_tables(
             source_table_path=table_paths.source_table_path,
             receiver_table_path=table_paths.receiver_table_path,
+            source_job_id=source_job_id,
+            receiver_source_job_id=receiver_job_id,
         )
     if imported.is_valid:
         return imported
     joined = '; '.join(imported.errors)
     raise ValueError(f'static table import failed: {joined}')
+
+
+def _artifact_job_id(artifact_id: str | None) -> str | None:
+    if artifact_id is None:
+        return None
+    job_id, _name = _parse_artifact_id(artifact_id)
+    return job_id
 
 
 def _is_source_receiver_static_table_npz(path: Path) -> bool:

--- a/app/services/refraction_static_table_apply_service.py
+++ b/app/services/refraction_static_table_apply_service.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Mapping
 from dataclasses import dataclass
+import hashlib
 import json
 from pathlib import Path
 import re
@@ -27,6 +29,7 @@ from app.services.job_artifact_refs import resolve_job_artifact_path
 from app.services.job_runner import JobCompletion, JobFailure, run_job_with_lifecycle
 from app.services.reader import get_reader
 from app.services.refraction_static_artifacts import (
+    REFRACTION_STATIC_HISTORY_JSON_NAME,
     REFRACTION_STATIC_REQUEST_JSON_NAME,
     SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
     static_history_double_application_qc,
@@ -53,7 +56,8 @@ STATIC_TABLE_APPLY_REQUEST_JSON_NAME = 'static_table_apply_request.json'
 STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME = 'static_table_apply_solution.npz'
 STATIC_TABLE_APPLY_QC_JSON_NAME = 'static_table_apply_qc.json'
 STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME = 'static_table_apply_trace_shifts.csv'
-STATIC_TABLE_APPLY_HISTORY_JSON_NAME = 'refraction_static_history.json'
+STATIC_TABLE_APPLY_HISTORY_JSON_NAME = 'static_table_apply_history.json'
+STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME = REFRACTION_STATIC_HISTORY_JSON_NAME
 
 _DONE_MESSAGE = 'static_table_apply_artifacts_written'
 _CORRECTED_DONE_MESSAGE = 'static_table_apply_corrected_trace_store_registered'
@@ -71,6 +75,7 @@ class _ResolvedTablePaths:
     combined_table_path: Path | None
     artifact_ids: dict[str, str]
     source_job_id: str | None
+    artifact_job_ids: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -102,6 +107,17 @@ class _StaticTableTraceShift:
     missing_receiver_identity: tuple[str, ...]
     source_identity_mode: EndpointIdentityMode
     receiver_identity_mode: EndpointIdentityMode
+
+
+@dataclass(frozen=True)
+class _StaticTableApplyLineage:
+    source_table_digest: str | None
+    receiver_table_digest: str | None
+    combined_table_digest: str
+    trace_shift_s_sorted_digest: str
+    applied_component_name: str
+    created_from_refraction_job_id: str | None
+    created_from_export_job_id: str | None
 
 
 def run_refraction_static_table_apply_job(
@@ -192,6 +208,19 @@ def _run_refraction_static_table_apply_job_body(
         max_abs_shift_ms=float(request.max_abs_shift_ms),
         require_all_traces_valid=True,
     )
+    table_lineage = _static_table_apply_lineage(
+        req=request,
+        state=state,
+        imported=imported,
+        table_paths=table_paths,
+        trace_shift=trace_shift,
+    )
+    table_reapply_qc = _static_table_reapply_qc(
+        req=request,
+        state=state,
+        table_lineage=table_lineage,
+    )
+    _enforce_static_table_reapply_guard(table_reapply_qc)
     double_application_qc = _double_application_qc(
         req=request,
         state=state,
@@ -211,6 +240,8 @@ def _run_refraction_static_table_apply_job_body(
         imported=imported,
         table_paths=table_paths,
         trace_shift=trace_shift,
+        table_lineage=table_lineage,
+        table_reapply_qc=table_reapply_qc,
         double_application_qc=double_application_qc,
         validation_status='ok',
         corrected_file_id=None,
@@ -229,8 +260,12 @@ def _run_refraction_static_table_apply_job_body(
             state=state,
             job_id=job_id,
             req=request,
+            imported=imported,
+            table_paths=table_paths,
             job_dir=job_dir,
             trace_shift=trace_shift,
+            table_lineage=table_lineage,
+            table_reapply_qc=table_reapply_qc,
             double_application_qc=double_application_qc,
             artifact_names=artifacts,
         )
@@ -241,19 +276,27 @@ def _run_refraction_static_table_apply_job_body(
             imported=imported,
             table_paths=table_paths,
             trace_shift=trace_shift,
+            table_lineage=table_lineage,
+            table_reapply_qc=table_reapply_qc,
             double_application_qc=double_application_qc,
             validation_status='ok',
             corrected_file_id=corrected_file_id,
         )
-        _write_static_table_apply_history(
+        history = _write_static_table_apply_history(
             path=job_dir / STATIC_TABLE_APPLY_HISTORY_JSON_NAME,
             job_id=job_id,
             req=request,
             imported=imported,
             table_paths=table_paths,
             trace_shift=trace_shift,
+            table_lineage=table_lineage,
+            table_reapply_qc=table_reapply_qc,
             double_application_qc=double_application_qc,
             corrected_file_id=corrected_file_id,
+        )
+        _write_json_atomic(
+            job_dir / STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME,
+            history,
         )
         with state.lock:
             state.jobs.set_static_corrected_file(
@@ -299,6 +342,7 @@ def _resolve_table_paths(
             combined_table_path=combined_path,
             artifact_ids=artifact_ids,
             source_job_id=source_job_id,
+            artifact_job_ids=(source_job_id,),
         )
 
     assert req.source_table_artifact_id is not None
@@ -321,6 +365,7 @@ def _resolve_table_paths(
         combined_table_path=None,
         artifact_ids=artifact_ids,
         source_job_id=source_job_id if source_job_id == receiver_job_id else None,
+        artifact_job_ids=tuple(dict.fromkeys((source_job_id, receiver_job_id))),
     )
 
 
@@ -938,8 +983,12 @@ def _register_corrected_trace_store(
     state: AppState,
     job_id: str,
     req: RefractionStaticTableApplyRequest,
+    imported: RefractionStaticTableImportResult,
+    table_paths: _ResolvedTablePaths,
     job_dir: Path,
     trace_shift: _StaticTableTraceShift,
+    table_lineage: _StaticTableApplyLineage,
+    table_reapply_qc: dict[str, Any],
     double_application_qc: dict[str, Any],
     artifact_names: tuple[str, ...],
 ) -> tuple[str, Path]:
@@ -951,6 +1000,17 @@ def _register_corrected_trace_store(
         job_id=job_id,
         output_name=req.output_name,
     )
+    history_metadata = _static_table_apply_history_payload(
+        job_id=job_id,
+        req=req,
+        imported=imported,
+        table_paths=table_paths,
+        trace_shift=trace_shift,
+        table_lineage=table_lineage,
+        table_reapply_qc=table_reapply_qc,
+        double_application_qc=double_application_qc,
+        corrected_file_id=corrected_file_id,
+    )
     corrected_file_json = job_dir / CORRECTED_FILE_JSON_NAME
     try:
         build_result = build_time_shifted_trace_store(
@@ -961,8 +1021,7 @@ def _register_corrected_trace_store(
             output_dtype='float32',
             derived_metadata=_derived_metadata(
                 job_id=job_id,
-                trace_shift=trace_shift,
-                double_application_qc=double_application_qc,
+                history_metadata=history_metadata,
             ),
             from_file_id=req.file_id,
             original_segy_path=_optional_string(source_meta.get('original_segy_path')),
@@ -995,6 +1054,7 @@ def _register_corrected_trace_store(
                 corrected_file_id=corrected_file_id,
                 build_result=build_result,
                 trace_shift=trace_shift,
+                table_lineage=table_lineage,
                 artifact_names=artifact_names,
             ),
         )
@@ -1019,6 +1079,8 @@ def _write_static_table_apply_qc(
     imported: RefractionStaticTableImportResult,
     table_paths: _ResolvedTablePaths,
     trace_shift: _StaticTableTraceShift,
+    table_lineage: _StaticTableApplyLineage,
+    table_reapply_qc: dict[str, Any],
     double_application_qc: dict[str, Any],
     validation_status: str,
     corrected_file_id: str | None,
@@ -1029,6 +1091,8 @@ def _write_static_table_apply_qc(
         imported=imported,
         table_paths=table_paths,
         trace_shift=trace_shift,
+        table_lineage=table_lineage,
+        table_reapply_qc=table_reapply_qc,
         double_application_qc=double_application_qc,
         validation_status=validation_status,
         corrected_file_id=corrected_file_id,
@@ -1045,6 +1109,8 @@ def _write_static_table_apply_artifacts(
     imported: RefractionStaticTableImportResult,
     table_paths: _ResolvedTablePaths,
     trace_shift: _StaticTableTraceShift,
+    table_lineage: _StaticTableApplyLineage,
+    table_reapply_qc: dict[str, Any],
     double_application_qc: dict[str, Any],
     validation_status: str,
     corrected_file_id: str | None,
@@ -1053,6 +1119,7 @@ def _write_static_table_apply_artifacts(
     qc_path = job_dir / STATIC_TABLE_APPLY_QC_JSON_NAME
     csv_path = job_dir / STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME
     history_path = job_dir / STATIC_TABLE_APPLY_HISTORY_JSON_NAME
+    refraction_history_path = job_dir / STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME
     _write_npz_atomic(solution_path, _solution_arrays(trace_shift, imported=imported))
     _write_static_table_apply_qc(
         path=qc_path,
@@ -1061,27 +1128,146 @@ def _write_static_table_apply_artifacts(
         imported=imported,
         table_paths=table_paths,
         trace_shift=trace_shift,
+        table_lineage=table_lineage,
+        table_reapply_qc=table_reapply_qc,
         double_application_qc=double_application_qc,
         validation_status=validation_status,
         corrected_file_id=corrected_file_id,
     )
     _write_trace_shift_csv(csv_path, trace_shift)
-    _write_static_table_apply_history(
+    history = _write_static_table_apply_history(
         path=history_path,
         job_id=job_id,
         req=req,
         imported=imported,
         table_paths=table_paths,
         trace_shift=trace_shift,
+        table_lineage=table_lineage,
+        table_reapply_qc=table_reapply_qc,
         double_application_qc=double_application_qc,
         corrected_file_id=corrected_file_id,
     )
+    _write_json_atomic(refraction_history_path, history)
     return (
         STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
         STATIC_TABLE_APPLY_QC_JSON_NAME,
         STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME,
         STATIC_TABLE_APPLY_HISTORY_JSON_NAME,
+        STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME,
     )
+
+
+def _static_table_apply_lineage(
+    *,
+    req: RefractionStaticTableApplyRequest,
+    state: AppState,
+    imported: RefractionStaticTableImportResult,
+    table_paths: _ResolvedTablePaths,
+    trace_shift: _StaticTableTraceShift,
+) -> _StaticTableApplyLineage:
+    source_digest: str | None = None
+    receiver_digest: str | None = None
+    if table_paths.combined_table_path is not None:
+        combined_digest = _file_sha256(table_paths.combined_table_path)
+    else:
+        assert table_paths.source_table_path is not None
+        assert table_paths.receiver_table_path is not None
+        source_digest = _file_sha256(table_paths.source_table_path)
+        receiver_digest = _file_sha256(table_paths.receiver_table_path)
+        combined_digest = _digest_json(
+            {
+                'source_table_digest': source_digest,
+                'receiver_table_digest': receiver_digest,
+            }
+        )
+    return _StaticTableApplyLineage(
+        source_table_digest=source_digest,
+        receiver_table_digest=receiver_digest,
+        combined_table_digest=combined_digest,
+        trace_shift_s_sorted_digest=_array_sha256(trace_shift.trace_shift_s_sorted),
+        applied_component_name='refraction',
+        created_from_refraction_job_id=_first_source_job_id(imported),
+        created_from_export_job_id=_created_from_export_job_id(
+            state=state,
+            table_paths=table_paths,
+        ),
+    )
+
+
+def _static_table_reapply_qc(
+    *,
+    req: RefractionStaticTableApplyRequest,
+    state: AppState,
+    table_lineage: _StaticTableApplyLineage,
+) -> dict[str, Any]:
+    source_meta = _source_trace_store_meta(req=req, state=state)
+    histories = _static_table_history_records(source_meta)
+    current_digests = _lineage_table_digest_set(table_lineage)
+    existing_digests: set[str] = set()
+    duplicate_component_digests: set[str] = set()
+    existing_source_jobs: set[str] = set()
+    duplicate_source_jobs: set[str] = set()
+    component_name = _history_text(table_lineage.applied_component_name)
+
+    for history in histories:
+        existing_digests.update(_history_table_digests(history))
+        existing_source_jobs.update(_history_source_job_ids(history))
+        duplicate_component_digests.update(
+            _history_duplicate_component_digests(
+                history,
+                component_name=component_name,
+                current_digests=current_digests,
+            )
+        )
+
+    duplicate_table_digests = sorted(current_digests.intersection(existing_digests))
+    current_source_jobs = {
+        job_id
+        for job_id in (
+            table_lineage.created_from_refraction_job_id,
+            table_lineage.created_from_export_job_id,
+        )
+        if job_id
+    }
+    duplicate_source_jobs = current_source_jobs.intersection(existing_source_jobs)
+
+    duplicate_reasons: list[str] = []
+    if duplicate_table_digests:
+        duplicate_reasons.append('same_table_digest')
+    if duplicate_component_digests:
+        duplicate_reasons.append('same_component_name_and_digest')
+    if duplicate_source_jobs:
+        duplicate_reasons.append('table_source_job_already_applied')
+
+    allow_override = bool(req.allow_reapply_same_static_table)
+    status = 'checked'
+    message = ''
+    warnings: list[str] = []
+    if duplicate_reasons:
+        detail = ', '.join(duplicate_reasons)
+        message = (
+            f'static table apply history check for input file_id {req.file_id!r}: '
+            f'{detail}; allow_reapply_same_static_table={allow_override}'
+        )
+        if allow_override:
+            status = 'duplicate_allowed_by_override'
+            warnings.append(message)
+        else:
+            status = 'duplicate_rejected'
+
+    return {
+        'status': status,
+        'allow_reapply_same_static_table': allow_override,
+        'override_used': bool(duplicate_reasons and allow_override),
+        'duplicate_reasons': duplicate_reasons,
+        'duplicate_table_digests': duplicate_table_digests,
+        'duplicate_component_digests': sorted(duplicate_component_digests),
+        'duplicate_source_job_ids': sorted(duplicate_source_jobs),
+        'existing_table_digests': sorted(existing_digests),
+        'existing_source_job_ids': sorted(existing_source_jobs),
+        'message': message,
+        'warnings': warnings,
+    }
 
 
 def _double_application_qc(
@@ -1115,6 +1301,171 @@ def _enforce_double_application_policy(qc: dict[str, Any]) -> None:
         or 'static history double-application policy rejected the job'
     )
     raise ValueError(message)
+
+
+def _enforce_static_table_reapply_guard(qc: dict[str, Any]) -> None:
+    if qc.get('status') != 'duplicate_rejected':
+        return
+    message = str(
+        qc.get('message') or 'static table history rejected duplicate application'
+    )
+    raise ValueError(message)
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open('rb') as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _array_sha256(values: np.ndarray) -> str:
+    arr = np.ascontiguousarray(np.asarray(values, dtype=np.dtype('<f8')))
+    digest = hashlib.sha256()
+    digest.update(str(arr.dtype).encode('ascii'))
+    digest.update(json.dumps(arr.shape, separators=(',', ':')).encode('ascii'))
+    digest.update(arr.tobytes(order='C'))
+    return digest.hexdigest()
+
+
+def _digest_json(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(',', ':'),
+        sort_keys=True,
+    ).encode('utf-8')
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _created_from_export_job_id(
+    *,
+    state: AppState,
+    table_paths: _ResolvedTablePaths,
+) -> str | None:
+    export_job_ids: list[str] = []
+    with state.lock:
+        for job_id in table_paths.artifact_job_ids:
+            job = state.jobs.get(job_id)
+            if not isinstance(job, Mapping):
+                continue
+            if job.get('statics_kind') == 'refraction_export':
+                export_job_ids.append(str(job_id))
+    unique = tuple(dict.fromkeys(export_job_ids))
+    return unique[0] if len(unique) == 1 else None
+
+
+def _static_table_history_records(
+    source_meta: Mapping[str, object],
+) -> tuple[Mapping[str, object], ...]:
+    records: list[Mapping[str, object]] = []
+
+    def visit(value: object) -> None:
+        if not isinstance(value, Mapping):
+            return
+        for key in ('static_table_apply_history', 'static_history'):
+            history = value.get(key)
+            if isinstance(history, Mapping):
+                records.append(history)
+        derived = value.get('derived')
+        if isinstance(derived, Mapping):
+            visit(derived)
+        components = value.get('components')
+        if isinstance(components, list):
+            for component in components:
+                if isinstance(component, Mapping):
+                    visit(component)
+
+    visit(source_meta)
+    return tuple(records)
+
+
+def _lineage_table_digest_set(lineage: _StaticTableApplyLineage) -> set[str]:
+    return {
+        digest
+        for digest in (
+            lineage.source_table_digest,
+            lineage.receiver_table_digest,
+            lineage.combined_table_digest,
+        )
+        if digest
+    }
+
+
+def _history_table_digests(history: Mapping[str, object]) -> set[str]:
+    digests = {
+        digest
+        for digest in (
+            _history_text(history.get('source_table_digest')),
+            _history_text(history.get('receiver_table_digest')),
+            _history_text(history.get('combined_table_digest')),
+        )
+        if digest
+    }
+    table_digests = history.get('table_digests')
+    if isinstance(table_digests, Mapping):
+        digests.update(
+            digest
+            for digest in (
+                _history_text(table_digests.get('source')),
+                _history_text(table_digests.get('receiver')),
+                _history_text(table_digests.get('combined')),
+            )
+            if digest
+        )
+    return digests
+
+
+def _history_source_job_ids(history: Mapping[str, object]) -> set[str]:
+    return {
+        job_id
+        for job_id in (
+            _history_text(history.get('created_from_refraction_job_id')),
+            _history_text(history.get('created_from_export_job_id')),
+            _history_text(history.get('source_job_id')),
+        )
+        if job_id
+    }
+
+
+def _history_duplicate_component_digests(
+    history: Mapping[str, object],
+    *,
+    component_name: str | None,
+    current_digests: set[str],
+) -> set[str]:
+    if not component_name:
+        return set()
+    components = history.get('components')
+    if not isinstance(components, list):
+        return set()
+    duplicates: set[str] = set()
+    for component in components:
+        if not isinstance(component, Mapping):
+            continue
+        if _history_text(component.get('name')) != component_name:
+            continue
+        component_digests = {
+            digest
+            for digest in (
+                _history_text(component.get('table_digest')),
+                _history_text(component.get('combined_table_digest')),
+                _history_text(component.get('source_table_digest')),
+                _history_text(component.get('receiver_table_digest')),
+            )
+            if digest
+        }
+        duplicates.update(component_digests.intersection(current_digests))
+    return duplicates
+
+
+def _history_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
 
 
 def _solution_arrays(
@@ -1173,6 +1524,8 @@ def _qc_payload(
     imported: RefractionStaticTableImportResult,
     table_paths: _ResolvedTablePaths,
     trace_shift: _StaticTableTraceShift,
+    table_lineage: _StaticTableApplyLineage,
+    table_reapply_qc: dict[str, Any],
     double_application_qc: dict[str, Any],
     validation_status: str,
     corrected_file_id: str | None,
@@ -1183,6 +1536,7 @@ def _qc_payload(
         STATIC_TABLE_APPLY_QC_JSON_NAME,
         STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME,
         STATIC_TABLE_APPLY_HISTORY_JSON_NAME,
+        STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME,
     ]
     if corrected_file_id is not None:
         artifact_names.append(CORRECTED_FILE_JSON_NAME)
@@ -1195,9 +1549,23 @@ def _qc_payload(
         'corrected_file_id': corrected_file_id,
         'validation_status': validation_status,
         'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+        'source_table_digest': table_lineage.source_table_digest,
+        'receiver_table_digest': table_lineage.receiver_table_digest,
+        'combined_table_digest': table_lineage.combined_table_digest,
+        'trace_shift_s_sorted_digest': (
+            table_lineage.trace_shift_s_sorted_digest
+        ),
+        'applied_component_name': table_lineage.applied_component_name,
+        'created_from_refraction_job_id': (
+            table_lineage.created_from_refraction_job_id
+        ),
+        'created_from_export_job_id': table_lineage.created_from_export_job_id,
         'missing_static_policy': req.missing_static_policy,
         'allow_missing_source_static': bool(req.allow_missing_source_static),
         'allow_missing_receiver_static': bool(req.allow_missing_receiver_static),
+        'allow_reapply_same_static_table': bool(
+            req.allow_reapply_same_static_table
+        ),
         'source_identity_mode': trace_shift.source_identity_mode,
         'receiver_identity_mode': trace_shift.receiver_identity_mode,
         'n_traces': int(trace_shift.trace_shift_s_sorted.shape[0]),
@@ -1221,6 +1589,7 @@ def _qc_payload(
         'register_corrected_file': bool(req.register_corrected_file),
         'table_artifact_ids': dict(table_paths.artifact_ids),
         'import_warnings': list(imported.warnings),
+        'static_table_reapply_guard': dict(table_reapply_qc),
         'double_application_policy': dict(double_application_qc),
         'artifact_names': artifact_names,
     }
@@ -1234,11 +1603,45 @@ def _write_static_table_apply_history(
     imported: RefractionStaticTableImportResult,
     table_paths: _ResolvedTablePaths,
     trace_shift: _StaticTableTraceShift,
+    table_lineage: _StaticTableApplyLineage,
+    table_reapply_qc: dict[str, Any],
+    double_application_qc: dict[str, Any],
+    corrected_file_id: str | None,
+) -> dict[str, Any]:
+    payload = _static_table_apply_history_payload(
+        job_id=job_id,
+        req=req,
+        imported=imported,
+        table_paths=table_paths,
+        trace_shift=trace_shift,
+        table_lineage=table_lineage,
+        table_reapply_qc=table_reapply_qc,
+        double_application_qc=double_application_qc,
+        corrected_file_id=corrected_file_id,
+    )
+    _write_json_atomic(path, payload)
+    return payload
+
+
+def _static_table_apply_history_payload(
+    *,
+    job_id: str,
+    req: RefractionStaticTableApplyRequest,
+    imported: RefractionStaticTableImportResult,
+    table_paths: _ResolvedTablePaths,
+    trace_shift: _StaticTableTraceShift,
+    table_lineage: _StaticTableApplyLineage,
+    table_reapply_qc: dict[str, Any],
     double_application_qc: dict[str, Any],
     corrected_file_id: str | None,
 ) -> dict[str, Any]:
     warnings = [
         *list(imported.warnings),
+        *[
+            str(item)
+            for item in table_reapply_qc.get('warnings', [])
+            if str(item)
+        ],
         *[
             str(item)
             for item in double_application_qc.get('warnings', [])
@@ -1250,13 +1653,24 @@ def _write_static_table_apply_history(
         'artifact_kind': 'refraction_static_history',
         'history_kind': 'static_table_apply',
         'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+        'source_table_digest': table_lineage.source_table_digest,
+        'receiver_table_digest': table_lineage.receiver_table_digest,
+        'combined_table_digest': table_lineage.combined_table_digest,
+        'trace_shift_s_sorted_digest': (
+            table_lineage.trace_shift_s_sorted_digest
+        ),
+        'applied_component_name': table_lineage.applied_component_name,
+        'created_from_refraction_job_id': (
+            table_lineage.created_from_refraction_job_id
+        ),
+        'created_from_export_job_id': table_lineage.created_from_export_job_id,
         'input_file_id': req.file_id,
         'output_file_id': corrected_file_id,
         'source_file_id': req.file_id,
         'corrected_file_id': corrected_file_id,
         'job_id': job_id,
         'source_export_format': 'canonical_static_table',
-        'source_job_id': _first_source_job_id(imported),
+        'source_job_id': table_lineage.created_from_refraction_job_id,
         'import_schema_name': 'canonical_static_table',
         'import_schema_version': int(imported.schema_version),
         'imported_table_artifacts': dict(table_paths.artifact_ids),
@@ -1268,17 +1682,24 @@ def _write_static_table_apply_history(
         'cumulative_shift_field': 'trace_shift_s_sorted',
         'components': [
             {
-                'name': 'refraction',
+                'name': table_lineage.applied_component_name,
                 'applied_to_trace_shift': True,
                 'artifact': STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+                'table_digest': table_lineage.combined_table_digest,
+                'trace_shift_s_sorted_digest': (
+                    table_lineage.trace_shift_s_sorted_digest
+                ),
             },
         ],
         'validation_status': 'ok',
         'warnings': warnings,
+        'allow_reapply_same_static_table': bool(
+            req.allow_reapply_same_static_table
+        ),
+        'static_table_reapply_guard': dict(table_reapply_qc),
         'double_application_policy': dict(double_application_qc),
         'double_application': dict(double_application_qc),
     }
-    _write_json_atomic(path, payload)
     return payload
 
 
@@ -1351,6 +1772,7 @@ def _corrected_file_payload(
     corrected_file_id: str,
     build_result: TimeShiftedTraceStoreResult,
     trace_shift: _StaticTableTraceShift,
+    table_lineage: _StaticTableApplyLineage,
     artifact_names: tuple[str, ...],
 ) -> dict[str, Any]:
     return {
@@ -1362,6 +1784,17 @@ def _corrected_file_payload(
         'corrected_file_id': corrected_file_id,
         'file_id': corrected_file_id,
         'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+        'source_table_digest': table_lineage.source_table_digest,
+        'receiver_table_digest': table_lineage.receiver_table_digest,
+        'combined_table_digest': table_lineage.combined_table_digest,
+        'trace_shift_s_sorted_digest': (
+            table_lineage.trace_shift_s_sorted_digest
+        ),
+        'applied_component_name': table_lineage.applied_component_name,
+        'created_from_refraction_job_id': (
+            table_lineage.created_from_refraction_job_id
+        ),
+        'created_from_export_job_id': table_lineage.created_from_export_job_id,
         'shift_field': 'trace_shift_s_sorted',
         'static_components_applied': ['refraction'],
         'interpolation': 'linear',
@@ -1384,6 +1817,10 @@ def _corrected_file_payload(
         ),
         'solution_artifact': STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
         'apply_qc_artifact': STATIC_TABLE_APPLY_QC_JSON_NAME,
+        'static_table_apply_history_artifact': STATIC_TABLE_APPLY_HISTORY_JSON_NAME,
+        'refraction_static_history_artifact': (
+            STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME
+        ),
         'artifact_names': [*artifact_names, CORRECTED_FILE_JSON_NAME],
     }
 
@@ -1391,12 +1828,11 @@ def _corrected_file_payload(
 def _derived_metadata(
     *,
     job_id: str,
-    trace_shift: _StaticTableTraceShift,
-    double_application_qc: dict[str, Any],
+    history_metadata: Mapping[str, Any],
 ) -> dict[str, Any]:
     warnings = [
         str(item)
-        for item in double_application_qc.get('warnings', [])
+        for item in history_metadata.get('warnings', [])
         if str(item)
     ]
     metadata: dict[str, Any] = {
@@ -1405,6 +1841,19 @@ def _derived_metadata(
         'derivation': 'refraction_static_table_apply',
         'source_job_id': str(job_id),
         'applied_to': 'raw_trace_store',
+        'source_table_digest': history_metadata.get('source_table_digest'),
+        'receiver_table_digest': history_metadata.get('receiver_table_digest'),
+        'combined_table_digest': history_metadata.get('combined_table_digest'),
+        'trace_shift_s_sorted_digest': history_metadata.get(
+            'trace_shift_s_sorted_digest'
+        ),
+        'applied_component_name': history_metadata.get('applied_component_name'),
+        'created_from_refraction_job_id': history_metadata.get(
+            'created_from_refraction_job_id'
+        ),
+        'created_from_export_job_id': history_metadata.get(
+            'created_from_export_job_id'
+        ),
         'components': [
             {
                 'name': 'static_table_apply',
@@ -1414,24 +1863,29 @@ def _derived_metadata(
                 'value_kind': 'applied_event_time_shift_s',
                 'static_components_applied': ['refraction'],
                 'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+                'table_digest': history_metadata.get('combined_table_digest'),
+                'trace_shift_s_sorted_digest': history_metadata.get(
+                    'trace_shift_s_sorted_digest'
+                ),
             }
         ],
         'solution_artifact': STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
         'shift_field': 'trace_shift_s_sorted',
         'value_kind': 'applied_event_time_shift_s',
         'static_components_applied': ['refraction'],
-        'source_identity_mode': trace_shift.source_identity_mode,
-        'receiver_identity_mode': trace_shift.receiver_identity_mode,
+        'source_identity_mode': (
+            history_metadata.get('endpoint_identity_mode', {}).get('source')
+            if isinstance(history_metadata.get('endpoint_identity_mode'), Mapping)
+            else None
+        ),
+        'receiver_identity_mode': (
+            history_metadata.get('endpoint_identity_mode', {}).get('receiver')
+            if isinstance(history_metadata.get('endpoint_identity_mode'), Mapping)
+            else None
+        ),
         'refraction_sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
-        'static_history': {
-            'components': [
-                {
-                    'name': 'refraction',
-                    'applied_to_trace_shift': True,
-                }
-            ],
-            'double_application_policy': dict(double_application_qc),
-        },
+        'static_table_apply_history': dict(history_metadata),
+        'static_history': dict(history_metadata),
     }
     if warnings:
         metadata['warnings'] = warnings
@@ -1586,7 +2040,8 @@ def _first_source_job_id(imported: RefractionStaticTableImportResult) -> str | N
     ]
     if not rows:
         return None
-    return str(rows[0].source_job_id)
+    source_job_id = str(rows[0].source_job_id).strip()
+    return source_job_id or None
 
 
 def _status_counts(statuses: np.ndarray) -> dict[str, int]:
@@ -1733,6 +2188,8 @@ def _cleanup_artifact(path: Path) -> None:
 
 __all__ = [
     'STATIC_TABLE_APPLY_QC_JSON_NAME',
+    'STATIC_TABLE_APPLY_HISTORY_JSON_NAME',
+    'STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME',
     'STATIC_TABLE_APPLY_REQUEST_JSON_NAME',
     'STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME',
     'STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME',

--- a/app/services/refraction_static_table_apply_service.py
+++ b/app/services/refraction_static_table_apply_service.py
@@ -200,6 +200,10 @@ def _run_refraction_static_table_apply_job_body(
         imported=imported,
         endpoint_keys=endpoint_keys,
     )
+    _validate_imported_endpoint_static_shifts(
+        imported,
+        max_abs_shift_ms=float(request.max_abs_shift_ms),
+    )
     validate_refraction_trace_shifts_for_application(
         trace_shift_s_sorted=trace_shift.trace_shift_s_sorted,
         trace_static_valid_mask_sorted=trace_shift.trace_static_valid_mask_sorted,
@@ -601,7 +605,7 @@ def _load_trace_endpoint_keys(
         imported=imported,
     )
     headers = {
-        byte: _reader_header(reader, byte, n_traces=n_traces)[sorted_trace_index]
+        byte: _reader_header(reader, byte, n_traces=n_traces)
         for byte in (
             geometry.source_id_byte,
             geometry.receiver_id_byte,
@@ -778,6 +782,55 @@ def _imported_source_job_ids(
         if source_job_id:
             ids.append(source_job_id)
     return tuple(dict.fromkeys(ids))
+
+
+def _validate_imported_endpoint_static_shifts(
+    imported: RefractionStaticTableImportResult,
+    *,
+    max_abs_shift_ms: float,
+) -> None:
+    limit = float(max_abs_shift_ms)
+    if not np.isfinite(limit) or limit < 0.0:
+        raise RefractionStaticTraceStoreApplyError(
+            'max_abs_shift_ms must be finite and non-negative'
+        )
+
+    max_abs_endpoint_shift_ms = 0.0
+    source_exceeds_count = 0
+    receiver_exceeds_count = 0
+    for endpoint_kind, row in _iter_imported_endpoint_statics(imported):
+        if row.static_status != 'ok':
+            continue
+        shift_ms = float(row.applied_shift_s) * 1000.0
+        if not np.isfinite(shift_ms):
+            raise RefractionStaticTraceStoreApplyError(
+                f'{endpoint_kind} imported endpoint static contains non-finite shift'
+            )
+        abs_shift_ms = abs(shift_ms)
+        max_abs_endpoint_shift_ms = max(max_abs_endpoint_shift_ms, abs_shift_ms)
+        if abs_shift_ms > limit:
+            if endpoint_kind == 'source':
+                source_exceeds_count += 1
+            else:
+                receiver_exceeds_count += 1
+
+    exceeds_count = source_exceeds_count + receiver_exceeds_count
+    if exceeds_count:
+        raise RefractionStaticTraceStoreApplyError(
+            'imported endpoint static shift exceeds max_abs_shift_ms: '
+            f'{max_abs_endpoint_shift_ms:.6g} > {limit:.6g}; '
+            f'source_exceeds_count={source_exceeds_count}; '
+            f'receiver_exceeds_count={receiver_exceeds_count}'
+        )
+
+
+def _iter_imported_endpoint_statics(
+    imported: RefractionStaticTableImportResult,
+) -> tuple[tuple[str, RefractionImportedEndpointStatic], ...]:
+    return (
+        *(('source', row) for row in imported.source_static_by_endpoint_key.values()),
+        *(('receiver', row) for row in imported.receiver_static_by_endpoint_key.values()),
+    )
 
 
 def _optional_static_job_dir(state: AppState, job_id: str) -> Path | None:

--- a/app/services/refraction_static_table_apply_service.py
+++ b/app/services/refraction_static_table_apply_service.py
@@ -1,0 +1,1740 @@
+"""Standalone M5 static-table apply job service."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import shutil
+import time
+from typing import Any, Literal
+from uuid import uuid4
+
+import numpy as np
+
+from app.api.schemas import (
+    RefractionStaticGeometryRequest,
+    RefractionStaticTableApplyRequest,
+)
+from app.core.state import AppState
+from app.services.corrected_trace_store import (
+    TimeShiftedTraceStoreResult,
+    build_time_shifted_trace_store,
+)
+from app.services.job_artifact_refs import resolve_job_artifact_path
+from app.services.job_runner import JobCompletion, JobFailure, run_job_with_lifecycle
+from app.services.reader import get_reader
+from app.services.refraction_static_artifacts import (
+    REFRACTION_STATIC_REQUEST_JSON_NAME,
+    SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+    static_history_double_application_qc,
+)
+from app.services.refraction_static_apply_trace_store import (
+    CORRECTED_FILE_JSON_NAME,
+    RefractionStaticTraceStoreApplyError,
+    validate_refraction_trace_shifts_for_application,
+)
+from app.services.refraction_static_export_units import (
+    REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+)
+from app.services.refraction_static_table_import import (
+    RefractionImportedEndpointStatic,
+    RefractionStaticTableImportResult,
+    import_refraction_static_table_csv,
+    import_refraction_static_tables,
+)
+from app.services.trace_store_index_validation import validate_sorted_to_original
+from app.services.trace_store_registration import register_trace_store, trace_store_cache_key
+from app.utils.segy_scalars import apply_segy_scalar, normalize_elevation_unit
+
+STATIC_TABLE_APPLY_REQUEST_JSON_NAME = 'static_table_apply_request.json'
+STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME = 'static_table_apply_solution.npz'
+STATIC_TABLE_APPLY_QC_JSON_NAME = 'static_table_apply_qc.json'
+STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME = 'static_table_apply_trace_shifts.csv'
+STATIC_TABLE_APPLY_HISTORY_JSON_NAME = 'refraction_static_history.json'
+
+_DONE_MESSAGE = 'static_table_apply_artifacts_written'
+_CORRECTED_DONE_MESSAGE = 'static_table_apply_corrected_trace_store_registered'
+_ARTIFACT_ID_RE = re.compile(r'^(?P<job_id>[^:]+):(?P<name>[^:]+)$')
+_SAFE_STORE_NAME_RE = re.compile(r'[^A-Za-z0-9_.-]+')
+
+
+EndpointIdentityMode = Literal['endpoint_key', 'endpoint_id']
+
+
+@dataclass(frozen=True)
+class _ResolvedTablePaths:
+    source_table_path: Path | None
+    receiver_table_path: Path | None
+    combined_table_path: Path | None
+    artifact_ids: dict[str, str]
+    source_job_id: str | None
+
+
+@dataclass(frozen=True)
+class _TraceEndpointKeys:
+    sorted_trace_index: np.ndarray
+    source_endpoint_key_sorted: np.ndarray
+    receiver_endpoint_key_sorted: np.ndarray
+    source_endpoint_id_sorted: np.ndarray
+    receiver_endpoint_id_sorted: np.ndarray
+    source_identity_sorted: np.ndarray
+    receiver_identity_sorted: np.ndarray
+
+
+@dataclass(frozen=True)
+class _StaticTableTraceShift:
+    sorted_trace_index: np.ndarray
+    source_endpoint_key_sorted: np.ndarray
+    receiver_endpoint_key_sorted: np.ndarray
+    source_endpoint_id_sorted: np.ndarray
+    receiver_endpoint_id_sorted: np.ndarray
+    source_identity_sorted: np.ndarray
+    receiver_identity_sorted: np.ndarray
+    source_static_shift_s_sorted: np.ndarray
+    receiver_static_shift_s_sorted: np.ndarray
+    trace_shift_s_sorted: np.ndarray
+    trace_static_status_sorted: np.ndarray
+    trace_static_valid_mask_sorted: np.ndarray
+    missing_source_identity: tuple[str, ...]
+    missing_receiver_identity: tuple[str, ...]
+    source_identity_mode: EndpointIdentityMode
+    receiver_identity_mode: EndpointIdentityMode
+
+
+def run_refraction_static_table_apply_job(
+    job_id: str,
+    req: RefractionStaticTableApplyRequest,
+    state: AppState,
+) -> None:
+    """Run the standalone static-table apply job lifecycle."""
+
+    def worker() -> JobCompletion:
+        return _run_refraction_static_table_apply_job_body(
+            job_id=job_id,
+            req=req,
+            state=state,
+        )
+
+    run_job_with_lifecycle(
+        state=state,
+        job_id=job_id,
+        worker=worker,
+        progress_1_on_done=False,
+        start_progress=0.0,
+        clear_message_on_start=True,
+        on_error=_handle_static_table_apply_error,
+    )
+
+
+def _run_refraction_static_table_apply_job_body(
+    *,
+    job_id: str,
+    req: RefractionStaticTableApplyRequest,
+    state: AppState,
+) -> JobCompletion:
+    request = RefractionStaticTableApplyRequest.model_validate(req)
+    job_dir = _resolve_job_dir(state, job_id)
+    job_dir.mkdir(parents=True, exist_ok=True)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.05,
+        message='writing_static_table_apply_request',
+    )
+    _write_json_atomic(
+        job_dir / STATIC_TABLE_APPLY_REQUEST_JSON_NAME,
+        {
+            'job_id': job_id,
+            'job_type': 'statics',
+            'statics_kind': 'refraction_static_table_apply',
+            'source_file_id': request.file_id,
+            'key1_byte': int(request.key1_byte),
+            'key2_byte': int(request.key2_byte),
+            'request': request.model_dump(mode='json'),
+        },
+    )
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.15,
+        message='validating_static_table_artifacts',
+    )
+    table_paths = _resolve_table_paths(state=state, req=request)
+    imported = _import_static_tables(table_paths)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.35,
+        message='mapping_static_table_to_traces',
+    )
+    endpoint_keys = _load_trace_endpoint_keys(
+        req=request,
+        state=state,
+        table_paths=table_paths,
+        imported=imported,
+    )
+    trace_shift = _build_trace_shift(
+        req=request,
+        imported=imported,
+        endpoint_keys=endpoint_keys,
+    )
+    validate_refraction_trace_shifts_for_application(
+        trace_shift_s_sorted=trace_shift.trace_shift_s_sorted,
+        trace_static_valid_mask_sorted=trace_shift.trace_static_valid_mask_sorted,
+        trace_static_status_sorted=trace_shift.trace_static_status_sorted,
+        n_traces=int(trace_shift.trace_shift_s_sorted.shape[0]),
+        max_abs_shift_ms=float(request.max_abs_shift_ms),
+        require_all_traces_valid=True,
+    )
+    double_application_qc = _double_application_qc(
+        req=request,
+        state=state,
+    )
+    _enforce_double_application_policy(double_application_qc)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=0.65,
+        message='writing_static_table_apply_artifacts',
+    )
+    artifacts = _write_static_table_apply_artifacts(
+        job_dir=job_dir,
+        job_id=job_id,
+        req=request,
+        imported=imported,
+        table_paths=table_paths,
+        trace_shift=trace_shift,
+        double_application_qc=double_application_qc,
+        validation_status='ok',
+        corrected_file_id=None,
+    )
+
+    corrected_file_id: str | None = None
+    corrected_store_path: Path | None = None
+    if request.register_corrected_file:
+        _set_job_progress_message(
+            state,
+            job_id,
+            progress=0.78,
+            message='applying_static_table_trace_shift',
+        )
+        corrected_file_id, corrected_store_path = _register_corrected_trace_store(
+            state=state,
+            job_id=job_id,
+            req=request,
+            job_dir=job_dir,
+            trace_shift=trace_shift,
+            double_application_qc=double_application_qc,
+            artifact_names=artifacts,
+        )
+        _write_static_table_apply_qc(
+            path=job_dir / STATIC_TABLE_APPLY_QC_JSON_NAME,
+            job_id=job_id,
+            req=request,
+            imported=imported,
+            table_paths=table_paths,
+            trace_shift=trace_shift,
+            double_application_qc=double_application_qc,
+            validation_status='ok',
+            corrected_file_id=corrected_file_id,
+        )
+        _write_static_table_apply_history(
+            path=job_dir / STATIC_TABLE_APPLY_HISTORY_JSON_NAME,
+            job_id=job_id,
+            req=request,
+            imported=imported,
+            table_paths=table_paths,
+            trace_shift=trace_shift,
+            double_application_qc=double_application_qc,
+            corrected_file_id=corrected_file_id,
+        )
+        with state.lock:
+            state.jobs.set_static_corrected_file(
+                job_id,
+                corrected_file_id=corrected_file_id,
+                corrected_store_path=str(corrected_store_path),
+            )
+        _set_job_progress_message(
+            state,
+            job_id,
+            progress=1.0,
+            message=_CORRECTED_DONE_MESSAGE,
+        )
+        return JobCompletion(finished_ts=time.time(), message=_CORRECTED_DONE_MESSAGE)
+
+    _set_job_progress_message(
+        state,
+        job_id,
+        progress=1.0,
+        message=_DONE_MESSAGE,
+    )
+    return JobCompletion(finished_ts=time.time(), message=_DONE_MESSAGE)
+
+
+def _resolve_table_paths(
+    *,
+    state: AppState,
+    req: RefractionStaticTableApplyRequest,
+) -> _ResolvedTablePaths:
+    artifact_ids: dict[str, str] = {}
+    if req.combined_table_artifact_id is not None:
+        artifact_ids['combined_table_artifact_id'] = req.combined_table_artifact_id
+        source_job_id, _artifact_name = _parse_artifact_id(
+            req.combined_table_artifact_id
+        )
+        combined_path = _resolve_table_artifact(
+            state,
+            artifact_id=req.combined_table_artifact_id,
+        )
+        return _ResolvedTablePaths(
+            source_table_path=None,
+            receiver_table_path=None,
+            combined_table_path=combined_path,
+            artifact_ids=artifact_ids,
+            source_job_id=source_job_id,
+        )
+
+    assert req.source_table_artifact_id is not None
+    assert req.receiver_table_artifact_id is not None
+    artifact_ids['source_table_artifact_id'] = req.source_table_artifact_id
+    artifact_ids['receiver_table_artifact_id'] = req.receiver_table_artifact_id
+    source_job_id, _source_name = _parse_artifact_id(req.source_table_artifact_id)
+    receiver_job_id, _receiver_name = _parse_artifact_id(req.receiver_table_artifact_id)
+    source_path = _resolve_table_artifact(
+        state,
+        artifact_id=req.source_table_artifact_id,
+    )
+    receiver_path = _resolve_table_artifact(
+        state,
+        artifact_id=req.receiver_table_artifact_id,
+    )
+    return _ResolvedTablePaths(
+        source_table_path=source_path,
+        receiver_table_path=receiver_path,
+        combined_table_path=None,
+        artifact_ids=artifact_ids,
+        source_job_id=source_job_id if source_job_id == receiver_job_id else None,
+    )
+
+
+def _parse_artifact_id(artifact_id: str) -> tuple[str, str]:
+    match = _ARTIFACT_ID_RE.match(artifact_id)
+    if match is None:
+        raise ValueError(
+            'static table artifact id must have the form '
+            '<job_id>:<artifact_name>'
+        )
+    return match.group('job_id'), match.group('name')
+
+
+def _resolve_table_artifact(state: AppState, *, artifact_id: str) -> Path:
+    job_id, name = _parse_artifact_id(artifact_id)
+    return resolve_job_artifact_path(
+        state,
+        job_id=job_id,
+        name=name,
+        allowed_job_types={'statics'},
+        reference_label='static_table_apply',
+    )
+
+
+def _import_static_tables(
+    table_paths: _ResolvedTablePaths,
+) -> RefractionStaticTableImportResult:
+    if table_paths.combined_table_path is not None:
+        if _is_source_receiver_static_table_npz(table_paths.combined_table_path):
+            imported = _import_source_receiver_static_table_npz(
+                table_paths.combined_table_path,
+                source_job_id=table_paths.source_job_id,
+            )
+        else:
+            imported = import_refraction_static_table_csv(table_paths.combined_table_path)
+    else:
+        assert table_paths.source_table_path is not None
+        assert table_paths.receiver_table_path is not None
+        imported = import_refraction_static_tables(
+            source_table_path=table_paths.source_table_path,
+            receiver_table_path=table_paths.receiver_table_path,
+        )
+    if imported.is_valid:
+        return imported
+    joined = '; '.join(imported.errors)
+    raise ValueError(f'static table import failed: {joined}')
+
+
+def _is_source_receiver_static_table_npz(path: Path) -> bool:
+    return (
+        path.name == SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME
+        or path.suffix.lower() == '.npz'
+    )
+
+
+def _import_source_receiver_static_table_npz(
+    path: Path,
+    *,
+    source_job_id: str | None,
+) -> RefractionStaticTableImportResult:
+    source_name = Path(path).name
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            sign_convention = _npz_scalar_string(data, 'sign_convention')
+            if sign_convention != REFRACTION_STATIC_REPO_SIGN_CONVENTION:
+                raise ValueError(
+                    f'{source_name} sign_convention must be '
+                    f'{REFRACTION_STATIC_REPO_SIGN_CONVENTION!r}'
+                )
+            source_rows = _import_npz_endpoint_static_rows(
+                data,
+                endpoint_kind='source',
+                source_job_id=source_job_id,
+                source_name=source_name,
+            )
+            receiver_rows = _import_npz_endpoint_static_rows(
+                data,
+                endpoint_kind='receiver',
+                source_job_id=source_job_id,
+                source_name=source_name,
+            )
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f'failed to import static table NPZ: {source_name}') from exc
+
+    return RefractionStaticTableImportResult(
+        source_static_by_endpoint_key=source_rows,
+        receiver_static_by_endpoint_key=receiver_rows,
+        n_source_rows=len(source_rows),
+        n_receiver_rows=len(receiver_rows),
+        warnings=(),
+        errors=(),
+        schema_version=1,
+        sign_convention=REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+    )
+
+
+def _import_npz_endpoint_static_rows(
+    data: Any,
+    *,
+    endpoint_kind: Literal['source', 'receiver'],
+    source_job_id: str | None,
+    source_name: str,
+) -> dict[str, RefractionImportedEndpointStatic]:
+    prefix = endpoint_kind
+    endpoint_key = _npz_1d_string_array(data, f'{prefix}_endpoint_key')
+    endpoint_id = _npz_1d_string_array(
+        data,
+        f'{prefix}_id',
+        expected_shape=endpoint_key.shape,
+    )
+    applied_shift_s = _npz_1d_float_array(
+        data,
+        f'{prefix}_total_applied_shift_s',
+        expected_shape=endpoint_key.shape,
+    )
+    static_status = _npz_1d_string_array(
+        data,
+        f'{prefix}_static_status',
+        expected_shape=endpoint_key.shape,
+    )
+
+    rows: dict[str, RefractionImportedEndpointStatic] = {}
+    for index, key_value in enumerate(endpoint_key.tolist()):
+        key = str(key_value)
+        if not key:
+            raise ValueError(
+                f'{source_name} {endpoint_kind} row {index + 1}: '
+                'endpoint_key must be non-empty'
+            )
+        if key in rows:
+            raise ValueError(
+                f'{source_name}: duplicate {endpoint_kind} endpoint_key {key!r}'
+            )
+        rows[key] = RefractionImportedEndpointStatic(
+            endpoint_kind=endpoint_kind,
+            endpoint_key=key,
+            endpoint_id=str(endpoint_id[index]),
+            applied_shift_s=float(applied_shift_s[index]),
+            static_status=str(static_status[index]),
+            source_job_id=str(source_job_id or ''),
+            row_number=index + 1,
+            source_name=source_name,
+            metadata={},
+        )
+    return rows
+
+
+def _npz_scalar_string(data: Any, name: str) -> str:
+    if name not in data.files:
+        raise ValueError(f'static table NPZ is missing required array {name!r}')
+    arr = np.asarray(data[name])
+    if arr.shape not in {(), (1,)}:
+        raise ValueError(f'static table NPZ array {name!r} must be scalar')
+    return str(arr.reshape(-1)[0])
+
+
+def _npz_1d_string_array(
+    data: Any,
+    name: str,
+    *,
+    expected_shape: tuple[int, ...] | None = None,
+) -> np.ndarray:
+    if name not in data.files:
+        raise ValueError(f'static table NPZ is missing required array {name!r}')
+    arr = np.asarray(data[name])
+    if arr.ndim != 1:
+        raise ValueError(f'static table NPZ array {name!r} must be 1D')
+    if expected_shape is not None and arr.shape != expected_shape:
+        raise ValueError(
+            f'static table NPZ array {name!r} shape mismatch: '
+            f'expected {expected_shape}, got {arr.shape}'
+        )
+    return _string_array(arr)
+
+
+def _npz_1d_float_array(
+    data: Any,
+    name: str,
+    *,
+    expected_shape: tuple[int, ...],
+) -> np.ndarray:
+    if name not in data.files:
+        raise ValueError(f'static table NPZ is missing required array {name!r}')
+    arr = np.asarray(data[name], dtype=np.float64)
+    if arr.ndim != 1:
+        raise ValueError(f'static table NPZ array {name!r} must be 1D')
+    if arr.shape != expected_shape:
+        raise ValueError(
+            f'static table NPZ array {name!r} shape mismatch: '
+            f'expected {expected_shape}, got {arr.shape}'
+        )
+    return np.ascontiguousarray(arr, dtype=np.float64)
+
+
+def _trace_endpoint_geometry(
+    req: RefractionStaticTableApplyRequest,
+    *,
+    state: AppState,
+    table_paths: _ResolvedTablePaths,
+    imported: RefractionStaticTableImportResult,
+) -> RefractionStaticGeometryRequest:
+    if 'geometry' not in req.model_fields_set:
+        producer_geometry = _producer_trace_endpoint_geometry(
+            state=state,
+            table_paths=table_paths,
+            imported=imported,
+        )
+        if producer_geometry is not None:
+            return producer_geometry
+    return RefractionStaticGeometryRequest.model_validate(req.geometry)
+
+
+def _load_trace_endpoint_keys(
+    *,
+    req: RefractionStaticTableApplyRequest,
+    state: AppState,
+    table_paths: _ResolvedTablePaths,
+    imported: RefractionStaticTableImportResult,
+) -> _TraceEndpointKeys:
+    reader = get_reader(req.file_id, req.key1_byte, req.key2_byte, state=state)
+    n_traces = _reader_n_traces(reader)
+    sorted_trace_index = validate_sorted_to_original(
+        reader.get_sorted_to_original(),
+        expected_n_traces=n_traces,
+        role='static-table target TraceStore',
+    )
+    geometry = _trace_endpoint_geometry(
+        req,
+        state=state,
+        table_paths=table_paths,
+        imported=imported,
+    )
+    headers = {
+        byte: _reader_header(reader, byte, n_traces=n_traces)[sorted_trace_index]
+        for byte in (
+            geometry.source_id_byte,
+            geometry.receiver_id_byte,
+            geometry.source_x_byte,
+            geometry.source_y_byte,
+            geometry.receiver_x_byte,
+            geometry.receiver_y_byte,
+            geometry.source_elevation_byte,
+            geometry.receiver_elevation_byte,
+            geometry.coordinate_scalar_byte,
+            geometry.elevation_scalar_byte,
+        )
+    }
+    source_id = _coerce_id_header(
+        headers[geometry.source_id_byte],
+        name='source_id',
+        n_traces=n_traces,
+    )
+    receiver_id = _coerce_id_header(
+        headers[geometry.receiver_id_byte],
+        name='receiver_id',
+        n_traces=n_traces,
+    )
+    coordinate_scalar = _coerce_scalar_header(
+        headers[geometry.coordinate_scalar_byte],
+        name='coordinate_scalar',
+        n_traces=n_traces,
+    )
+    elevation_scalar = _coerce_scalar_header(
+        headers[geometry.elevation_scalar_byte],
+        name='elevation_scalar',
+        n_traces=n_traces,
+    )
+    source_x = _scaled_header_to_meters(
+        headers[geometry.source_x_byte],
+        scalars=coordinate_scalar,
+        unit=geometry.coordinate_unit,
+        name='source_x',
+        n_traces=n_traces,
+    )
+    source_y = _scaled_header_to_meters(
+        headers[geometry.source_y_byte],
+        scalars=coordinate_scalar,
+        unit=geometry.coordinate_unit,
+        name='source_y',
+        n_traces=n_traces,
+    )
+    receiver_x = _scaled_header_to_meters(
+        headers[geometry.receiver_x_byte],
+        scalars=coordinate_scalar,
+        unit=geometry.coordinate_unit,
+        name='receiver_x',
+        n_traces=n_traces,
+    )
+    receiver_y = _scaled_header_to_meters(
+        headers[geometry.receiver_y_byte],
+        scalars=coordinate_scalar,
+        unit=geometry.coordinate_unit,
+        name='receiver_y',
+        n_traces=n_traces,
+    )
+    source_elevation = _scaled_header_to_meters(
+        headers[geometry.source_elevation_byte],
+        scalars=elevation_scalar,
+        unit=geometry.elevation_unit,
+        name='source_elevation',
+        n_traces=n_traces,
+    )
+    receiver_elevation = _scaled_header_to_meters(
+        headers[geometry.receiver_elevation_byte],
+        scalars=elevation_scalar,
+        unit=geometry.elevation_unit,
+        name='receiver_elevation',
+        n_traces=n_traces,
+    )
+    source_key = _endpoint_key_array(
+        endpoint_kind='source',
+        endpoint_id=source_id,
+        x_m=source_x,
+        y_m=source_y,
+        elevation_m=source_elevation,
+    )
+    receiver_key = _endpoint_key_array(
+        endpoint_kind='receiver',
+        endpoint_id=receiver_id,
+        x_m=receiver_x,
+        y_m=receiver_y,
+        elevation_m=receiver_elevation,
+    )
+    return _TraceEndpointKeys(
+        sorted_trace_index=sorted_trace_index,
+        source_endpoint_key_sorted=source_key,
+        receiver_endpoint_key_sorted=receiver_key,
+        source_endpoint_id_sorted=_string_array(source_id),
+        receiver_endpoint_id_sorted=_string_array(receiver_id),
+        source_identity_sorted=source_key
+        if (req.source_key_header or 'endpoint_key') == 'endpoint_key'
+        else _string_array(source_id),
+        receiver_identity_sorted=receiver_key
+        if (req.receiver_key_header or 'endpoint_key') == 'endpoint_key'
+        else _string_array(receiver_id),
+    )
+
+
+def _producer_trace_endpoint_geometry(
+    *,
+    state: AppState,
+    table_paths: _ResolvedTablePaths,
+    imported: RefractionStaticTableImportResult,
+) -> RefractionStaticGeometryRequest | None:
+    geometries = [
+        _geometry_from_refraction_static_request(path)
+        for path in _producer_refraction_request_paths(
+            state=state,
+            table_paths=table_paths,
+            imported=imported,
+        )
+    ]
+    if not geometries:
+        return None
+    first = geometries[0]
+    first_payload = first.model_dump(mode='json')
+    for geometry in geometries[1:]:
+        if geometry.model_dump(mode='json') != first_payload:
+            raise ValueError(
+                'referenced static table artifacts have conflicting producer geometry'
+            )
+    return first
+
+
+def _producer_refraction_request_paths(
+    *,
+    state: AppState,
+    table_paths: _ResolvedTablePaths,
+    imported: RefractionStaticTableImportResult,
+) -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    for table_path in (
+        table_paths.combined_table_path,
+        table_paths.source_table_path,
+        table_paths.receiver_table_path,
+    ):
+        if table_path is not None:
+            candidates.append(table_path.parent / REFRACTION_STATIC_REQUEST_JSON_NAME)
+
+    for source_job_id in _imported_source_job_ids(imported):
+        job_dir = _optional_static_job_dir(state, source_job_id)
+        if job_dir is not None:
+            candidates.append(job_dir / REFRACTION_STATIC_REQUEST_JSON_NAME)
+
+    existing: list[Path] = []
+    seen: set[str] = set()
+    for path in candidates:
+        if not path.is_file():
+            continue
+        key = str(path.resolve())
+        if key in seen:
+            continue
+        seen.add(key)
+        existing.append(path)
+    return tuple(existing)
+
+
+def _imported_source_job_ids(
+    imported: RefractionStaticTableImportResult,
+) -> tuple[str, ...]:
+    ids: list[str] = []
+    rows = [
+        *imported.source_static_by_endpoint_key.values(),
+        *imported.receiver_static_by_endpoint_key.values(),
+    ]
+    for row in rows:
+        source_job_id = str(row.source_job_id).strip()
+        if source_job_id:
+            ids.append(source_job_id)
+    return tuple(dict.fromkeys(ids))
+
+
+def _optional_static_job_dir(state: AppState, job_id: str) -> Path | None:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        artifacts_dir = job.get('artifacts_dir') if isinstance(job, dict) else None
+    if not isinstance(artifacts_dir, str) or not artifacts_dir:
+        return None
+    return Path(artifacts_dir)
+
+
+def _geometry_from_refraction_static_request(
+    path: Path,
+) -> RefractionStaticGeometryRequest:
+    payload = _read_json_object(path)
+    request = payload.get('request')
+    if not isinstance(request, dict):
+        raise ValueError(f'{path.name} must contain a request object')
+    geometry = request.get('geometry')
+    if not isinstance(geometry, dict):
+        raise ValueError(f'{path.name} request must contain geometry')
+    return RefractionStaticGeometryRequest.model_validate(geometry)
+
+
+def _build_trace_shift(
+    *,
+    req: RefractionStaticTableApplyRequest,
+    imported: RefractionStaticTableImportResult,
+    endpoint_keys: _TraceEndpointKeys,
+) -> _StaticTableTraceShift:
+    source_mode = _identity_mode(req.source_key_header)
+    receiver_mode = _identity_mode(req.receiver_key_header)
+    source_map = _imported_static_map(
+        imported.source_static_by_endpoint_key.values(),
+        identity_mode=source_mode,
+        endpoint_kind='source',
+    )
+    receiver_map = _imported_static_map(
+        imported.receiver_static_by_endpoint_key.values(),
+        identity_mode=receiver_mode,
+        endpoint_kind='receiver',
+    )
+
+    source_shift, source_missing_mask = _map_trace_static(
+        endpoint_identity_sorted=endpoint_keys.source_identity_sorted,
+        static_by_identity=source_map,
+        endpoint_kind='source',
+    )
+    receiver_shift, receiver_missing_mask = _map_trace_static(
+        endpoint_identity_sorted=endpoint_keys.receiver_identity_sorted,
+        static_by_identity=receiver_map,
+        endpoint_kind='receiver',
+    )
+    missing_source = _unique_missing(
+        endpoint_keys.source_identity_sorted,
+        source_missing_mask,
+    )
+    missing_receiver = _unique_missing(
+        endpoint_keys.receiver_identity_sorted,
+        receiver_missing_mask,
+    )
+    _apply_missing_policy(
+        req=req,
+        source_shift=source_shift,
+        receiver_shift=receiver_shift,
+        source_missing_mask=source_missing_mask,
+        receiver_missing_mask=receiver_missing_mask,
+        missing_source=missing_source,
+        missing_receiver=missing_receiver,
+    )
+    trace_status = _trace_status(
+        source_missing_mask=source_missing_mask,
+        receiver_missing_mask=receiver_missing_mask,
+    )
+    valid_mask = np.ones(source_shift.shape, dtype=bool)
+    trace_shift = source_shift + receiver_shift
+    return _StaticTableTraceShift(
+        sorted_trace_index=endpoint_keys.sorted_trace_index,
+        source_endpoint_key_sorted=endpoint_keys.source_endpoint_key_sorted,
+        receiver_endpoint_key_sorted=endpoint_keys.receiver_endpoint_key_sorted,
+        source_endpoint_id_sorted=endpoint_keys.source_endpoint_id_sorted,
+        receiver_endpoint_id_sorted=endpoint_keys.receiver_endpoint_id_sorted,
+        source_identity_sorted=endpoint_keys.source_identity_sorted,
+        receiver_identity_sorted=endpoint_keys.receiver_identity_sorted,
+        source_static_shift_s_sorted=np.ascontiguousarray(source_shift, dtype=np.float64),
+        receiver_static_shift_s_sorted=np.ascontiguousarray(
+            receiver_shift,
+            dtype=np.float64,
+        ),
+        trace_shift_s_sorted=np.ascontiguousarray(trace_shift, dtype=np.float64),
+        trace_static_status_sorted=np.ascontiguousarray(trace_status),
+        trace_static_valid_mask_sorted=np.ascontiguousarray(valid_mask, dtype=bool),
+        missing_source_identity=missing_source,
+        missing_receiver_identity=missing_receiver,
+        source_identity_mode=source_mode,
+        receiver_identity_mode=receiver_mode,
+    )
+
+
+def _identity_mode(value: str | None) -> EndpointIdentityMode:
+    return 'endpoint_key' if value is None else value
+
+
+def _imported_static_map(
+    rows: Any,
+    *,
+    identity_mode: EndpointIdentityMode,
+    endpoint_kind: str,
+) -> dict[str, RefractionImportedEndpointStatic]:
+    out: dict[str, RefractionImportedEndpointStatic] = {}
+    for row in rows:
+        if identity_mode == 'endpoint_key':
+            identity = row.endpoint_key
+        else:
+            if row.endpoint_id is None:
+                raise ValueError(
+                    f'{endpoint_kind} static table row {row.row_number} is '
+                    'missing endpoint_id required by endpoint_id matching'
+                )
+            identity = row.endpoint_id
+        if identity in out:
+            raise ValueError(
+                f'duplicate {identity_mode} for {endpoint_kind}: {identity!r}'
+            )
+        out[str(identity)] = row
+    return out
+
+
+def _map_trace_static(
+    *,
+    endpoint_identity_sorted: np.ndarray,
+    static_by_identity: dict[str, RefractionImportedEndpointStatic],
+    endpoint_kind: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    identities = np.asarray(endpoint_identity_sorted, dtype=str)
+    shifts = np.full(identities.shape, np.nan, dtype=np.float64)
+    missing = np.zeros(identities.shape, dtype=bool)
+    for index, identity in enumerate(identities.tolist()):
+        row = static_by_identity.get(identity)
+        if row is None:
+            missing[index] = True
+            continue
+        if row.static_status != 'ok' or not np.isfinite(row.applied_shift_s):
+            raise ValueError(
+                f'{endpoint_kind} static row for {identity!r} is not apply-ready'
+            )
+        shifts[index] = float(row.applied_shift_s)
+    return shifts, missing
+
+
+def _apply_missing_policy(
+    *,
+    req: RefractionStaticTableApplyRequest,
+    source_shift: np.ndarray,
+    receiver_shift: np.ndarray,
+    source_missing_mask: np.ndarray,
+    receiver_missing_mask: np.ndarray,
+    missing_source: tuple[str, ...],
+    missing_receiver: tuple[str, ...],
+) -> None:
+    errors: list[str] = []
+    source_zero_allowed = (
+        req.missing_static_policy == 'zero' and req.allow_missing_source_static
+    )
+    receiver_zero_allowed = (
+        req.missing_static_policy == 'zero' and req.allow_missing_receiver_static
+    )
+    if missing_source and not source_zero_allowed:
+        errors.append(
+            'missing_source_static: '
+            f'{len(missing_source)} source endpoint statics are missing'
+        )
+    if missing_receiver and not receiver_zero_allowed:
+        errors.append(
+            'missing_receiver_static: '
+            f'{len(missing_receiver)} receiver endpoint statics are missing'
+        )
+    if errors:
+        raise ValueError('; '.join(errors))
+    if missing_source:
+        source_shift[source_missing_mask] = 0.0
+    if missing_receiver:
+        receiver_shift[receiver_missing_mask] = 0.0
+
+
+def _trace_status(
+    *,
+    source_missing_mask: np.ndarray,
+    receiver_missing_mask: np.ndarray,
+) -> np.ndarray:
+    status = np.full(source_missing_mask.shape, 'ok', dtype='<U48')
+    source_only = source_missing_mask & ~receiver_missing_mask
+    receiver_only = receiver_missing_mask & ~source_missing_mask
+    both = source_missing_mask & receiver_missing_mask
+    status[source_only] = 'missing_source_static_zeroed'
+    status[receiver_only] = 'missing_receiver_static_zeroed'
+    status[both] = 'missing_source_receiver_static_zeroed'
+    return status
+
+
+def _register_corrected_trace_store(
+    *,
+    state: AppState,
+    job_id: str,
+    req: RefractionStaticTableApplyRequest,
+    job_dir: Path,
+    trace_shift: _StaticTableTraceShift,
+    double_application_qc: dict[str, Any],
+    artifact_names: tuple[str, ...],
+) -> tuple[str, Path]:
+    source_store_path = Path(state.file_registry.get_store_path(req.file_id))
+    source_meta = _read_json_object(source_store_path / 'meta.json')
+    corrected_file_id = str(uuid4())
+    output_store_path = _corrected_store_path(
+        source_store_path=source_store_path,
+        job_id=job_id,
+        output_name=req.output_name,
+    )
+    corrected_file_json = job_dir / CORRECTED_FILE_JSON_NAME
+    try:
+        build_result = build_time_shifted_trace_store(
+            source_store_path=source_store_path,
+            output_store_path=output_store_path,
+            trace_shift_s_sorted=trace_shift.trace_shift_s_sorted,
+            fill_value=req.fill_value,
+            output_dtype='float32',
+            derived_metadata=_derived_metadata(
+                job_id=job_id,
+                trace_shift=trace_shift,
+                double_application_qc=double_application_qc,
+            ),
+            from_file_id=req.file_id,
+            original_segy_path=_optional_string(source_meta.get('original_segy_path')),
+            header_bytes_to_materialize=(req.key1_byte, req.key2_byte),
+        )
+        reader = register_trace_store(
+            state=state,
+            file_id=corrected_file_id,
+            store_dir=build_result.store_path,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            dt=build_result.dt,
+            update_registry=True,
+            touch_meta=True,
+            preload_header_bytes=(req.key1_byte, req.key2_byte),
+        )
+        _verify_registered_trace_store(
+            state=state,
+            file_id=corrected_file_id,
+            store_path=build_result.store_path,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            reader=reader,
+        )
+        _write_json_atomic(
+            corrected_file_json,
+            _corrected_file_payload(
+                req=req,
+                job_id=job_id,
+                corrected_file_id=corrected_file_id,
+                build_result=build_result,
+                trace_shift=trace_shift,
+                artifact_names=artifact_names,
+            ),
+        )
+    except Exception:
+        _cleanup_registration(
+            state,
+            file_id=corrected_file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+        )
+        _cleanup_store(output_store_path)
+        _cleanup_artifact(corrected_file_json)
+        raise
+    return corrected_file_id, build_result.store_path
+
+
+def _write_static_table_apply_qc(
+    *,
+    path: Path,
+    job_id: str,
+    req: RefractionStaticTableApplyRequest,
+    imported: RefractionStaticTableImportResult,
+    table_paths: _ResolvedTablePaths,
+    trace_shift: _StaticTableTraceShift,
+    double_application_qc: dict[str, Any],
+    validation_status: str,
+    corrected_file_id: str | None,
+) -> dict[str, Any]:
+    qc = _qc_payload(
+        job_id=job_id,
+        req=req,
+        imported=imported,
+        table_paths=table_paths,
+        trace_shift=trace_shift,
+        double_application_qc=double_application_qc,
+        validation_status=validation_status,
+        corrected_file_id=corrected_file_id,
+    )
+    _write_json_atomic(path, qc)
+    return qc
+
+
+def _write_static_table_apply_artifacts(
+    *,
+    job_dir: Path,
+    job_id: str,
+    req: RefractionStaticTableApplyRequest,
+    imported: RefractionStaticTableImportResult,
+    table_paths: _ResolvedTablePaths,
+    trace_shift: _StaticTableTraceShift,
+    double_application_qc: dict[str, Any],
+    validation_status: str,
+    corrected_file_id: str | None,
+) -> tuple[str, ...]:
+    solution_path = job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME
+    qc_path = job_dir / STATIC_TABLE_APPLY_QC_JSON_NAME
+    csv_path = job_dir / STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME
+    history_path = job_dir / STATIC_TABLE_APPLY_HISTORY_JSON_NAME
+    _write_npz_atomic(solution_path, _solution_arrays(trace_shift, imported=imported))
+    _write_static_table_apply_qc(
+        path=qc_path,
+        job_id=job_id,
+        req=req,
+        imported=imported,
+        table_paths=table_paths,
+        trace_shift=trace_shift,
+        double_application_qc=double_application_qc,
+        validation_status=validation_status,
+        corrected_file_id=corrected_file_id,
+    )
+    _write_trace_shift_csv(csv_path, trace_shift)
+    _write_static_table_apply_history(
+        path=history_path,
+        job_id=job_id,
+        req=req,
+        imported=imported,
+        table_paths=table_paths,
+        trace_shift=trace_shift,
+        double_application_qc=double_application_qc,
+        corrected_file_id=corrected_file_id,
+    )
+    return (
+        STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+        STATIC_TABLE_APPLY_QC_JSON_NAME,
+        STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME,
+        STATIC_TABLE_APPLY_HISTORY_JSON_NAME,
+    )
+
+
+def _double_application_qc(
+    *,
+    req: RefractionStaticTableApplyRequest,
+    state: AppState,
+) -> dict[str, Any]:
+    source_meta = _source_trace_store_meta(req=req, state=state)
+    return static_history_double_application_qc(
+        input_file_id=req.file_id,
+        policy=req.double_application_policy,
+        requested_components=('refraction',),
+        source_meta=source_meta,
+    )
+
+
+def _source_trace_store_meta(
+    *,
+    req: RefractionStaticTableApplyRequest,
+    state: AppState,
+) -> dict[str, Any]:
+    source_store_path = Path(state.file_registry.get_store_path(req.file_id))
+    return _read_json_object(source_store_path / 'meta.json')
+
+
+def _enforce_double_application_policy(qc: dict[str, Any]) -> None:
+    if qc.get('status') != 'duplicate_rejected':
+        return
+    message = str(
+        qc.get('message')
+        or 'static history double-application policy rejected the job'
+    )
+    raise ValueError(message)
+
+
+def _solution_arrays(
+    trace_shift: _StaticTableTraceShift,
+    *,
+    imported: RefractionStaticTableImportResult,
+) -> dict[str, np.ndarray]:
+    return {
+        'schema_version': np.asarray(1, dtype=np.int64),
+        'artifact_kind': np.asarray('static_table_apply_solution'),
+        'sign_convention': np.asarray(REFRACTION_STATIC_REPO_SIGN_CONVENTION),
+        'import_schema_version': np.asarray(imported.schema_version, dtype=np.int64),
+        'source_identity_mode': np.asarray(trace_shift.source_identity_mode),
+        'receiver_identity_mode': np.asarray(trace_shift.receiver_identity_mode),
+        'sorted_trace_index': np.asarray(trace_shift.sorted_trace_index, dtype=np.int64),
+        'source_endpoint_key_sorted': _string_array(
+            trace_shift.source_endpoint_key_sorted
+        ),
+        'receiver_endpoint_key_sorted': _string_array(
+            trace_shift.receiver_endpoint_key_sorted
+        ),
+        'source_endpoint_id_sorted': _string_array(
+            trace_shift.source_endpoint_id_sorted
+        ),
+        'receiver_endpoint_id_sorted': _string_array(
+            trace_shift.receiver_endpoint_id_sorted
+        ),
+        'source_identity_sorted': _string_array(trace_shift.source_identity_sorted),
+        'receiver_identity_sorted': _string_array(trace_shift.receiver_identity_sorted),
+        'source_static_shift_s_sorted': np.asarray(
+            trace_shift.source_static_shift_s_sorted,
+            dtype=np.float64,
+        ),
+        'receiver_static_shift_s_sorted': np.asarray(
+            trace_shift.receiver_static_shift_s_sorted,
+            dtype=np.float64,
+        ),
+        'trace_shift_s_sorted': np.asarray(
+            trace_shift.trace_shift_s_sorted,
+            dtype=np.float64,
+        ),
+        'trace_static_status_sorted': _string_array(
+            trace_shift.trace_static_status_sorted
+        ),
+        'trace_static_valid_mask_sorted': np.asarray(
+            trace_shift.trace_static_valid_mask_sorted,
+            dtype=bool,
+        ),
+    }
+
+
+def _qc_payload(
+    *,
+    job_id: str,
+    req: RefractionStaticTableApplyRequest,
+    imported: RefractionStaticTableImportResult,
+    table_paths: _ResolvedTablePaths,
+    trace_shift: _StaticTableTraceShift,
+    double_application_qc: dict[str, Any],
+    validation_status: str,
+    corrected_file_id: str | None,
+) -> dict[str, Any]:
+    shift_ms = trace_shift.trace_shift_s_sorted * 1000.0
+    artifact_names = [
+        STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+        STATIC_TABLE_APPLY_QC_JSON_NAME,
+        STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME,
+        STATIC_TABLE_APPLY_HISTORY_JSON_NAME,
+    ]
+    if corrected_file_id is not None:
+        artifact_names.append(CORRECTED_FILE_JSON_NAME)
+    return {
+        'schema_version': 1,
+        'artifact_kind': 'static_table_apply_qc',
+        'statics_kind': 'refraction_static_table_apply',
+        'job_id': job_id,
+        'source_file_id': req.file_id,
+        'corrected_file_id': corrected_file_id,
+        'validation_status': validation_status,
+        'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+        'missing_static_policy': req.missing_static_policy,
+        'allow_missing_source_static': bool(req.allow_missing_source_static),
+        'allow_missing_receiver_static': bool(req.allow_missing_receiver_static),
+        'source_identity_mode': trace_shift.source_identity_mode,
+        'receiver_identity_mode': trace_shift.receiver_identity_mode,
+        'n_traces': int(trace_shift.trace_shift_s_sorted.shape[0]),
+        'n_source_rows': int(imported.n_source_rows),
+        'n_receiver_rows': int(imported.n_receiver_rows),
+        'n_missing_source_endpoints': len(trace_shift.missing_source_identity),
+        'n_missing_receiver_endpoints': len(trace_shift.missing_receiver_identity),
+        'missing_source_identity': list(trace_shift.missing_source_identity),
+        'missing_receiver_identity': list(trace_shift.missing_receiver_identity),
+        'trace_static_status_counts': _status_counts(
+            trace_shift.trace_static_status_sorted
+        ),
+        'n_positive_trace_shifts': int(np.count_nonzero(shift_ms > 0.0)),
+        'n_negative_trace_shifts': int(np.count_nonzero(shift_ms < 0.0)),
+        'n_zero_trace_shifts': int(np.count_nonzero(shift_ms == 0.0)),
+        'applied_shift_min_ms': _stat(shift_ms, 'min'),
+        'applied_shift_max_ms': _stat(shift_ms, 'max'),
+        'applied_shift_median_ms': _stat(shift_ms, 'median'),
+        'max_abs_applied_shift_ms': _stat(np.abs(shift_ms), 'max'),
+        'max_abs_shift_ms': float(req.max_abs_shift_ms),
+        'register_corrected_file': bool(req.register_corrected_file),
+        'table_artifact_ids': dict(table_paths.artifact_ids),
+        'import_warnings': list(imported.warnings),
+        'double_application_policy': dict(double_application_qc),
+        'artifact_names': artifact_names,
+    }
+
+
+def _write_static_table_apply_history(
+    *,
+    path: Path,
+    job_id: str,
+    req: RefractionStaticTableApplyRequest,
+    imported: RefractionStaticTableImportResult,
+    table_paths: _ResolvedTablePaths,
+    trace_shift: _StaticTableTraceShift,
+    double_application_qc: dict[str, Any],
+    corrected_file_id: str | None,
+) -> dict[str, Any]:
+    warnings = [
+        *list(imported.warnings),
+        *[
+            str(item)
+            for item in double_application_qc.get('warnings', [])
+            if str(item)
+        ],
+    ]
+    payload: dict[str, Any] = {
+        'schema_version': 1,
+        'artifact_kind': 'refraction_static_history',
+        'history_kind': 'static_table_apply',
+        'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+        'input_file_id': req.file_id,
+        'output_file_id': corrected_file_id,
+        'source_file_id': req.file_id,
+        'corrected_file_id': corrected_file_id,
+        'job_id': job_id,
+        'source_export_format': 'canonical_static_table',
+        'source_job_id': _first_source_job_id(imported),
+        'import_schema_name': 'canonical_static_table',
+        'import_schema_version': int(imported.schema_version),
+        'imported_table_artifacts': dict(table_paths.artifact_ids),
+        'endpoint_identity_mode': {
+            'source': trace_shift.source_identity_mode,
+            'receiver': trace_shift.receiver_identity_mode,
+        },
+        'cumulative_shift_artifact': STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+        'cumulative_shift_field': 'trace_shift_s_sorted',
+        'components': [
+            {
+                'name': 'refraction',
+                'applied_to_trace_shift': True,
+                'artifact': STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+            },
+        ],
+        'validation_status': 'ok',
+        'warnings': warnings,
+        'double_application_policy': dict(double_application_qc),
+        'double_application': dict(double_application_qc),
+    }
+    _write_json_atomic(path, payload)
+    return payload
+
+
+def _write_trace_shift_csv(path: Path, trace_shift: _StaticTableTraceShift) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+    columns = (
+        'sorted_trace_index',
+        'source_endpoint_key',
+        'receiver_endpoint_key',
+        'source_endpoint_id',
+        'receiver_endpoint_id',
+        'source_identity',
+        'receiver_identity',
+        'source_static_shift_ms',
+        'receiver_static_shift_ms',
+        'trace_shift_ms',
+        'trace_static_status',
+        'sign_convention',
+    )
+    try:
+        with tmp_path.open('w', encoding='utf-8', newline='') as handle:
+            writer = csv.DictWriter(handle, fieldnames=columns, lineterminator='\n')
+            writer.writeheader()
+            for index in range(int(trace_shift.trace_shift_s_sorted.shape[0])):
+                writer.writerow(
+                    {
+                        'sorted_trace_index': int(trace_shift.sorted_trace_index[index]),
+                        'source_endpoint_key': str(
+                            trace_shift.source_endpoint_key_sorted[index]
+                        ),
+                        'receiver_endpoint_key': str(
+                            trace_shift.receiver_endpoint_key_sorted[index]
+                        ),
+                        'source_endpoint_id': str(
+                            trace_shift.source_endpoint_id_sorted[index]
+                        ),
+                        'receiver_endpoint_id': str(
+                            trace_shift.receiver_endpoint_id_sorted[index]
+                        ),
+                        'source_identity': str(trace_shift.source_identity_sorted[index]),
+                        'receiver_identity': str(
+                            trace_shift.receiver_identity_sorted[index]
+                        ),
+                        'source_static_shift_ms': _format_ms(
+                            trace_shift.source_static_shift_s_sorted[index]
+                        ),
+                        'receiver_static_shift_ms': _format_ms(
+                            trace_shift.receiver_static_shift_s_sorted[index]
+                        ),
+                        'trace_shift_ms': _format_ms(
+                            trace_shift.trace_shift_s_sorted[index]
+                        ),
+                        'trace_static_status': str(
+                            trace_shift.trace_static_status_sorted[index]
+                        ),
+                        'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+                    }
+                )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _corrected_file_payload(
+    *,
+    req: RefractionStaticTableApplyRequest,
+    job_id: str,
+    corrected_file_id: str,
+    build_result: TimeShiftedTraceStoreResult,
+    trace_shift: _StaticTableTraceShift,
+    artifact_names: tuple[str, ...],
+) -> dict[str, Any]:
+    return {
+        'schema_version': 1,
+        'artifact_kind': 'corrected_file',
+        'statics_kind': 'refraction_static_table_apply',
+        'apply_mode': 'static_table',
+        'source_file_id': req.file_id,
+        'corrected_file_id': corrected_file_id,
+        'file_id': corrected_file_id,
+        'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+        'shift_field': 'trace_shift_s_sorted',
+        'static_components_applied': ['refraction'],
+        'interpolation': 'linear',
+        'fill_value': float(req.fill_value),
+        'output_dtype': 'float32',
+        'store_name': build_result.store_path.name,
+        'derived_from_file_id': req.file_id,
+        'derived_by': 'refraction_static_table_apply',
+        'derivation': 'refraction_static_table_apply',
+        'source_job_id': job_id,
+        'job_id': job_id,
+        'key1_byte': int(req.key1_byte),
+        'key2_byte': int(req.key2_byte),
+        'dt': float(build_result.dt),
+        'n_traces': int(build_result.n_traces),
+        'n_samples': int(build_result.n_samples),
+        'sample_interval_s': float(build_result.dt),
+        'max_abs_applied_shift_ms': float(
+            np.max(np.abs(trace_shift.trace_shift_s_sorted * 1000.0))
+        ),
+        'solution_artifact': STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+        'apply_qc_artifact': STATIC_TABLE_APPLY_QC_JSON_NAME,
+        'artifact_names': [*artifact_names, CORRECTED_FILE_JSON_NAME],
+    }
+
+
+def _derived_metadata(
+    *,
+    job_id: str,
+    trace_shift: _StaticTableTraceShift,
+    double_application_qc: dict[str, Any],
+) -> dict[str, Any]:
+    warnings = [
+        str(item)
+        for item in double_application_qc.get('warnings', [])
+        if str(item)
+    ]
+    metadata: dict[str, Any] = {
+        'statics_kind': 'refraction_static_table_apply',
+        'derived_by': 'refraction_static_table_apply',
+        'derivation': 'refraction_static_table_apply',
+        'source_job_id': str(job_id),
+        'applied_to': 'raw_trace_store',
+        'components': [
+            {
+                'name': 'static_table_apply',
+                'job_id': str(job_id),
+                'solution_artifact': STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+                'shift_field': 'trace_shift_s_sorted',
+                'value_kind': 'applied_event_time_shift_s',
+                'static_components_applied': ['refraction'],
+                'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+            }
+        ],
+        'solution_artifact': STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+        'shift_field': 'trace_shift_s_sorted',
+        'value_kind': 'applied_event_time_shift_s',
+        'static_components_applied': ['refraction'],
+        'source_identity_mode': trace_shift.source_identity_mode,
+        'receiver_identity_mode': trace_shift.receiver_identity_mode,
+        'refraction_sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+        'static_history': {
+            'components': [
+                {
+                    'name': 'refraction',
+                    'applied_to_trace_shift': True,
+                }
+            ],
+            'double_application_policy': dict(double_application_qc),
+        },
+    }
+    if warnings:
+        metadata['warnings'] = warnings
+    return metadata
+
+
+def _corrected_store_path(
+    *,
+    source_store_path: Path,
+    job_id: str,
+    output_name: str | None,
+) -> Path:
+    store_name = (
+        _safe_store_name_component(output_name)
+        if output_name is not None
+        else (
+            f'{_safe_store_name_component(source_store_path.name)}'
+            f'.statics.static-table.{_safe_store_name_component(job_id)}'
+        )
+    )
+    output_path = source_store_path.parent / store_name
+    if output_path.exists() or output_path.is_symlink():
+        raise RefractionStaticTraceStoreApplyError(
+            f'corrected output path already exists: {output_path}'
+        )
+    return output_path
+
+
+def _verify_registered_trace_store(
+    *,
+    state: AppState,
+    file_id: str,
+    store_path: Path,
+    key1_byte: int,
+    key2_byte: int,
+    reader: Any,
+) -> None:
+    registered_path = Path(state.file_registry.get_store_path(file_id))
+    if registered_path.resolve() != store_path.resolve():
+        raise RuntimeError('registered corrected TraceStore path mismatch')
+    cache_key = trace_store_cache_key(file_id, key1_byte, key2_byte)
+    with state.lock:
+        if cache_key not in state.cached_readers:
+            raise RuntimeError('registered corrected TraceStore reader is missing')
+    key1_values = np.asarray(reader.get_key1_values())
+    if key1_values.size == 0:
+        raise RuntimeError('registered corrected TraceStore has no key1 values')
+
+
+def _reader_n_traces(reader: Any) -> int:
+    traces = getattr(reader, 'traces', None)
+    if isinstance(traces, np.ndarray) and traces.ndim == 2:
+        return int(traces.shape[0])
+    raise ValueError('target TraceStore reader.traces must be a 2D array')
+
+
+def _reader_header(reader: Any, byte: int, *, n_traces: int) -> np.ndarray:
+    values = np.asarray(reader.ensure_header(byte))
+    if values.ndim != 1 or values.shape != (n_traces,):
+        raise ValueError(
+            f'header byte {byte} shape mismatch: '
+            f'expected {(n_traces,)}, got {values.shape}'
+        )
+    return values
+
+
+def _coerce_id_header(values: np.ndarray, *, name: str, n_traces: int) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1 or arr.shape != (n_traces,):
+        raise ValueError(f'{name} shape mismatch: expected {(n_traces,)}, got {arr.shape}')
+    if np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{name} must contain integer-compatible values')
+    if np.issubdtype(arr.dtype, np.integer):
+        return np.ascontiguousarray(arr, dtype=np.int64)
+    if not np.issubdtype(arr.dtype, np.number):
+        raise ValueError(f'{name} must contain integer-compatible values')
+    arr_f64 = arr.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(arr_f64)):
+        raise ValueError(f'{name} must contain finite values')
+    if not np.all(arr_f64 == np.rint(arr_f64)):
+        raise ValueError(f'{name} must contain integer-compatible values')
+    return np.ascontiguousarray(arr_f64, dtype=np.int64)
+
+
+def _coerce_scalar_header(values: np.ndarray, *, name: str, n_traces: int) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1 or arr.shape != (n_traces,):
+        raise ValueError(f'{name} shape mismatch: expected {(n_traces,)}, got {arr.shape}')
+    if np.issubdtype(arr.dtype, np.integer):
+        return np.ascontiguousarray(arr, dtype=np.int64)
+    if np.issubdtype(arr.dtype, np.bool_) or not np.issubdtype(arr.dtype, np.number):
+        raise ValueError(f'{name} must contain integer-compatible values')
+    arr_f64 = arr.astype(np.float64, copy=False)
+    valid = np.isfinite(arr_f64) & (arr_f64 == np.rint(arr_f64))
+    if not np.all(valid):
+        raise ValueError(f'{name} must contain integer-compatible values')
+    return np.ascontiguousarray(arr_f64.astype(np.int64), dtype=np.int64)
+
+
+def _scaled_header_to_meters(
+    values: np.ndarray,
+    *,
+    scalars: np.ndarray,
+    unit: str,
+    name: str,
+    n_traces: int,
+) -> np.ndarray:
+    raw = np.asarray(values)
+    if raw.ndim != 1 or raw.shape != (n_traces,):
+        raise ValueError(f'{name} shape mismatch: expected {(n_traces,)}, got {raw.shape}')
+    if np.issubdtype(raw.dtype, np.bool_) or not np.issubdtype(raw.dtype, np.number):
+        raise ValueError(f'{name} must have a real numeric dtype')
+    raw_f64 = raw.astype(np.float64, copy=False)
+    if not np.all(np.isfinite(raw_f64)):
+        raise ValueError(f'{name} must contain finite values')
+    return np.ascontiguousarray(
+        normalize_elevation_unit(apply_segy_scalar(raw_f64, scalars), unit),
+        dtype=np.float64,
+    )
+
+
+def _endpoint_key_array(
+    *,
+    endpoint_kind: str,
+    endpoint_id: np.ndarray,
+    x_m: np.ndarray,
+    y_m: np.ndarray,
+    elevation_m: np.ndarray,
+) -> np.ndarray:
+    values = [
+        (
+            f'{endpoint_kind}:'
+            f'{int(endpoint_id[index])}:'
+            f'{float(x_m[index]):.17g}:'
+            f'{float(y_m[index]):.17g}:'
+            f'{float(elevation_m[index]):.17g}'
+        )
+        for index in range(int(endpoint_id.shape[0]))
+    ]
+    return _string_array(values)
+
+
+def _unique_missing(values: np.ndarray, missing_mask: np.ndarray) -> tuple[str, ...]:
+    missing = [str(value) for value in np.asarray(values, dtype=str)[missing_mask]]
+    return tuple(dict.fromkeys(missing))
+
+
+def _first_source_job_id(imported: RefractionStaticTableImportResult) -> str | None:
+    rows = [
+        *imported.source_static_by_endpoint_key.values(),
+        *imported.receiver_static_by_endpoint_key.values(),
+    ]
+    if not rows:
+        return None
+    return str(rows[0].source_job_id)
+
+
+def _status_counts(statuses: np.ndarray) -> dict[str, int]:
+    unique, counts = np.unique(np.asarray(statuses, dtype=str), return_counts=True)
+    return {str(status): int(count) for status, count in zip(unique, counts, strict=True)}
+
+
+def _stat(values: np.ndarray, name: str) -> float | None:
+    arr = np.asarray(values, dtype=np.float64)
+    arr = arr[np.isfinite(arr)]
+    if arr.size == 0:
+        return None
+    if name == 'min':
+        return float(np.min(arr))
+    if name == 'max':
+        return float(np.max(arr))
+    if name == 'median':
+        return float(np.median(arr))
+    raise ValueError(f'unsupported stat: {name}')
+
+
+def _format_ms(value_s: object) -> str:
+    value_ms = float(value_s) * 1000.0
+    if not np.isfinite(value_ms):
+        return ''
+    return f'{value_ms:.6f}'
+
+
+def _string_array(values: Any) -> np.ndarray:
+    texts = [str(value) for value in np.asarray(values).reshape(-1).tolist()]
+    max_len = max((len(text) for text in texts), default=1)
+    return np.asarray(texts, dtype=f'<U{max_len}')
+
+
+def _safe_store_name_component(value: str) -> str:
+    safe = _SAFE_STORE_NAME_RE.sub('_', str(value))
+    if safe in {'', '.', '..'}:
+        raise RefractionStaticTraceStoreApplyError(
+            'TraceStore name cannot be made filesystem-safe'
+        )
+    return safe
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError('source TraceStore original_segy_path must be a string or null')
+    return value
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+    try:
+        with tmp_path.open('w', encoding='utf-8') as handle:
+            json.dump(
+                payload,
+                handle,
+                allow_nan=False,
+                ensure_ascii=True,
+                sort_keys=True,
+            )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _write_npz_atomic(path: Path, payload: dict[str, np.ndarray]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f'{path.name}.{uuid4().hex}.tmp')
+    try:
+        with tmp_path.open('wb') as handle:
+            np.savez_compressed(handle, **payload)
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f'invalid JSON file: {path}') from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f'JSON file must contain an object: {path}')
+    return payload
+
+
+def _resolve_job_dir(state: AppState, job_id: str) -> Path:
+    with state.lock:
+        job = state.jobs.get(job_id)
+        artifacts_dir = job.get('artifacts_dir') if isinstance(job, dict) else None
+    if not isinstance(artifacts_dir, str) or not artifacts_dir:
+        raise ValueError('job artifacts_dir is not available')
+    return Path(artifacts_dir)
+
+
+def _set_job_progress_message(
+    state: AppState,
+    job_id: str,
+    *,
+    progress: float,
+    message: str,
+) -> None:
+    with state.lock:
+        if state.jobs.get(job_id) is None:
+            return
+        state.jobs.set_progress(job_id, progress)
+        state.jobs.set_message(job_id, message)
+
+
+def _handle_static_table_apply_error(_exc: Exception) -> JobFailure:
+    return JobFailure(finished_ts=time.time())
+
+
+def _cleanup_registration(
+    state: AppState,
+    *,
+    file_id: str,
+    key1_byte: int,
+    key2_byte: int,
+) -> None:
+    with state.lock:
+        state.file_registry.pop(file_id, None)
+        state.cached_readers.pop(trace_store_cache_key(file_id, key1_byte, key2_byte), None)
+
+
+def _cleanup_store(output_path: Path) -> None:
+    for tmp_path in output_path.parent.glob(f'{output_path.name}.tmp-*'):
+        if tmp_path.is_dir():
+            shutil.rmtree(tmp_path, ignore_errors=True)
+    if output_path.exists():
+        shutil.rmtree(output_path, ignore_errors=True)
+
+
+def _cleanup_artifact(path: Path) -> None:
+    path.unlink(missing_ok=True)
+    for tmp_path in path.parent.glob(f'{path.name}.*.tmp'):
+        tmp_path.unlink(missing_ok=True)
+
+
+__all__ = [
+    'STATIC_TABLE_APPLY_QC_JSON_NAME',
+    'STATIC_TABLE_APPLY_REQUEST_JSON_NAME',
+    'STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME',
+    'STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME',
+    'run_refraction_static_table_apply_job',
+]

--- a/app/services/refraction_static_table_import.py
+++ b/app/services/refraction_static_table_import.py
@@ -1,0 +1,329 @@
+"""Import service for M5 canonical refraction static tables."""
+
+from __future__ import annotations
+
+import csv
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.services.refraction_static_export_types import RefractionStaticEndpointKind
+from app.services.refraction_static_export_units import (
+    REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+    RefractionStaticExportUnits,
+)
+from app.services.refraction_static_table_validator import (
+    CANONICAL_STATIC_TABLE_FORMAT_VERSION,
+    CANONICAL_STATIC_TABLE_OPTIONAL_COLUMNS,
+    RefractionStaticTableNormalizedRow,
+    validate_canonical_static_table_rows,
+)
+
+
+@dataclass(frozen=True)
+class RefractionImportedEndpointStatic:
+    """Validated endpoint static row normalized for later apply workflows."""
+
+    endpoint_kind: RefractionStaticEndpointKind
+    endpoint_key: str
+    endpoint_id: str | None
+    applied_shift_s: float
+    static_status: str
+    source_job_id: str
+    row_number: int
+    source_name: str
+    metadata: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class RefractionStaticTableImportResult:
+    """Validated static table import result split by endpoint kind."""
+
+    source_static_by_endpoint_key: Mapping[str, RefractionImportedEndpointStatic]
+    receiver_static_by_endpoint_key: Mapping[str, RefractionImportedEndpointStatic]
+    n_source_rows: int
+    n_receiver_rows: int
+    warnings: tuple[str, ...]
+    errors: tuple[str, ...]
+    schema_version: int
+    sign_convention: str
+
+    @property
+    def is_valid(self) -> bool:
+        """Whether all supplied tables were valid and importable."""
+        return not self.errors
+
+
+@dataclass(frozen=True)
+class _LoadedStaticTable:
+    rows: tuple[dict[str, str | None], ...]
+    columns: tuple[str, ...]
+    source_name: str
+    expected_endpoint_kind: RefractionStaticEndpointKind | None = None
+
+
+def import_refraction_static_table_csv(
+    path: Path,
+    *,
+    sign_convention_override: str | None = None,
+    shift_units: RefractionStaticExportUnits | str | None = None,
+) -> RefractionStaticTableImportResult:
+    """Import one combined canonical static CSV table."""
+    return import_refraction_static_tables(
+        combined_table_path=path,
+        sign_convention_override=sign_convention_override,
+        shift_units=shift_units,
+    )
+
+
+def import_refraction_static_source_receiver_csvs(
+    *,
+    source_table_path: Path,
+    receiver_table_path: Path,
+    sign_convention_override: str | None = None,
+    shift_units: RefractionStaticExportUnits | str | None = None,
+) -> RefractionStaticTableImportResult:
+    """Import separate canonical source and receiver static CSV tables."""
+    return import_refraction_static_tables(
+        source_table_path=source_table_path,
+        receiver_table_path=receiver_table_path,
+        sign_convention_override=sign_convention_override,
+        shift_units=shift_units,
+    )
+
+
+def import_refraction_static_tables(
+    *,
+    combined_table_path: Path | None = None,
+    source_table_path: Path | None = None,
+    receiver_table_path: Path | None = None,
+    sign_convention_override: str | None = None,
+    shift_units: RefractionStaticExportUnits | str | None = None,
+) -> RefractionStaticTableImportResult:
+    """Import canonical static table CSVs and normalize shifts to seconds."""
+    input_error = _validate_table_path_combination(
+        combined_table_path=combined_table_path,
+        source_table_path=source_table_path,
+        receiver_table_path=receiver_table_path,
+    )
+    if input_error is not None:
+        return _empty_result(errors=(input_error,))
+
+    tables = _load_input_tables(
+        combined_table_path=combined_table_path,
+        source_table_path=source_table_path,
+        receiver_table_path=receiver_table_path,
+    )
+    return import_refraction_static_table_rows(
+        tables,
+        sign_convention_override=sign_convention_override,
+        shift_units=shift_units,
+    )
+
+
+def import_refraction_static_table_rows(
+    tables: Sequence[_LoadedStaticTable],
+    *,
+    sign_convention_override: str | None = None,
+    shift_units: RefractionStaticExportUnits | str | None = None,
+) -> RefractionStaticTableImportResult:
+    """Import already loaded canonical static table rows."""
+    if not tables:
+        return _empty_result(errors=('at least one static table is required',))
+
+    valid_tables: list[
+        tuple[_LoadedStaticTable, tuple[RefractionStaticTableNormalizedRow, ...]]
+    ] = []
+    warnings: list[str] = []
+    errors: list[str] = []
+    n_source_rows = 0
+    n_receiver_rows = 0
+
+    for table in tables:
+        validation = validate_canonical_static_table_rows(
+            table.rows,
+            columns=table.columns,
+            sign_convention_override=sign_convention_override,
+            shift_units=shift_units,
+        )
+        warnings.extend(validation.warnings)
+        errors.extend(validation.errors)
+        n_source_rows += validation.n_source_rows
+        n_receiver_rows += validation.n_receiver_rows
+        if not validation.is_valid:
+            continue
+        table_kind_errors = _separate_table_kind_errors(
+            validation.normalized_rows,
+            expected_endpoint_kind=table.expected_endpoint_kind,
+            source_name=table.source_name,
+        )
+        errors.extend(table_kind_errors)
+        valid_tables.append((table, validation.normalized_rows))
+
+    if errors:
+        return _empty_result(
+            n_source_rows=n_source_rows,
+            n_receiver_rows=n_receiver_rows,
+            warnings=tuple(warnings),
+            errors=tuple(errors),
+        )
+
+    source_map: dict[str, RefractionImportedEndpointStatic] = {}
+    receiver_map: dict[str, RefractionImportedEndpointStatic] = {}
+    for table, normalized_rows in valid_tables:
+        for normalized in normalized_rows:
+            raw = table.rows[normalized.row_number - 1]
+            endpoint_static = _imported_endpoint_static(
+                normalized,
+                raw=raw,
+                source_name=table.source_name,
+            )
+            if endpoint_static.endpoint_kind == 'source':
+                source_map[endpoint_static.endpoint_key] = endpoint_static
+            else:
+                receiver_map[endpoint_static.endpoint_key] = endpoint_static
+
+    return RefractionStaticTableImportResult(
+        source_static_by_endpoint_key=source_map,
+        receiver_static_by_endpoint_key=receiver_map,
+        n_source_rows=n_source_rows,
+        n_receiver_rows=n_receiver_rows,
+        warnings=tuple(warnings),
+        errors=(),
+        schema_version=CANONICAL_STATIC_TABLE_FORMAT_VERSION,
+        sign_convention=REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+    )
+
+
+def _load_input_tables(
+    *,
+    combined_table_path: Path | None,
+    source_table_path: Path | None,
+    receiver_table_path: Path | None,
+) -> tuple[_LoadedStaticTable, ...]:
+    if combined_table_path is not None:
+        return (_load_static_table(combined_table_path),)
+    assert source_table_path is not None
+    assert receiver_table_path is not None
+    return (
+        _load_static_table(source_table_path, expected_endpoint_kind='source'),
+        _load_static_table(receiver_table_path, expected_endpoint_kind='receiver'),
+    )
+
+
+def _load_static_table(
+    path: Path,
+    *,
+    expected_endpoint_kind: RefractionStaticEndpointKind | None = None,
+) -> _LoadedStaticTable:
+    table_path = Path(path)
+    with table_path.open('r', encoding='utf-8-sig', newline='') as handle:
+        reader = csv.DictReader(handle)
+        return _LoadedStaticTable(
+            rows=tuple(dict(row) for row in reader),
+            columns=tuple(reader.fieldnames or ()),
+            source_name=table_path.name,
+            expected_endpoint_kind=expected_endpoint_kind,
+        )
+
+
+def _validate_table_path_combination(
+    *,
+    combined_table_path: Path | None,
+    source_table_path: Path | None,
+    receiver_table_path: Path | None,
+) -> str | None:
+    has_combined = combined_table_path is not None
+    has_separate = source_table_path is not None or receiver_table_path is not None
+    if has_combined and has_separate:
+        return 'provide either combined_table_path or separate source/receiver paths'
+    if has_combined:
+        return None
+    if source_table_path is None or receiver_table_path is None:
+        return 'separate static table import requires source_table_path and receiver_table_path'
+    return None
+
+
+def _separate_table_kind_errors(
+    normalized_rows: Sequence[RefractionStaticTableNormalizedRow],
+    *,
+    expected_endpoint_kind: RefractionStaticEndpointKind | None,
+    source_name: str,
+) -> tuple[str, ...]:
+    if expected_endpoint_kind is None:
+        return ()
+    errors: list[str] = []
+    for row in normalized_rows:
+        if row.endpoint_kind == expected_endpoint_kind:
+            continue
+        errors.append(
+            f'{source_name} row {row.row_number}: endpoint_kind must be '
+            f'{expected_endpoint_kind!r} for this separate table'
+        )
+    return tuple(errors)
+
+
+def _imported_endpoint_static(
+    row: RefractionStaticTableNormalizedRow,
+    *,
+    raw: Mapping[str, Any],
+    source_name: str,
+) -> RefractionImportedEndpointStatic:
+    if row.applied_shift_s is None:
+        raise ValueError('validated import row is missing applied_shift_s')
+    return RefractionImportedEndpointStatic(
+        endpoint_kind=row.endpoint_kind,
+        endpoint_key=row.endpoint_key,
+        endpoint_id=row.endpoint_id,
+        applied_shift_s=float(row.applied_shift_s),
+        static_status=row.static_status,
+        source_job_id=row.source_job_id,
+        row_number=row.row_number,
+        source_name=source_name,
+        metadata=_metadata_from_row(raw),
+    )
+
+
+def _metadata_from_row(row: Mapping[str, Any]) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for column in CANONICAL_STATIC_TABLE_OPTIONAL_COLUMNS:
+        value = _optional_text(row.get(column))
+        if value is not None:
+            metadata[column] = value
+    return metadata
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _empty_result(
+    *,
+    n_source_rows: int = 0,
+    n_receiver_rows: int = 0,
+    warnings: tuple[str, ...] = (),
+    errors: tuple[str, ...],
+) -> RefractionStaticTableImportResult:
+    return RefractionStaticTableImportResult(
+        source_static_by_endpoint_key={},
+        receiver_static_by_endpoint_key={},
+        n_source_rows=n_source_rows,
+        n_receiver_rows=n_receiver_rows,
+        warnings=warnings,
+        errors=errors,
+        schema_version=CANONICAL_STATIC_TABLE_FORMAT_VERSION,
+        sign_convention=REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+    )
+
+
+__all__ = [
+    'RefractionImportedEndpointStatic',
+    'RefractionStaticTableImportResult',
+    'import_refraction_static_source_receiver_csvs',
+    'import_refraction_static_table_csv',
+    'import_refraction_static_tables',
+]

--- a/app/services/refraction_static_table_import.py
+++ b/app/services/refraction_static_table_import.py
@@ -61,6 +61,7 @@ class _LoadedStaticTable:
     columns: tuple[str, ...]
     source_name: str
     expected_endpoint_kind: RefractionStaticEndpointKind | None = None
+    default_source_job_id: str | None = None
 
 
 def import_refraction_static_table_csv(
@@ -81,6 +82,8 @@ def import_refraction_static_source_receiver_csvs(
     *,
     source_table_path: Path,
     receiver_table_path: Path,
+    source_job_id: str | None = None,
+    receiver_source_job_id: str | None = None,
     sign_convention_override: str | None = None,
     shift_units: RefractionStaticExportUnits | str | None = None,
 ) -> RefractionStaticTableImportResult:
@@ -88,6 +91,8 @@ def import_refraction_static_source_receiver_csvs(
     return import_refraction_static_tables(
         source_table_path=source_table_path,
         receiver_table_path=receiver_table_path,
+        source_job_id=source_job_id,
+        receiver_source_job_id=receiver_source_job_id,
         sign_convention_override=sign_convention_override,
         shift_units=shift_units,
     )
@@ -98,6 +103,8 @@ def import_refraction_static_tables(
     combined_table_path: Path | None = None,
     source_table_path: Path | None = None,
     receiver_table_path: Path | None = None,
+    source_job_id: str | None = None,
+    receiver_source_job_id: str | None = None,
     sign_convention_override: str | None = None,
     shift_units: RefractionStaticExportUnits | str | None = None,
 ) -> RefractionStaticTableImportResult:
@@ -114,6 +121,8 @@ def import_refraction_static_tables(
         combined_table_path=combined_table_path,
         source_table_path=source_table_path,
         receiver_table_path=receiver_table_path,
+        source_job_id=source_job_id,
+        receiver_source_job_id=receiver_source_job_id,
     )
     return import_refraction_static_table_rows(
         tables,
@@ -141,9 +150,10 @@ def import_refraction_static_table_rows(
     n_receiver_rows = 0
 
     for table in tables:
+        canonical_rows, canonical_columns = _canonicalized_table_rows(table)
         validation = validate_canonical_static_table_rows(
-            table.rows,
-            columns=table.columns,
+            canonical_rows,
+            columns=canonical_columns,
             sign_convention_override=sign_convention_override,
             shift_units=shift_units,
         )
@@ -172,8 +182,9 @@ def import_refraction_static_table_rows(
     source_map: dict[str, RefractionImportedEndpointStatic] = {}
     receiver_map: dict[str, RefractionImportedEndpointStatic] = {}
     for table, normalized_rows in valid_tables:
+        canonical_rows, _canonical_columns = _canonicalized_table_rows(table)
         for normalized in normalized_rows:
-            raw = table.rows[normalized.row_number - 1]
+            raw = canonical_rows[normalized.row_number - 1]
             endpoint_static = _imported_endpoint_static(
                 normalized,
                 raw=raw,
@@ -201,14 +212,24 @@ def _load_input_tables(
     combined_table_path: Path | None,
     source_table_path: Path | None,
     receiver_table_path: Path | None,
+    source_job_id: str | None,
+    receiver_source_job_id: str | None,
 ) -> tuple[_LoadedStaticTable, ...]:
     if combined_table_path is not None:
         return (_load_static_table(combined_table_path),)
     assert source_table_path is not None
     assert receiver_table_path is not None
     return (
-        _load_static_table(source_table_path, expected_endpoint_kind='source'),
-        _load_static_table(receiver_table_path, expected_endpoint_kind='receiver'),
+        _load_static_table(
+            source_table_path,
+            expected_endpoint_kind='source',
+            default_source_job_id=source_job_id,
+        ),
+        _load_static_table(
+            receiver_table_path,
+            expected_endpoint_kind='receiver',
+            default_source_job_id=receiver_source_job_id or source_job_id,
+        ),
     )
 
 
@@ -216,6 +237,7 @@ def _load_static_table(
     path: Path,
     *,
     expected_endpoint_kind: RefractionStaticEndpointKind | None = None,
+    default_source_job_id: str | None = None,
 ) -> _LoadedStaticTable:
     table_path = Path(path)
     with table_path.open('r', encoding='utf-8-sig', newline='') as handle:
@@ -225,7 +247,96 @@ def _load_static_table(
             columns=tuple(reader.fieldnames or ()),
             source_name=table_path.name,
             expected_endpoint_kind=expected_endpoint_kind,
+            default_source_job_id=default_source_job_id,
         )
+
+
+def _canonicalized_table_rows(
+    table: _LoadedStaticTable,
+) -> tuple[tuple[dict[str, str | None], ...], tuple[str, ...]]:
+    if not _is_documented_endpoint_static_table(table):
+        return table.rows, table.columns
+    endpoint_kind = _documented_endpoint_kind(table)
+    rows = tuple(
+        _canonicalized_endpoint_static_row(
+            row,
+            endpoint_kind=endpoint_kind,
+            default_source_job_id=table.default_source_job_id,
+        )
+        for row in table.rows
+    )
+    columns = _columns_from_rows(rows)
+    return rows, columns
+
+
+def _is_documented_endpoint_static_table(table: _LoadedStaticTable) -> bool:
+    column_set = set(table.columns)
+    if 'endpoint_key' in column_set or 'applied_shift_ms' in column_set:
+        return False
+    return bool(
+        {'source_endpoint_key', 'total_applied_shift_ms'} <= column_set
+        or {'receiver_endpoint_key', 'total_applied_shift_ms'} <= column_set
+    )
+
+
+def _documented_endpoint_kind(
+    table: _LoadedStaticTable,
+) -> RefractionStaticEndpointKind:
+    column_set = set(table.columns)
+    if 'source_endpoint_key' in column_set:
+        return 'source'
+    if 'receiver_endpoint_key' in column_set:
+        return 'receiver'
+    if table.expected_endpoint_kind is None:
+        raise ValueError(
+            f'{table.source_name}: documented static table must include '
+            'source_endpoint_key or receiver_endpoint_key'
+        )
+    return table.expected_endpoint_kind
+
+
+def _canonicalized_endpoint_static_row(
+    row: Mapping[str, Any],
+    *,
+    endpoint_kind: RefractionStaticEndpointKind,
+    default_source_job_id: str | None,
+) -> dict[str, str | None]:
+    prefix = 'source' if endpoint_kind == 'source' else 'receiver'
+    out: dict[str, str | None] = {
+        'format_name': _row_text(row, 'format_name') or 'canonical_static_table',
+        'format_version': _row_text(row, 'format_version') or '1',
+        'source_job_id': _row_text(row, 'source_job_id')
+        or _optional_text(default_source_job_id),
+        'endpoint_kind': _row_text(row, 'endpoint_kind') or endpoint_kind,
+        'endpoint_key': _row_text(row, 'endpoint_key')
+        or _row_text(row, f'{prefix}_endpoint_key'),
+        'endpoint_id': _row_text(row, 'endpoint_id') or _row_text(row, f'{prefix}_id'),
+        'applied_shift_ms': _row_text(row, 'applied_shift_ms')
+        or _row_text(row, 'total_applied_shift_ms'),
+        'static_status': _row_text(row, 'static_status'),
+        'sign_convention': _row_text(row, 'sign_convention'),
+    }
+    if f'{prefix}_node_id' in row:
+        out['node_id'] = _row_text(row, f'{prefix}_node_id')
+    for column in CANONICAL_STATIC_TABLE_OPTIONAL_COLUMNS:
+        if column in out:
+            continue
+        if column in row:
+            out[column] = _row_text(row, column)
+    return out
+
+
+def _columns_from_rows(rows: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
+    columns: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in columns:
+                columns.append(str(key))
+    return tuple(columns)
+
+
+def _row_text(row: Mapping[str, Any], column: str) -> str | None:
+    return _optional_text(row.get(column))
 
 
 def _validate_table_path_combination(

--- a/app/services/refraction_static_types.py
+++ b/app/services/refraction_static_types.py
@@ -925,6 +925,7 @@ class RefractionStaticArtifactSet:
     refraction_statics_csv: Path
     near_surface_model_csv: Path
     first_break_residuals_csv: Path
+    refraction_first_break_time_export_csv: Path
     refraction_static_components_csv: Path
     source_static_table_csv: Path
     receiver_static_table_csv: Path

--- a/app/tests/_refraction_static_artifact_helpers.py
+++ b/app/tests/_refraction_static_artifact_helpers.py
@@ -212,6 +212,12 @@ def _result() -> RefractionDatumStaticsResult:
         residual_time_s=np.asarray([0.001, -0.002, -0.001]),
         used_row_mask=np.asarray([True, False, True], dtype=bool),
         rejected_by_robust_mask=np.asarray([False, True, False], dtype=bool),
+        row_layer_kind=np.asarray(['v2_t1', 'v2_t1', 'v2_t1'], dtype='<U16'),
+        row_layer_index=np.asarray([1, 1, 1], dtype=np.int64),
+        row_source_endpoint_key=np.asarray(['s0', 's1', 's0'], dtype='<U16'),
+        row_receiver_endpoint_key=np.asarray(['r0', 'r1', 'r1'], dtype='<U16'),
+        row_rejection_reason=np.asarray(['ok', '', 'ok'], dtype='<U32'),
+        row_velocity_m_s=np.full(3, 2500.0, dtype=np.float64),
         qc={
             'robust_iteration_count': 1,
             'floating_datum_below_refractor_count': 0,

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -23,6 +23,7 @@ from app.services.refraction_static_apply_trace_store import (
 from app.services.refraction_static_artifacts import (
     FIRST_BREAK_RESIDUALS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
     REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
@@ -97,6 +98,7 @@ FINAL_REFRACTION_ARTIFACTS = {
     REFRACTION_STATICS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
     FIRST_BREAK_RESIDUALS_CSV_NAME,
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     REFRACTION_STATIC_COMPONENTS_CSV_NAME,
     REFRACTION_STATIC_HISTORY_JSON_NAME,
     SOURCE_STATIC_TABLE_CSV_NAME,
@@ -1142,6 +1144,7 @@ def test_run_refraction_static_apply_job_artifact_only_writes_real_final_artifac
     assert len(_read_csv(job_dir / REFRACTION_STATICS_CSV_NAME)) == 4
     assert len(_read_csv(job_dir / NEAR_SURFACE_MODEL_CSV_NAME)) == 3
     assert len(_read_csv(job_dir / FIRST_BREAK_RESIDUALS_CSV_NAME)) == 3
+    assert len(_read_csv(job_dir / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME)) == 3
     assert len(_read_csv(job_dir / REFRACTION_STATIC_COMPONENTS_CSV_NAME)) == 4
 
     files_response = client.get(f'/statics/job/{job_id}/files')

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -672,8 +672,12 @@ def test_write_refraction_static_artifacts_csvs(tmp_path: Path) -> None:
     assert len(first_break_rows) == 3
     assert first_break_rows[0]['source_endpoint_key'] == 's0'
     assert first_break_rows[0]['receiver_endpoint_key'] == 'r0'
-    assert float(first_break_rows[0]['observed_pick_time_ms']) == pytest.approx(50.0)
-    assert float(first_break_rows[0]['modeled_pick_time_ms']) == pytest.approx(49.0)
+    assert float(first_break_rows[0]['observed_first_break_time_ms']) == pytest.approx(
+        50.0
+    )
+    assert float(first_break_rows[0]['modeled_first_break_time_ms']) == pytest.approx(
+        49.0
+    )
     assert float(first_break_rows[0]['residual_ms']) == pytest.approx(1.0)
 
     component_rows = _read_csv(paths.refraction_static_components_csv)
@@ -697,42 +701,36 @@ def test_first_break_time_export_contains_observed_modeled_residual(
     )
 
     assert tuple(fieldnames) == (
-        'schema_version',
-        'trace_index_sorted',
+        'format_name',
+        'format_version',
+        'source_job_id',
+        'observation_index',
+        'sorted_trace_index',
         'source_endpoint_key',
         'receiver_endpoint_key',
-        'source_node_id',
-        'receiver_node_id',
+        'source_id',
+        'receiver_id',
         'offset_m',
-        'midpoint_x_m',
-        'midpoint_y_m',
-        'cell_ix',
-        'cell_iy',
         'layer_kind',
-        'used_for_layer',
-        'observed_pick_time_ms',
-        'modeled_pick_time_ms',
+        'observed_first_break_time_ms',
+        'modeled_first_break_time_ms',
         'residual_ms',
-        'moveout_time_ms',
-        'source_time_term_ms',
-        'receiver_time_term_ms',
-        'velocity_m_s',
-        'rejection_reason',
-        'observation_status',
+        'used_in_solve',
+        'reject_reason',
         'sign_convention',
     )
-    assert rows[0]['schema_version'] == '1'
-    assert rows[0]['trace_index_sorted'] == '0'
+    assert rows[0]['format_name'] == 'first_break_time'
+    assert rows[0]['format_version'] == '1'
+    assert rows[0]['source_job_id'] == ''
+    assert rows[0]['observation_index'] == '0'
+    assert rows[0]['sorted_trace_index'] == '0'
+    assert rows[0]['source_id'] == '100'
+    assert rows[0]['receiver_id'] == '200'
     assert rows[0]['layer_kind'] == 'v2_t1'
-    assert rows[0]['used_for_layer'] == 'true'
-    assert rows[0]['observation_status'] == 'used'
-    assert float(rows[0]['observed_pick_time_ms']) == pytest.approx(50.0)
-    assert float(rows[0]['modeled_pick_time_ms']) == pytest.approx(49.0)
+    assert rows[0]['used_in_solve'] == 'true'
+    assert float(rows[0]['observed_first_break_time_ms']) == pytest.approx(50.0)
+    assert float(rows[0]['modeled_first_break_time_ms']) == pytest.approx(49.0)
     assert float(rows[0]['residual_ms']) == pytest.approx(1.0)
-    assert float(rows[0]['source_time_term_ms']) == pytest.approx(10.0)
-    assert float(rows[0]['receiver_time_term_ms']) == pytest.approx(12.0)
-    assert float(rows[0]['moveout_time_ms']) == pytest.approx(27.0)
-    assert float(rows[0]['velocity_m_s']) == pytest.approx(2500.0)
     assert rows[0]['sign_convention'] == (
         artifact_module.FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION
     )
@@ -749,9 +747,8 @@ def test_first_break_time_export_marks_rejected_observations(
 
     rows = _read_csv(paths.refraction_first_break_time_export_csv)
 
-    assert rows[1]['used_for_layer'] == 'false'
-    assert rows[1]['observation_status'] == 'rejected'
-    assert rows[1]['rejection_reason'] == 'robust_outlier'
+    assert rows[1]['used_in_solve'] == 'false'
+    assert rows[1]['reject_reason'] == 'robust_outlier'
 
 
 def test_first_break_time_export_preserves_unassigned_layer_context(
@@ -777,13 +774,8 @@ def test_first_break_time_export_preserves_unassigned_layer_context(
     rows = _read_csv(paths.refraction_first_break_time_export_csv)
 
     assert rows[1]['layer_kind'] == ''
-    assert rows[1]['used_for_layer'] == 'false'
-    assert rows[1]['observation_status'] == 'rejected'
-    assert rows[1]['rejection_reason'] == 'outside_layer_gate'
-    assert rows[1]['source_time_term_ms'] == ''
-    assert rows[1]['receiver_time_term_ms'] == ''
-    assert rows[1]['moveout_time_ms'] == ''
-    assert rows[1]['velocity_m_s'] == ''
+    assert rows[1]['used_in_solve'] == 'false'
+    assert rows[1]['reject_reason'] == 'outside_layer_gate'
 
 
 def test_first_break_time_export_residual_matches_solution_npz(

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -14,6 +14,7 @@ from app.services.refraction_static_artifacts import (
     FIRST_BREAK_RESIDUALS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
     REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
     REFRACTION_REFRACTOR_VELOCITY_QC_JSON_NAME,
@@ -129,6 +130,7 @@ EXPECTED_FILENAMES = {
     REFRACTION_STATICS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
     FIRST_BREAK_RESIDUALS_CSV_NAME,
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     REFRACTION_STATIC_COMPONENTS_CSV_NAME,
     REFRACTION_STATIC_HISTORY_JSON_NAME,
     SOURCE_STATIC_TABLE_CSV_NAME,
@@ -180,6 +182,7 @@ def test_write_refraction_static_artifacts_npz_schema(tmp_path: Path) -> None:
         REFRACTION_STATICS_CSV_NAME,
         NEAR_SURFACE_MODEL_CSV_NAME,
         FIRST_BREAK_RESIDUALS_CSV_NAME,
+        REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
         REFRACTION_STATIC_COMPONENTS_CSV_NAME,
         SOURCE_STATIC_TABLE_CSV_NAME,
         RECEIVER_STATIC_TABLE_CSV_NAME,
@@ -444,7 +447,7 @@ def test_write_refraction_static_artifacts_qc_json(tmp_path: Path) -> None:
     assert payload['status_counts']['trace_static_status']['ok'] == 3
     assert payload['status_counts']['node_datum_status']['ok'] == 2
     assert payload['first_break_fit']['residual_rms_ms'] == pytest.approx(1.0)
-    assert len(payload['artifacts']) == 11
+    assert len(payload['artifacts']) == 12
     artifact_names = {item['name'] for item in payload['artifacts']}
     assert REFRACTION_V1_QC_JSON_NAME not in artifact_names
     assert REFRACTION_V1_ESTIMATES_CSV_NAME not in artifact_names
@@ -665,11 +668,141 @@ def test_write_refraction_static_artifacts_csvs(tmp_path: Path) -> None:
     assert float(residual_rows[0]['observed_pick_time_ms']) == pytest.approx(50.0)
     assert float(residual_rows[1]['residual_ms']) == pytest.approx(-2.0)
 
+    first_break_rows = _read_csv(paths.refraction_first_break_time_export_csv)
+    assert len(first_break_rows) == 3
+    assert first_break_rows[0]['source_endpoint_key'] == 's0'
+    assert first_break_rows[0]['receiver_endpoint_key'] == 'r0'
+    assert float(first_break_rows[0]['observed_pick_time_ms']) == pytest.approx(50.0)
+    assert float(first_break_rows[0]['modeled_pick_time_ms']) == pytest.approx(49.0)
+    assert float(first_break_rows[0]['residual_ms']) == pytest.approx(1.0)
+
     component_rows = _read_csv(paths.refraction_static_components_csv)
     assert len(component_rows) == 4
     assert {row['kind'] for row in component_rows} == {'source', 'receiver'}
     assert float(component_rows[0]['half_intercept_time_ms']) == pytest.approx(10.0)
     assert 'refraction_shift_ms' in component_rows[0]
+
+
+def test_first_break_time_export_contains_observed_modeled_residual(
+    tmp_path: Path,
+) -> None:
+    paths = write_refraction_static_artifacts(
+        result=_result(),
+        req=_request(),
+        job_dir=tmp_path,
+    )
+
+    rows, fieldnames = _read_csv_with_fieldnames(
+        paths.refraction_first_break_time_export_csv
+    )
+
+    assert tuple(fieldnames) == (
+        'schema_version',
+        'trace_index_sorted',
+        'source_endpoint_key',
+        'receiver_endpoint_key',
+        'source_node_id',
+        'receiver_node_id',
+        'offset_m',
+        'midpoint_x_m',
+        'midpoint_y_m',
+        'cell_ix',
+        'cell_iy',
+        'layer_kind',
+        'used_for_layer',
+        'observed_pick_time_ms',
+        'modeled_pick_time_ms',
+        'residual_ms',
+        'moveout_time_ms',
+        'source_time_term_ms',
+        'receiver_time_term_ms',
+        'velocity_m_s',
+        'rejection_reason',
+        'observation_status',
+        'sign_convention',
+    )
+    assert rows[0]['schema_version'] == '1'
+    assert rows[0]['trace_index_sorted'] == '0'
+    assert rows[0]['layer_kind'] == 'v2_t1'
+    assert rows[0]['used_for_layer'] == 'true'
+    assert rows[0]['observation_status'] == 'used'
+    assert float(rows[0]['observed_pick_time_ms']) == pytest.approx(50.0)
+    assert float(rows[0]['modeled_pick_time_ms']) == pytest.approx(49.0)
+    assert float(rows[0]['residual_ms']) == pytest.approx(1.0)
+    assert float(rows[0]['source_time_term_ms']) == pytest.approx(10.0)
+    assert float(rows[0]['receiver_time_term_ms']) == pytest.approx(12.0)
+    assert float(rows[0]['moveout_time_ms']) == pytest.approx(27.0)
+    assert float(rows[0]['velocity_m_s']) == pytest.approx(2500.0)
+    assert rows[0]['sign_convention'] == (
+        artifact_module.FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION
+    )
+
+
+def test_first_break_time_export_marks_rejected_observations(
+    tmp_path: Path,
+) -> None:
+    paths = write_refraction_static_artifacts(
+        result=_result(),
+        req=_request(),
+        job_dir=tmp_path,
+    )
+
+    rows = _read_csv(paths.refraction_first_break_time_export_csv)
+
+    assert rows[1]['used_for_layer'] == 'false'
+    assert rows[1]['observation_status'] == 'rejected'
+    assert rows[1]['rejection_reason'] == 'robust_outlier'
+
+
+def test_first_break_time_export_preserves_unassigned_layer_context(
+    tmp_path: Path,
+) -> None:
+    result = replace(
+        _result(),
+        row_layer_kind=np.asarray(['v2_t1', '', 'v2_t1'], dtype='<U16'),
+        row_layer_index=np.asarray([1, 0, 1], dtype=np.int64),
+        rejected_by_robust_mask=np.asarray([False, False, False], dtype=bool),
+        row_rejection_reason=np.asarray(
+            ['ok', 'outside_layer_gate', 'ok'],
+            dtype='<U32',
+        ),
+        row_velocity_m_s=np.asarray([2500.0, np.nan, 2500.0], dtype=np.float64),
+    )
+    paths = write_refraction_static_artifacts(
+        result=result,
+        req=_request(),
+        job_dir=tmp_path,
+    )
+
+    rows = _read_csv(paths.refraction_first_break_time_export_csv)
+
+    assert rows[1]['layer_kind'] == ''
+    assert rows[1]['used_for_layer'] == 'false'
+    assert rows[1]['observation_status'] == 'rejected'
+    assert rows[1]['rejection_reason'] == 'outside_layer_gate'
+    assert rows[1]['source_time_term_ms'] == ''
+    assert rows[1]['receiver_time_term_ms'] == ''
+    assert rows[1]['moveout_time_ms'] == ''
+    assert rows[1]['velocity_m_s'] == ''
+
+
+def test_first_break_time_export_residual_matches_solution_npz(
+    tmp_path: Path,
+) -> None:
+    paths = write_refraction_static_artifacts(
+        result=_result(),
+        req=_request(),
+        job_dir=tmp_path,
+    )
+
+    rows = _read_csv(paths.refraction_first_break_time_export_csv)
+    with np.load(paths.solution_npz, allow_pickle=False) as data:
+        residual_ms = data['residual_time_s'] * 1000.0
+
+    np.testing.assert_allclose(
+        np.asarray([float(row['residual_ms']) for row in rows]),
+        residual_ms,
+    )
 
 
 def test_refraction_static_artifacts_manifest_and_download_visibility(
@@ -1521,6 +1654,12 @@ def _multilayer_shaped_solve_cell_result():
         used_row_mask=np.asarray([True, False, True, False], dtype=bool),
         rejected_by_robust_mask=np.asarray([False, True, False, False], dtype=bool),
         row_midpoint_cell_id=np.asarray([0, 1, 0, 1], dtype=np.int64),
+        row_layer_kind=np.asarray(['v2_t1', 'v2_t1', 'v2_t1', 'v2_t1'], dtype='<U16'),
+        row_layer_index=np.ones(4, dtype=np.int64),
+        row_source_endpoint_key=np.asarray(['s0', 's1', 's0', 's1'], dtype='<U16'),
+        row_receiver_endpoint_key=np.asarray(['r0', 'r1', 'r1', 'r0'], dtype='<U16'),
+        row_rejection_reason=np.asarray(['ok', '', 'ok', 'not_used'], dtype='<U32'),
+        row_velocity_m_s=np.full(4, 2500.0, dtype=np.float64),
     )
 
 

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -672,12 +672,8 @@ def test_write_refraction_static_artifacts_csvs(tmp_path: Path) -> None:
     assert len(first_break_rows) == 3
     assert first_break_rows[0]['source_endpoint_key'] == 's0'
     assert first_break_rows[0]['receiver_endpoint_key'] == 'r0'
-    assert float(first_break_rows[0]['observed_first_break_time_ms']) == pytest.approx(
-        50.0
-    )
-    assert float(first_break_rows[0]['modeled_first_break_time_ms']) == pytest.approx(
-        49.0
-    )
+    assert float(first_break_rows[0]['observed_pick_time_ms']) == pytest.approx(50.0)
+    assert float(first_break_rows[0]['modeled_pick_time_ms']) == pytest.approx(49.0)
     assert float(first_break_rows[0]['residual_ms']) == pytest.approx(1.0)
 
     component_rows = _read_csv(paths.refraction_static_components_csv)
@@ -701,36 +697,44 @@ def test_first_break_time_export_contains_observed_modeled_residual(
     )
 
     assert tuple(fieldnames) == (
-        'format_name',
-        'format_version',
-        'source_job_id',
-        'observation_index',
-        'sorted_trace_index',
+        'schema_version',
+        'trace_index_sorted',
         'source_endpoint_key',
         'receiver_endpoint_key',
-        'source_id',
-        'receiver_id',
+        'source_node_id',
+        'receiver_node_id',
         'offset_m',
+        'midpoint_x_m',
+        'midpoint_y_m',
+        'cell_ix',
+        'cell_iy',
         'layer_kind',
-        'observed_first_break_time_ms',
-        'modeled_first_break_time_ms',
+        'used_for_layer',
+        'observed_pick_time_ms',
+        'modeled_pick_time_ms',
         'residual_ms',
-        'used_in_solve',
-        'reject_reason',
+        'moveout_time_ms',
+        'source_time_term_ms',
+        'receiver_time_term_ms',
+        'velocity_m_s',
+        'rejection_reason',
+        'observation_status',
         'sign_convention',
     )
-    assert rows[0]['format_name'] == 'first_break_time'
-    assert rows[0]['format_version'] == '1'
-    assert rows[0]['source_job_id'] == ''
-    assert rows[0]['observation_index'] == '0'
-    assert rows[0]['sorted_trace_index'] == '0'
-    assert rows[0]['source_id'] == '100'
-    assert rows[0]['receiver_id'] == '200'
+    assert rows[0]['schema_version'] == '1'
+    assert rows[0]['trace_index_sorted'] == '0'
+    assert rows[0]['source_node_id'] == '0'
+    assert rows[0]['receiver_node_id'] == '1'
     assert rows[0]['layer_kind'] == 'v2_t1'
-    assert rows[0]['used_in_solve'] == 'true'
-    assert float(rows[0]['observed_first_break_time_ms']) == pytest.approx(50.0)
-    assert float(rows[0]['modeled_first_break_time_ms']) == pytest.approx(49.0)
+    assert rows[0]['used_for_layer'] == 'true'
+    assert rows[0]['observation_status'] == 'used'
+    assert float(rows[0]['observed_pick_time_ms']) == pytest.approx(50.0)
+    assert float(rows[0]['modeled_pick_time_ms']) == pytest.approx(49.0)
     assert float(rows[0]['residual_ms']) == pytest.approx(1.0)
+    assert float(rows[0]['moveout_time_ms']) == pytest.approx(27.0)
+    assert float(rows[0]['source_time_term_ms']) == pytest.approx(10.0)
+    assert float(rows[0]['receiver_time_term_ms']) == pytest.approx(12.0)
+    assert float(rows[0]['velocity_m_s']) == pytest.approx(2500.0)
     assert rows[0]['sign_convention'] == (
         artifact_module.FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION
     )
@@ -747,8 +751,9 @@ def test_first_break_time_export_marks_rejected_observations(
 
     rows = _read_csv(paths.refraction_first_break_time_export_csv)
 
-    assert rows[1]['used_in_solve'] == 'false'
-    assert rows[1]['reject_reason'] == 'robust_outlier'
+    assert rows[1]['used_for_layer'] == 'false'
+    assert rows[1]['rejection_reason'] == 'robust_outlier'
+    assert rows[1]['observation_status'] == 'rejected'
 
 
 def test_first_break_time_export_preserves_unassigned_layer_context(
@@ -774,8 +779,8 @@ def test_first_break_time_export_preserves_unassigned_layer_context(
     rows = _read_csv(paths.refraction_first_break_time_export_csv)
 
     assert rows[1]['layer_kind'] == ''
-    assert rows[1]['used_in_solve'] == 'false'
-    assert rows[1]['reject_reason'] == 'outside_layer_gate'
+    assert rows[1]['used_for_layer'] == 'false'
+    assert rows[1]['rejection_reason'] == 'outside_layer_gate'
 
 
 def test_first_break_time_export_residual_matches_solution_npz(

--- a/app/tests/test_refraction_static_cell_qc_artifacts.py
+++ b/app/tests/test_refraction_static_cell_qc_artifacts.py
@@ -235,11 +235,10 @@ def test_observation_residual_artifact_includes_cell_ids_and_rejection_reason(
         assert row['rejection_reason'] == 'ok'
 
 
-def test_first_break_time_export_contains_cell_indices_for_cell_solve(
+def test_first_break_time_export_uses_documented_public_schema_for_cell_solve(
     tmp_path: Path,
 ) -> None:
     result, req, input_model = _clean_result()
-    expected_cell_id = synthetic_cell_midpoint_cell_id_sorted(input_model)
 
     write_refraction_static_artifacts(
         result=result,
@@ -249,12 +248,12 @@ def test_first_break_time_export_contains_cell_indices_for_cell_solve(
 
     rows = _read_csv(tmp_path / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME)
     for row in rows:
-        trace_index = int(row['trace_index_sorted'])
-        cell_id = int(expected_cell_id[trace_index])
-        assert int(row['cell_ix']) == cell_id
-        assert int(row['cell_iy']) == 0
+        assert row['format_name'] == 'first_break_time'
+        assert row['sorted_trace_index']
+        assert 'cell_ix' not in row
+        assert 'cell_iy' not in row
         assert row['layer_kind'] == 'v2_t1'
-        assert row['used_for_layer'] == 'true'
+        assert row['used_in_solve'] == 'true'
 
 
 def test_cell_velocity_artifact_records_smoothing_metadata(

--- a/app/tests/test_refraction_static_cell_qc_artifacts.py
+++ b/app/tests/test_refraction_static_cell_qc_artifacts.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from app.services.refraction_static_artifacts import write_refraction_static_artifacts
+from app.services.refraction_static_artifacts import (
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
+    write_refraction_static_artifacts,
+)
 from app.tests._refraction_static_synthetic import (
     SYNTHETIC_CELL_SIZE_X_M,
     SYNTHETIC_CELL_V2_M_S,
@@ -230,6 +233,28 @@ def test_observation_residual_artifact_includes_cell_ids_and_rejection_reason(
         assert float(row['residual_s']) == pytest.approx(0.0, abs=1.0e-8)
         assert row['used_in_solve'] == 'true'
         assert row['rejection_reason'] == 'ok'
+
+
+def test_first_break_time_export_contains_cell_indices_for_cell_solve(
+    tmp_path: Path,
+) -> None:
+    result, req, input_model = _clean_result()
+    expected_cell_id = synthetic_cell_midpoint_cell_id_sorted(input_model)
+
+    write_refraction_static_artifacts(
+        result=result,
+        req=req,
+        job_dir=tmp_path,
+    )
+
+    rows = _read_csv(tmp_path / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME)
+    for row in rows:
+        trace_index = int(row['trace_index_sorted'])
+        cell_id = int(expected_cell_id[trace_index])
+        assert int(row['cell_ix']) == cell_id
+        assert int(row['cell_iy']) == 0
+        assert row['layer_kind'] == 'v2_t1'
+        assert row['used_for_layer'] == 'true'
 
 
 def test_cell_velocity_artifact_records_smoothing_metadata(

--- a/app/tests/test_refraction_static_cell_qc_artifacts.py
+++ b/app/tests/test_refraction_static_cell_qc_artifacts.py
@@ -239,6 +239,7 @@ def test_first_break_time_export_uses_documented_public_schema_for_cell_solve(
     tmp_path: Path,
 ) -> None:
     result, req, input_model = _clean_result()
+    expected_cell_id = synthetic_cell_midpoint_cell_id_sorted(input_model)
 
     write_refraction_static_artifacts(
         result=result,
@@ -248,12 +249,16 @@ def test_first_break_time_export_uses_documented_public_schema_for_cell_solve(
 
     rows = _read_csv(tmp_path / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME)
     for row in rows:
-        assert row['format_name'] == 'first_break_time'
-        assert row['sorted_trace_index']
-        assert 'cell_ix' not in row
-        assert 'cell_iy' not in row
+        trace_index = int(row['trace_index_sorted'])
+        cell_id = int(expected_cell_id[trace_index])
+        assert row['schema_version'] == '1'
+        assert row['trace_index_sorted']
+        assert int(row['cell_ix']) == cell_id
+        assert int(row['cell_iy']) == 0
         assert row['layer_kind'] == 'v2_t1'
-        assert row['used_in_solve'] == 'true'
+        assert row['used_for_layer'] == 'true'
+        assert row['observation_status'] == 'used'
+        assert row['velocity_m_s']
 
 
 def test_cell_velocity_artifact_records_smoothing_metadata(

--- a/app/tests/test_refraction_static_export_contract.py
+++ b/app/tests/test_refraction_static_export_contract.py
@@ -521,9 +521,9 @@ def test_run_refraction_static_export_job_writes_first_break_time_artifact(
         )
     )
     assert rows[0]['source_endpoint_key'] == 'source:1001'
-    assert rows[0]['source_job_id'] == 'source-refraction-job'
-    assert rows[0]['observed_first_break_time_ms'] == '50.0'
-    assert rows[0]['modeled_first_break_time_ms'] == '48.5'
+    assert 'source_job_id' not in rows[0]
+    assert rows[0]['observed_pick_time_ms'] == '50.0'
+    assert rows[0]['modeled_pick_time_ms'] == '48.5'
     assert rows[0]['residual_ms'] == '1.5'
     meta = json.loads(
         (export_job_dir / REFRACTION_STATIC_EXPORT_JOB_META_JSON_NAME).read_text(
@@ -592,22 +592,28 @@ def _write_source_artifact_stub(path: Path, artifact_name: str) -> None:
         _write_csv(
             path,
             {
-                'format_name': 'first_break_time',
-                'format_version': '1',
-                'source_job_id': 'source-refraction-job',
-                'observation_index': '0',
-                'sorted_trace_index': '0',
+                'schema_version': '1',
+                'trace_index_sorted': '0',
                 'source_endpoint_key': 'source:1001',
                 'receiver_endpoint_key': 'receiver:2001',
-                'source_id': '1001',
-                'receiver_id': '2001',
+                'source_node_id': '10',
+                'receiver_node_id': '20',
                 'offset_m': '100.0',
+                'midpoint_x_m': '1005.0',
+                'midpoint_y_m': '2005.0',
+                'cell_ix': '',
+                'cell_iy': '',
                 'layer_kind': 'v2_t1',
-                'observed_first_break_time_ms': '50.0',
-                'modeled_first_break_time_ms': '48.5',
+                'used_for_layer': 'true',
+                'observed_pick_time_ms': '50.0',
+                'modeled_pick_time_ms': '48.5',
                 'residual_ms': '1.5',
-                'used_in_solve': 'true',
-                'reject_reason': 'ok',
+                'moveout_time_ms': '30.0',
+                'source_time_term_ms': '10.0',
+                'receiver_time_term_ms': '8.5',
+                'velocity_m_s': '2300.0',
+                'rejection_reason': 'ok',
+                'observation_status': 'used',
                 'sign_convention': FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION,
             },
         )

--- a/app/tests/test_refraction_static_export_contract.py
+++ b/app/tests/test_refraction_static_export_contract.py
@@ -17,7 +17,9 @@ from app.api.schemas import (
 )
 from app.main import app
 from app.services.refraction_static_artifacts import (
+    FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION,
     RECEIVER_STATIC_TABLE_CSV_NAME,
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
     REFRACTION_STATIC_REQUEST_JSON_NAME,
     REFRACTION_STATIC_SOLUTION_NPZ_NAME,
@@ -480,6 +482,56 @@ def test_run_refraction_static_export_job_writes_lsst_artifacts(
     ]
 
 
+def test_run_refraction_static_export_job_writes_first_break_time_artifact(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _create_source_refraction_job(
+        client,
+        tmp_path,
+        artifact_names=(
+            REFRACTION_STATIC_REQUEST_JSON_NAME,
+            REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
+            REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
+        ),
+    )
+    req = RefractionStaticExportJobRequest.model_validate(
+        {
+            'source_job_id': 'source-refraction-job',
+            'export': {'enabled': True, 'formats': ['first_break_time']},
+        }
+    )
+    export_job_id = 'export-first-break-time-job'
+    export_job_dir = tmp_path / 'jobs' / export_job_id
+    with client.app.state.sv.lock:
+        client.app.state.sv.jobs.create_static_job(
+            export_job_id,
+            file_id='raw-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='refraction_export',
+            artifacts_dir=str(export_job_dir),
+        )
+
+    run_refraction_static_export_job(export_job_id, req, client.app.state.sv)
+
+    rows = _read_csv_text(
+        (export_job_dir / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME).read_text(
+            encoding='utf-8'
+        )
+    )
+    assert rows[0]['source_endpoint_key'] == 'source:1001'
+    assert rows[0]['observed_pick_time_ms'] == '50.0'
+    assert rows[0]['modeled_pick_time_ms'] == '48.5'
+    assert rows[0]['residual_ms'] == '1.5'
+    meta = json.loads(
+        (export_job_dir / REFRACTION_STATIC_EXPORT_JOB_META_JSON_NAME).read_text(
+            encoding='utf-8',
+        )
+    )
+    assert meta['generated_artifacts'] == [REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME]
+
+
 def _write_source_artifact_stub(path: Path, artifact_name: str) -> None:
     if artifact_name == SOURCE_STATIC_TABLE_CSV_NAME:
         _write_csv(
@@ -532,6 +584,36 @@ def _write_source_artifact_stub(path: Path, artifact_name: str) -> None:
                 'receiver_field_shift_ms': '-0.5',
                 'receiver_field_static_status': 'ok',
                 'receiver_total_with_field_shift_ms': '-3.75',
+            },
+        )
+        return
+    if artifact_name == REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME:
+        _write_csv(
+            path,
+            {
+                'schema_version': '1',
+                'trace_index_sorted': '0',
+                'source_endpoint_key': 'source:1001',
+                'receiver_endpoint_key': 'receiver:2001',
+                'source_node_id': '10',
+                'receiver_node_id': '20',
+                'offset_m': '100.0',
+                'midpoint_x_m': '1005.0',
+                'midpoint_y_m': '2005.0',
+                'cell_ix': '',
+                'cell_iy': '',
+                'layer_kind': 'v2_t1',
+                'used_for_layer': 'true',
+                'observed_pick_time_ms': '50.0',
+                'modeled_pick_time_ms': '48.5',
+                'residual_ms': '1.5',
+                'moveout_time_ms': '27.5',
+                'source_time_term_ms': '12.5',
+                'receiver_time_term_ms': '8.5',
+                'velocity_m_s': '2400.0',
+                'rejection_reason': 'ok',
+                'observation_status': 'used',
+                'sign_convention': FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION,
             },
         )
         return

--- a/app/tests/test_refraction_static_export_contract.py
+++ b/app/tests/test_refraction_static_export_contract.py
@@ -521,8 +521,9 @@ def test_run_refraction_static_export_job_writes_first_break_time_artifact(
         )
     )
     assert rows[0]['source_endpoint_key'] == 'source:1001'
-    assert rows[0]['observed_pick_time_ms'] == '50.0'
-    assert rows[0]['modeled_pick_time_ms'] == '48.5'
+    assert rows[0]['source_job_id'] == 'source-refraction-job'
+    assert rows[0]['observed_first_break_time_ms'] == '50.0'
+    assert rows[0]['modeled_first_break_time_ms'] == '48.5'
     assert rows[0]['residual_ms'] == '1.5'
     meta = json.loads(
         (export_job_dir / REFRACTION_STATIC_EXPORT_JOB_META_JSON_NAME).read_text(
@@ -591,28 +592,22 @@ def _write_source_artifact_stub(path: Path, artifact_name: str) -> None:
         _write_csv(
             path,
             {
-                'schema_version': '1',
-                'trace_index_sorted': '0',
+                'format_name': 'first_break_time',
+                'format_version': '1',
+                'source_job_id': 'source-refraction-job',
+                'observation_index': '0',
+                'sorted_trace_index': '0',
                 'source_endpoint_key': 'source:1001',
                 'receiver_endpoint_key': 'receiver:2001',
-                'source_node_id': '10',
-                'receiver_node_id': '20',
+                'source_id': '1001',
+                'receiver_id': '2001',
                 'offset_m': '100.0',
-                'midpoint_x_m': '1005.0',
-                'midpoint_y_m': '2005.0',
-                'cell_ix': '',
-                'cell_iy': '',
                 'layer_kind': 'v2_t1',
-                'used_for_layer': 'true',
-                'observed_pick_time_ms': '50.0',
-                'modeled_pick_time_ms': '48.5',
+                'observed_first_break_time_ms': '50.0',
+                'modeled_first_break_time_ms': '48.5',
                 'residual_ms': '1.5',
-                'moveout_time_ms': '27.5',
-                'source_time_term_ms': '12.5',
-                'receiver_time_term_ms': '8.5',
-                'velocity_m_s': '2400.0',
-                'rejection_reason': 'ok',
-                'observation_status': 'used',
+                'used_in_solve': 'true',
+                'reject_reason': 'ok',
                 'sign_convention': FIRST_BREAK_TIME_EXPORT_SIGN_CONVENTION,
             },
         )

--- a/app/tests/test_refraction_static_multilayer_artifacts.py
+++ b/app/tests/test_refraction_static_multilayer_artifacts.py
@@ -323,9 +323,9 @@ def test_first_break_time_export_contains_layer_kind_for_multilayer(
     for row in rows:
         assert row['source_endpoint_key']
         assert row['receiver_endpoint_key']
-        assert row['source_time_term_ms']
-        assert row['receiver_time_term_ms']
-        assert row['moveout_time_ms']
+        assert row['observed_first_break_time_ms']
+        assert row['modeled_first_break_time_ms']
+        assert row['used_in_solve']
 
 
 def test_multilayer_residual_csv_reports_cell_ids_for_solve_cell_layer(

--- a/app/tests/test_refraction_static_multilayer_artifacts.py
+++ b/app/tests/test_refraction_static_multilayer_artifacts.py
@@ -16,6 +16,7 @@ from app.services.refraction_static_artifacts import (
     FIRST_BREAK_RESIDUALS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
     RECEIVER_STATIC_TABLE_CSV_NAME,
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     REFRACTION_CELL_SOLVER_HISTORY_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_CELLS_CSV_NAME,
     REFRACTION_REFRACTOR_VELOCITY_GRID_NPZ_NAME,
@@ -58,6 +59,7 @@ _CORE_FINAL_ARTIFACT_NAMES = {
     REFRACTION_STATICS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
     FIRST_BREAK_RESIDUALS_CSV_NAME,
+    REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME,
     REFRACTION_STATIC_COMPONENTS_CSV_NAME,
     SOURCE_STATIC_TABLE_CSV_NAME,
     RECEIVER_STATIC_TABLE_CSV_NAME,
@@ -304,6 +306,26 @@ def test_multilayer_residual_csv_contains_layer_kind_and_layer_index(
     assert vsub_rows
     assert {row['layer_index'] for row in vsub_rows} == {'3'}
     assert all(row['residual_time_s'] != '' for row in vsub_rows)
+
+
+def test_first_break_time_export_contains_layer_kind_for_multilayer(
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'job'
+    compute_three_layer_workflow(job_dir=job_dir)
+
+    rows = _read_csv(job_dir / REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME)
+
+    assert rows
+    assert {'v2_t1', 'v3_t2', 'vsub_t3'} <= {
+        row['layer_kind'] for row in rows
+    }
+    for row in rows:
+        assert row['source_endpoint_key']
+        assert row['receiver_endpoint_key']
+        assert row['source_time_term_ms']
+        assert row['receiver_time_term_ms']
+        assert row['moveout_time_ms']
 
 
 def test_multilayer_residual_csv_reports_cell_ids_for_solve_cell_layer(

--- a/app/tests/test_refraction_static_multilayer_artifacts.py
+++ b/app/tests/test_refraction_static_multilayer_artifacts.py
@@ -323,9 +323,13 @@ def test_first_break_time_export_contains_layer_kind_for_multilayer(
     for row in rows:
         assert row['source_endpoint_key']
         assert row['receiver_endpoint_key']
-        assert row['observed_first_break_time_ms']
-        assert row['modeled_first_break_time_ms']
-        assert row['used_in_solve']
+        assert row['observed_pick_time_ms']
+        assert row['modeled_pick_time_ms']
+        assert row['used_for_layer']
+        assert row['moveout_time_ms']
+        assert row['source_time_term_ms']
+        assert row['receiver_time_term_ms']
+        assert row['velocity_m_s']
 
 
 def test_multilayer_residual_csv_reports_cell_ids_for_solve_cell_layer(

--- a/app/tests/test_refraction_static_table_apply.py
+++ b/app/tests/test_refraction_static_table_apply.py
@@ -135,6 +135,50 @@ def _canonical_row(
     }
 
 
+def _documented_static_table_row(
+    *,
+    endpoint_kind: str,
+    endpoint_key: str,
+    endpoint_id: int,
+    total_applied_shift_ms: float,
+) -> dict[str, str]:
+    prefix = endpoint_kind
+    return {
+        'endpoint_kind': endpoint_kind,
+        f'{prefix}_endpoint_key': endpoint_key,
+        f'{prefix}_id': str(endpoint_id),
+        f'{prefix}_node_id': str(endpoint_id),
+        f'{prefix}_v2_cell_id': '',
+        'x_m': '0.000',
+        'y_m': '0.000',
+        'surface_elevation_m': '0.000',
+        'floating_datum_elevation_m': '0.000',
+        'flat_datum_elevation_m': '',
+        't1_ms': '0.000000',
+        'v1_m_s': '800.000',
+        'v2_m_s': '2400.000',
+        'v2_status': 'ok',
+        'sh1_weathering_thickness_m': '0.000',
+        'total_weathering_thickness_m': '0.000',
+        'refractor_elevation_m': '0.000',
+        'weathering_correction_ms': '0.000000',
+        'floating_datum_correction_ms': '0.000000',
+        'flat_datum_correction_ms': '0.000000',
+        'elevation_correction_ms': '0.000000',
+        'total_static_ms': f'{total_applied_shift_ms:.6f}',
+        'total_applied_shift_ms': f'{total_applied_shift_ms:.6f}',
+        'solution_status': 'ok',
+        'weathering_status': 'ok',
+        'datum_status': 'ok',
+        'static_status': 'ok',
+        'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+        'pick_count': '1',
+        'used_pick_count': '1',
+        'residual_rms_ms': '0.000000',
+        'residual_mad_ms': '0.000000',
+    }
+
+
 def _write_table(
     path: Path,
     *,
@@ -617,6 +661,76 @@ def test_static_table_apply_imports_source_receiver_static_table_npz(
             data['trace_shift_s_sorted'],
             [0.008, 0.004, 0.004, 0.0],
         )
+
+
+def test_static_table_apply_imports_documented_source_receiver_csvs(
+    tmp_path: Path,
+) -> None:
+    state, _store = _write_target_store(tmp_path)
+    table_dir = tmp_path / 'jobs' / TABLE_JOB_ID
+    source_table_path = table_dir / 'source_static_table.csv'
+    receiver_table_path = table_dir / 'receiver_static_table.csv'
+    _write_rows(
+        source_table_path,
+        [
+            _documented_static_table_row(
+                endpoint_kind='source',
+                endpoint_key=SOURCE_KEYS[100],
+                endpoint_id=100,
+                total_applied_shift_ms=8.0,
+            ),
+            _documented_static_table_row(
+                endpoint_kind='source',
+                endpoint_key=SOURCE_KEYS[101],
+                endpoint_id=101,
+                total_applied_shift_ms=4.0,
+            ),
+        ],
+    )
+    _write_rows(
+        receiver_table_path,
+        [
+            _documented_static_table_row(
+                endpoint_kind='receiver',
+                endpoint_key=RECEIVER_KEYS[200],
+                endpoint_id=200,
+                total_applied_shift_ms=0.0,
+            ),
+            _documented_static_table_row(
+                endpoint_kind='receiver',
+                endpoint_key=RECEIVER_KEYS[201],
+                endpoint_id=201,
+                total_applied_shift_ms=-4.0,
+            ),
+        ],
+    )
+    _write_refraction_static_request(table_dir)
+    _create_table_job(state, tmp_path, source_table_path, statics_kind='refraction')
+    job_dir = tmp_path / 'jobs' / APPLY_JOB_ID
+    _create_apply_job(state, job_dir)
+
+    req = RefractionStaticTableApplyRequest.model_validate(
+        {
+            'file_id': SOURCE_FILE_ID,
+            'key1_byte': KEY1,
+            'key2_byte': KEY2,
+            'source_table_artifact_id': f'{TABLE_JOB_ID}:{source_table_path.name}',
+            'receiver_table_artifact_id': f'{TABLE_JOB_ID}:{receiver_table_path.name}',
+            'register_corrected_file': False,
+        }
+    )
+
+    run_refraction_static_table_apply_job(APPLY_JOB_ID, req, state)
+
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    with np.load(job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME, allow_pickle=False) as data:
+        np.testing.assert_allclose(
+            data['trace_shift_s_sorted'],
+            [0.008, 0.004, 0.004, 0.0],
+        )
+    history = _read_static_table_apply_history(job_dir)
+    assert history['created_from_refraction_job_id'] == TABLE_JOB_ID
 
 
 def test_static_table_apply_does_not_require_producer_geometry(

--- a/app/tests/test_refraction_static_table_apply.py
+++ b/app/tests/test_refraction_static_table_apply.py
@@ -462,14 +462,22 @@ def test_static_table_history_records_sign_convention(tmp_path: Path) -> None:
     assert history['sign_convention'] == REFRACTION_STATIC_REPO_SIGN_CONVENTION
 
 
-def test_static_table_apply_reorders_original_headers_to_sorted_trace_shift(
+def test_static_table_apply_uses_materialized_sorted_headers_for_trace_shift(
     tmp_path: Path,
 ) -> None:
     sorted_to_original = np.asarray([2, 0, 3, 1], dtype=np.int64)
-    state, _store = _write_target_store(
+    state, store = _write_target_store(
         tmp_path,
         sorted_to_original=sorted_to_original,
     )
+    _write_header(store, 9, [100, 100, 101, 101])
+    _write_header(store, 13, [201, 200, 201, 200])
+    _write_header(store, 73, [1000, 1000, 1010, 1010])
+    _write_header(store, 77, [2000, 2000, 2000, 2000])
+    _write_header(store, 81, [1110, 1100, 1110, 1100])
+    _write_header(store, 85, [2000, 2000, 2000, 2000])
+    _write_header(store, 45, [10, 10, 12, 12])
+    _write_header(store, 41, [22, 20, 22, 20])
     table_path = tmp_path / 'jobs' / TABLE_JOB_ID / 'canonical_static_table.csv'
     _write_table(table_path)
     _write_refraction_static_request(table_path.parent)
@@ -504,6 +512,68 @@ def test_static_table_apply_reorders_original_headers_to_sorted_trace_shift(
             data['trace_shift_s_sorted'],
             [0.004, 0.008, 0.0, 0.004],
         )
+
+
+def test_static_table_apply_rejects_large_endpoint_shift_even_when_trace_sum_cancels(
+    tmp_path: Path,
+) -> None:
+    state, _store = _write_target_store(tmp_path)
+    table_path = tmp_path / 'jobs' / TABLE_JOB_ID / 'canonical_static_table.csv'
+    rows = [
+        _canonical_row(
+            endpoint_kind='source',
+            endpoint_key=SOURCE_KEYS[100],
+            endpoint_id=100,
+            applied_shift_ms=1000.0,
+        ),
+        _canonical_row(
+            endpoint_kind='source',
+            endpoint_key=SOURCE_KEYS[101],
+            endpoint_id=101,
+            applied_shift_ms=1000.0,
+        ),
+        _canonical_row(
+            endpoint_kind='receiver',
+            endpoint_key=RECEIVER_KEYS[200],
+            endpoint_id=200,
+            applied_shift_ms=-1000.0,
+        ),
+        _canonical_row(
+            endpoint_kind='receiver',
+            endpoint_key=RECEIVER_KEYS[201],
+            endpoint_id=201,
+            applied_shift_ms=-1000.0,
+        ),
+    ]
+    table_path.parent.mkdir(parents=True, exist_ok=True)
+    with table_path.open('w', encoding='utf-8', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=tuple(rows[0]), lineterminator='\n')
+        writer.writeheader()
+        writer.writerows(rows)
+    _write_refraction_static_request(table_path.parent)
+    _create_table_job(state, tmp_path, table_path)
+    job_dir = tmp_path / 'jobs' / APPLY_JOB_ID
+    _create_apply_job(state, job_dir)
+    req = RefractionStaticTableApplyRequest.model_validate(
+        {
+            'file_id': SOURCE_FILE_ID,
+            'key1_byte': KEY1,
+            'key2_byte': KEY2,
+            'combined_table_artifact_id': f'{TABLE_JOB_ID}:{table_path.name}',
+            'register_corrected_file': False,
+            'max_abs_shift_ms': 250.0,
+        }
+    )
+
+    run_refraction_static_table_apply_job(APPLY_JOB_ID, req, state)
+
+    with state.lock:
+        job = dict(state.jobs[APPLY_JOB_ID])
+    assert job['status'] == 'error'
+    assert 'imported endpoint static shift exceeds max_abs_shift_ms' in str(
+        job['message']
+    )
+    assert not (job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME).exists()
 
 
 def test_static_table_apply_imports_source_receiver_static_table_npz(

--- a/app/tests/test_refraction_static_table_apply.py
+++ b/app/tests/test_refraction_static_table_apply.py
@@ -120,11 +120,12 @@ def _canonical_row(
     endpoint_key: str,
     endpoint_id: int,
     applied_shift_ms: float,
+    source_job_id: str = 'refraction-source-job',
 ) -> dict[str, str]:
     return {
         'format_name': 'canonical_static_table',
         'format_version': '1',
-        'source_job_id': 'refraction-source-job',
+        'source_job_id': source_job_id,
         'endpoint_kind': endpoint_kind,
         'endpoint_key': endpoint_key,
         'endpoint_id': str(endpoint_id),
@@ -179,6 +180,14 @@ def _write_table(
             ),
         )
 
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open('w', encoding='utf-8', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=tuple(rows[0]), lineterminator='\n')
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_rows(path: Path, rows: list[dict[str, str]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open('w', encoding='utf-8', newline='') as handle:
         writer = csv.DictWriter(handle, fieldnames=tuple(rows[0]), lineterminator='\n')
@@ -275,7 +284,8 @@ def _run_apply(
     endpoint_id_matching: bool = False,
     write_producer_geometry: bool = True,
     lineage_components: list[str] | None = None,
-    double_application_policy: str = 'warn',
+    double_application_policy: str = 'fail',
+    allow_reapply_same_static_table: bool = False,
 ) -> tuple[AppState, Path, Path]:
     state, store = _write_target_store(tmp_path)
     if lineage_components is not None:
@@ -300,6 +310,7 @@ def _run_apply(
         'missing_static_policy': missing_static_policy,
         'allow_missing_source_static': allow_missing_source_static,
         'double_application_policy': double_application_policy,
+        'allow_reapply_same_static_table': allow_reapply_same_static_table,
         'max_abs_shift_ms': 250.0,
     }
     if endpoint_id_matching:
@@ -783,22 +794,39 @@ def test_static_table_apply_history_checks_trace_store_lineage(
     )
 
     with state.lock:
-        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
-    qc = json.loads((job_dir / STATIC_TABLE_APPLY_QC_JSON_NAME).read_text())
-    history = json.loads((job_dir / 'refraction_static_history.json').read_text())
-    assert qc['double_application_policy']['status'] == 'duplicate_warned'
-    assert qc['double_application_policy']['duplicate_components'] == ['refraction']
-    assert history['double_application_policy']['status'] == 'duplicate_warned'
-    assert 'double_application_policy=warn' in history['warnings'][0]
+        job = dict(state.jobs[APPLY_JOB_ID])
+    assert job['status'] == 'error'
+    assert 'double_application_policy=fail' in str(job['message'])
+    assert not (job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME).exists()
 
 
-def test_static_table_apply_double_application_policy_fail_rejects(
+def test_static_table_apply_lineage_override_allows_reapply(
     tmp_path: Path,
 ) -> None:
     state, _store, job_dir = _run_apply(
         tmp_path,
         lineage_components=['refraction'],
-        double_application_policy='fail',
+        allow_reapply_same_static_table=True,
+    )
+
+    with state.lock:
+        job = dict(state.jobs[APPLY_JOB_ID])
+    assert job['status'] == 'done', job.get('message')
+    qc = json.loads((job_dir / STATIC_TABLE_APPLY_QC_JSON_NAME).read_text())
+    history = json.loads((job_dir / 'refraction_static_history.json').read_text())
+    assert qc['double_application_policy']['status'] == 'duplicate_allowed'
+    assert qc['double_application_policy']['duplicate_components'] == ['refraction']
+    assert history['double_application_policy']['status'] == 'duplicate_allowed'
+    assert 'double_application_policy=allow' in history['warnings'][0]
+
+
+def test_static_table_apply_double_application_policy_allow_does_not_override(
+    tmp_path: Path,
+) -> None:
+    state, _store, job_dir = _run_apply(
+        tmp_path,
+        lineage_components=['refraction'],
+        double_application_policy='allow',
     )
 
     with state.lock:
@@ -806,6 +834,133 @@ def test_static_table_apply_double_application_policy_fail_rejects(
     assert job['status'] == 'error'
     assert 'double_application_policy=fail' in str(job['message'])
     assert not (job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME).exists()
+
+
+def test_static_table_apply_checks_all_imported_source_job_ids(
+    tmp_path: Path,
+) -> None:
+    state, store = _write_target_store(tmp_path)
+    table_dir = tmp_path / 'jobs' / TABLE_JOB_ID
+    source_table_path = table_dir / 'source_static_table.csv'
+    receiver_table_path = table_dir / 'receiver_static_table.csv'
+    _write_rows(
+        source_table_path,
+        [
+            _canonical_row(
+                endpoint_kind='source',
+                endpoint_key=SOURCE_KEYS[100],
+                endpoint_id=100,
+                applied_shift_ms=8.0,
+                source_job_id='source-producer-job',
+            ),
+            _canonical_row(
+                endpoint_kind='source',
+                endpoint_key=SOURCE_KEYS[101],
+                endpoint_id=101,
+                applied_shift_ms=4.0,
+                source_job_id='source-producer-job',
+            ),
+        ],
+    )
+    _write_rows(
+        receiver_table_path,
+        [
+            _canonical_row(
+                endpoint_kind='receiver',
+                endpoint_key=RECEIVER_KEYS[200],
+                endpoint_id=200,
+                applied_shift_ms=0.0,
+                source_job_id='receiver-producer-job',
+            ),
+            _canonical_row(
+                endpoint_kind='receiver',
+                endpoint_key=RECEIVER_KEYS[201],
+                endpoint_id=201,
+                applied_shift_ms=-4.0,
+                source_job_id='receiver-producer-job',
+            ),
+        ],
+    )
+    _write_refraction_static_request(table_dir)
+    _create_table_job(state, tmp_path, source_table_path)
+    job_dir = tmp_path / 'jobs' / APPLY_JOB_ID
+    _create_apply_job(state, job_dir)
+    req = RefractionStaticTableApplyRequest.model_validate(
+        {
+            'file_id': SOURCE_FILE_ID,
+            'key1_byte': KEY1,
+            'key2_byte': KEY2,
+            'source_table_artifact_id': f'{TABLE_JOB_ID}:{source_table_path.name}',
+            'receiver_table_artifact_id': f'{TABLE_JOB_ID}:{receiver_table_path.name}',
+            'register_corrected_file': False,
+        }
+    )
+    run_refraction_static_table_apply_job(APPLY_JOB_ID, req, state)
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    history = _read_static_table_apply_history(job_dir)
+    assert history['created_from_refraction_job_ids'] == [
+        'source-producer-job',
+        'receiver-producer-job',
+    ]
+
+    meta_path = store / 'meta.json'
+    meta = json.loads(meta_path.read_text(encoding='utf-8'))
+    meta['derived'] = {'static_table_apply_history': history}
+    meta_path.write_text(json.dumps(meta), encoding='utf-8')
+
+    new_table_path = table_dir / 'receiver_lineage_static_table.csv'
+    _write_rows(
+        new_table_path,
+        [
+            _canonical_row(
+                endpoint_kind='source',
+                endpoint_key=SOURCE_KEYS[100],
+                endpoint_id=100,
+                applied_shift_ms=8.0,
+                source_job_id='receiver-producer-job',
+            ),
+            _canonical_row(
+                endpoint_kind='source',
+                endpoint_key=SOURCE_KEYS[101],
+                endpoint_id=101,
+                applied_shift_ms=4.0,
+                source_job_id='receiver-producer-job',
+            ),
+            _canonical_row(
+                endpoint_kind='receiver',
+                endpoint_key=RECEIVER_KEYS[200],
+                endpoint_id=200,
+                applied_shift_ms=0.0,
+                source_job_id='receiver-producer-job',
+            ),
+            _canonical_row(
+                endpoint_kind='receiver',
+                endpoint_key=RECEIVER_KEYS[201],
+                endpoint_id=201,
+                applied_shift_ms=-4.0,
+                source_job_id='receiver-producer-job',
+            ),
+        ],
+    )
+    second_job_dir = tmp_path / 'jobs' / SECOND_APPLY_JOB_ID
+    _create_apply_job(state, second_job_dir, job_id=SECOND_APPLY_JOB_ID)
+    second_req = RefractionStaticTableApplyRequest.model_validate(
+        {
+            'file_id': SOURCE_FILE_ID,
+            'key1_byte': KEY1,
+            'key2_byte': KEY2,
+            'combined_table_artifact_id': f'{TABLE_JOB_ID}:{new_table_path.name}',
+            'register_corrected_file': False,
+        }
+    )
+    run_refraction_static_table_apply_job(SECOND_APPLY_JOB_ID, second_req, state)
+
+    with state.lock:
+        second_job = dict(state.jobs[SECOND_APPLY_JOB_ID])
+    assert second_job['status'] == 'error'
+    assert 'table_source_job_already_applied' in str(second_job['message'])
+    assert not (second_job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME).exists()
 
 
 def test_static_table_apply_trace_shift_matches_expected_synthetic(

--- a/app/tests/test_refraction_static_table_apply.py
+++ b/app/tests/test_refraction_static_table_apply.py
@@ -1,0 +1,684 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.routers.statics as statics_router_module
+from app.api.schemas import RefractionStaticTableApplyRequest
+from app.core.state import AppState, create_app_state
+from app.main import app
+from app.services.refraction_static_export_units import (
+    REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+)
+from app.services.refraction_static_table_apply_service import (
+    STATIC_TABLE_APPLY_QC_JSON_NAME,
+    STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
+    STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME,
+    run_refraction_static_table_apply_job,
+)
+from app.services.refraction_static_apply_trace_store import CORRECTED_FILE_JSON_NAME
+from app.services.refraction_static_artifacts import (
+    REFRACTION_STATIC_REQUEST_JSON_NAME,
+    SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
+)
+from app.tests.test_refraction_static_apply_trace_store import (
+    DT,
+    KEY1,
+    KEY2,
+    SOURCE_FILE_ID,
+    _write_source_store,
+)
+
+TABLE_JOB_ID = 'static-table-import-job'
+APPLY_JOB_ID = 'static-table-apply-job'
+
+
+def _endpoint_key(
+    endpoint_kind: str,
+    endpoint_id: int,
+    x_m: float,
+    y_m: float,
+    elevation_m: float,
+) -> str:
+    return (
+        f'{endpoint_kind}:'
+        f'{endpoint_id}:'
+        f'{x_m:.17g}:'
+        f'{y_m:.17g}:'
+        f'{elevation_m:.17g}'
+    )
+
+
+SOURCE_KEYS = {
+    100: _endpoint_key('source', 100, 1000.0, 2000.0, 10.0),
+    101: _endpoint_key('source', 101, 1010.0, 2000.0, 12.0),
+}
+RECEIVER_KEYS = {
+    200: _endpoint_key('receiver', 200, 1100.0, 2000.0, 20.0),
+    201: _endpoint_key('receiver', 201, 1110.0, 2000.0, 22.0),
+}
+DEFAULT_GEOMETRY = {
+    'source_id_byte': 9,
+    'receiver_id_byte': 13,
+    'source_x_byte': 73,
+    'source_y_byte': 77,
+    'receiver_x_byte': 81,
+    'receiver_y_byte': 85,
+    'source_elevation_byte': 45,
+    'receiver_elevation_byte': 41,
+    'coordinate_scalar_byte': 71,
+    'elevation_scalar_byte': 69,
+    'coordinate_unit': 'm',
+    'elevation_unit': 'm',
+}
+
+
+def _write_header(store: Path, byte: int, values: list[int] | list[float]) -> None:
+    np.save(store / f'headers_byte_{byte}.npy', np.asarray(values))
+
+
+def _write_target_store(
+    tmp_path: Path,
+    *,
+    sorted_to_original: np.ndarray | None = None,
+) -> tuple[AppState, Path]:
+    store = tmp_path / 'trace_stores' / 'line001.sgy'
+    traces = np.zeros((4, 16), dtype=np.float32)
+    traces[:, 8] = 1.0
+    if sorted_to_original is None:
+        sorted_to_original = np.arange(4, dtype=np.int64)
+    _write_source_store(store, traces=traces, sorted_to_original=sorted_to_original)
+
+    _write_header(store, 9, [100, 101, 100, 101])
+    _write_header(store, 13, [200, 200, 201, 201])
+    _write_header(store, 73, [1000, 1010, 1000, 1010])
+    _write_header(store, 77, [2000, 2000, 2000, 2000])
+    _write_header(store, 81, [1100, 1100, 1110, 1110])
+    _write_header(store, 85, [2000, 2000, 2000, 2000])
+    _write_header(store, 45, [10, 12, 10, 12])
+    _write_header(store, 41, [20, 20, 22, 22])
+    _write_header(store, 71, [1, 1, 1, 1])
+    _write_header(store, 69, [1, 1, 1, 1])
+
+    state = create_app_state()
+    state.file_registry.update(SOURCE_FILE_ID, store_path=str(store), dt=DT)
+    return state, store
+
+
+def _canonical_row(
+    *,
+    endpoint_kind: str,
+    endpoint_key: str,
+    endpoint_id: int,
+    applied_shift_ms: float,
+) -> dict[str, str]:
+    return {
+        'format_name': 'canonical_static_table',
+        'format_version': '1',
+        'source_job_id': 'refraction-source-job',
+        'endpoint_kind': endpoint_kind,
+        'endpoint_key': endpoint_key,
+        'endpoint_id': str(endpoint_id),
+        'applied_shift_ms': f'{applied_shift_ms:.6f}',
+        'static_status': 'ok',
+        'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+    }
+
+
+def _write_table(
+    path: Path,
+    *,
+    include_source_101: bool = True,
+    endpoint_id_matching_keys: bool = False,
+) -> None:
+    source_100_key = 'source-row-100' if endpoint_id_matching_keys else SOURCE_KEYS[100]
+    source_101_key = 'source-row-101' if endpoint_id_matching_keys else SOURCE_KEYS[101]
+    receiver_200_key = (
+        'receiver-row-200' if endpoint_id_matching_keys else RECEIVER_KEYS[200]
+    )
+    receiver_201_key = (
+        'receiver-row-201' if endpoint_id_matching_keys else RECEIVER_KEYS[201]
+    )
+    rows = [
+        _canonical_row(
+            endpoint_kind='source',
+            endpoint_key=source_100_key,
+            endpoint_id=100,
+            applied_shift_ms=8.0,
+        ),
+        _canonical_row(
+            endpoint_kind='receiver',
+            endpoint_key=receiver_200_key,
+            endpoint_id=200,
+            applied_shift_ms=0.0,
+        ),
+        _canonical_row(
+            endpoint_kind='receiver',
+            endpoint_key=receiver_201_key,
+            endpoint_id=201,
+            applied_shift_ms=-4.0,
+        ),
+    ]
+    if include_source_101:
+        rows.insert(
+            1,
+            _canonical_row(
+                endpoint_kind='source',
+                endpoint_key=source_101_key,
+                endpoint_id=101,
+                applied_shift_ms=4.0,
+            ),
+        )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open('w', encoding='utf-8', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=tuple(rows[0]), lineterminator='\n')
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_source_receiver_static_table_npz(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        path,
+        sign_convention=np.asarray(REFRACTION_STATIC_REPO_SIGN_CONVENTION),
+        source_endpoint_key=np.asarray(
+            [SOURCE_KEYS[100], SOURCE_KEYS[101]],
+            dtype='<U80',
+        ),
+        source_id=np.asarray([100, 101], dtype=np.int64),
+        source_total_applied_shift_s=np.asarray([0.008, 0.004], dtype=np.float64),
+        source_static_status=np.asarray(['ok', 'ok'], dtype='<U2'),
+        receiver_endpoint_key=np.asarray(
+            [RECEIVER_KEYS[200], RECEIVER_KEYS[201]],
+            dtype='<U80',
+        ),
+        receiver_id=np.asarray([200, 201], dtype=np.int64),
+        receiver_total_applied_shift_s=np.asarray([0.0, -0.004], dtype=np.float64),
+        receiver_static_status=np.asarray(['ok', 'ok'], dtype='<U2'),
+    )
+
+
+def _write_refraction_static_request(
+    job_dir: Path,
+    *,
+    geometry: dict[str, Any] | None = None,
+) -> None:
+    payload = {
+        'job_id': TABLE_JOB_ID,
+        'job_type': 'statics',
+        'statics_kind': 'refraction',
+        'source_file_id': SOURCE_FILE_ID,
+        'key1_byte': KEY1,
+        'key2_byte': KEY2,
+        'request': {'geometry': geometry or DEFAULT_GEOMETRY},
+    }
+    job_dir.mkdir(parents=True, exist_ok=True)
+    (job_dir / REFRACTION_STATIC_REQUEST_JSON_NAME).write_text(
+        json.dumps(payload),
+        encoding='utf-8',
+    )
+
+
+def _create_table_job(
+    state: AppState,
+    tmp_path: Path,
+    table_path: Path,
+    *,
+    statics_kind: str = 'refraction_export',
+) -> None:
+    with state.lock:
+        state.jobs.create_static_job(
+            TABLE_JOB_ID,
+            file_id=SOURCE_FILE_ID,
+            key1_byte=KEY1,
+            key2_byte=KEY2,
+            statics_kind=statics_kind,
+            artifacts_dir=str(table_path.parent),
+        )
+
+
+def _create_apply_job(state: AppState, job_dir: Path) -> None:
+    with state.lock:
+        state.jobs.create_static_job(
+            APPLY_JOB_ID,
+            file_id=SOURCE_FILE_ID,
+            key1_byte=KEY1,
+            key2_byte=KEY2,
+            statics_kind='refraction_static_table_apply',
+            artifacts_dir=str(job_dir),
+        )
+
+
+def _run_apply(
+    tmp_path: Path,
+    *,
+    include_source_101: bool = True,
+    register_corrected_file: bool = False,
+    missing_static_policy: str = 'fail',
+    allow_missing_source_static: bool = False,
+    endpoint_id_matching: bool = False,
+    write_producer_geometry: bool = True,
+    lineage_components: list[str] | None = None,
+    double_application_policy: str = 'warn',
+) -> tuple[AppState, Path, Path]:
+    state, store = _write_target_store(tmp_path)
+    if lineage_components is not None:
+        _write_source_lineage(store, lineage_components)
+    table_path = tmp_path / 'jobs' / TABLE_JOB_ID / 'canonical_static_table.csv'
+    _write_table(
+        table_path,
+        include_source_101=include_source_101,
+        endpoint_id_matching_keys=endpoint_id_matching,
+    )
+    if write_producer_geometry:
+        _write_refraction_static_request(table_path.parent)
+    _create_table_job(state, tmp_path, table_path)
+    job_dir = tmp_path / 'jobs' / APPLY_JOB_ID
+    _create_apply_job(state, job_dir)
+    payload: dict[str, Any] = {
+        'file_id': SOURCE_FILE_ID,
+        'key1_byte': KEY1,
+        'key2_byte': KEY2,
+        'combined_table_artifact_id': f'{TABLE_JOB_ID}:{table_path.name}',
+        'register_corrected_file': register_corrected_file,
+        'missing_static_policy': missing_static_policy,
+        'allow_missing_source_static': allow_missing_source_static,
+        'double_application_policy': double_application_policy,
+        'max_abs_shift_ms': 250.0,
+    }
+    if endpoint_id_matching:
+        payload['source_key_header'] = 'endpoint_id'
+        payload['receiver_key_header'] = 'endpoint_id'
+    req = RefractionStaticTableApplyRequest.model_validate(payload)
+
+    run_refraction_static_table_apply_job(APPLY_JOB_ID, req, state)
+    return state, store, job_dir
+
+
+def _write_source_lineage(store: Path, components: list[str]) -> None:
+    meta_path = store / 'meta.json'
+    meta = json.loads(meta_path.read_text(encoding='utf-8'))
+    meta['derived'] = {
+        'components': [
+            {
+                'name': 'refraction_static_correction',
+                'static_components_applied': components,
+            }
+        ]
+    }
+    meta_path.write_text(json.dumps(meta), encoding='utf-8')
+
+
+def test_static_table_apply_maps_source_receiver_to_trace_shift(tmp_path: Path) -> None:
+    state, _store, job_dir = _run_apply(tmp_path)
+
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    with np.load(job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME, allow_pickle=False) as data:
+        np.testing.assert_allclose(
+            data['trace_shift_s_sorted'],
+            [0.008, 0.004, 0.004, 0.0],
+        )
+        np.testing.assert_array_equal(data['trace_static_status_sorted'], ['ok'] * 4)
+
+    rows = list(
+        csv.DictReader(
+            (job_dir / STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME).open(
+                encoding='utf-8'
+            )
+        )
+    )
+    assert [row['trace_shift_ms'] for row in rows] == [
+        '8.000000',
+        '4.000000',
+        '4.000000',
+        '0.000000',
+    ]
+
+
+def test_static_table_apply_reorders_original_headers_to_sorted_trace_shift(
+    tmp_path: Path,
+) -> None:
+    sorted_to_original = np.asarray([2, 0, 3, 1], dtype=np.int64)
+    state, _store = _write_target_store(
+        tmp_path,
+        sorted_to_original=sorted_to_original,
+    )
+    table_path = tmp_path / 'jobs' / TABLE_JOB_ID / 'canonical_static_table.csv'
+    _write_table(table_path)
+    _write_refraction_static_request(table_path.parent)
+    _create_table_job(state, tmp_path, table_path)
+    job_dir = tmp_path / 'jobs' / APPLY_JOB_ID
+    _create_apply_job(state, job_dir)
+    req = RefractionStaticTableApplyRequest.model_validate(
+        {
+            'file_id': SOURCE_FILE_ID,
+            'key1_byte': KEY1,
+            'key2_byte': KEY2,
+            'combined_table_artifact_id': f'{TABLE_JOB_ID}:{table_path.name}',
+            'register_corrected_file': False,
+        }
+    )
+
+    run_refraction_static_table_apply_job(APPLY_JOB_ID, req, state)
+
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    with np.load(job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME, allow_pickle=False) as data:
+        np.testing.assert_array_equal(data['sorted_trace_index'], sorted_to_original)
+        np.testing.assert_array_equal(
+            data['source_endpoint_id_sorted'],
+            ['100', '100', '101', '101'],
+        )
+        np.testing.assert_array_equal(
+            data['receiver_endpoint_id_sorted'],
+            ['201', '200', '201', '200'],
+        )
+        np.testing.assert_allclose(
+            data['trace_shift_s_sorted'],
+            [0.004, 0.008, 0.0, 0.004],
+        )
+
+
+def test_static_table_apply_imports_source_receiver_static_table_npz(
+    tmp_path: Path,
+) -> None:
+    state, _store = _write_target_store(tmp_path)
+    table_path = tmp_path / 'jobs' / TABLE_JOB_ID / SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME
+    _write_source_receiver_static_table_npz(table_path)
+    _write_refraction_static_request(table_path.parent)
+    _create_table_job(state, tmp_path, table_path, statics_kind='refraction')
+    job_dir = tmp_path / 'jobs' / APPLY_JOB_ID
+    _create_apply_job(state, job_dir)
+
+    req = RefractionStaticTableApplyRequest.model_validate(
+        {
+            'file_id': SOURCE_FILE_ID,
+            'key1_byte': KEY1,
+            'key2_byte': KEY2,
+            'combined_table_artifact_id': f'{TABLE_JOB_ID}:{table_path.name}',
+            'register_corrected_file': False,
+        }
+    )
+
+    run_refraction_static_table_apply_job(APPLY_JOB_ID, req, state)
+
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    with np.load(job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME, allow_pickle=False) as data:
+        np.testing.assert_allclose(
+            data['trace_shift_s_sorted'],
+            [0.008, 0.004, 0.004, 0.0],
+        )
+
+
+def test_static_table_apply_does_not_require_producer_geometry(
+    tmp_path: Path,
+) -> None:
+    state, _store, job_dir = _run_apply(tmp_path, write_producer_geometry=False)
+
+    with state.lock:
+        job = dict(state.jobs[APPLY_JOB_ID])
+    assert job['status'] == 'done'
+    assert (job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME).exists()
+
+
+def test_static_table_apply_uses_producer_geometry_when_request_omits_geometry(
+    tmp_path: Path,
+) -> None:
+    state, store = _write_target_store(tmp_path)
+    geometry = {
+        'source_id_byte': 109,
+        'receiver_id_byte': 113,
+        'source_x_byte': 173,
+        'source_y_byte': 177,
+        'receiver_x_byte': 181,
+        'receiver_y_byte': 185,
+        'source_elevation_byte': 145,
+        'receiver_elevation_byte': 141,
+        'coordinate_scalar_byte': 171,
+        'elevation_scalar_byte': 169,
+        'coordinate_unit': 'm',
+        'elevation_unit': 'm',
+    }
+    _write_header(store, 109, [300, 301, 300, 301])
+    _write_header(store, 113, [400, 400, 401, 401])
+    _write_header(store, 173, [3000, 3010, 3000, 3010])
+    _write_header(store, 177, [5000, 5000, 5000, 5000])
+    _write_header(store, 181, [3100, 3100, 3110, 3110])
+    _write_header(store, 185, [5000, 5000, 5000, 5000])
+    _write_header(store, 145, [30, 32, 30, 32])
+    _write_header(store, 141, [40, 40, 42, 42])
+    _write_header(store, 171, [1, 1, 1, 1])
+    _write_header(store, 169, [1, 1, 1, 1])
+
+    source_keys = {
+        300: _endpoint_key('source', 300, 3000.0, 5000.0, 30.0),
+        301: _endpoint_key('source', 301, 3010.0, 5000.0, 32.0),
+    }
+    receiver_keys = {
+        400: _endpoint_key('receiver', 400, 3100.0, 5000.0, 40.0),
+        401: _endpoint_key('receiver', 401, 3110.0, 5000.0, 42.0),
+    }
+    table_path = tmp_path / 'jobs' / TABLE_JOB_ID / 'canonical_static_table.csv'
+    rows = [
+        _canonical_row(
+            endpoint_kind='source',
+            endpoint_key=source_keys[300],
+            endpoint_id=300,
+            applied_shift_ms=8.0,
+        ),
+        _canonical_row(
+            endpoint_kind='source',
+            endpoint_key=source_keys[301],
+            endpoint_id=301,
+            applied_shift_ms=4.0,
+        ),
+        _canonical_row(
+            endpoint_kind='receiver',
+            endpoint_key=receiver_keys[400],
+            endpoint_id=400,
+            applied_shift_ms=0.0,
+        ),
+        _canonical_row(
+            endpoint_kind='receiver',
+            endpoint_key=receiver_keys[401],
+            endpoint_id=401,
+            applied_shift_ms=-4.0,
+        ),
+    ]
+    table_path.parent.mkdir(parents=True, exist_ok=True)
+    with table_path.open('w', encoding='utf-8', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=tuple(rows[0]), lineterminator='\n')
+        writer.writeheader()
+        writer.writerows(rows)
+    _write_refraction_static_request(table_path.parent, geometry=geometry)
+    _create_table_job(state, tmp_path, table_path, statics_kind='refraction')
+    job_dir = tmp_path / 'jobs' / APPLY_JOB_ID
+    _create_apply_job(state, job_dir)
+
+    req = RefractionStaticTableApplyRequest.model_validate(
+        {
+            'file_id': SOURCE_FILE_ID,
+            'key1_byte': KEY1,
+            'key2_byte': KEY2,
+            'combined_table_artifact_id': f'{TABLE_JOB_ID}:{table_path.name}',
+            'register_corrected_file': False,
+        }
+    )
+
+    run_refraction_static_table_apply_job(APPLY_JOB_ID, req, state)
+
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    with np.load(job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME, allow_pickle=False) as data:
+        np.testing.assert_array_equal(
+            data['source_endpoint_key_sorted'],
+            [source_keys[300], source_keys[301], source_keys[300], source_keys[301]],
+        )
+        np.testing.assert_allclose(
+            data['trace_shift_s_sorted'],
+            [0.008, 0.004, 0.004, 0.0],
+        )
+
+
+def test_static_table_apply_rejects_missing_source_static_by_default(
+    tmp_path: Path,
+) -> None:
+    state, _store, job_dir = _run_apply(tmp_path, include_source_101=False)
+
+    with state.lock:
+        job = dict(state.jobs[APPLY_JOB_ID])
+    assert job['status'] == 'error'
+    assert 'missing_source_static' in str(job['message'])
+    assert not (job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME).exists()
+
+
+def test_static_table_apply_zero_policy_allows_missing_static(tmp_path: Path) -> None:
+    state, _store, job_dir = _run_apply(
+        tmp_path,
+        include_source_101=False,
+        missing_static_policy='zero',
+        allow_missing_source_static=True,
+    )
+
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    with np.load(job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME, allow_pickle=False) as data:
+        np.testing.assert_allclose(
+            data['trace_shift_s_sorted'],
+            [0.008, 0.0, 0.004, -0.004],
+        )
+        assert data['trace_static_status_sorted'][1] == 'missing_source_static_zeroed'
+    qc = json.loads((job_dir / STATIC_TABLE_APPLY_QC_JSON_NAME).read_text())
+    assert qc['n_missing_source_endpoints'] == 1
+    assert qc['trace_static_status_counts']['missing_source_static_zeroed'] == 2
+
+
+def test_static_table_apply_registers_corrected_file(tmp_path: Path) -> None:
+    state, _store, job_dir = _run_apply(tmp_path, register_corrected_file=True)
+
+    with state.lock:
+        job = dict(state.jobs[APPLY_JOB_ID])
+    assert job['status'] == 'done', job.get('message')
+    corrected_file_id = job['corrected_file_id']
+    corrected_store_path = Path(str(job['corrected_store_path']))
+    assert state.file_registry.get_store_path(str(corrected_file_id)) == str(
+        corrected_store_path
+    )
+    assert (job_dir / CORRECTED_FILE_JSON_NAME).exists()
+    qc = json.loads((job_dir / STATIC_TABLE_APPLY_QC_JSON_NAME).read_text())
+    assert qc['corrected_file_id'] == corrected_file_id
+    assert CORRECTED_FILE_JSON_NAME in qc['artifact_names']
+
+    corrected = np.load(corrected_store_path / 'traces.npy')
+    assert [int(np.argmax(corrected[index])) for index in range(4)] == [10, 9, 9, 8]
+
+    corrected_meta = json.loads((corrected_store_path / 'meta.json').read_text())
+    assert corrected_meta['derived']['static_components_applied'] == ['refraction']
+
+
+def test_static_table_apply_history_checks_trace_store_lineage(
+    tmp_path: Path,
+) -> None:
+    state, _store, job_dir = _run_apply(
+        tmp_path,
+        lineage_components=['refraction'],
+    )
+
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    qc = json.loads((job_dir / STATIC_TABLE_APPLY_QC_JSON_NAME).read_text())
+    history = json.loads((job_dir / 'refraction_static_history.json').read_text())
+    assert qc['double_application_policy']['status'] == 'duplicate_warned'
+    assert qc['double_application_policy']['duplicate_components'] == ['refraction']
+    assert history['double_application_policy']['status'] == 'duplicate_warned'
+    assert 'double_application_policy=warn' in history['warnings'][0]
+
+
+def test_static_table_apply_double_application_policy_fail_rejects(
+    tmp_path: Path,
+) -> None:
+    state, _store, job_dir = _run_apply(
+        tmp_path,
+        lineage_components=['refraction'],
+        double_application_policy='fail',
+    )
+
+    with state.lock:
+        job = dict(state.jobs[APPLY_JOB_ID])
+    assert job['status'] == 'error'
+    assert 'double_application_policy=fail' in str(job['message'])
+    assert not (job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME).exists()
+
+
+def test_static_table_apply_trace_shift_matches_expected_synthetic(
+    tmp_path: Path,
+) -> None:
+    state, _store, job_dir = _run_apply(tmp_path, endpoint_id_matching=True)
+
+    with state.lock:
+        assert state.jobs[APPLY_JOB_ID]['status'] == 'done'
+    with np.load(job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME, allow_pickle=False) as data:
+        assert str(data['source_identity_mode']) == 'endpoint_id'
+        assert str(data['receiver_identity_mode']) == 'endpoint_id'
+        np.testing.assert_allclose(
+            data['source_static_shift_s_sorted'],
+            [0.008, 0.004, 0.008, 0.004],
+        )
+        np.testing.assert_allclose(
+            data['receiver_static_shift_s_sorted'],
+            [0.0, 0.0, -0.004, -0.004],
+        )
+        np.testing.assert_allclose(
+            data['trace_shift_s_sorted'],
+            [0.008, 0.004, 0.004, 0.0],
+        )
+
+
+def test_static_table_apply_endpoint_creates_job(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv('PIPELINE_JOBS_DIR', str(tmp_path / 'jobs'))
+    captured: dict[str, Any] = {}
+
+    def _capture_start_job_thread(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        _capture_start_job_thread,
+    )
+    with app.state.sv.lock:
+        app.state.sv.jobs.clear()
+        app.state.sv.cached_readers.clear()
+        app.state.sv.file_registry.clear()
+    with TestClient(app) as client:
+        response = client.post(
+            '/statics/refraction/static-table/apply',
+            json={
+                'file_id': SOURCE_FILE_ID,
+                'combined_table_artifact_id': 'table-job:canonical.csv',
+            },
+        )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['state'] == 'queued'
+    assert captured['target'] is run_refraction_static_table_apply_job
+    with app.state.sv.lock:
+        job = dict(app.state.sv.jobs[payload['job_id']])
+    assert job['statics_kind'] == 'refraction_static_table_apply'
+    with app.state.sv.lock:
+        app.state.sv.jobs.clear()
+        app.state.sv.cached_readers.clear()
+        app.state.sv.file_registry.clear()

--- a/app/tests/test_refraction_static_table_apply.py
+++ b/app/tests/test_refraction_static_table_apply.py
@@ -17,7 +17,9 @@ from app.services.refraction_static_export_units import (
     REFRACTION_STATIC_REPO_SIGN_CONVENTION,
 )
 from app.services.refraction_static_table_apply_service import (
+    STATIC_TABLE_APPLY_HISTORY_JSON_NAME,
     STATIC_TABLE_APPLY_QC_JSON_NAME,
+    STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME,
     STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME,
     STATIC_TABLE_APPLY_TRACE_SHIFTS_CSV_NAME,
     run_refraction_static_table_apply_job,
@@ -37,6 +39,7 @@ from app.tests.test_refraction_static_apply_trace_store import (
 
 TABLE_JOB_ID = 'static-table-import-job'
 APPLY_JOB_ID = 'static-table-apply-job'
+SECOND_APPLY_JOB_ID = 'static-table-apply-job-2'
 
 
 def _endpoint_key(
@@ -244,11 +247,17 @@ def _create_table_job(
         )
 
 
-def _create_apply_job(state: AppState, job_dir: Path) -> None:
+def _create_apply_job(
+    state: AppState,
+    job_dir: Path,
+    *,
+    job_id: str = APPLY_JOB_ID,
+    file_id: str = SOURCE_FILE_ID,
+) -> None:
     with state.lock:
         state.jobs.create_static_job(
-            APPLY_JOB_ID,
-            file_id=SOURCE_FILE_ID,
+            job_id,
+            file_id=file_id,
             key1_byte=KEY1,
             key2_byte=KEY2,
             statics_kind='refraction_static_table_apply',
@@ -316,6 +325,39 @@ def _write_source_lineage(store: Path, components: list[str]) -> None:
     meta_path.write_text(json.dumps(meta), encoding='utf-8')
 
 
+def _read_static_table_apply_history(job_dir: Path) -> dict[str, Any]:
+    return json.loads(
+        (job_dir / STATIC_TABLE_APPLY_HISTORY_JSON_NAME).read_text(
+            encoding='utf-8',
+        )
+    )
+
+
+def _rerun_same_table_against_file(
+    *,
+    state: AppState,
+    tmp_path: Path,
+    file_id: str,
+    allow_reapply_same_static_table: bool = False,
+) -> Path:
+    job_dir = tmp_path / 'jobs' / SECOND_APPLY_JOB_ID
+    _create_apply_job(state, job_dir, job_id=SECOND_APPLY_JOB_ID, file_id=file_id)
+    req = RefractionStaticTableApplyRequest.model_validate(
+        {
+            'file_id': file_id,
+            'key1_byte': KEY1,
+            'key2_byte': KEY2,
+            'combined_table_artifact_id': (
+                f'{TABLE_JOB_ID}:canonical_static_table.csv'
+            ),
+            'register_corrected_file': False,
+            'allow_reapply_same_static_table': allow_reapply_same_static_table,
+        }
+    )
+    run_refraction_static_table_apply_job(SECOND_APPLY_JOB_ID, req, state)
+    return job_dir
+
+
 def test_static_table_apply_maps_source_receiver_to_trace_shift(tmp_path: Path) -> None:
     state, _store, job_dir = _run_apply(tmp_path)
 
@@ -341,6 +383,83 @@ def test_static_table_apply_maps_source_receiver_to_trace_shift(tmp_path: Path) 
         '4.000000',
         '0.000000',
     ]
+
+
+def test_static_table_apply_writes_history(tmp_path: Path) -> None:
+    _state, _store, job_dir = _run_apply(tmp_path)
+
+    history = _read_static_table_apply_history(job_dir)
+    legacy_history = json.loads(
+        (job_dir / STATIC_TABLE_APPLY_REFRACTION_HISTORY_JSON_NAME).read_text(
+            encoding='utf-8',
+        )
+    )
+    assert legacy_history == history
+    assert history['source_table_digest'] is None
+    assert history['receiver_table_digest'] is None
+    assert len(history['combined_table_digest']) == 64
+    assert history['input_file_id'] == SOURCE_FILE_ID
+    assert history['output_file_id'] is None
+    assert history['applied_component_name'] == 'refraction'
+    assert len(history['trace_shift_s_sorted_digest']) == 64
+
+
+def test_static_table_apply_rejects_duplicate_table_digest(
+    tmp_path: Path,
+) -> None:
+    state, _store, _job_dir = _run_apply(tmp_path, register_corrected_file=True)
+    with state.lock:
+        corrected_file_id = str(state.jobs[APPLY_JOB_ID]['corrected_file_id'])
+
+    second_job_dir = _rerun_same_table_against_file(
+        state=state,
+        tmp_path=tmp_path,
+        file_id=corrected_file_id,
+    )
+
+    with state.lock:
+        job = dict(state.jobs[SECOND_APPLY_JOB_ID])
+    assert job['status'] == 'error'
+    assert 'allow_reapply_same_static_table=False' in str(job['message'])
+    assert not (second_job_dir / STATIC_TABLE_APPLY_SOLUTION_NPZ_NAME).exists()
+
+
+def test_static_table_apply_override_allows_reapply(tmp_path: Path) -> None:
+    state, _store, _job_dir = _run_apply(tmp_path, register_corrected_file=True)
+    with state.lock:
+        corrected_file_id = str(state.jobs[APPLY_JOB_ID]['corrected_file_id'])
+
+    second_job_dir = _rerun_same_table_against_file(
+        state=state,
+        tmp_path=tmp_path,
+        file_id=corrected_file_id,
+        allow_reapply_same_static_table=True,
+    )
+
+    with state.lock:
+        job = dict(state.jobs[SECOND_APPLY_JOB_ID])
+    assert job['status'] == 'done', job.get('message')
+    history = _read_static_table_apply_history(second_job_dir)
+    guard = history['static_table_reapply_guard']
+    assert history['allow_reapply_same_static_table'] is True
+    assert guard['status'] == 'duplicate_allowed_by_override'
+    assert guard['override_used'] is True
+    assert 'same_table_digest' in guard['duplicate_reasons']
+
+
+def test_static_table_history_records_source_job_id(tmp_path: Path) -> None:
+    _state, _store, job_dir = _run_apply(tmp_path)
+
+    history = _read_static_table_apply_history(job_dir)
+    assert history['created_from_refraction_job_id'] == 'refraction-source-job'
+    assert history['created_from_export_job_id'] == TABLE_JOB_ID
+
+
+def test_static_table_history_records_sign_convention(tmp_path: Path) -> None:
+    _state, _store, job_dir = _run_apply(tmp_path)
+
+    history = _read_static_table_apply_history(job_dir)
+    assert history['sign_convention'] == REFRACTION_STATIC_REPO_SIGN_CONVENTION
 
 
 def test_static_table_apply_reorders_original_headers_to_sorted_trace_shift(

--- a/app/tests/test_refraction_static_table_import.py
+++ b/app/tests/test_refraction_static_table_import.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from app.services.refraction_static_export_types import (
+    REFRACTION_STATIC_EXPORT_SIGN_CONVENTION,
+)
+from app.services.refraction_static_table_import import (
+    import_refraction_static_source_receiver_csvs,
+    import_refraction_static_table_csv,
+)
+
+
+def _canonical_row(
+    *,
+    endpoint_kind: str = 'source',
+    endpoint_key: str = 'source:1001',
+    endpoint_id: str = '1001',
+    applied_shift_ms: str | None = '12.5',
+    applied_shift_s: str | None = None,
+    static_status: str = 'ok',
+    sign_convention: str = REFRACTION_STATIC_EXPORT_SIGN_CONVENTION,
+    comment: str | None = None,
+) -> dict[str, str]:
+    row = {
+        'format_name': 'canonical_static_table',
+        'format_version': '1',
+        'source_job_id': 'refraction-job',
+        'endpoint_kind': endpoint_kind,
+        'endpoint_key': endpoint_key,
+        'endpoint_id': endpoint_id,
+        'static_status': static_status,
+        'sign_convention': sign_convention,
+    }
+    if applied_shift_ms is not None:
+        row['applied_shift_ms'] = applied_shift_ms
+    if applied_shift_s is not None:
+        row['applied_shift_s'] = applied_shift_s
+    if comment is not None:
+        row['comment'] = comment
+    return row
+
+
+def _write_csv(path: Path, rows: tuple[dict[str, str], ...]) -> None:
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open('w', encoding='utf-8', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator='\n')
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_import_combined_static_table_success(tmp_path: Path) -> None:
+    table_path = tmp_path / 'combined.csv'
+    _write_csv(
+        table_path,
+        (
+            _canonical_row(comment='reviewed source static'),
+            _canonical_row(
+                endpoint_kind='receiver',
+                endpoint_key='receiver:2001',
+                endpoint_id='2001',
+                applied_shift_ms='-3.25',
+            ),
+        ),
+    )
+
+    result = import_refraction_static_table_csv(table_path)
+
+    assert result.is_valid is True
+    assert result.n_source_rows == 1
+    assert result.n_receiver_rows == 1
+    assert result.errors == ()
+    assert result.sign_convention == REFRACTION_STATIC_EXPORT_SIGN_CONVENTION
+    assert result.source_static_by_endpoint_key['source:1001'].applied_shift_s == (
+        pytest.approx(0.0125)
+    )
+    assert result.source_static_by_endpoint_key['source:1001'].metadata['comment'] == (
+        'reviewed source static'
+    )
+    assert result.receiver_static_by_endpoint_key[
+        'receiver:2001'
+    ].applied_shift_s == pytest.approx(-0.00325)
+
+
+def test_import_separate_source_receiver_static_tables_success(tmp_path: Path) -> None:
+    source_path = tmp_path / 'source.csv'
+    receiver_path = tmp_path / 'receiver.csv'
+    _write_csv(source_path, (_canonical_row(applied_shift_ms='10.0'),))
+    _write_csv(
+        receiver_path,
+        (
+            _canonical_row(
+                endpoint_kind='receiver',
+                endpoint_key='receiver:2001',
+                endpoint_id='2001',
+                applied_shift_ms=None,
+                applied_shift_s='-0.0025',
+            ),
+        ),
+    )
+
+    result = import_refraction_static_source_receiver_csvs(
+        source_table_path=source_path,
+        receiver_table_path=receiver_path,
+    )
+
+    assert result.is_valid is True
+    assert tuple(result.source_static_by_endpoint_key) == ('source:1001',)
+    assert tuple(result.receiver_static_by_endpoint_key) == ('receiver:2001',)
+    assert result.source_static_by_endpoint_key['source:1001'].source_name == (
+        'source.csv'
+    )
+    assert result.receiver_static_by_endpoint_key['receiver:2001'].source_name == (
+        'receiver.csv'
+    )
+    assert result.receiver_static_by_endpoint_key[
+        'receiver:2001'
+    ].applied_shift_s == pytest.approx(-0.0025)
+
+
+def test_import_static_table_normalizes_to_seconds(tmp_path: Path) -> None:
+    table_path = tmp_path / 'seconds.csv'
+    _write_csv(
+        table_path,
+        (
+            _canonical_row(
+                applied_shift_ms=None,
+                applied_shift_s='0.125',
+            ),
+        ),
+    )
+
+    result = import_refraction_static_table_csv(table_path)
+
+    assert result.is_valid is True
+    assert result.source_static_by_endpoint_key['source:1001'].applied_shift_s == (
+        pytest.approx(0.125)
+    )
+
+
+def test_import_static_table_rejects_duplicate_endpoint_keys(tmp_path: Path) -> None:
+    table_path = tmp_path / 'duplicates.csv'
+    _write_csv(
+        table_path,
+        (
+            _canonical_row(endpoint_key='source:duplicate', endpoint_id='1001'),
+            _canonical_row(endpoint_key='source:duplicate', endpoint_id='1002'),
+        ),
+    )
+
+    result = import_refraction_static_table_csv(table_path)
+
+    assert result.is_valid is False
+    assert result.source_static_by_endpoint_key == {}
+    assert any('duplicate endpoint_key for source' in error for error in result.errors)
+
+
+def test_import_static_table_rejects_bad_sign_convention(tmp_path: Path) -> None:
+    table_path = tmp_path / 'bad-sign.csv'
+    _write_csv(
+        table_path,
+        (
+            _canonical_row(sign_convention='delay_positive_ms'),
+        ),
+    )
+
+    result = import_refraction_static_table_csv(table_path)
+
+    assert result.is_valid is False
+    assert result.receiver_static_by_endpoint_key == {}
+    assert any('sign_convention must be' in error for error in result.errors)

--- a/app/tests/test_refraction_static_table_import.py
+++ b/app/tests/test_refraction_static_table_import.py
@@ -44,6 +44,32 @@ def _canonical_row(
     return row
 
 
+def _documented_static_row(
+    *,
+    endpoint_kind: str,
+    endpoint_key: str,
+    endpoint_id: str,
+    total_applied_shift_ms: str,
+) -> dict[str, str]:
+    prefix = endpoint_kind
+    return {
+        'endpoint_kind': endpoint_kind,
+        f'{prefix}_endpoint_key': endpoint_key,
+        f'{prefix}_id': endpoint_id,
+        f'{prefix}_node_id': endpoint_id,
+        'x_m': '1000.000',
+        'y_m': '2000.000',
+        'surface_elevation_m': '10.000',
+        't1_ms': '50.000000',
+        'v1_m_s': '800.000',
+        'v2_m_s': '2400.000',
+        'total_static_ms': total_applied_shift_ms,
+        'total_applied_shift_ms': total_applied_shift_ms,
+        'static_status': 'ok',
+        'sign_convention': REFRACTION_STATIC_EXPORT_SIGN_CONVENTION,
+    }
+
+
 def _write_csv(path: Path, rows: tuple[dict[str, str], ...]) -> None:
     fieldnames: list[str] = []
     for row in rows:
@@ -123,6 +149,52 @@ def test_import_separate_source_receiver_static_tables_success(tmp_path: Path) -
     assert result.receiver_static_by_endpoint_key[
         'receiver:2001'
     ].applied_shift_s == pytest.approx(-0.0025)
+
+
+def test_import_documented_source_receiver_static_tables_success(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / 'source_static_table.csv'
+    receiver_path = tmp_path / 'receiver_static_table.csv'
+    _write_csv(
+        source_path,
+        (
+            _documented_static_row(
+                endpoint_kind='source',
+                endpoint_key='source:1001',
+                endpoint_id='1001',
+                total_applied_shift_ms='12.5',
+            ),
+        ),
+    )
+    _write_csv(
+        receiver_path,
+        (
+            _documented_static_row(
+                endpoint_kind='receiver',
+                endpoint_key='receiver:2001',
+                endpoint_id='2001',
+                total_applied_shift_ms='-3.25',
+            ),
+        ),
+    )
+
+    result = import_refraction_static_source_receiver_csvs(
+        source_table_path=source_path,
+        receiver_table_path=receiver_path,
+        source_job_id='refraction-source-job',
+    )
+
+    assert result.is_valid is True
+    assert result.source_static_by_endpoint_key['source:1001'].applied_shift_s == (
+        pytest.approx(0.0125)
+    )
+    assert result.receiver_static_by_endpoint_key[
+        'receiver:2001'
+    ].applied_shift_s == pytest.approx(-0.00325)
+    assert result.source_static_by_endpoint_key['source:1001'].source_job_id == (
+        'refraction-source-job'
+    )
 
 
 def test_import_static_table_normalizes_to_seconds(tmp_path: Path) -> None:

--- a/docs/statics/refraction_multilayer_time_term.md
+++ b/docs/statics/refraction_multilayer_time_term.md
@@ -507,6 +507,7 @@ refraction_static_qc.json
 refraction_statics.csv
 near_surface_model.csv
 first_break_residuals.csv
+refraction_first_break_time_export.csv
 refraction_static_components.csv
 source_static_table.csv
 receiver_static_table.csv


### PR DESCRIPTION
Closes #506
Closes #507
Closes #508
Closes #509

## Issues
- #506 [statics][refraction][m5] Add first-break observed/modeled/residual export
- #507 [statics][refraction][m5] Implement static table import and normalization service
- #508 [statics][refraction][m5] Add standalone static-table apply API for TraceStore
- #509 [statics][refraction][m5] Add static history and double-application guard for static-table workflows  ## Background

Batch range: #506-#509
