### PR TITLE
Batch: address issues #518-#520

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -2813,6 +2813,18 @@ class RefractionStaticExportRequest(BaseModel):
             raise ValueError('export.rounding_ms must be finite and >= 0')
         return rounded
 
+    @model_validator(mode='after')
+    def _check_supported_export_options(self) -> 'RefractionStaticExportRequest':
+        if self.units != 'milliseconds':
+            raise ValueError('export.units must be "milliseconds"')
+        if self.rounding_ms not in (None, 0.001):
+            raise ValueError(
+                'export.rounding_ms is reserved and must be null or 0.001'
+            )
+        if not self.include_legacy_alias_columns:
+            raise ValueError('export.include_legacy_alias_columns must be true')
+        return self
+
 
 class RefractionStaticApplyRequest(BaseModel):
     """Request model for ``/statics/refraction/apply`` jobs."""

--- a/app/services/refraction_static_export_service.py
+++ b/app/services/refraction_static_export_service.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 from app.api.schemas import (
     REFRACTION_STATIC_DEFAULT_EXPORT_FORMATS,
+    RefractionStaticApplyRequest,
     RefractionStaticExportFormat,
     RefractionStaticExportJobRequest,
     RefractionStaticExportRequest,
@@ -44,10 +45,24 @@ from app.services.refraction_static_lsst_export import (
     write_refraction_lsst_csv,
     write_refraction_lsst_plus_csv,
 )
+from app.services.refraction_static_table_validator import (
+    CANONICAL_STATIC_TABLE_FORMAT_NAME,
+    CANONICAL_STATIC_TABLE_FORMAT_VERSION,
+    CANONICAL_STATIC_TABLE_OPTIONAL_COLUMNS,
+    CANONICAL_STATIC_TABLE_REQUIRED_COLUMNS,
+)
 
 REFRACTION_STATIC_EXPORT_REQUEST_JSON_NAME = 'refraction_static_export_request.json'
 REFRACTION_STATIC_EXPORT_JOB_META_JSON_NAME = 'job_meta.json'
 REFRACTION_STATIC_EXPORT_DONE_MESSAGE = 'refraction_static_export_artifacts_written'
+CANONICAL_SOURCE_STATIC_TABLE_CSV_NAME = 'canonical_source_static_table.csv'
+CANONICAL_RECEIVER_STATIC_TABLE_CSV_NAME = 'canonical_receiver_static_table.csv'
+CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME = (
+    'canonical_source_receiver_static_table.csv'
+)
+_CANONICAL_STATIC_TABLE_COLUMNS = (
+    CANONICAL_STATIC_TABLE_REQUIRED_COLUMNS + CANONICAL_STATIC_TABLE_OPTIONAL_COLUMNS
+)
 
 _BASE_SOURCE_ARTIFACTS = (
     REFRACTION_STATIC_REQUEST_JSON_NAME,
@@ -310,6 +325,14 @@ def _generated_refraction_static_export_artifacts(
     requested_formats: tuple[RefractionStaticExportFormat, ...],
 ) -> tuple[str, ...]:
     names: list[str] = []
+    if 'canonical_static_table' in requested_formats:
+        names.extend(
+            (
+                CANONICAL_SOURCE_STATIC_TABLE_CSV_NAME,
+                CANONICAL_RECEIVER_STATIC_TABLE_CSV_NAME,
+                CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME,
+            )
+        )
     if 'time_term_spreadsheet' in requested_formats:
         names.append(REFRACTION_TIME_TERM_SPREADSHEET_CSV_NAME)
     if 'lsst' in requested_formats:
@@ -327,6 +350,15 @@ def _write_requested_export_artifacts(
     req: RefractionStaticExportJobRequest,
     source: ResolvedRefractionStaticExportSourceJob,
 ) -> None:
+    if 'canonical_static_table' in source.requested_formats:
+        _write_canonical_static_table_exports(
+            source=source,
+            job_dir=job_dir,
+            fail_on_invalid_static_status=bool(
+                req.export.fail_on_invalid_static_status
+            ),
+            include_inactive_endpoints=bool(req.export.include_inactive_endpoints),
+        )
     if 'time_term_spreadsheet' in source.requested_formats:
         _write_time_term_spreadsheet_export(
             source=source,
@@ -359,6 +391,192 @@ def _write_requested_export_artifacts(
             ),
             include_inactive_endpoints=bool(req.export.include_inactive_endpoints),
         )
+
+
+def write_inline_refraction_static_export_artifacts(
+    *,
+    job_id: str,
+    req: RefractionStaticApplyRequest,
+    job_dir: Path,
+) -> None:
+    """Write requested M5 export artifacts from the current apply job outputs."""
+    requested_formats = resolve_refraction_static_export_formats(req.export)
+    if not requested_formats:
+        return
+    source = ResolvedRefractionStaticExportSourceJob(
+        source_job_id=job_id,
+        source_file_id=req.file_id,
+        key1_byte=req.key1_byte,
+        key2_byte=req.key2_byte,
+        source_artifacts_dir=Path(job_dir),
+        requested_formats=requested_formats,
+        required_source_artifacts=required_refraction_static_export_source_artifacts(
+            requested_formats,
+        ),
+    )
+    _write_requested_export_artifacts(
+        job_dir=Path(job_dir),
+        req=RefractionStaticExportJobRequest(
+            source_job_id=job_id,
+            export=req.export,
+        ),
+        source=source,
+    )
+
+
+def _write_canonical_static_table_exports(
+    *,
+    source: ResolvedRefractionStaticExportSourceJob,
+    job_dir: Path,
+    fail_on_invalid_static_status: bool,
+    include_inactive_endpoints: bool,
+) -> None:
+    source_rows = _canonical_static_table_rows(
+        _load_static_table_rows(source.source_artifacts_dir / SOURCE_STATIC_TABLE_CSV_NAME),
+        endpoint_kind='source',
+        source_job_id=source.source_job_id,
+        fail_on_invalid_static_status=fail_on_invalid_static_status,
+        include_inactive_endpoints=include_inactive_endpoints,
+    )
+    receiver_rows = _canonical_static_table_rows(
+        _load_static_table_rows(
+            source.source_artifacts_dir / RECEIVER_STATIC_TABLE_CSV_NAME,
+        ),
+        endpoint_kind='receiver',
+        source_job_id=source.source_job_id,
+        fail_on_invalid_static_status=fail_on_invalid_static_status,
+        include_inactive_endpoints=include_inactive_endpoints,
+    )
+    root = Path(job_dir)
+    _write_canonical_static_table_csv(
+        root / CANONICAL_SOURCE_STATIC_TABLE_CSV_NAME,
+        source_rows,
+    )
+    _write_canonical_static_table_csv(
+        root / CANONICAL_RECEIVER_STATIC_TABLE_CSV_NAME,
+        receiver_rows,
+    )
+    _write_canonical_static_table_csv(
+        root / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME,
+        source_rows + receiver_rows,
+    )
+
+
+def _canonical_static_table_rows(
+    rows: tuple[dict[str, str | None], ...],
+    *,
+    endpoint_kind: RefractionStaticEndpointKind,
+    source_job_id: str,
+    fail_on_invalid_static_status: bool,
+    include_inactive_endpoints: bool,
+) -> tuple[dict[str, str], ...]:
+    out: list[dict[str, str]] = []
+    for row in rows:
+        if row.get('sign_convention') != REFRACTION_STATIC_REPO_SIGN_CONVENTION:
+            raise RefractionStaticExportValidationError(
+                f'{endpoint_kind} static table sign_convention must be '
+                f'{REFRACTION_STATIC_REPO_SIGN_CONVENTION!r}'
+            )
+        if row.get('endpoint_kind') != endpoint_kind:
+            raise RefractionStaticExportValidationError(
+                f'{endpoint_kind} static table contains endpoint_kind '
+                f'{row.get("endpoint_kind")!r}'
+            )
+        prefix = 'source' if endpoint_kind == 'source' else 'receiver'
+        endpoint_key = _required_row_text(row, f'{prefix}_endpoint_key')
+        status = _required_row_text(row, 'static_status')
+        if not _include_static_table_row_for_canonical_export(
+            endpoint_kind=endpoint_kind,
+            endpoint_key=endpoint_key,
+            static_status=status,
+            fail_on_invalid_static_status=fail_on_invalid_static_status,
+            include_inactive_endpoints=include_inactive_endpoints,
+        ):
+            continue
+        out.append(
+            _canonical_static_table_row(
+                row,
+                endpoint_kind=endpoint_kind,
+                source_job_id=source_job_id,
+                endpoint_key=endpoint_key,
+                static_status=status,
+            )
+        )
+    return tuple(out)
+
+
+def _include_static_table_row_for_canonical_export(
+    *,
+    endpoint_kind: RefractionStaticEndpointKind,
+    endpoint_key: str,
+    static_status: str,
+    fail_on_invalid_static_status: bool,
+    include_inactive_endpoints: bool,
+) -> bool:
+    if static_status == 'ok':
+        return True
+    if fail_on_invalid_static_status:
+        raise RefractionStaticExportValidationError(
+            f'{endpoint_kind} endpoint {endpoint_key!r} has invalid '
+            f'static_status {static_status!r}'
+        )
+    return include_inactive_endpoints
+
+
+def _canonical_static_table_row(
+    row: dict[str, str | None],
+    *,
+    endpoint_kind: RefractionStaticEndpointKind,
+    source_job_id: str,
+    endpoint_key: str,
+    static_status: str,
+) -> dict[str, str]:
+    prefix = 'source' if endpoint_kind == 'source' else 'receiver'
+    out = {column: '' for column in _CANONICAL_STATIC_TABLE_COLUMNS}
+    out.update(
+        {
+            'format_name': CANONICAL_STATIC_TABLE_FORMAT_NAME,
+            'format_version': str(CANONICAL_STATIC_TABLE_FORMAT_VERSION),
+            'source_job_id': source_job_id,
+            'endpoint_kind': endpoint_kind,
+            'endpoint_key': endpoint_key,
+            'endpoint_id': _optional_row_text(row.get(f'{prefix}_id')) or '',
+            'applied_shift_ms': _optional_row_text(
+                row.get('total_applied_shift_ms')
+            )
+            or '',
+            'static_status': static_status,
+            'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+            'node_id': _optional_row_text(row.get(f'{prefix}_node_id')) or '',
+        }
+    )
+    for column in CANONICAL_STATIC_TABLE_OPTIONAL_COLUMNS:
+        value = _optional_row_text(row.get(column))
+        if value is not None:
+            out[column] = value
+    return out
+
+
+def _write_canonical_static_table_csv(
+    path: Path,
+    rows: tuple[dict[str, str], ...],
+) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = target.with_name(f'{target.name}.{uuid4().hex}.tmp')
+    try:
+        with tmp_path.open('w', encoding='utf-8', newline='') as handle:
+            writer = csv.DictWriter(
+                handle,
+                fieldnames=list(_CANONICAL_STATIC_TABLE_COLUMNS),
+                lineterminator='\n',
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+        tmp_path.replace(target)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def _write_time_term_spreadsheet_export(
@@ -584,6 +802,9 @@ def _handle_refraction_static_export_job_error(_exc: Exception) -> JobFailure:
 
 
 __all__ = [
+    'CANONICAL_RECEIVER_STATIC_TABLE_CSV_NAME',
+    'CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME',
+    'CANONICAL_SOURCE_STATIC_TABLE_CSV_NAME',
     'REFRACTION_STATIC_EXPORT_DONE_MESSAGE',
     'REFRACTION_STATIC_EXPORT_JOB_META_JSON_NAME',
     'REFRACTION_STATIC_EXPORT_REQUEST_JSON_NAME',
@@ -594,4 +815,5 @@ __all__ = [
     'resolve_refraction_static_export_formats',
     'run_refraction_static_export_job',
     'validate_refraction_static_export_source_job',
+    'write_inline_refraction_static_export_artifacts',
 ]

--- a/app/services/refraction_static_export_service.py
+++ b/app/services/refraction_static_export_service.py
@@ -302,13 +302,18 @@ def _refraction_static_export_job_payload(
         'export': {
             'enabled': bool(req.export.enabled),
             'requested_formats': list(source.requested_formats),
-            'units': req.export.units,
+            'units': 'milliseconds',
+            'unit_policy': 'milliseconds_only',
+            'time_column_suffix': '_ms',
             'rounding_ms': req.export.rounding_ms,
+            'rounding_ms_policy': 'reserved_no_op',
+            'numeric_csv_precision': 'format_schema_fixed',
             'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION,
             'include_inactive_endpoints': bool(req.export.include_inactive_endpoints),
             'include_legacy_alias_columns': bool(
                 req.export.include_legacy_alias_columns
             ),
+            'legacy_alias_columns_policy': 'required_true',
             'fail_on_invalid_static_status': bool(
                 req.export.fail_on_invalid_static_status
             ),

--- a/app/services/refraction_static_export_service.py
+++ b/app/services/refraction_static_export_service.py
@@ -40,9 +40,13 @@ from app.services.refraction_static_export_types import (
     RefractionStaticExportBundle,
 )
 from app.services.refraction_static_lsst_export import (
+    REFRACTION_LSST_CARDS_TXT_NAME,
     REFRACTION_LSST_CSV_NAME,
+    REFRACTION_LSST_PLUS_CARDS_TXT_NAME,
     REFRACTION_LSST_PLUS_CSV_NAME,
+    write_refraction_lsst_cards_txt,
     write_refraction_lsst_csv,
+    write_refraction_lsst_plus_cards_txt,
     write_refraction_lsst_plus_csv,
 )
 from app.services.refraction_static_table_validator import (
@@ -342,8 +346,10 @@ def _generated_refraction_static_export_artifacts(
         names.append(REFRACTION_TIME_TERM_SPREADSHEET_CSV_NAME)
     if 'lsst' in requested_formats:
         names.append(REFRACTION_LSST_CSV_NAME)
+        names.append(REFRACTION_LSST_CARDS_TXT_NAME)
     if 'lsst_plus' in requested_formats:
         names.append(REFRACTION_LSST_PLUS_CSV_NAME)
+        names.append(REFRACTION_LSST_PLUS_CARDS_TXT_NAME)
     if 'first_break_time' in requested_formats:
         names.append(REFRACTION_FIRST_BREAK_TIME_EXPORT_CSV_NAME)
     return tuple(names)
@@ -387,10 +393,26 @@ def _write_requested_export_artifacts(
             ),
             include_inactive_endpoints=bool(req.export.include_inactive_endpoints),
         )
+        write_refraction_lsst_cards_txt(
+            bundle,
+            job_dir / REFRACTION_LSST_CARDS_TXT_NAME,
+            fail_on_invalid_static_status=bool(
+                req.export.fail_on_invalid_static_status
+            ),
+            include_inactive_endpoints=bool(req.export.include_inactive_endpoints),
+        )
     if 'lsst_plus' in source.requested_formats:
         write_refraction_lsst_plus_csv(
             bundle,
             job_dir / REFRACTION_LSST_PLUS_CSV_NAME,
+            fail_on_invalid_static_status=bool(
+                req.export.fail_on_invalid_static_status
+            ),
+            include_inactive_endpoints=bool(req.export.include_inactive_endpoints),
+        )
+        write_refraction_lsst_plus_cards_txt(
+            bundle,
+            job_dir / REFRACTION_LSST_PLUS_CARDS_TXT_NAME,
             fail_on_invalid_static_status=bool(
                 req.export.fail_on_invalid_static_status
             ),

--- a/app/services/refraction_static_lsst_export.py
+++ b/app/services/refraction_static_lsst_export.py
@@ -19,9 +19,11 @@ from app.services.refraction_static_export_units import (
 )
 
 REFRACTION_LSST_CSV_NAME: Final = 'refraction_lsst.csv'
+REFRACTION_LSST_CARDS_TXT_NAME: Final = 'refraction_lsst_cards.txt'
 REFRACTION_LSST_FORMAT_NAME: Final = 'lsst'
 REFRACTION_LSST_FORMAT_VERSION: Final = 1
 REFRACTION_LSST_PLUS_CSV_NAME: Final = 'refraction_lsst_plus.csv'
+REFRACTION_LSST_PLUS_CARDS_TXT_NAME: Final = 'refraction_lsst_plus_cards.txt'
 REFRACTION_LSST_PLUS_FORMAT_NAME: Final = 'lsst_plus'
 REFRACTION_LSST_PLUS_FORMAT_VERSION: Final = 1
 
@@ -123,6 +125,41 @@ def write_refraction_lsst_csv(
     Path(path).write_text(text, encoding='utf-8')
 
 
+def format_refraction_lsst_cards_txt(
+    bundle: RefractionStaticExportBundle,
+    *,
+    fail_on_invalid_static_status: bool = True,
+    include_inactive_endpoints: bool = False,
+) -> str:
+    """Format endpoint rows as deterministic repo-owned LSST card text."""
+    _validate_bundle(bundle)
+    rows = _included_rows(
+        bundle,
+        fail_on_invalid_static_status=fail_on_invalid_static_status,
+        include_inactive_endpoints=include_inactive_endpoints,
+    )
+    lines = _card_header(format_name=REFRACTION_LSST_FORMAT_NAME)
+    for row in rows:
+        lines.extend(_lsst_card_lines(row))
+    return '\n'.join(lines) + '\n'
+
+
+def write_refraction_lsst_cards_txt(
+    bundle: RefractionStaticExportBundle,
+    path: Path,
+    *,
+    fail_on_invalid_static_status: bool = True,
+    include_inactive_endpoints: bool = False,
+) -> None:
+    """Write deterministic repo-owned LSST card text to ``path``."""
+    text = format_refraction_lsst_cards_txt(
+        bundle,
+        fail_on_invalid_static_status=fail_on_invalid_static_status,
+        include_inactive_endpoints=include_inactive_endpoints,
+    )
+    Path(path).write_text(text, encoding='utf-8')
+
+
 def format_refraction_lsst_plus_csv(
     bundle: RefractionStaticExportBundle,
     *,
@@ -158,6 +195,41 @@ def write_refraction_lsst_plus_csv(
 ) -> None:
     """Write documented M5 LSST+ CSV text to ``path``."""
     text = format_refraction_lsst_plus_csv(
+        bundle,
+        fail_on_invalid_static_status=fail_on_invalid_static_status,
+        include_inactive_endpoints=include_inactive_endpoints,
+    )
+    Path(path).write_text(text, encoding='utf-8')
+
+
+def format_refraction_lsst_plus_cards_txt(
+    bundle: RefractionStaticExportBundle,
+    *,
+    fail_on_invalid_static_status: bool = False,
+    include_inactive_endpoints: bool = True,
+) -> str:
+    """Format endpoint rows as deterministic repo-owned LSST+ card text."""
+    _validate_bundle(bundle)
+    rows = _included_rows(
+        bundle,
+        fail_on_invalid_static_status=fail_on_invalid_static_status,
+        include_inactive_endpoints=include_inactive_endpoints,
+    )
+    lines = _card_header(format_name=REFRACTION_LSST_PLUS_FORMAT_NAME)
+    for row in rows:
+        lines.extend(_lsst_plus_card_lines(row))
+    return '\n'.join(lines) + '\n'
+
+
+def write_refraction_lsst_plus_cards_txt(
+    bundle: RefractionStaticExportBundle,
+    path: Path,
+    *,
+    fail_on_invalid_static_status: bool = False,
+    include_inactive_endpoints: bool = True,
+) -> None:
+    """Write deterministic repo-owned LSST+ card text to ``path``."""
+    text = format_refraction_lsst_plus_cards_txt(
         bundle,
         fail_on_invalid_static_status=fail_on_invalid_static_status,
         include_inactive_endpoints=include_inactive_endpoints,
@@ -203,6 +275,298 @@ def _included_rows(
             )
         )
     return tuple(rows)
+
+
+def _card_header(*, format_name: str) -> list[str]:
+    return [
+        f'# format={format_name}',
+        '# schema_version=1',
+        f'# sign_convention={REFRACTION_STATIC_REPO_SIGN_CONVENTION}',
+        '# units=ms',
+        '# missing_values=omit',
+    ]
+
+
+def _lsst_card_lines(row: RefractionStaticEndpointExportRow) -> list[str]:
+    status = _required_static_status(row)
+    valid = status == 'ok'
+    if row.endpoint_kind == 'source':
+        cards = (
+            ('SDT1', 'time', row.t1_s, True),
+            ('SSTAT', 'time', row.total_applied_shift_s, True),
+            ('SVW', 'velocity', row.v1_m_s, True),
+            ('SVV2', 'velocity', row.v2_m_s, True),
+            ('SDT2', 'time', row.t2_s, False),
+            ('SDT3', 'time', row.t3_s, False),
+            ('SVV3', 'velocity', row.v3_m_s, False),
+            ('SVSB', 'velocity', row.vsub_m_s, False),
+        )
+    else:
+        cards = (
+            ('RDT1', 'time', row.t1_s, True),
+            ('RSTAT', 'time', row.total_applied_shift_s, True),
+            ('RVW', 'velocity', row.v1_m_s, True),
+            ('RVV2', 'velocity', row.v2_m_s, True),
+            ('RDT2', 'time', row.t2_s, False),
+            ('RDT3', 'time', row.t3_s, False),
+            ('RVV3', 'velocity', row.v3_m_s, False),
+            ('RVSB', 'velocity', row.vsub_m_s, False),
+        )
+    endpoint_key = _format_text(
+        row.endpoint_key,
+        required=True,
+        row=row,
+        field_name='endpoint_key',
+    )
+    lines: list[str] = []
+    for card_name, value_kind, value, required_for_ok in cards:
+        formatted = _format_card_value(
+            value,
+            value_kind=value_kind,
+            required=valid and required_for_ok,
+            row=row,
+            field_name=card_name,
+        )
+        if formatted:
+            lines.append(f'{card_name} {endpoint_key} {formatted}')
+    return lines
+
+
+def _lsst_plus_card_lines(row: RefractionStaticEndpointExportRow) -> list[str]:
+    status = _required_static_status(row)
+    valid = status == 'ok'
+    endpoint_key = _format_text(
+        row.endpoint_key,
+        required=True,
+        row=row,
+        field_name='endpoint_key',
+    )
+    endpoint_card = 'SRC' if row.endpoint_kind == 'source' else 'REC'
+    lines = [
+        _card_row(
+            endpoint_card,
+            endpoint_key,
+            _card_named_value(
+                'station',
+                row.station_id,
+                value_kind='text',
+                required=False,
+                row=row,
+                field_name='station_id',
+            ),
+            _card_named_value(
+                'x',
+                row.x_m,
+                value_kind='m',
+                required=valid,
+                row=row,
+                field_name='x_m',
+            ),
+            _card_named_value(
+                'y',
+                row.y_m,
+                value_kind='m',
+                required=valid,
+                row=row,
+                field_name='y_m',
+            ),
+            _card_named_value(
+                'elev',
+                row.elevation_m,
+                value_kind='m',
+                required=valid,
+                row=row,
+                field_name='elevation_m',
+            ),
+            f'status={status}',
+        )
+    ]
+    lines.append(
+        _card_row(
+            'STC',
+            row.endpoint_kind,
+            endpoint_key,
+            _card_named_value(
+                'total',
+                row.total_applied_shift_s,
+                value_kind='time',
+                required=valid,
+                row=row,
+                field_name='total_applied_shift_ms',
+            ),
+            _card_named_value(
+                'weathering',
+                row.weathering_correction_s,
+                value_kind='time',
+                required=valid,
+                row=row,
+                field_name='weathering_correction_ms',
+            ),
+            _card_named_value(
+                'elevation',
+                row.elevation_correction_s,
+                value_kind='time',
+                required=valid,
+                row=row,
+                field_name='elevation_correction_ms',
+            ),
+            _card_named_value(
+                'field',
+                row.field_correction_s,
+                value_kind='time',
+                required=False,
+                row=row,
+                field_name='field_correction_ms',
+            ),
+            _card_named_value(
+                'manual',
+                row.manual_static_shift_s,
+                value_kind='time',
+                required=False,
+                row=row,
+                field_name='manual_static_ms',
+            ),
+        )
+    )
+    lines.append(
+        _card_row(
+            'LYR',
+            row.endpoint_kind,
+            endpoint_key,
+            _card_named_value(
+                't1',
+                row.t1_s,
+                value_kind='time',
+                required=valid,
+                row=row,
+                field_name='t1_ms',
+            ),
+            _card_named_value(
+                't2',
+                row.t2_s,
+                value_kind='time',
+                required=False,
+                row=row,
+                field_name='t2_ms',
+            ),
+            _card_named_value(
+                't3',
+                row.t3_s,
+                value_kind='time',
+                required=False,
+                row=row,
+                field_name='t3_ms',
+            ),
+            _card_named_value(
+                'sh1',
+                row.sh1_m,
+                value_kind='m',
+                required=valid,
+                row=row,
+                field_name='sh1_m',
+            ),
+            _card_named_value(
+                'sh2',
+                row.sh2_m,
+                value_kind='m',
+                required=False,
+                row=row,
+                field_name='sh2_m',
+            ),
+            _card_named_value(
+                'sh3',
+                row.sh3_m,
+                value_kind='m',
+                required=False,
+                row=row,
+                field_name='sh3_m',
+            ),
+            _card_named_value(
+                'v1',
+                row.v1_m_s,
+                value_kind='velocity',
+                required=valid,
+                row=row,
+                field_name='v1_m_s',
+            ),
+            _card_named_value(
+                'v2',
+                row.v2_m_s,
+                value_kind='velocity',
+                required=valid,
+                row=row,
+                field_name='v2_m_s',
+            ),
+            _card_named_value(
+                'v3',
+                row.v3_m_s,
+                value_kind='velocity',
+                required=False,
+                row=row,
+                field_name='v3_m_s',
+            ),
+            _card_named_value(
+                'vsub',
+                row.vsub_m_s,
+                value_kind='velocity',
+                required=False,
+                row=row,
+                field_name='vsub_m_s',
+            ),
+        )
+    )
+    return lines
+
+
+def _card_row(*parts: str) -> str:
+    return ' '.join(part for part in parts if part)
+
+
+def _card_named_value(
+    name: str,
+    value: object,
+    *,
+    value_kind: str,
+    required: bool,
+    row: RefractionStaticEndpointExportRow,
+    field_name: str,
+) -> str:
+    formatted = _format_card_value(
+        value,
+        value_kind=value_kind,
+        required=required,
+        row=row,
+        field_name=field_name,
+    )
+    if not formatted:
+        return ''
+    return f'{name}={formatted}'
+
+
+def _format_card_value(
+    value: object,
+    *,
+    value_kind: str,
+    required: bool,
+    row: RefractionStaticEndpointExportRow,
+    field_name: str,
+) -> str:
+    if value_kind == 'time':
+        return _format_time_ms(value, required=required, row=row, field_name=field_name)
+    if value_kind == 'm':
+        return _format_m(value, required=required, row=row, field_name=field_name)
+    if value_kind == 'velocity':
+        return _format_velocity(
+            value,
+            required=required,
+            row=row,
+            field_name=field_name,
+        )
+    if value_kind == 'text':
+        return _format_text(value, required=required, row=row, field_name=field_name)
+    raise RefractionStaticLsstExportError(
+        f'{_row_label(row)} unknown LSST card value kind {value_kind!r}'
+    )
 
 
 def _include_row(
@@ -673,10 +1037,12 @@ def _row_label(row: RefractionStaticEndpointExportRow) -> str:
 
 
 __all__ = [
+    'REFRACTION_LSST_CARDS_TXT_NAME',
     'REFRACTION_LSST_CSV_NAME',
     'REFRACTION_LSST_FORMAT_NAME',
     'REFRACTION_LSST_FORMAT_VERSION',
     'REFRACTION_LSST_PLUS_COLUMNS',
+    'REFRACTION_LSST_PLUS_CARDS_TXT_NAME',
     'REFRACTION_LSST_PLUS_CSV_NAME',
     'REFRACTION_LSST_PLUS_FIELD_COLUMNS',
     'REFRACTION_LSST_PLUS_FORMAT_NAME',
@@ -684,8 +1050,12 @@ __all__ = [
     'REFRACTION_LSST_OPTIONAL_MULTILAYER_COLUMNS',
     'REFRACTION_LSST_REQUIRED_COLUMNS',
     'RefractionStaticLsstExportError',
+    'format_refraction_lsst_cards_txt',
     'format_refraction_lsst_csv',
+    'format_refraction_lsst_plus_cards_txt',
     'format_refraction_lsst_plus_csv',
+    'write_refraction_lsst_cards_txt',
     'write_refraction_lsst_csv',
+    'write_refraction_lsst_plus_cards_txt',
     'write_refraction_lsst_plus_csv',
 ]

--- a/app/services/refraction_static_service.py
+++ b/app/services/refraction_static_service.py
@@ -33,6 +33,7 @@ from app.services.refraction_static_datum import (
 )
 from app.services.refraction_static_export_service import (
     resolve_refraction_static_export_formats,
+    write_inline_refraction_static_export_artifacts,
 )
 from app.services.refraction_static_field_composition import (
     compose_refraction_endpoint_field_corrections,
@@ -461,6 +462,18 @@ def _finish_refraction_static_apply_job(
     job_dir: Path,
     result: RefractionDatumStaticsResult,
 ) -> JobCompletion:
+    if req.export.enabled:
+        _set_job_progress_message(
+            state,
+            job_id,
+            progress=0.91,
+            message='writing_refraction_static_export_artifacts',
+        )
+        write_inline_refraction_static_export_artifacts(
+            job_id=job_id,
+            req=req,
+            job_dir=job_dir,
+        )
     if req.apply.register_corrected_file:
         _set_job_progress_message(
             state,

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -41,6 +41,9 @@ from app.services.refraction_static_artifacts import (
     SOURCE_RECEIVER_STATIC_TABLE_NPZ_NAME,
     SOURCE_STATIC_TABLE_CSV_NAME,
 )
+from app.services.refraction_static_export_service import (
+    CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME,
+)
 from app.services.refraction_static_layer_observations import (
     build_refraction_layer_observation_masks,
     refraction_layer_observation_qc,
@@ -1171,6 +1174,74 @@ def test_run_refraction_static_apply_job_artifact_only_writes_real_final_artifac
     assert request_download.json()['job_id'] == job_id
 
 
+def test_run_refraction_static_apply_job_inline_canonical_export_uses_invalid_policy(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_id = 'refraction-inline-canonical-export'
+    job_dir = tmp_path / 'jobs' / job_id
+    payload = _payload()
+    payload['export'] = {
+        'enabled': True,
+        'formats': ['canonical_static_table'],
+        'fail_on_invalid_static_status': False,
+        'include_inactive_endpoints': False,
+    }
+    req = RefractionStaticApplyRequest.model_validate(payload)
+    _create_refraction_job(client, job_id=job_id, req=req, job_dir=job_dir)
+    _stub_upstream_refraction_result(monkeypatch, datum_result=object())
+
+    def _write_static_table_artifacts(**kwargs: Any) -> object:
+        root = Path(kwargs['job_dir'])
+        root.mkdir(parents=True, exist_ok=True)
+        _write_csv_rows(
+            root / SOURCE_STATIC_TABLE_CSV_NAME,
+            [
+                _source_static_export_row(
+                    endpoint_key='source:1001',
+                    source_id='1001',
+                    total_applied_shift_ms='12.5',
+                    static_status='ok',
+                ),
+                _source_static_export_row(
+                    endpoint_key='source:inactive',
+                    source_id='1002',
+                    total_applied_shift_ms='',
+                    static_status='inactive_endpoint',
+                ),
+            ],
+        )
+        _write_csv_rows(
+            root / RECEIVER_STATIC_TABLE_CSV_NAME,
+            [
+                _receiver_static_export_row(
+                    endpoint_key='receiver:2001',
+                    receiver_id='2001',
+                    total_applied_shift_ms='-3.25',
+                    static_status='ok',
+                ),
+            ],
+        )
+        return object()
+
+    monkeypatch.setattr(
+        refraction_service_module,
+        'write_refraction_static_artifacts',
+        _write_static_table_artifacts,
+    )
+
+    run_refraction_static_apply_job(job_id, req, client.app.state.sv)
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    assert job['status'] == 'done'
+    rows = _read_csv(job_dir / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME)
+    assert [row['endpoint_key'] for row in rows] == ['source:1001', 'receiver:2001']
+    assert rows[0]['applied_shift_ms'] == '12.5'
+    assert rows[1]['applied_shift_ms'] == '-3.25'
+
+
 def test_refraction_static_job_lists_v1_artifacts_when_v1_estimated(
     client: TestClient,
     tmp_path: Path,
@@ -2149,6 +2220,55 @@ def _listed_job_files(client: TestClient, job_id: str) -> set[str]:
 def _read_csv(path: Path) -> list[dict[str, str]]:
     with path.open(encoding='utf-8', newline='') as handle:
         return list(csv.DictReader(handle))
+
+
+def _write_csv_rows(path: Path, rows: list[dict[str, str]]) -> None:
+    assert rows
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open('w', encoding='utf-8', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator='\n')
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _source_static_export_row(
+    *,
+    endpoint_key: str,
+    source_id: str,
+    total_applied_shift_ms: str,
+    static_status: str,
+) -> dict[str, str]:
+    return {
+        'endpoint_kind': 'source',
+        'source_endpoint_key': endpoint_key,
+        'source_id': source_id,
+        'source_node_id': source_id,
+        'total_applied_shift_ms': total_applied_shift_ms,
+        'static_status': static_status,
+        'sign_convention': 'corrected(t) = raw(t - shift_s)',
+    }
+
+
+def _receiver_static_export_row(
+    *,
+    endpoint_key: str,
+    receiver_id: str,
+    total_applied_shift_ms: str,
+    static_status: str,
+) -> dict[str, str]:
+    return {
+        'endpoint_kind': 'receiver',
+        'receiver_endpoint_key': endpoint_key,
+        'receiver_id': receiver_id,
+        'receiver_node_id': receiver_id,
+        'total_applied_shift_ms': total_applied_shift_ms,
+        'static_status': static_status,
+        'sign_convention': 'corrected(t) = raw(t - shift_s)',
+    }
 
 
 def _segy_output_files(root: Path) -> list[Path]:

--- a/app/tests/test_refraction_static_export_contract.py
+++ b/app/tests/test_refraction_static_export_contract.py
@@ -180,6 +180,50 @@ def test_refraction_export_rejects_unknown_format(client: TestClient) -> None:
     assert response.status_code == 422
 
 
+def test_refraction_export_units_seconds_are_rejected(client: TestClient) -> None:
+    response = client.post(
+        '/statics/refraction/export',
+        json={
+            'source_job_id': 'source-refraction-job',
+            'export': {'enabled': True, 'units': 'seconds'},
+        },
+    )
+
+    assert response.status_code == 422
+    assert 'export.units must be "milliseconds"' in str(response.json())
+
+
+def test_refraction_export_rejects_custom_rounding_ms(client: TestClient) -> None:
+    response = client.post(
+        '/statics/refraction/export',
+        json={
+            'source_job_id': 'source-refraction-job',
+            'export': {'enabled': True, 'rounding_ms': 0.01},
+        },
+    )
+
+    assert response.status_code == 422
+    assert 'export.rounding_ms is reserved' in str(response.json())
+
+
+def test_refraction_export_rejects_legacy_alias_suppression(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        '/statics/refraction/export',
+        json={
+            'source_job_id': 'source-refraction-job',
+            'export': {
+                'enabled': True,
+                'include_legacy_alias_columns': False,
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert 'export.include_legacy_alias_columns must be true' in str(response.json())
+
+
 def test_refraction_export_rejects_incomplete_source_job(
     client: TestClient,
     tmp_path: Path,
@@ -292,6 +336,13 @@ def test_run_refraction_static_export_job_writes_requested_format_metadata(
     assert meta['export']['requested_formats'] == list(
         REFRACTION_STATIC_DEFAULT_EXPORT_FORMATS
     )
+    assert meta['export']['units'] == 'milliseconds'
+    assert meta['export']['unit_policy'] == 'milliseconds_only'
+    assert meta['export']['time_column_suffix'] == '_ms'
+    assert meta['export']['rounding_ms_policy'] == 'reserved_no_op'
+    assert meta['export']['numeric_csv_precision'] == 'format_schema_fixed'
+    assert meta['export']['include_legacy_alias_columns'] is True
+    assert meta['export']['legacy_alias_columns_policy'] == 'required_true'
     assert meta['export']['sign_convention'] == REFRACTION_STATIC_REPO_SIGN_CONVENTION
     assert meta['generated_artifacts'] == [
         CANONICAL_SOURCE_STATIC_TABLE_CSV_NAME,

--- a/app/tests/test_refraction_static_export_contract.py
+++ b/app/tests/test_refraction_static_export_contract.py
@@ -39,7 +39,9 @@ from app.services.refraction_static_export_units import (
     REFRACTION_STATIC_REPO_SIGN_CONVENTION,
 )
 from app.services.refraction_static_lsst_export import (
+    REFRACTION_LSST_CARDS_TXT_NAME,
     REFRACTION_LSST_CSV_NAME,
+    REFRACTION_LSST_PLUS_CARDS_TXT_NAME,
     REFRACTION_LSST_PLUS_CSV_NAME,
 )
 from app.services.refraction_static_table_import import (
@@ -695,17 +697,31 @@ def test_run_refraction_static_export_job_writes_lsst_artifacts(
     lsst_rows = _read_csv_text(
         (export_job_dir / REFRACTION_LSST_CSV_NAME).read_text(encoding='utf-8')
     )
+    lsst_cards = (export_job_dir / REFRACTION_LSST_CARDS_TXT_NAME).read_text(
+        encoding='utf-8'
+    )
     lsst_plus_rows = _read_csv_text(
         (export_job_dir / REFRACTION_LSST_PLUS_CSV_NAME).read_text(encoding='utf-8')
     )
+    lsst_plus_cards = (
+        export_job_dir / REFRACTION_LSST_PLUS_CARDS_TXT_NAME
+    ).read_text(encoding='utf-8')
     assert [row['endpoint_kind'] for row in lsst_rows] == ['source', 'receiver']
     assert lsst_rows[0]['endpoint_key'] == 'source:1001'
     assert lsst_rows[0]['total_applied_shift_ms'] == '12.500000'
     assert lsst_rows[1]['endpoint_key'] == 'receiver:2001'
     assert lsst_rows[1]['total_applied_shift_ms'] == '-3.250000'
+    assert '# format=lsst\n' in lsst_cards
+    assert 'SSTAT source:1001 12.500000\n' in lsst_cards
+    assert 'RSTAT receiver:2001 -3.250000\n' in lsst_cards
     assert lsst_plus_rows[0]['format_name'] == 'lsst_plus'
     assert lsst_plus_rows[0]['source_field_shift_ms'] == '1.500000'
     assert lsst_plus_rows[1]['receiver_field_shift_ms'] == '-0.500000'
+    assert '# format=lsst_plus\n' in lsst_plus_cards
+    assert (
+        'STC source source:1001 total=12.500000 weathering=10.000000 '
+        'elevation=2.500000 field=1.500000\n'
+    ) in lsst_plus_cards
     meta = json.loads(
         (export_job_dir / REFRACTION_STATIC_EXPORT_JOB_META_JSON_NAME).read_text(
             encoding='utf-8',
@@ -713,7 +729,9 @@ def test_run_refraction_static_export_job_writes_lsst_artifacts(
     )
     assert meta['generated_artifacts'] == [
         REFRACTION_LSST_CSV_NAME,
+        REFRACTION_LSST_CARDS_TXT_NAME,
         REFRACTION_LSST_PLUS_CSV_NAME,
+        REFRACTION_LSST_PLUS_CARDS_TXT_NAME,
     ]
 
 

--- a/app/tests/test_refraction_static_export_contract.py
+++ b/app/tests/test_refraction_static_export_contract.py
@@ -28,6 +28,9 @@ from app.services.refraction_static_artifacts import (
     SOURCE_STATIC_TABLE_CSV_NAME,
 )
 from app.services.refraction_static_export_service import (
+    CANONICAL_RECEIVER_STATIC_TABLE_CSV_NAME,
+    CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME,
+    CANONICAL_SOURCE_STATIC_TABLE_CSV_NAME,
     REFRACTION_STATIC_EXPORT_JOB_META_JSON_NAME,
     REFRACTION_STATIC_EXPORT_REQUEST_JSON_NAME,
     run_refraction_static_export_job,
@@ -38,6 +41,9 @@ from app.services.refraction_static_export_units import (
 from app.services.refraction_static_lsst_export import (
     REFRACTION_LSST_CSV_NAME,
     REFRACTION_LSST_PLUS_CSV_NAME,
+)
+from app.services.refraction_static_table_import import (
+    import_refraction_static_table_csv,
 )
 from app.tests._refraction_static_synthetic import synthetic_refraction_apply_request
 
@@ -287,7 +293,29 @@ def test_run_refraction_static_export_job_writes_requested_format_metadata(
         REFRACTION_STATIC_DEFAULT_EXPORT_FORMATS
     )
     assert meta['export']['sign_convention'] == REFRACTION_STATIC_REPO_SIGN_CONVENTION
-    assert meta['generated_artifacts'] == [REFRACTION_TIME_TERM_SPREADSHEET_CSV_NAME]
+    assert meta['generated_artifacts'] == [
+        CANONICAL_SOURCE_STATIC_TABLE_CSV_NAME,
+        CANONICAL_RECEIVER_STATIC_TABLE_CSV_NAME,
+        CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME,
+        REFRACTION_TIME_TERM_SPREADSHEET_CSV_NAME,
+    ]
+    canonical_rows = _read_csv_text(
+        (export_job_dir / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME).read_text(
+            encoding='utf-8',
+        )
+    )
+    assert [row['endpoint_kind'] for row in canonical_rows] == [
+        'source',
+        'receiver',
+    ]
+    assert canonical_rows[0]['format_name'] == 'canonical_static_table'
+    assert canonical_rows[0]['applied_shift_ms'] == '12.5'
+    assert canonical_rows[1]['applied_shift_ms'] == '-3.25'
+    import_result = import_refraction_static_table_csv(
+        export_job_dir / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME
+    )
+    assert import_result.is_valid is True
+    assert import_result.errors == ()
     spreadsheet_rows = _read_csv_text(
         (export_job_dir / REFRACTION_TIME_TERM_SPREADSHEET_CSV_NAME).read_text(
             encoding='utf-8',
@@ -421,6 +449,162 @@ def test_run_refraction_static_export_job_time_term_spreadsheet_includes_inactiv
         'receiver:2001',
     ]
     assert rows[1]['static_status'] == 'inactive'
+
+
+def test_run_refraction_static_export_job_canonical_rejects_invalid_rows_by_default(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    source_dir = _create_source_refraction_job(
+        client,
+        tmp_path,
+        artifact_names=(
+            REFRACTION_STATIC_REQUEST_JSON_NAME,
+            REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
+            SOURCE_STATIC_TABLE_CSV_NAME,
+            RECEIVER_STATIC_TABLE_CSV_NAME,
+        ),
+    )
+    _append_invalid_source_row(source_dir)
+    req = RefractionStaticExportJobRequest.model_validate(
+        {
+            'source_job_id': 'source-refraction-job',
+            'export': {'enabled': True, 'formats': ['canonical_static_table']},
+        }
+    )
+    export_job_id = 'export-job-invalid-canonical'
+    export_job_dir = tmp_path / 'jobs' / export_job_id
+    with client.app.state.sv.lock:
+        client.app.state.sv.jobs.create_static_job(
+            export_job_id,
+            file_id='raw-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='refraction_export',
+            artifacts_dir=str(export_job_dir),
+        )
+
+    run_refraction_static_export_job(export_job_id, req, client.app.state.sv)
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[export_job_id])
+    assert job['status'] == 'error'
+    assert 'inactive_endpoint' in str(job['message'])
+    assert not (export_job_dir / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME).exists()
+
+
+def test_run_refraction_static_export_job_canonical_skips_invalid_rows_when_not_included(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    source_dir = _create_source_refraction_job(
+        client,
+        tmp_path,
+        artifact_names=(
+            REFRACTION_STATIC_REQUEST_JSON_NAME,
+            REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
+            SOURCE_STATIC_TABLE_CSV_NAME,
+            RECEIVER_STATIC_TABLE_CSV_NAME,
+        ),
+    )
+    _append_invalid_source_row(source_dir)
+    req = RefractionStaticExportJobRequest.model_validate(
+        {
+            'source_job_id': 'source-refraction-job',
+            'export': {
+                'enabled': True,
+                'formats': ['canonical_static_table'],
+                'fail_on_invalid_static_status': False,
+                'include_inactive_endpoints': False,
+            },
+        }
+    )
+    export_job_id = 'export-job-canonical-skip-invalid'
+    export_job_dir = tmp_path / 'jobs' / export_job_id
+    with client.app.state.sv.lock:
+        client.app.state.sv.jobs.create_static_job(
+            export_job_id,
+            file_id='raw-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='refraction_export',
+            artifacts_dir=str(export_job_dir),
+        )
+
+    run_refraction_static_export_job(export_job_id, req, client.app.state.sv)
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[export_job_id])
+    assert job['status'] == 'done'
+    rows = _read_csv_text(
+        (export_job_dir / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME).read_text(
+            encoding='utf-8',
+        )
+    )
+    assert [row['endpoint_key'] for row in rows] == ['source:1001', 'receiver:2001']
+    import_result = import_refraction_static_table_csv(
+        export_job_dir / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME
+    )
+    assert import_result.is_valid is True
+
+
+def test_run_refraction_static_export_job_canonical_includes_invalid_rows_when_requested(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    source_dir = _create_source_refraction_job(
+        client,
+        tmp_path,
+        artifact_names=(
+            REFRACTION_STATIC_REQUEST_JSON_NAME,
+            REFRACTION_STATIC_ARTIFACTS_JSON_NAME,
+            SOURCE_STATIC_TABLE_CSV_NAME,
+            RECEIVER_STATIC_TABLE_CSV_NAME,
+        ),
+    )
+    _append_invalid_source_row(source_dir)
+    req = RefractionStaticExportJobRequest.model_validate(
+        {
+            'source_job_id': 'source-refraction-job',
+            'export': {
+                'enabled': True,
+                'formats': ['canonical_static_table'],
+                'fail_on_invalid_static_status': False,
+                'include_inactive_endpoints': True,
+            },
+        }
+    )
+    export_job_id = 'export-job-canonical-include-invalid'
+    export_job_dir = tmp_path / 'jobs' / export_job_id
+    with client.app.state.sv.lock:
+        client.app.state.sv.jobs.create_static_job(
+            export_job_id,
+            file_id='raw-file-id',
+            key1_byte=189,
+            key2_byte=193,
+            statics_kind='refraction_export',
+            artifacts_dir=str(export_job_dir),
+        )
+
+    run_refraction_static_export_job(export_job_id, req, client.app.state.sv)
+
+    rows = _read_csv_text(
+        (export_job_dir / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME).read_text(
+            encoding='utf-8',
+        )
+    )
+    assert [row['endpoint_key'] for row in rows] == [
+        'source:1001',
+        'source:inactive',
+        'receiver:2001',
+    ]
+    assert rows[1]['static_status'] == 'inactive_endpoint'
+    assert rows[1]['applied_shift_ms'] == ''
+    import_result = import_refraction_static_table_csv(
+        export_job_dir / CANONICAL_SOURCE_RECEIVER_STATIC_TABLE_CSV_NAME
+    )
+    assert import_result.is_valid is False
+    assert any('inactive_endpoint' in error for error in import_result.errors)
 
 
 def test_run_refraction_static_export_job_writes_lsst_artifacts(
@@ -631,6 +815,26 @@ def _write_csv_rows(path: Path, rows: list[dict[str, str]]) -> None:
         writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
         writer.writeheader()
         writer.writerows(rows)
+
+
+def _append_invalid_source_row(source_dir: Path) -> None:
+    with (source_dir / SOURCE_STATIC_TABLE_CSV_NAME).open(
+        encoding='utf-8',
+        newline='',
+    ) as handle:
+        source_rows = list(csv.DictReader(handle))
+    inactive_row = dict(source_rows[0])
+    inactive_row.update(
+        {
+            'source_endpoint_key': 'source:inactive',
+            'source_id': '1002',
+            'source_node_id': '11',
+            'total_static_ms': '',
+            'total_applied_shift_ms': '',
+            'static_status': 'inactive_endpoint',
+        }
+    )
+    _write_csv_rows(source_dir / SOURCE_STATIC_TABLE_CSV_NAME, source_rows + [inactive_row])
 
 
 def _read_csv_text(text: str) -> list[dict[str, str]]:

--- a/app/tests/test_refraction_static_lsst_export.py
+++ b/app/tests/test_refraction_static_lsst_export.py
@@ -15,18 +15,24 @@ from app.services.refraction_static_export_types import (
     RefractionStaticExportBundle,
 )
 from app.services.refraction_static_lsst_export import (
+    REFRACTION_LSST_CARDS_TXT_NAME,
     REFRACTION_LSST_CSV_NAME,
     REFRACTION_LSST_FORMAT_NAME,
     REFRACTION_LSST_FORMAT_VERSION,
     REFRACTION_LSST_PLUS_COLUMNS,
+    REFRACTION_LSST_PLUS_CARDS_TXT_NAME,
     REFRACTION_LSST_PLUS_CSV_NAME,
     REFRACTION_LSST_PLUS_FORMAT_NAME,
     REFRACTION_LSST_PLUS_FORMAT_VERSION,
     REFRACTION_LSST_REQUIRED_COLUMNS,
     RefractionStaticLsstExportError,
+    format_refraction_lsst_cards_txt,
     format_refraction_lsst_csv,
+    format_refraction_lsst_plus_cards_txt,
     format_refraction_lsst_plus_csv,
+    write_refraction_lsst_cards_txt,
     write_refraction_lsst_csv,
+    write_refraction_lsst_plus_cards_txt,
     write_refraction_lsst_plus_csv,
 )
 
@@ -56,7 +62,9 @@ for name in {sorted(_FORBIDDEN_IMPORTS)!r}:
 
 module = importlib.import_module('app.services.refraction_static_lsst_export')
 assert module.format_refraction_lsst_csv is not None
+assert module.format_refraction_lsst_cards_txt is not None
 assert module.format_refraction_lsst_plus_csv is not None
+assert module.format_refraction_lsst_plus_cards_txt is not None
 
 forbidden = set({sorted(_FORBIDDEN_IMPORTS)!r})
 print(json.dumps(sorted(name for name in sys.modules if name in forbidden)))
@@ -103,59 +111,7 @@ def test_lsst_export_emits_source_and_receiver_t1_rows() -> None:
 
 
 def test_lsst_export_emits_multilayer_columns_when_available() -> None:
-    bundle = RefractionStaticExportBundle(
-        source_job_id='refraction-job-503',
-        source_rows=(
-            RefractionStaticEndpointExportRow(
-                endpoint_kind='source',
-                endpoint_key='s100',
-                endpoint_id=100,
-                node_id=10,
-                x_m=1000.0,
-                y_m=2000.0,
-                elevation_m=25.0,
-                t1_s=0.012,
-                t2_s=0.020,
-                t3_s=0.030,
-                v1_m_s=800.0,
-                v2_m_s=2400.0,
-                v3_m_s=3600.0,
-                vsub_m_s=5000.0,
-                sh1_m=8.0,
-                sh2_m=12.0,
-                sh3_m=16.0,
-                total_weathering_thickness_m=36.0,
-                weathering_correction_s=-0.003,
-                elevation_correction_s=0.001,
-                total_applied_shift_s=-0.004,
-            ),
-        ),
-        receiver_rows=(
-            RefractionStaticEndpointExportRow(
-                endpoint_kind='receiver',
-                endpoint_key='r200',
-                endpoint_id=200,
-                node_id=20,
-                x_m=1010.0,
-                y_m=2010.0,
-                elevation_m=30.0,
-                t1_s=0.011,
-                t2_s=0.021,
-                t3_s=0.031,
-                v1_m_s=800.0,
-                v2_m_s=2350.0,
-                v3_m_s=3650.0,
-                vsub_m_s=5100.0,
-                sh1_m=7.0,
-                sh2_m=11.0,
-                sh3_m=15.0,
-                total_weathering_thickness_m=33.0,
-                weathering_correction_s=-0.002,
-                elevation_correction_s=0.0015,
-                total_applied_shift_s=0.005,
-            ),
-        ),
-    )
+    bundle = _multilayer_bundle()
 
     rows, fieldnames = _read_csv_text(format_refraction_lsst_csv(bundle))
 
@@ -307,6 +263,62 @@ def test_lsst_export_writes_expected_file_name(tmp_path: Path) -> None:
     )
 
 
+def test_lsst_cards_txt_has_header_and_card_rows() -> None:
+    text = format_refraction_lsst_cards_txt(_basic_bundle())
+    lines = text.splitlines()
+
+    assert lines[:5] == [
+        '# format=lsst',
+        '# schema_version=1',
+        '# sign_convention=corrected(t) = raw(t - shift_s)',
+        '# units=ms',
+        '# missing_values=omit',
+    ]
+    assert 'SDT1 s100 12.345600' in lines
+    assert 'SVV2 s100 2400.000' in lines
+
+
+def test_lsst_cards_txt_is_not_csv_mirror() -> None:
+    bundle = _basic_bundle()
+    text = format_refraction_lsst_cards_txt(bundle)
+
+    assert text != format_refraction_lsst_csv(bundle)
+    assert not text.startswith('format_name,')
+    assert 'format_name,format_version' not in text
+
+
+def test_lsst_cards_txt_emits_source_and_receiver_stat_cards() -> None:
+    lines = format_refraction_lsst_cards_txt(_basic_bundle()).splitlines()
+
+    assert 'SSTAT s100 -3.250000' in lines
+    assert 'RSTAT r200 4.500000' in lines
+    assert 'SDT1 s100 12.345600' in lines
+    assert 'RDT1 r200 23.000000' in lines
+
+
+def test_lsst_cards_txt_emits_multilayer_cards_when_available() -> None:
+    lines = format_refraction_lsst_cards_txt(_multilayer_bundle()).splitlines()
+
+    assert 'SDT2 s100 20.000000' in lines
+    assert 'SDT3 s100 30.000000' in lines
+    assert 'SVV3 s100 3600.000' in lines
+    assert 'SVSB s100 5000.000' in lines
+    assert 'RDT2 r200 21.000000' in lines
+    assert 'RDT3 r200 31.000000' in lines
+    assert 'RVV3 r200 3650.000' in lines
+    assert 'RVSB r200 5100.000' in lines
+
+
+def test_lsst_cards_txt_writes_expected_file_name(tmp_path: Path) -> None:
+    path = tmp_path / REFRACTION_LSST_CARDS_TXT_NAME
+
+    write_refraction_lsst_cards_txt(_basic_bundle(), path)
+
+    assert path.read_text(encoding='utf-8') == format_refraction_lsst_cards_txt(
+        _basic_bundle()
+    )
+
+
 def test_lsst_plus_export_contains_endpoint_metadata() -> None:
     rows, fieldnames = _read_csv_text(format_refraction_lsst_plus_csv(_lsst_plus_bundle()))
 
@@ -439,6 +451,82 @@ def test_lsst_plus_export_writes_expected_file_name(tmp_path: Path) -> None:
     )
 
 
+def test_lsst_plus_cards_txt_has_endpoint_component_and_layer_rows() -> None:
+    text = format_refraction_lsst_plus_cards_txt(_lsst_plus_bundle())
+    lines = text.splitlines()
+
+    assert lines[:5] == [
+        '# format=lsst_plus',
+        '# schema_version=1',
+        '# sign_convention=corrected(t) = raw(t - shift_s)',
+        '# units=ms',
+        '# missing_values=omit',
+    ]
+    assert (
+        'SRC s100 station=1000 x=1000.000 y=2000.000 elev=25.000 status=ok'
+        in lines
+    )
+    assert (
+        'REC r200 station=2000 x=1010.000 y=2010.000 elev=30.000 status=ok'
+        in lines
+    )
+    assert (
+        'STC source s100 total=-3.250000 weathering=-4.000000 '
+        'elevation=0.750000 field=1.250000 manual=0.500000'
+    ) in lines
+    assert (
+        'STC receiver r200 total=4.500000 weathering=-2.500000 '
+        'elevation=1.000000 field=-0.250000 manual=-0.250000'
+    ) in lines
+    assert (
+        'LYR source s100 t1=12.345600 t2=20.000000 t3=30.000000 '
+        'sh1=8.250 sh2=12.000 sh3=16.000 v1=800.000 v2=2400.000 '
+        'v3=3600.000 vsub=5000.000'
+    ) in lines
+    assert 'LYR receiver r200 t1=23.000000 sh1=9.500 v1=800.000 v2=2300.000' in lines
+
+
+def test_lsst_plus_cards_txt_is_not_csv_mirror() -> None:
+    bundle = _lsst_plus_bundle()
+    text = format_refraction_lsst_plus_cards_txt(bundle)
+
+    assert text != format_refraction_lsst_plus_csv(bundle)
+    assert not text.startswith('format_name,')
+    assert 'format_name,format_version' not in text
+
+
+def test_lsst_plus_cards_txt_is_deterministic() -> None:
+    bundle = _lsst_plus_source_only_bundle()
+    expected = (
+        '# format=lsst_plus\n'
+        '# schema_version=1\n'
+        '# sign_convention=corrected(t) = raw(t - shift_s)\n'
+        '# units=ms\n'
+        '# missing_values=omit\n'
+        'SRC s100 station=1000 x=1000.000 y=2000.000 elev=25.000 status=ok\n'
+        'STC source s100 total=-3.250000 weathering=-4.000000 '
+        'elevation=0.750000 field=1.250000 manual=0.500000\n'
+        'LYR source s100 t1=12.345600 t2=20.000000 t3=30.000000 '
+        'sh1=8.250 sh2=12.000 sh3=16.000 v1=800.000 v2=2400.000 '
+        'v3=3600.000 vsub=5000.000\n'
+    )
+
+    assert format_refraction_lsst_plus_cards_txt(bundle) == expected
+    assert format_refraction_lsst_plus_cards_txt(bundle) == (
+        format_refraction_lsst_plus_cards_txt(bundle)
+    )
+
+
+def test_lsst_plus_cards_txt_writes_expected_file_name(tmp_path: Path) -> None:
+    path = tmp_path / REFRACTION_LSST_PLUS_CARDS_TXT_NAME
+
+    write_refraction_lsst_plus_cards_txt(_lsst_plus_source_only_bundle(), path)
+
+    assert path.read_text(encoding='utf-8') == format_refraction_lsst_plus_cards_txt(
+        _lsst_plus_source_only_bundle()
+    )
+
+
 def _read_csv_text(text: str) -> tuple[list[dict[str, str]], list[str]]:
     reader = csv.DictReader(io.StringIO(text))
     return list(reader), list(reader.fieldnames or ())
@@ -486,6 +574,62 @@ def _basic_bundle(
                 weathering_correction_s=-0.0025,
                 elevation_correction_s=0.001,
                 total_applied_shift_s=0.0045,
+            ),
+        ),
+    )
+
+
+def _multilayer_bundle() -> RefractionStaticExportBundle:
+    return RefractionStaticExportBundle(
+        source_job_id='refraction-job-503',
+        source_rows=(
+            RefractionStaticEndpointExportRow(
+                endpoint_kind='source',
+                endpoint_key='s100',
+                endpoint_id=100,
+                node_id=10,
+                x_m=1000.0,
+                y_m=2000.0,
+                elevation_m=25.0,
+                t1_s=0.012,
+                t2_s=0.020,
+                t3_s=0.030,
+                v1_m_s=800.0,
+                v2_m_s=2400.0,
+                v3_m_s=3600.0,
+                vsub_m_s=5000.0,
+                sh1_m=8.0,
+                sh2_m=12.0,
+                sh3_m=16.0,
+                total_weathering_thickness_m=36.0,
+                weathering_correction_s=-0.003,
+                elevation_correction_s=0.001,
+                total_applied_shift_s=-0.004,
+            ),
+        ),
+        receiver_rows=(
+            RefractionStaticEndpointExportRow(
+                endpoint_kind='receiver',
+                endpoint_key='r200',
+                endpoint_id=200,
+                node_id=20,
+                x_m=1010.0,
+                y_m=2010.0,
+                elevation_m=30.0,
+                t1_s=0.011,
+                t2_s=0.021,
+                t3_s=0.031,
+                v1_m_s=800.0,
+                v2_m_s=2350.0,
+                v3_m_s=3650.0,
+                vsub_m_s=5100.0,
+                sh1_m=7.0,
+                sh2_m=11.0,
+                sh3_m=15.0,
+                total_weathering_thickness_m=33.0,
+                weathering_correction_s=-0.002,
+                elevation_correction_s=0.0015,
+                total_applied_shift_s=0.005,
             ),
         ),
     )

--- a/docs/statics/refraction_m5_exports_table_workflow.md
+++ b/docs/statics/refraction_m5_exports_table_workflow.md
@@ -140,6 +140,15 @@ M5 CSV writers should use deterministic decimal output:
 - slowness in seconds per meter: at least 12 significant digits;
 - status, kind, ID, and key columns: exact text or integer values.
 
+Current public export requests are constrained to this millisecond CSV schema:
+
+- `export.units` must be `milliseconds`;
+- `export.rounding_ms` is reserved for future display/card outputs and does
+  not control machine-readable CSV precision; only the default `0.001` or
+  `null` is accepted;
+- `export.include_legacy_alias_columns` must be `true`; current M5 exports
+  always write the documented column sets and do not support alias suppression.
+
 `canonical_static_table` import converts millisecond columns to seconds before
 TraceStore application. Import validation must reject non-finite values in
 required apply fields.


### PR DESCRIPTION
Closes #518
Closes #519
Closes #520

## Issues
- #518 [statics][refraction][m5] Make canonical static-table export apply-ready and honor invalid-row policy
- #519 [statics][refraction][m5] Wire or constrain export units, rounding, and legacy-alias request fields
- #520 [statics][refraction][m5] Implement real LSST/LSST+ card text outputs instead of CSV mirrors

Batch range: #518-#520
