### PR TITLE
Batch: address issues #583-#586

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -344,6 +344,15 @@ def refraction_static_apply(
     req: RefractionStaticApplyRequest,
     request: Request,
 ) -> RefractionStaticApplyResponse:
+    if req.pick_source.kind == 'uploaded_npz':
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                'pick_source.kind uploaded_npz requires multipart '
+                '/statics/refraction/apply-with-picks'
+            ),
+        )
+
     state = get_state(request.app)
     cleanup_in_memory_state(state)
     maybe_cleanup_expired_jobs()

--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import threading
 from pathlib import Path
+from typing import Annotated
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
+from pydantic import ValidationError
 
 from app.api._helpers import get_state
 from app.api.schemas import (
@@ -75,6 +78,15 @@ from app.services.time_term_static_service import run_time_term_static_apply_job
 
 router = APIRouter()
 
+UPLOADED_REFRACTION_PICKS_NPZ_NAME = 'uploaded_picks_time_s.npz'
+_UPLOAD_CHUNK_SIZE = 1024 * 1024
+_MAX_UPLOADED_PICK_NPZ_BYTES = 256 * 1024 * 1024
+_ACCEPTED_NPZ_CONTENT_TYPES = {
+    'application/x-npz',
+    'application/zip',
+    'application/x-zip-compressed',
+}
+
 
 def _get_static_job_or_404(state: AppState, job_id: str) -> dict[str, object]:
     with state.lock:
@@ -106,6 +118,62 @@ def _static_job_status_payload(
         'progress': float(progress) if isinstance(progress, (int, float)) else 0.0,
         'message': message if isinstance(message, str) else '',
     }
+
+
+def _parse_refraction_apply_request_json(
+    request_json: str,
+) -> RefractionStaticApplyRequest:
+    try:
+        return RefractionStaticApplyRequest.model_validate_json(request_json)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=json.loads(exc.json()),
+        ) from exc
+
+
+def _validate_refraction_pick_upload(pick_npz: UploadFile) -> None:
+    filename = pick_npz.filename or ''
+    content_type = (pick_npz.content_type or '').split(';', 1)[0].strip().lower()
+    if filename.lower().endswith('.npz'):
+        return
+    if content_type in _ACCEPTED_NPZ_CONTENT_TYPES:
+        return
+    raise HTTPException(
+        status_code=422,
+        detail='pick_npz must be an .npz upload',
+    )
+
+
+def _store_refraction_pick_upload(
+    *,
+    pick_npz: UploadFile,
+    job_dir: Path,
+) -> tuple[Path, int]:
+    job_dir.mkdir(parents=True, exist_ok=True)
+    target_path = job_dir / UPLOADED_REFRACTION_PICKS_NPZ_NAME
+    tmp_path = target_path.with_name(f'{target_path.name}.{uuid4().hex}.tmp')
+    total_size = 0
+    try:
+        with tmp_path.open('wb') as handle:
+            while True:
+                chunk = pick_npz.file.read(_UPLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+                total_size += len(chunk)
+                if total_size > _MAX_UPLOADED_PICK_NPZ_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail='pick_npz exceeds maximum upload size',
+                    )
+                handle.write(chunk)
+        if total_size == 0:
+            raise HTTPException(status_code=422, detail='pick_npz is empty')
+        tmp_path.replace(target_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    return target_path, total_size
 
 
 @router.post('/statics/datum/apply', response_model=DatumStaticApplyResponse)
@@ -299,6 +367,69 @@ def refraction_static_apply(
         thread_factory=threading.Thread,
         target=run_refraction_static_apply_job,
         args=(job_id, req, state),
+    )
+
+    response: RefractionStaticApplyResponse = {'job_id': job_id, 'state': status}
+    if req.export.enabled:
+        response['requested_formats'] = list(requested_formats)
+    return response
+
+
+@router.post(
+    '/statics/refraction/apply-with-picks',
+    response_model=RefractionStaticApplyResponse,
+    response_model_exclude_none=True,
+)
+def refraction_static_apply_with_picks(
+    request: Request,
+    request_json: Annotated[str, Form(...)],
+    pick_npz: Annotated[UploadFile, File(...)],
+) -> RefractionStaticApplyResponse:
+    req = _parse_refraction_apply_request_json(request_json)
+    if req.pick_source.kind != 'uploaded_npz':
+        raise HTTPException(
+            status_code=422,
+            detail='pick_source.kind must be uploaded_npz',
+        )
+    _validate_refraction_pick_upload(pick_npz)
+
+    state = get_state(request.app)
+    cleanup_in_memory_state(state)
+    maybe_cleanup_expired_jobs()
+
+    job_id = str(uuid4())
+    job_dir = get_job_dir(job_id)
+    stored_path, _size_bytes = _store_refraction_pick_upload(
+        pick_npz=pick_npz,
+        job_dir=job_dir,
+    )
+    upload_metadata = {
+        'original_filename': pick_npz.filename or '',
+        'stored_name': UPLOADED_REFRACTION_PICKS_NPZ_NAME,
+    }
+
+    requested_formats = resolve_refraction_static_export_formats(req.export)
+    with state.lock:
+        job_state = state.jobs.create_static_job(
+            job_id,
+            file_id=req.file_id,
+            key1_byte=req.key1_byte,
+            key2_byte=req.key2_byte,
+            statics_kind='refraction',
+            artifacts_dir=str(job_dir),
+        )
+        job_state['pick_source'] = {
+            'kind': 'uploaded_npz',
+            **upload_metadata,
+        }
+        if req.export.enabled:
+            job_state['export_formats'] = list(requested_formats)
+        status = job_state['status']
+
+    start_job_thread(
+        thread_factory=threading.Thread,
+        target=run_refraction_static_apply_job,
+        args=(job_id, req, state, stored_path, upload_metadata),
     )
 
     response: RefractionStaticApplyResponse = {'job_id': job_id, 'state': status}

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1305,12 +1305,33 @@ class RefractionStaticPickSourceRequest(BaseModel):
 
     model_config = ConfigDict(extra='forbid')
 
-    kind: Literal['batch_predicted_npz', 'manual_npz_artifact', 'manual_memmap']
+    kind: Literal[
+        'uploaded_npz',
+        'batch_predicted_npz',
+        'manual_npz_artifact',
+        'manual_memmap',
+    ] = Field(
+        description=(
+            'Use uploaded_npz for Static Correction UI direct .npz uploads; '
+            'artifact-backed kinds are retained for legacy job-artifact flows.'
+        )
+    )
     job_id: str | None = None
     artifact_name: str | None = None
 
     @model_validator(mode='after')
     def _check_ref(self) -> 'RefractionStaticPickSourceRequest':
+        if self.kind == 'uploaded_npz':
+            if self.job_id is not None:
+                raise ValueError(
+                    'pick_source.job_id must be omitted for uploaded_npz'
+                )
+            if self.artifact_name is not None:
+                raise ValueError(
+                    'pick_source.artifact_name must be omitted for uploaded_npz'
+                )
+            return self
+
         if self.kind == 'manual_memmap':
             if self.job_id is not None or self.artifact_name is not None:
                 raise ValueError(

--- a/app/services/refraction_static_inputs.py
+++ b/app/services/refraction_static_inputs.py
@@ -572,6 +572,10 @@ def _load_refraction_pick_source(
     sorted_trace_index: np.ndarray,
 ) -> _LoadedRefractionPickSource:
     pick_source = req.pick_source
+    if pick_source.kind == 'uploaded_npz':
+        raise ValueError(
+            'pick_source.kind=uploaded_npz requires the multipart upload endpoint'
+        )
     if pick_source.kind == 'manual_memmap':
         return _load_manual_memmap_pick_source(
             file_id=req.file_id,

--- a/app/services/refraction_static_inputs.py
+++ b/app/services/refraction_static_inputs.py
@@ -172,6 +172,8 @@ def build_refraction_static_input_model(
     req: RefractionStaticApplyRequest,
     state: AppState,
     job_dir: Path | None = None,
+    uploaded_pick_npz_path: Path | None = None,
+    uploaded_pick_metadata: Mapping[str, object] | None = None,
 ) -> RefractionStaticInputModel:
     """Build a sorted-order refraction statics input model for a request."""
     file_id = _non_empty_str(req.file_id, name='file_id')
@@ -194,6 +196,8 @@ def build_refraction_static_input_model(
         n_samples=n_samples,
         dt=dt,
         sorted_trace_index=sorted_trace_index,
+        uploaded_pick_npz_path=uploaded_pick_npz_path,
+        uploaded_pick_metadata=uploaded_pick_metadata,
     )
     headers = _load_refraction_trace_headers(
         reader=reader,
@@ -570,11 +574,31 @@ def _load_refraction_pick_source(
     n_samples: int,
     dt: float,
     sorted_trace_index: np.ndarray,
+    uploaded_pick_npz_path: Path | None = None,
+    uploaded_pick_metadata: Mapping[str, object] | None = None,
 ) -> _LoadedRefractionPickSource:
     pick_source = req.pick_source
     if pick_source.kind == 'uploaded_npz':
-        raise ValueError(
-            'pick_source.kind=uploaded_npz requires the multipart upload endpoint'
+        if uploaded_pick_npz_path is None:
+            raise ValueError(
+                'pick_source.kind=uploaded_npz requires the multipart upload endpoint'
+            )
+        loaded = _load_npz_refraction_pick_source(
+            uploaded_pick_npz_path,
+            reader=reader,
+            n_traces=n_traces,
+            n_samples=n_samples,
+            dt=dt,
+            sorted_trace_index=sorted_trace_index,
+        )
+        metadata = dict(loaded.metadata)
+        if uploaded_pick_metadata is not None:
+            metadata.update(dict(uploaded_pick_metadata))
+        return _LoadedRefractionPickSource(
+            picks_time_s_sorted=loaded.picks_time_s_sorted,
+            sorted_trace_index=loaded.sorted_trace_index,
+            source_kind='uploaded_npz',
+            metadata=metadata,
         )
     if pick_source.kind == 'manual_memmap':
         return _load_manual_memmap_pick_source(

--- a/app/services/refraction_static_inputs.py
+++ b/app/services/refraction_static_inputs.py
@@ -25,6 +25,13 @@ from app.services.geometry_linkage_loader import (
     load_geometry_linkage_artifact,
 )
 from app.services.job_artifact_refs import resolve_job_artifact_path
+from app.services.refraction_static_pick_source_loader import (
+    PICK_TIME_KEYS,
+    REFRACTION_PICK_ORDER_TRACE_STORE_SORTED as _ORDER_TRACE_STORE_SORTED,
+    LoadedRefractionPickSource,
+    load_npz_refraction_pick_source_from_path,
+    load_refraction_pick_source_from_npz_path,
+)
 from app.services.reader import get_reader
 from app.services.refraction_static_layer_observations import (
     build_refraction_layer_observation_masks,
@@ -45,18 +52,9 @@ from app.trace_store.reader import TraceStoreSectionReader
 from app.utils.pick_cache_file1d_mem import path_for_file
 from app.utils.segy_scalars import apply_segy_scalar, normalize_elevation_unit
 
-PICK_TIME_KEYS: tuple[str, ...] = (
-    'pick_time_s',
-    'picks_time_s',
-    'predicted_picks_time_s',
-    'first_break_time_s',
-)
-
 REFRACTION_INPUT_QC_JSON_NAME = 'refraction_input_model_qc.json'
 REFRACTION_INPUT_PREVIEW_CSV_NAME = 'refraction_input_model_preview.csv'
 
-_ORDER_TRACE_STORE_SORTED = 'trace_store_sorted'
-_ORDER_ORIGINAL_TRACE = 'original_trace_order'
 _FEET_TO_METERS = 0.3048
 _COORD_ATOL_M = 1.0e-6
 _ENDPOINT_KEY_DTYPE = '<U192'
@@ -97,12 +95,7 @@ _PREVIEW_COLUMNS = (
 )
 
 
-@dataclass(frozen=True)
-class _LoadedRefractionPickSource:
-    picks_time_s_sorted: np.ndarray
-    sorted_trace_index: np.ndarray
-    source_kind: str
-    metadata: dict[str, Any]
+_LoadedRefractionPickSource = LoadedRefractionPickSource
 
 
 @dataclass(frozen=True)
@@ -583,12 +576,12 @@ def _load_refraction_pick_source(
             raise ValueError(
                 'pick_source.kind=uploaded_npz requires the multipart upload endpoint'
             )
-        loaded = _load_npz_refraction_pick_source(
-            uploaded_pick_npz_path,
-            reader=reader,
+        loaded = load_refraction_pick_source_from_npz_path(
+            npz_path=uploaded_pick_npz_path,
+            request=req,
             n_traces=n_traces,
             n_samples=n_samples,
-            dt=dt,
+            dt_s=dt,
             sorted_trace_index=sorted_trace_index,
         )
         metadata = dict(loaded.metadata)
@@ -709,60 +702,19 @@ def _load_npz_refraction_pick_source(
     dt: float,
     sorted_trace_index: np.ndarray,
 ) -> _LoadedRefractionPickSource:
-    path = Path(npz_path)
-    try:
-        npz_file = np.load(path, allow_pickle=False)
-    except Exception as exc:  # noqa: BLE001
-        msg = f'Could not read npz pick source: {path}'
-        raise ValueError(msg) from exc
-
-    with npz_file as npz:
-        key = _select_pick_key(npz.files)
-        metadata = _validate_pick_npz_metadata(
-            npz,
-            n_traces=n_traces,
-            n_samples=n_samples,
-            dt=dt,
-            path=path,
-            key=key,
-        )
-        picks = _coerce_pick_array(np.asarray(npz[key]))
-        if picks.shape != (n_traces,):
-            msg = (
-                'pick array length mismatch: '
-                f'expected {(n_traces,)}, got {picks.shape}'
-            )
-            raise ValueError(msg)
-
-        artifact_order = _read_npz_order(npz)
-        reader_sorted_to_original = _reader_sorted_to_original(
-            reader,
-            n_traces=n_traces,
-        )
-        if 'sorted_to_original' in npz.files:
-            npz_sorted_to_original = validate_sorted_to_original(
-                np.asarray(npz['sorted_to_original']),
-                expected_n_traces=n_traces,
-                role='npz',
-            )
-            if not np.array_equal(npz_sorted_to_original, reader_sorted_to_original):
-                raise ValueError('sorted_to_original mismatch')
-            metadata['has_sorted_to_original'] = True
-        else:
-            metadata['has_sorted_to_original'] = False
-
-    if artifact_order == _ORDER_TRACE_STORE_SORTED:
-        picks_sorted = picks
-    elif artifact_order == _ORDER_ORIGINAL_TRACE:
-        picks_sorted = np.ascontiguousarray(picks[reader_sorted_to_original])
-    else:
-        raise ValueError(f'unsupported pick artifact order: {artifact_order}')
-
-    return _LoadedRefractionPickSource(
-        picks_time_s_sorted=picks_sorted,
-        sorted_trace_index=sorted_trace_index,
+    reader_sorted_to_original = _reader_sorted_to_original(
+        reader,
+        n_traces=n_traces,
+    )
+    if not np.array_equal(reader_sorted_to_original, sorted_trace_index):
+        raise ValueError('sorted_trace_index mismatch')
+    return load_npz_refraction_pick_source_from_path(
+        npz_path,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt_s=dt,
+        sorted_trace_index=reader_sorted_to_original,
         source_kind='npz',
-        metadata=metadata,
     )
 
 
@@ -1592,60 +1544,6 @@ def _validate_pick_mask(
     return reasons == 'ok', reasons
 
 
-def _select_pick_key(keys: list[str]) -> str:
-    for key in PICK_TIME_KEYS:
-        if key in keys:
-            return key
-    accepted = ', '.join(PICK_TIME_KEYS)
-    raise ValueError(f'unsupported pick artifact key; accepted keys: {accepted}')
-
-
-def _validate_pick_npz_metadata(
-    npz: np.lib.npyio.NpzFile,
-    *,
-    n_traces: int,
-    n_samples: int,
-    dt: float,
-    path: Path,
-    key: str,
-) -> dict[str, Any]:
-    metadata: dict[str, Any] = {
-        'npz_path': str(path),
-        'npz_keys': tuple(npz.files),
-        'accepted_pick_key': key,
-        'accepted_key_priority': PICK_TIME_KEYS,
-    }
-    if 'n_traces' in npz.files:
-        value = _read_int_scalar_from_npz(npz, 'n_traces')
-        metadata['n_traces'] = value
-        if value != n_traces:
-            raise ValueError(f'n_traces mismatch: expected {n_traces}, got {value}')
-    if 'n_samples' in npz.files:
-        value = _read_int_scalar_from_npz(npz, 'n_samples')
-        metadata['n_samples'] = value
-        if value != n_samples:
-            raise ValueError(f'n_samples mismatch: expected {n_samples}, got {value}')
-    if 'dt' in npz.files:
-        value = _read_float_scalar_from_npz(npz, 'dt')
-        metadata['dt'] = value
-        if not np.isfinite(value) or abs(value - dt) > 1.0e-9:
-            raise ValueError(f'dt mismatch: expected {dt}, got {value}')
-    return metadata
-
-
-def _read_npz_order(npz: np.lib.npyio.NpzFile) -> str:
-    for key in ('order', 'trace_order'):
-        if key not in npz.files:
-            continue
-        value = _read_string_scalar_from_npz(npz, key)
-        if value in {_ORDER_TRACE_STORE_SORTED, 'sorted'}:
-            return _ORDER_TRACE_STORE_SORTED
-        if value in {_ORDER_ORIGINAL_TRACE, 'original'}:
-            return _ORDER_ORIGINAL_TRACE
-        raise ValueError(f'unsupported pick artifact {key}: {value}')
-    return _ORDER_ORIGINAL_TRACE
-
-
 def _unique_endpoints(
     endpoint_kind: str,
     endpoint_id_values: np.ndarray,
@@ -1926,34 +1824,6 @@ def _reader_dt(reader: TraceStoreSectionReader, *, state: AppState, file_id: str
     return _coerce_positive_float(state.file_registry.get_dt(file_id), name='dt')
 
 
-def _read_int_scalar_from_npz(npz: np.lib.npyio.NpzFile, key: str) -> int:
-    arr = np.asarray(npz[key])
-    if arr.size != 1 or np.issubdtype(arr.dtype, np.bool_):
-        raise ValueError(f'{key} must be an integer scalar')
-    if not np.issubdtype(arr.dtype, np.integer):
-        raise ValueError(f'{key} must be an integer scalar')
-    return int(arr.reshape(-1)[0])
-
-
-def _read_float_scalar_from_npz(npz: np.lib.npyio.NpzFile, key: str) -> float:
-    arr = np.asarray(npz[key])
-    if arr.size != 1:
-        raise ValueError(f'{key} must be a numeric scalar')
-    if np.issubdtype(arr.dtype, np.bool_) or not _is_real_numeric_dtype(arr.dtype):
-        raise ValueError(f'{key} must be a numeric scalar')
-    return float(arr.reshape(-1)[0])
-
-
-def _read_string_scalar_from_npz(npz: np.lib.npyio.NpzFile, key: str) -> str:
-    arr = np.asarray(npz[key])
-    if arr.size != 1:
-        raise ValueError(f'{key} must be a string scalar')
-    value = arr.reshape(-1)[0]
-    if isinstance(value, bytes):
-        return value.decode('utf-8')
-    return str(value)
-
-
 def _preview_rows(input_model: RefractionStaticInputModel) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for i in range(input_model.n_traces):
@@ -2124,9 +1994,11 @@ __all__ = [
     'PICK_TIME_KEYS',
     'REFRACTION_INPUT_PREVIEW_CSV_NAME',
     'REFRACTION_INPUT_QC_JSON_NAME',
+    'LoadedRefractionPickSource',
     'RefractionEndpointTable',
     'RefractionStaticInputModel',
     'build_refraction_static_input_model',
     'build_refraction_static_input_model_from_arrays',
+    'load_refraction_pick_source_from_npz_path',
     'write_refraction_static_input_artifacts',
 ]

--- a/app/services/refraction_static_pick_source_loader.py
+++ b/app/services/refraction_static_pick_source_loader.py
@@ -1,0 +1,282 @@
+"""Dependency-light refraction first-break pick NPZ loading."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from app.api.schemas import RefractionStaticApplyRequest
+from app.services.trace_store_index_validation import validate_sorted_to_original
+
+PICK_TIME_KEYS: tuple[str, ...] = (
+    'pick_time_s',
+    'picks_time_s',
+    'predicted_picks_time_s',
+    'first_break_time_s',
+)
+
+REFRACTION_PICK_ORDER_TRACE_STORE_SORTED = 'trace_store_sorted'
+REFRACTION_PICK_ORDER_ORIGINAL_TRACE = 'original_trace_order'
+
+
+@dataclass(frozen=True)
+class LoadedRefractionPickSource:
+    picks_time_s_sorted: np.ndarray
+    sorted_trace_index: np.ndarray
+    source_kind: str
+    metadata: dict[str, Any]
+
+
+def load_refraction_pick_source_from_npz_path(
+    *,
+    npz_path: Path,
+    request: RefractionStaticApplyRequest,
+    n_traces: int,
+    n_samples: int,
+    dt_s: float,
+    sorted_trace_index: np.ndarray,
+) -> LoadedRefractionPickSource:
+    """Load uploaded first-break picks from a concrete NPZ path."""
+    if request.pick_source.kind != 'uploaded_npz':
+        raise ValueError('pick_source.kind must be uploaded_npz for direct NPZ loading')
+    loaded = load_npz_refraction_pick_source_from_path(
+        npz_path,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt_s=dt_s,
+        sorted_trace_index=sorted_trace_index,
+        source_kind='uploaded_npz',
+    )
+    metadata = dict(loaded.metadata)
+    metadata['loaded_from'] = 'uploaded_npz'
+    return LoadedRefractionPickSource(
+        picks_time_s_sorted=loaded.picks_time_s_sorted,
+        sorted_trace_index=loaded.sorted_trace_index,
+        source_kind='uploaded_npz',
+        metadata=metadata,
+    )
+
+
+def load_npz_refraction_pick_source_from_path(
+    npz_path: Path,
+    *,
+    n_traces: int,
+    n_samples: int,
+    dt_s: float,
+    sorted_trace_index: np.ndarray,
+    source_kind: str,
+) -> LoadedRefractionPickSource:
+    """Load a refraction pick NPZ and normalize pick times to sorted order."""
+    path = Path(npz_path)
+    sorted_to_original = validate_sorted_to_original(
+        np.asarray(sorted_trace_index),
+        expected_n_traces=n_traces,
+        role='sorted_trace_index',
+    )
+    try:
+        npz_file = np.load(path, allow_pickle=False)
+    except Exception as exc:  # noqa: BLE001
+        msg = f'Could not read npz pick source: {path}'
+        raise ValueError(msg) from exc
+
+    try:
+        with npz_file as npz:
+            key = _select_pick_key(npz.files)
+            metadata = _validate_pick_npz_metadata(
+                npz,
+                n_traces=n_traces,
+                n_samples=n_samples,
+                dt_s=dt_s,
+                path=path,
+                key=key,
+            )
+            picks = _coerce_pick_array(np.asarray(npz[key]))
+            if picks.shape != (n_traces,):
+                msg = (
+                    'pick array length mismatch: '
+                    f'expected {(n_traces,)}, got {picks.shape}'
+                )
+                raise ValueError(msg)
+
+            artifact_order = _read_npz_order(npz)
+            if 'sorted_to_original' in npz.files:
+                npz_sorted_to_original = validate_sorted_to_original(
+                    np.asarray(npz['sorted_to_original']),
+                    expected_n_traces=n_traces,
+                    role='npz',
+                )
+                if not np.array_equal(npz_sorted_to_original, sorted_to_original):
+                    raise ValueError('sorted_to_original mismatch')
+                metadata['has_sorted_to_original'] = True
+            else:
+                metadata['has_sorted_to_original'] = False
+            metadata.update(_optional_pick_npz_array_metadata(npz, n_traces=n_traces))
+    except ValueError as exc:
+        msg = f'Invalid npz pick source {path}: {exc}'
+        raise ValueError(msg) from exc
+
+    if artifact_order == REFRACTION_PICK_ORDER_TRACE_STORE_SORTED:
+        picks_sorted = picks
+    elif artifact_order == REFRACTION_PICK_ORDER_ORIGINAL_TRACE:
+        picks_sorted = np.ascontiguousarray(picks[sorted_to_original])
+    else:
+        raise ValueError(f'unsupported pick artifact order: {artifact_order}')
+
+    return LoadedRefractionPickSource(
+        picks_time_s_sorted=picks_sorted,
+        sorted_trace_index=sorted_to_original,
+        source_kind=source_kind,
+        metadata=metadata,
+    )
+
+
+def _select_pick_key(keys: list[str]) -> str:
+    for key in PICK_TIME_KEYS:
+        if key in keys:
+            return key
+    accepted = ', '.join(PICK_TIME_KEYS)
+    raise ValueError(f'unsupported pick artifact key; accepted keys: {accepted}')
+
+
+def _validate_pick_npz_metadata(
+    npz: np.lib.npyio.NpzFile,
+    *,
+    n_traces: int,
+    n_samples: int,
+    dt_s: float,
+    path: Path,
+    key: str,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        'npz_path': str(path),
+        'npz_keys': tuple(npz.files),
+        'accepted_pick_key': key,
+        'accepted_key_priority': PICK_TIME_KEYS,
+    }
+    if 'n_traces' in npz.files:
+        value = _read_int_scalar_from_npz(npz, 'n_traces')
+        metadata['n_traces'] = value
+        if value != n_traces:
+            raise ValueError(f'n_traces mismatch: expected {n_traces}, got {value}')
+    if 'n_samples' in npz.files:
+        value = _read_int_scalar_from_npz(npz, 'n_samples')
+        metadata['n_samples'] = value
+        if value != n_samples:
+            raise ValueError(f'n_samples mismatch: expected {n_samples}, got {value}')
+    if 'dt' in npz.files:
+        value = _read_float_scalar_from_npz(npz, 'dt')
+        metadata['dt'] = value
+        if not np.isfinite(value) or abs(value - dt_s) > 1.0e-9:
+            raise ValueError(f'dt mismatch: expected {dt_s}, got {value}')
+    return metadata
+
+
+def _optional_pick_npz_array_metadata(
+    npz: np.lib.npyio.NpzFile,
+    *,
+    n_traces: int,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if 'valid_pick_mask' in npz.files:
+        mask = np.asarray(npz['valid_pick_mask'])
+        if mask.shape != (n_traces,):
+            raise ValueError(
+                'valid_pick_mask shape mismatch: '
+                f'expected {(n_traces,)}, got {mask.shape}'
+            )
+        if not np.issubdtype(mask.dtype, np.bool_):
+            raise ValueError('valid_pick_mask must have a bool dtype')
+        metadata['has_valid_pick_mask'] = True
+        metadata['n_valid_pick_mask'] = int(np.count_nonzero(mask))
+    else:
+        metadata['has_valid_pick_mask'] = False
+
+    if 'confidence' in npz.files:
+        confidence = np.asarray(npz['confidence'])
+        if confidence.ndim != 0 and confidence.shape != (n_traces,):
+            raise ValueError(
+                'confidence shape mismatch: '
+                f'expected scalar or {(n_traces,)}, got {confidence.shape}'
+            )
+        if np.issubdtype(confidence.dtype, np.bool_) or not _is_real_numeric_dtype(
+            confidence.dtype
+        ):
+            raise ValueError('confidence must have a real numeric dtype')
+        metadata['has_confidence'] = True
+        metadata['confidence_shape'] = tuple(int(dim) for dim in confidence.shape)
+    else:
+        metadata['has_confidence'] = False
+    return metadata
+
+
+def _read_npz_order(npz: np.lib.npyio.NpzFile) -> str:
+    for key in ('order', 'trace_order'):
+        if key not in npz.files:
+            continue
+        value = _read_string_scalar_from_npz(npz, key)
+        if value in {REFRACTION_PICK_ORDER_TRACE_STORE_SORTED, 'sorted'}:
+            return REFRACTION_PICK_ORDER_TRACE_STORE_SORTED
+        if value in {REFRACTION_PICK_ORDER_ORIGINAL_TRACE, 'original'}:
+            return REFRACTION_PICK_ORDER_ORIGINAL_TRACE
+        raise ValueError(f'unsupported pick artifact {key}: {value}')
+    return REFRACTION_PICK_ORDER_ORIGINAL_TRACE
+
+
+def _coerce_pick_array(values: np.ndarray) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError('pick_time_s_sorted must be 1D')
+    if np.issubdtype(arr.dtype, np.bool_) or not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError('pick_time_s_sorted must have a real numeric dtype')
+    out = np.ascontiguousarray(arr, dtype=np.float64)
+    if not np.all(np.isfinite(out)):
+        raise ValueError('pick_time_s_sorted must contain finite values')
+    return out
+
+
+def _read_int_scalar_from_npz(npz: np.lib.npyio.NpzFile, key: str) -> int:
+    arr = np.asarray(npz[key])
+    if arr.size != 1 or np.issubdtype(arr.dtype, np.bool_):
+        raise ValueError(f'{key} must be an integer scalar')
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(f'{key} must be an integer scalar')
+    return int(arr.reshape(-1)[0])
+
+
+def _read_float_scalar_from_npz(npz: np.lib.npyio.NpzFile, key: str) -> float:
+    arr = np.asarray(npz[key])
+    if arr.size != 1:
+        raise ValueError(f'{key} must be a numeric scalar')
+    if np.issubdtype(arr.dtype, np.bool_) or not _is_real_numeric_dtype(arr.dtype):
+        raise ValueError(f'{key} must be a numeric scalar')
+    return float(arr.reshape(-1)[0])
+
+
+def _read_string_scalar_from_npz(npz: np.lib.npyio.NpzFile, key: str) -> str:
+    arr = np.asarray(npz[key])
+    if arr.size != 1:
+        raise ValueError(f'{key} must be a string scalar')
+    value = arr.reshape(-1)[0]
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    return str(value)
+
+
+def _is_real_numeric_dtype(dtype: np.dtype) -> bool:
+    return np.issubdtype(dtype, np.number) and not np.issubdtype(
+        dtype,
+        np.complexfloating,
+    )
+
+
+__all__ = [
+    'LoadedRefractionPickSource',
+    'PICK_TIME_KEYS',
+    'REFRACTION_PICK_ORDER_ORIGINAL_TRACE',
+    'REFRACTION_PICK_ORDER_TRACE_STORE_SORTED',
+    'load_npz_refraction_pick_source_from_path',
+    'load_refraction_pick_source_from_npz_path',
+]

--- a/app/services/refraction_static_service.py
+++ b/app/services/refraction_static_service.py
@@ -141,6 +141,8 @@ def resolve_refraction_first_layer_request(
     req: RefractionStaticApplyRequest,
     state: AppState,
     job_dir: Path,
+    uploaded_pick_npz_path: Path | None = None,
+    uploaded_pick_metadata: dict[str, object] | None = None,
 ) -> _ResolvedFirstLayerRequest:
     """Resolve V1 for a full refraction statics request."""
     mode = req.model.first_layer_mode
@@ -170,6 +172,8 @@ def resolve_refraction_first_layer_request(
         req=v1_req,
         state=state,
         job_dir=job_dir,
+        uploaded_pick_npz_path=uploaded_pick_npz_path,
+        uploaded_pick_metadata=uploaded_pick_metadata,
     )
     estimate = estimate_global_v1_from_direct_arrivals(
         input_model=input_model,
@@ -422,8 +426,16 @@ def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
 
 def _refraction_static_request_payload(
     req: RefractionStaticApplyRequest,
+    *,
+    uploaded_pick_metadata: dict[str, object] | None = None,
 ) -> dict[str, Any]:
     payload = req.model_dump(mode='json')
+    if uploaded_pick_metadata is not None:
+        pick_source = payload.get('pick_source')
+        if isinstance(pick_source, dict):
+            pick_source.update(uploaded_pick_metadata)
+            pick_source.pop('job_id', None)
+            pick_source.pop('artifact_name', None)
     if 'field_corrections' not in req.model_fields_set:
         payload.pop('field_corrections', None)
     if 'export' not in req.model_fields_set:
@@ -1088,6 +1100,8 @@ def _run_public_multilayer_refraction_static_apply_job(
     state: AppState,
     job_dir: Path,
     first_layer: _ResolvedFirstLayerRequest,
+    uploaded_pick_npz_path: Path | None = None,
+    uploaded_pick_metadata: dict[str, object] | None = None,
 ) -> JobCompletion:
     _set_job_progress_message(
         state,
@@ -1099,6 +1113,8 @@ def _run_public_multilayer_refraction_static_apply_job(
         req=req,
         state=state,
         job_dir=job_dir,
+        uploaded_pick_npz_path=uploaded_pick_npz_path,
+        uploaded_pick_metadata=uploaded_pick_metadata,
     )
     _set_job_progress_message(
         state,
@@ -1177,6 +1193,8 @@ def _run_refraction_static_apply_job_body(
     job_id: str,
     req: RefractionStaticApplyRequest,
     state: AppState,
+    uploaded_pick_npz_path: Path | None = None,
+    uploaded_pick_metadata: dict[str, object] | None = None,
 ) -> JobCompletion | None:
     req = RefractionStaticApplyRequest.model_validate(req)
     _set_job_progress_message(
@@ -1195,7 +1213,10 @@ def _run_refraction_static_apply_job_body(
         'source_file_id': req.file_id,
         'key1_byte': req.key1_byte,
         'key2_byte': req.key2_byte,
-        'request': _refraction_static_request_payload(req),
+        'request': _refraction_static_request_payload(
+            req,
+            uploaded_pick_metadata=uploaded_pick_metadata,
+        ),
     }
     if req.export.enabled:
         request_record['export'] = {
@@ -1220,6 +1241,8 @@ def _run_refraction_static_apply_job_body(
         req=req,
         state=state,
         job_dir=job_dir,
+        uploaded_pick_npz_path=uploaded_pick_npz_path,
+        uploaded_pick_metadata=uploaded_pick_metadata,
     )
     input_req = first_layer.req
     if public_multilayer_apply:
@@ -1229,6 +1252,8 @@ def _run_refraction_static_apply_job_body(
             state=state,
             job_dir=job_dir,
             first_layer=first_layer,
+            uploaded_pick_npz_path=uploaded_pick_npz_path,
+            uploaded_pick_metadata=uploaded_pick_metadata,
         )
 
     active_req = _solver_request_for_refraction_static_apply(input_req)
@@ -1241,6 +1266,7 @@ def _run_refraction_static_apply_job_body(
     weathering_input_model = first_layer.input_model
     if (
         first_layer.resolved.mode == 'estimate_direct_arrival'
+        or input_req.pick_source.kind == 'uploaded_npz'
         or input_req.model.method == 'multilayer_time_term'
         or input_req.field_corrections.source_depth.mode != 'none'
         or input_req.field_corrections.uphole.mode != 'none'
@@ -1250,6 +1276,8 @@ def _run_refraction_static_apply_job_body(
             req=input_req,
             state=state,
             job_dir=job_dir,
+            uploaded_pick_npz_path=uploaded_pick_npz_path,
+            uploaded_pick_metadata=uploaded_pick_metadata,
         )
     weathering_input_model = _solver_input_model_for_refraction_static_apply(
         req=input_req,
@@ -1357,6 +1385,8 @@ def run_refraction_static_apply_job(
     job_id: str,
     req: RefractionStaticApplyRequest,
     state: AppState,
+    uploaded_pick_npz_path: Path | None = None,
+    uploaded_pick_metadata: dict[str, object] | None = None,
 ) -> None:
     """Start the refraction statics job lifecycle."""
 
@@ -1365,6 +1395,8 @@ def run_refraction_static_apply_job(
             job_id=job_id,
             req=req,
             state=state,
+            uploaded_pick_npz_path=uploaded_pick_npz_path,
+            uploaded_pick_metadata=uploaded_pick_metadata,
         )
 
     run_job_with_lifecycle(

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -2126,6 +2126,7 @@
               <label class="static-correction-field" for="staticCorrectionPickKind">pick_source.kind
                 <select id="staticCorrectionPickKind" name="pick_source.kind"
                   data-testid="static-correction-pick-kind">
+                  <option value="uploaded_npz">uploaded_npz</option>
                   <option value="batch_predicted_npz" selected>batch_predicted_npz</option>
                   <option value="manual_npz_artifact">manual_npz_artifact</option>
                 </select>

--- a/app/static/refraction_static_run.js
+++ b/app/static/refraction_static_run.js
@@ -93,6 +93,7 @@
       optional: true,
     },
   ];
+  const UPLOADED_PICK_KIND = 'uploaded_npz';
   const ARTIFACT_PICK_KINDS = new Set(['batch_predicted_npz', 'manual_npz_artifact']);
   const LINKAGE_THRESHOLD_MODES = new Set(['auto_threshold']);
   const LINKAGE_ARTIFACT_NAME = 'geometry_linkage.npz';
@@ -534,6 +535,12 @@
     if (!pickKind) {
       errors.push('pick_source.kind is required.');
     }
+    if (pickKind === UPLOADED_PICK_KIND) {
+      if (errors.length) {
+        throw validationError(errors);
+      }
+      return { kind: UPLOADED_PICK_KIND };
+    }
     if (ARTIFACT_PICK_KINDS.has(pickKind)) {
       if (!pickSource.job_id) {
         errors.push('pick_source.job_id is required for artifact-backed pick sources.');
@@ -549,6 +556,17 @@
       throw validationError(errors);
     }
     return pickSource;
+  }
+
+  function updateStaticCorrectionPickSourceControls(targetDom = dom) {
+    if (!targetDom) return;
+    const uploaded = trimValue(targetDom.pickKind && targetDom.pickKind.value) === UPLOADED_PICK_KIND;
+    if (targetDom.pickJobId) {
+      targetDom.pickJobId.disabled = uploaded;
+    }
+    if (targetDom.pickArtifactName) {
+      targetDom.pickArtifactName.disabled = uploaded;
+    }
   }
 
   function validateStaticCorrectionGeometryRequest(targetDom = dom) {
@@ -1777,6 +1795,11 @@
       return;
     }
 
+    if (trimValue(dom.pickKind.value) === UPLOADED_PICK_KIND) {
+      dom.pickArtifactList.hidden = true;
+      return;
+    }
+
     if (!state.pickArtifacts.length) {
       dom.pickArtifactList.hidden = true;
       return;
@@ -1954,13 +1977,17 @@
     if (state.showValidationSummary) {
       state.validationErrors = preview.errors;
     }
+    updateStaticCorrectionPickSourceControls(dom);
     updateStaticCorrectionLinkageOptions(dom);
     dom.status.textContent = state.message;
     dom.error.hidden = !state.error;
     dom.error.textContent = state.error;
     dom.runButton.disabled = state.phase !== 'idle' || isStaticJobActive();
     if (dom.loadPickArtifactsButton) {
-      dom.loadPickArtifactsButton.disabled = state.loadingPickArtifacts;
+      dom.loadPickArtifactsButton.disabled = (
+        state.loadingPickArtifacts
+        || trimValue(dom.pickKind.value) === UPLOADED_PICK_KIND
+      );
     }
     if (dom.requestPreview) {
       dom.requestPreview.textContent = preview.payload
@@ -1978,6 +2005,13 @@
     if (!dom) return;
     const pickKind = trimValue(dom.pickKind.value);
     const jobId = trimValue(dom.pickJobId.value);
+    if (pickKind === UPLOADED_PICK_KIND) {
+      state.error = 'Artifact listing is not available for pick_source.kind uploaded_npz.';
+      state.message = 'Use the direct pick upload flow for uploaded_npz.';
+      state.pickArtifacts = [];
+      render();
+      return;
+    }
     if (!jobId) {
       state.error = 'pick_source.job_id is required before loading pick artifacts.';
       state.message = 'Enter the batch job ID that produced the first-break pick artifact.';

--- a/app/static/viewer/bootstrap.js
+++ b/app/static/viewer/bootstrap.js
@@ -1,5 +1,5 @@
 // /viewer/bootstrap.js
-import { createStore } from './store.js';
+import { createSeisViewerState, createStore } from './store.js';
 import * as GridCore from './core/grid.js';
 import { buildLayout, buildPickShapes, buildPickMarkerTraces, buildPendingPickMarkerTrace } from './core/layout.js';
 import { initPrefs, getPref } from './settings/prefs.js';
@@ -56,6 +56,11 @@ const toNum = (v, d) => {
 };
 const toStr = (v, d) => (v == null ? d : String(v));
 const toBool = (v) => (typeof v === 'string' ? v === 'true' : !!v);
+const toIntOrNull = (v) => {
+  if (typeof v === 'string' && v.trim() === '') return null;
+  const x = Number(v);
+  return Number.isInteger(x) ? x : null;
+};
 const readAxisRange = (ev, axisName) => {
   if (!ev || typeof ev !== 'object') return null;
   const packed = ev[`${axisName}.range`];
@@ -106,9 +111,22 @@ if (!(typeof window.defaultDt === 'number' && Number.isFinite(window.defaultDt) 
 
 // Read initial values from existing DOM / globals
 const slider = document.getElementById('key1_slider');
+const readActiveViewerTargetState = (state = {}) => {
+  const fileId = state.fileId ?? document.getElementById('file_id')?.value ?? window.currentFileId ?? '';
+  const displayName = state.displayName ?? window.currentFileName ?? '';
+  return {
+    fileId,
+    displayName,
+    key1Byte: toIntOrNull(state.key1Byte ?? window.currentKey1Byte),
+    key2Byte: toIntOrNull(state.key2Byte ?? window.currentKey2Byte),
+    isFileLoaded: state.isFileLoaded === undefined
+      ? Boolean(fileId && displayName)
+      : Boolean(state.isFileLoaded),
+  };
+};
 
 const initial = {
-  fileId: document.getElementById('file_id')?.value || (window.currentFileId || ''),
+  ...readActiveViewerTargetState(),
   pickMode: !!window.isPickMode,
   wiggleDensity: toNum(getPref('wiggle_density'), 0.20),
   gain: toNum(getPref('gain'), toNum(document.getElementById('gain')?.value, 1)),
@@ -126,6 +144,11 @@ const store = createStore(initial);
 
 // Expose for debugging
 window.store = store;
+window.SeisViewerState = createSeisViewerState(store);
+window.SeisViewerState.syncActiveFileTarget = function syncActiveFileTarget(state) {
+  store.patch(readActiveViewerTargetState(state));
+  return window.SeisViewerState.getActiveFileTarget();
+};
 
 // ---- Sync global wiggle-threshold at boot
   window.WIGGLE_DENSITY_THRESHOLD = store.get().wiggleDensity;
@@ -235,8 +258,7 @@ if (typeof window.loadSettings === 'function') {
   const _load = window.loadSettings;
   window.loadSettings = async function () {
     await _load();
-    window.store.patch({
-      fileId: document.getElementById('file_id')?.value || (window.currentFileId || ''),
+    store.patch({
       key1Values: Array.isArray(window.key1Values) ? window.key1Values : [],
       sectionShape: window.sectionShape || null,
       pipelineKey: window.latestPipelineKey || null,
@@ -244,4 +266,11 @@ if (typeof window.loadSettings === 'function') {
     // dt が変わる可能性があるので、閾値更新は不要だが、必要ならここで再フェッチ可能
   };
 }
+document.getElementById('file_id')?.addEventListener('change', () => {
+  store.patch({
+    ...readActiveViewerTargetState(),
+    displayName: '',
+    isFileLoaded: false,
+  });
+});
 store.subscribe(() => { });

--- a/app/static/viewer/store.js
+++ b/app/static/viewer/store.js
@@ -10,3 +10,37 @@ export function createStore(initial) {
     subscribe(fn) { subs.add(fn); return () => subs.delete(fn); },
   };
 }
+
+function toFiniteInteger(value) {
+  if (typeof value === 'string' && value.trim() === '') return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export function getActiveFileTargetFromState(state) {
+  if (!state || typeof state !== 'object') return null;
+
+  const fileId = String(state.fileId || '').trim();
+  if (!fileId) return null;
+  if (state.isFileLoaded !== true) return null;
+
+  const key1Byte = toFiniteInteger(state.key1Byte);
+  const key2Byte = toFiniteInteger(state.key2Byte);
+  if (key1Byte === null || key2Byte === null) return null;
+
+  const label = String(state.displayName || state.fileName || fileId).trim() || fileId;
+  return {
+    fileId,
+    displayName: label,
+    key1Byte,
+    key2Byte,
+  };
+}
+
+export function createSeisViewerState(store) {
+  return {
+    getActiveFileTarget() {
+      return getActiveFileTargetFromState(store.get());
+    },
+  };
+}

--- a/app/static/viewer/store.js
+++ b/app/static/viewer/store.js
@@ -12,6 +12,7 @@ export function createStore(initial) {
 }
 
 function toFiniteInteger(value) {
+  if (value === null || value === undefined) return null;
   if (typeof value === 'string' && value.trim() === '') return null;
   const parsed = Number(value);
   return Number.isInteger(parsed) ? parsed : null;

--- a/app/static/viewer/viewer_legacy.js
+++ b/app/static/viewer/viewer_legacy.js
@@ -2729,6 +2729,18 @@
       }
     }
 
+    function syncActiveViewerTargetState(isFileLoaded) {
+      if (window.SeisViewerState && typeof window.SeisViewerState.syncActiveFileTarget === 'function') {
+        window.SeisViewerState.syncActiveFileTarget({
+          fileId: currentFileId,
+          displayName: currentFileName,
+          key1Byte: currentKey1Byte,
+          key2Byte: currentKey2Byte,
+          isFileLoaded: Boolean(isFileLoaded),
+        });
+      }
+    }
+
     async function loadSettings() {
       const params = new URLSearchParams(window.location.search);
       currentFileId = params.get('file_id') || localStorage.getItem('file_id') || '';
@@ -2746,6 +2758,7 @@
         sectionShape = null;
         updateSectionNavigation({ syncDisplay: true, syncJumpInput: true });
         showViewerEmptyState('no-dataset');
+        syncActiveViewerTargetState(false);
         return;
       }
       localStorage.setItem('file_id', currentFileId);
@@ -2757,6 +2770,7 @@
         sectionShape = null;
         updateSectionNavigation({ syncDisplay: true, syncJumpInput: true });
         showViewerEmptyState('unavailable');
+        syncActiveViewerTargetState(false);
         return;
       }
       await fetchKey1Values();
@@ -2764,15 +2778,18 @@
         sectionShape = null;
         updateSectionNavigation({ syncDisplay: true, syncJumpInput: true });
         showViewerEmptyState('unavailable');
+        syncActiveViewerTargetState(false);
         return;
       }
       await fetchSectionMeta();
       if (!Array.isArray(sectionShape) || sectionShape.length < 2) {
         updateSectionNavigation({ syncDisplay: true, syncJumpInput: true });
         showViewerEmptyState('unavailable');
+        syncActiveViewerTargetState(false);
         return;
       }
       hideViewerEmptyState();
+      syncActiveViewerTargetState(true);
       await fetchAndPlot();
     }
 
@@ -3381,27 +3398,32 @@
           if (!currentFileId) {
             currentFileName = '';
             showViewerEmptyState('no-dataset');
+            syncActiveViewerTargetState(false);
             return;
           }
           await fetchCurrentFileName();
           if (!currentFileName) {
             updateSectionNavigation({ syncDisplay: true, syncJumpInput: true });
             showViewerEmptyState('unavailable');
+            syncActiveViewerTargetState(false);
             return;
           }
           await fetchKey1Values();
           if (!Array.isArray(key1Values) || key1Values.length === 0) {
             updateSectionNavigation({ syncDisplay: true, syncJumpInput: true });
             showViewerEmptyState('unavailable');
+            syncActiveViewerTargetState(false);
             return;
           }
           await fetchSectionMeta();
           if (!Array.isArray(sectionShape) || sectionShape.length < 2) {
             updateSectionNavigation({ syncDisplay: true, syncJumpInput: true });
             showViewerEmptyState('unavailable');
+            syncActiveViewerTargetState(false);
             return;
           }
           hideViewerEmptyState();
+          syncActiveViewerTargetState(true);
           (typeof fetchAndPlotDebounced?.flush === 'function')
             ? fetchAndPlotDebounced.flush()
             : fetchAndPlot();

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -297,6 +297,29 @@ def test_refraction_static_apply_endpoint_starts_job(
     assert job['key2_byte'] == 193
 
 
+def test_refraction_static_apply_endpoint_rejects_uploaded_npz_json(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+
+    response = client.post(
+        '/statics/refraction/apply',
+        json=_uploaded_pick_payload(),
+    )
+
+    assert response.status_code == 422
+    assert '/statics/refraction/apply-with-picks' in response.text
+    assert started == []
+    with client.app.state.sv.lock:
+        assert len(client.app.state.sv.jobs) == 0
+
+
 def test_refraction_apply_with_uploaded_picks_accepts_multipart_npz(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/app/tests/test_refraction_static_apply_job_api.py
+++ b/app/tests/test_refraction_static_apply_job_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 from dataclasses import replace
+import io
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -238,6 +239,24 @@ def _payload() -> dict[str, Any]:
     }
 
 
+def _uploaded_pick_payload() -> dict[str, Any]:
+    payload = _payload()
+    payload['pick_source'] = {'kind': 'uploaded_npz'}
+    return payload
+
+
+def _pick_npz_bytes() -> bytes:
+    buffer = io.BytesIO()
+    np.savez(
+        buffer,
+        picks_time_s=np.asarray([0.010, 0.020], dtype=np.float32),
+        n_traces=np.asarray(2, dtype=np.int64),
+        n_samples=np.asarray(100, dtype=np.int64),
+        dt=np.asarray(0.001, dtype=np.float64),
+    )
+    return buffer.getvalue()
+
+
 def test_refraction_static_apply_endpoint_starts_job(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -276,6 +295,240 @@ def test_refraction_static_apply_endpoint_starts_job(
     assert job['file_id'] == 'raw-file-id'
     assert job['key1_byte'] == 189
     assert job['key2_byte'] == 193
+
+
+def test_refraction_apply_with_uploaded_picks_accepts_multipart_npz(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+    upload_bytes = _pick_npz_bytes()
+
+    response = client.post(
+        '/statics/refraction/apply-with-picks',
+        data={'request_json': json.dumps(_uploaded_pick_payload())},
+        files={
+            'pick_npz': (
+                '../predicted_picks_time_s.npz',
+                upload_bytes,
+                'application/octet-stream',
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['state'] == 'queued'
+    assert len(started) == 1
+    assert started[0]['target'] is statics_router_module.run_refraction_static_apply_job
+    assert started[0]['args'][0] == payload['job_id']
+    assert isinstance(started[0]['args'][1], RefractionStaticApplyRequest)
+    assert started[0]['args'][1].pick_source.kind == 'uploaded_npz'
+    assert started[0]['args'][3].name == 'uploaded_picks_time_s.npz'
+    assert started[0]['args'][4] == {
+        'original_filename': '../predicted_picks_time_s.npz',
+        'stored_name': 'uploaded_picks_time_s.npz',
+    }
+
+    state = client.app.state.sv
+    with state.lock:
+        job = dict(state.jobs[payload['job_id']])
+    job_dir = Path(str(job['artifacts_dir']))
+    assert (job_dir / 'uploaded_picks_time_s.npz').read_bytes() == upload_bytes
+    assert job['pick_source'] == {
+        'kind': 'uploaded_npz',
+        'original_filename': '../predicted_picks_time_s.npz',
+        'stored_name': 'uploaded_picks_time_s.npz',
+    }
+
+
+def test_refraction_apply_with_uploaded_picks_rejects_missing_file(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+
+    response = client.post(
+        '/statics/refraction/apply-with-picks',
+        data={'request_json': json.dumps(_uploaded_pick_payload())},
+    )
+
+    assert response.status_code == 422
+    assert started == []
+    with client.app.state.sv.lock:
+        assert len(client.app.state.sv.jobs) == 0
+
+
+def test_refraction_apply_with_uploaded_picks_rejects_non_uploaded_npz_kind(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+
+    response = client.post(
+        '/statics/refraction/apply-with-picks',
+        data={'request_json': json.dumps(_payload())},
+        files={
+            'pick_npz': (
+                'predicted_picks_time_s.npz',
+                _pick_npz_bytes(),
+                'application/octet-stream',
+            )
+        },
+    )
+
+    assert response.status_code == 422
+    assert 'uploaded_npz' in response.text
+    assert started == []
+    with client.app.state.sv.lock:
+        assert len(client.app.state.sv.jobs) == 0
+
+
+def test_refraction_apply_with_uploaded_picks_rejects_empty_upload(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+
+    response = client.post(
+        '/statics/refraction/apply-with-picks',
+        data={'request_json': json.dumps(_uploaded_pick_payload())},
+        files={
+            'pick_npz': (
+                'predicted_picks_time_s.npz',
+                b'',
+                'application/octet-stream',
+            )
+        },
+    )
+
+    assert response.status_code == 422
+    assert 'empty' in response.text
+    assert started == []
+    with client.app.state.sv.lock:
+        assert len(client.app.state.sv.jobs) == 0
+
+
+def test_refraction_apply_with_uploaded_picks_stores_input_artifact_metadata(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **kwargs: started.append(kwargs),
+    )
+    response = client.post(
+        '/statics/refraction/apply-with-picks',
+        data={'request_json': json.dumps(_uploaded_pick_payload())},
+        files={
+            'pick_npz': (
+                'predicted_picks_time_s.npz',
+                _pick_npz_bytes(),
+                'application/octet-stream',
+            )
+        },
+    )
+    assert response.status_code == 200
+    job_id = response.json()['job_id']
+
+    build_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        refraction_service_module,
+        'build_refraction_static_input_model',
+        lambda **kwargs: build_calls.append(kwargs) or object(),
+    )
+    monkeypatch.setattr(
+        refraction_service_module,
+        'compute_weathering_replacement_statics_from_first_breaks',
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        refraction_service_module,
+        'build_refraction_datum_statics',
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        refraction_service_module,
+        'write_refraction_static_artifacts',
+        lambda **_kwargs: object(),
+    )
+
+    started[0]['target'](*started[0]['args'])
+
+    with client.app.state.sv.lock:
+        job = dict(client.app.state.sv.jobs[job_id])
+    job_dir = Path(str(job['artifacts_dir']))
+    request_payload = json.loads(
+        (job_dir / REQUEST_JSON_NAME).read_text(encoding='utf-8')
+    )
+    assert request_payload['request']['pick_source'] == {
+        'kind': 'uploaded_npz',
+        'original_filename': 'predicted_picks_time_s.npz',
+        'stored_name': 'uploaded_picks_time_s.npz',
+    }
+    assert len(build_calls) == 1
+    assert build_calls[0]['uploaded_pick_npz_path'] == (
+        job_dir / 'uploaded_picks_time_s.npz'
+    )
+    assert build_calls[0]['uploaded_pick_metadata'] == {
+        'original_filename': 'predicted_picks_time_s.npz',
+        'stored_name': 'uploaded_picks_time_s.npz',
+    }
+
+
+def test_refraction_apply_with_uploaded_picks_job_status_and_files(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        statics_router_module,
+        'start_job_thread',
+        lambda **_kwargs: object(),
+    )
+    response = client.post(
+        '/statics/refraction/apply-with-picks',
+        data={'request_json': json.dumps(_uploaded_pick_payload())},
+        files={
+            'pick_npz': (
+                'predicted_picks_time_s.npz',
+                _pick_npz_bytes(),
+                'application/octet-stream',
+            )
+        },
+    )
+    assert response.status_code == 200
+    job_id = response.json()['job_id']
+
+    status_response = client.get(f'/statics/job/{job_id}/status')
+    assert status_response.status_code == 200
+    assert status_response.json()['state'] == 'queued'
+
+    files_response = client.get(f'/statics/job/{job_id}/files')
+    assert files_response.status_code == 200
+    file_names = {item['name'] for item in files_response.json()['files']}
+    assert 'uploaded_picks_time_s.npz' in file_names
 
 
 def test_refraction_static_apply_endpoint_accepts_omitted_linkage(

--- a/app/tests/test_refraction_static_inputs.py
+++ b/app/tests/test_refraction_static_inputs.py
@@ -675,6 +675,38 @@ def test_build_refraction_static_input_model_loads_npz_original_order(
     assert model.metadata['pick_source_metadata']['accepted_pick_key'] == 'picks_time_s'
 
 
+def test_uploaded_npz_pick_source_does_not_resolve_job_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fail_artifact_resolution(*_args: Any, **_kwargs: Any) -> object:
+        pytest.fail('uploaded_npz should not resolve a job artifact')
+
+    monkeypatch.setattr(
+        inputs_module,
+        'resolve_job_artifact_path',
+        _fail_artifact_resolution,
+    )
+    req = RefractionStaticApplyRequest(
+        file_id='line-a',
+        pick_source={'kind': 'uploaded_npz'},
+        geometry=_geometry(),
+        linkage={'mode': 'none'},
+        model=RefractionStaticModelRequest(weathering_velocity_m_s=800.0),
+        datum={'mode': 'none'},
+    )
+
+    with pytest.raises(ValueError, match='multipart upload'):
+        inputs_module._load_refraction_pick_source(
+            req=req,
+            state=AppState(),
+            reader=object(),
+            n_traces=0,
+            n_samples=0,
+            dt=0.001,
+            sorted_trace_index=np.asarray([], dtype=np.int64),
+        )
+
+
 def test_build_refraction_static_input_model_omitted_linkage_skips_artifact_resolution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/app/tests/test_refraction_static_inputs.py
+++ b/app/tests/test_refraction_static_inputs.py
@@ -22,6 +22,9 @@ from app.services.refraction_static_inputs import (
     build_refraction_static_input_model,
     build_refraction_static_input_model_from_arrays,
 )
+from app.services.refraction_static_pick_source_loader import (
+    load_refraction_pick_source_from_npz_path,
+)
 
 
 def _geometry(**overrides: Any) -> RefractionStaticGeometryRequest:
@@ -58,6 +61,17 @@ def _linkage(mode: str = 'none') -> RefractionStaticLinkageRequest:
     if mode != 'none':
         payload['job_id'] = 'linkage-job'
     return RefractionStaticLinkageRequest.model_validate(payload)
+
+
+def _uploaded_npz_request() -> RefractionStaticApplyRequest:
+    return RefractionStaticApplyRequest(
+        file_id='line-a',
+        pick_source={'kind': 'uploaded_npz'},
+        geometry=_geometry(),
+        linkage={'mode': 'none'},
+        model=RefractionStaticModelRequest(weathering_velocity_m_s=800.0),
+        datum={'mode': 'none'},
+    )
 
 
 def _headers(
@@ -705,6 +719,141 @@ def test_uploaded_npz_pick_source_does_not_resolve_job_artifact(
             dt=0.001,
             sorted_trace_index=np.asarray([], dtype=np.int64),
         )
+
+
+def test_uploaded_npz_pick_loader_reads_pick_time_s(tmp_path: Path) -> None:
+    sorted_to_original = np.asarray([2, 0, 3, 1], dtype=np.int64)
+    npz_path = tmp_path / 'uploaded_picks_time_s.npz'
+    np.savez(
+        npz_path,
+        pick_time_s=np.asarray([0.020, 0.040, 0.010, 0.030], dtype=np.float32),
+        sorted_to_original=sorted_to_original,
+        valid_pick_mask=np.asarray([True, True, True, False], dtype=bool),
+        confidence=np.asarray([0.9, 0.8, 0.7, 0.6], dtype=np.float32),
+        n_traces=np.asarray(4, dtype=np.int64),
+        n_samples=np.asarray(100, dtype=np.int64),
+        dt=np.asarray(0.001, dtype=np.float64),
+    )
+
+    loaded = load_refraction_pick_source_from_npz_path(
+        npz_path=npz_path,
+        request=_uploaded_npz_request(),
+        n_traces=4,
+        n_samples=100,
+        dt_s=0.001,
+        sorted_trace_index=sorted_to_original,
+    )
+
+    np.testing.assert_allclose(loaded.picks_time_s_sorted, [0.010, 0.020, 0.030, 0.040])
+    np.testing.assert_array_equal(loaded.sorted_trace_index, sorted_to_original)
+    assert loaded.source_kind == 'uploaded_npz'
+    assert loaded.metadata['loaded_from'] == 'uploaded_npz'
+    assert loaded.metadata['accepted_pick_key'] == 'pick_time_s'
+    assert loaded.metadata['has_valid_pick_mask'] is True
+    assert loaded.metadata['has_confidence'] is True
+    assert loaded.metadata['npz_path'].endswith('uploaded_picks_time_s.npz')
+
+
+def test_uploaded_npz_pick_loader_reads_predicted_picks_alias(tmp_path: Path) -> None:
+    sorted_to_original = np.asarray([0, 1, 2], dtype=np.int64)
+    npz_path = tmp_path / 'uploaded_picks_time_s.npz'
+    np.savez(
+        npz_path,
+        predicted_picks_time_s=np.asarray([0.010, 0.020, 0.030], dtype=np.float32),
+        sorted_to_original=sorted_to_original,
+    )
+
+    loaded = load_refraction_pick_source_from_npz_path(
+        npz_path=npz_path,
+        request=_uploaded_npz_request(),
+        n_traces=3,
+        n_samples=100,
+        dt_s=0.001,
+        sorted_trace_index=sorted_to_original,
+    )
+
+    np.testing.assert_allclose(loaded.picks_time_s_sorted, [0.010, 0.020, 0.030])
+    assert loaded.metadata['accepted_pick_key'] == 'predicted_picks_time_s'
+
+
+def test_uploaded_npz_pick_loader_validates_trace_count(tmp_path: Path) -> None:
+    npz_path = tmp_path / 'uploaded_picks_time_s.npz'
+    np.savez(
+        npz_path,
+        pick_time_s=np.asarray([0.010, 0.020, 0.030], dtype=np.float32),
+        n_traces=np.asarray(3, dtype=np.int64),
+    )
+
+    with pytest.raises(ValueError, match='uploaded_picks_time_s.npz'):
+        load_refraction_pick_source_from_npz_path(
+            npz_path=npz_path,
+            request=_uploaded_npz_request(),
+            n_traces=4,
+            n_samples=100,
+            dt_s=0.001,
+            sorted_trace_index=np.arange(4, dtype=np.int64),
+        )
+
+
+@pytest.mark.parametrize('bad_value', [np.nan, np.inf])
+def test_uploaded_npz_pick_loader_rejects_nonfinite_picks(
+    tmp_path: Path,
+    bad_value: float,
+) -> None:
+    npz_path = tmp_path / 'uploaded_picks_time_s.npz'
+    picks = np.asarray([0.010, bad_value, 0.030], dtype=np.float64)
+    np.savez(npz_path, pick_time_s=picks)
+
+    with pytest.raises(ValueError, match='uploaded_picks_time_s.npz.*finite'):
+        load_refraction_pick_source_from_npz_path(
+            npz_path=npz_path,
+            request=_uploaded_npz_request(),
+            n_traces=3,
+            n_samples=100,
+            dt_s=0.001,
+            sorted_trace_index=np.arange(3, dtype=np.int64),
+        )
+
+
+def test_uploaded_npz_pick_loader_rejects_pickle_or_invalid_npz(
+    tmp_path: Path,
+) -> None:
+    npz_path = tmp_path / 'uploaded_picks_time_s.npz'
+    np.savez(npz_path, pick_time_s=np.asarray([{'time': 0.010}], dtype=object))
+
+    with pytest.raises(ValueError, match='uploaded_picks_time_s.npz'):
+        load_refraction_pick_source_from_npz_path(
+            npz_path=npz_path,
+            request=_uploaded_npz_request(),
+            n_traces=1,
+            n_samples=100,
+            dt_s=0.001,
+            sorted_trace_index=np.arange(1, dtype=np.int64),
+        )
+
+
+def test_uploaded_npz_pick_loader_preserves_sorted_to_original(tmp_path: Path) -> None:
+    sorted_to_original = np.asarray([2, 0, 3, 1], dtype=np.int64)
+    npz_path = tmp_path / 'uploaded_picks_time_s.npz'
+    np.savez(
+        npz_path,
+        picks_time_s=np.asarray([0.030, 0.010, 0.040, 0.020], dtype=np.float32),
+        sorted_to_original=sorted_to_original,
+        order=np.asarray('trace_store_sorted'),
+    )
+
+    loaded = load_refraction_pick_source_from_npz_path(
+        npz_path=npz_path,
+        request=_uploaded_npz_request(),
+        n_traces=4,
+        n_samples=100,
+        dt_s=0.001,
+        sorted_trace_index=sorted_to_original,
+    )
+
+    np.testing.assert_allclose(loaded.picks_time_s_sorted, [0.030, 0.010, 0.040, 0.020])
+    np.testing.assert_array_equal(loaded.sorted_trace_index, sorted_to_original)
+    assert loaded.metadata['has_sorted_to_original'] is True
 
 
 def test_build_refraction_static_input_model_omitted_linkage_skips_artifact_resolution(

--- a/app/tests/test_refraction_static_request.py
+++ b/app/tests/test_refraction_static_request.py
@@ -273,6 +273,47 @@ def test_refraction_pick_source_defaults_batch_artifact_name() -> None:
     assert req.pick_source.artifact_name == 'predicted_picks_time_s.npz'
 
 
+def test_refraction_static_pick_source_uploaded_npz_valid_without_job_id() -> None:
+    payload = _payload()
+    payload['pick_source'] = {'kind': 'uploaded_npz'}
+
+    req = _validate(payload)
+
+    assert req.pick_source.kind == 'uploaded_npz'
+    assert req.pick_source.job_id is None
+    assert req.pick_source.artifact_name is None
+
+
+def test_refraction_static_pick_source_uploaded_npz_rejects_job_id() -> None:
+    payload = _payload()
+    payload['pick_source'] = {
+        'kind': 'uploaded_npz',
+        'job_id': 'first-break-job-id',
+    }
+
+    with pytest.raises(ValidationError, match='uploaded_npz'):
+        _validate(payload)
+
+
+def test_refraction_static_pick_source_uploaded_npz_rejects_artifact_name() -> None:
+    payload = _payload()
+    payload['pick_source'] = {
+        'kind': 'uploaded_npz',
+        'artifact_name': 'predicted_picks_time_s.npz',
+    }
+
+    with pytest.raises(ValidationError, match='uploaded_npz'):
+        _validate(payload)
+
+
+def test_refraction_static_legacy_pick_source_still_valid() -> None:
+    req = _validate(_payload())
+
+    assert req.pick_source.kind == 'batch_predicted_npz'
+    assert req.pick_source.job_id == 'first-break-job-id'
+    assert req.pick_source.artifact_name == 'predicted_picks_time_s.npz'
+
+
 def test_refraction_pick_source_rejects_artifact_source_without_job_id() -> None:
     payload = _payload()
     payload['pick_source'] = {

--- a/app/tests/ui/active_viewer_target.test.js
+++ b/app/tests/ui/active_viewer_target.test.js
@@ -1,0 +1,71 @@
+import { expect, test } from 'vitest';
+
+import {
+  createSeisViewerState,
+  createStore,
+  getActiveFileTargetFromState,
+} from '../../static/viewer/store.js';
+
+test('test_active_viewer_target_empty_before_file_load', () => {
+  const store = createStore({
+    fileId: '',
+    displayName: '',
+    key1Byte: 9,
+    key2Byte: 13,
+    isFileLoaded: false,
+  });
+  const viewerState = createSeisViewerState(store);
+
+  expect(viewerState.getActiveFileTarget()).toBeNull();
+  expect(getActiveFileTargetFromState({
+    fileId: 'pending-file',
+    displayName: '',
+    key1Byte: 9,
+    key2Byte: 13,
+    isFileLoaded: false,
+  })).toBeNull();
+});
+
+test('test_active_viewer_target_contains_file_id_and_sort_keys_after_load', () => {
+  const store = createStore({
+    fileId: 'file-a',
+    displayName: 'LineA.sgy',
+    key1Byte: '9',
+    key2Byte: '13',
+    isFileLoaded: true,
+  });
+  const viewerState = createSeisViewerState(store);
+
+  expect(viewerState.getActiveFileTarget()).toEqual({
+    fileId: 'file-a',
+    displayName: 'LineA.sgy',
+    key1Byte: 9,
+    key2Byte: 13,
+  });
+});
+
+test('test_active_viewer_target_updates_when_new_file_loaded', () => {
+  const store = createStore({
+    fileId: 'file-a',
+    displayName: 'LineA.sgy',
+    key1Byte: 9,
+    key2Byte: 13,
+    isFileLoaded: true,
+  });
+  const viewerState = createSeisViewerState(store);
+
+  store.patch({
+    fileId: 'file-b',
+    displayName: 'LineB.sgy',
+    key1Byte: 21,
+    key2Byte: 25,
+    isFileLoaded: true,
+  });
+
+  expect(viewerState.getActiveFileTarget()).toEqual({
+    fileId: 'file-b',
+    displayName: 'LineB.sgy',
+    key1Byte: 21,
+    key2Byte: 25,
+  });
+});

--- a/app/tests/ui/active_viewer_target.test.js
+++ b/app/tests/ui/active_viewer_target.test.js
@@ -44,6 +44,24 @@ test('test_active_viewer_target_contains_file_id_and_sort_keys_after_load', () =
   });
 });
 
+test('test_active_viewer_target_rejects_null_sort_key_bytes', () => {
+  expect(getActiveFileTargetFromState({
+    fileId: 'file-a',
+    displayName: 'LineA.sgy',
+    key1Byte: null,
+    key2Byte: 13,
+    isFileLoaded: true,
+  })).toBeNull();
+
+  expect(getActiveFileTargetFromState({
+    fileId: 'file-a',
+    displayName: 'LineA.sgy',
+    key1Byte: 9,
+    key2Byte: null,
+    isFileLoaded: true,
+  })).toBeNull();
+});
+
 test('test_active_viewer_target_updates_when_new_file_loaded', () => {
   const store = createStore({
     fileId: 'file-a',

--- a/app/tests/ui/refraction_static_geometry.test.js
+++ b/app/tests/ui/refraction_static_geometry.test.js
@@ -23,6 +23,7 @@ function renderStaticCorrectionForm() {
       <button id="staticCorrectionLoadPresetButton" type="button"></button>
       <button id="staticCorrectionDeletePresetButton" type="button"></button>
       <select id="staticCorrectionPickKind">
+        <option value="uploaded_npz">uploaded_npz</option>
         <option value="batch_predicted_npz" selected>batch_predicted_npz</option>
         <option value="manual_npz_artifact">manual_npz_artifact</option>
       </select>
@@ -475,6 +476,20 @@ test('request preview renders valid JSON and updates when fields change', () => 
   expect(preview.model.first_layer.weathering_velocity_m_s).toBe(925);
 });
 
+test('request preview supports uploaded pick source without artifact fields', () => {
+  loadStaticCorrectionScript();
+  const kind = document.getElementById('staticCorrectionPickKind');
+
+  kind.value = 'uploaded_npz';
+  kind.dispatchEvent(new Event('change', { bubbles: true }));
+
+  const preview = JSON.parse(document.getElementById('staticCorrectionRequestPreview').textContent);
+  expect(preview.pick_source).toEqual({ kind: 'uploaded_npz' });
+  expect(document.getElementById('staticCorrectionPickJobId').disabled).toBe(true);
+  expect(document.getElementById('staticCorrectionPickArtifactName').disabled).toBe(true);
+  expect(document.getElementById('staticCorrectionLoadPickArtifactsButton').disabled).toBe(true);
+});
+
 test('validation summary lists invalid fields before submit', () => {
   loadStaticCorrectionScript();
   document.getElementById('staticCorrectionFileId').value = '';
@@ -624,6 +639,7 @@ test('checked auto-threshold linkage validates threshold only when enabled', () 
 });
 
 test('field correction and export sections are collapsed details controls', () => {
+  expect(INDEX_HTML).toContain('<option value="uploaded_npz">uploaded_npz</option>');
   expect(INDEX_HTML).toContain('<details id="staticCorrectionFieldCorrectionsSection"');
   expect(INDEX_HTML).toContain('<summary id="staticCorrectionFieldCorrectionsHeading">Field corrections</summary>');
   expect(INDEX_HTML).toContain('<details id="staticCorrectionExportSection"');


### PR DESCRIPTION
Closes #583
Closes #584
Closes #585
Closes #586

## Issues
- #583 [api][statics] Add `uploaded_npz` pick source contract for refraction statics
- #584 [api][statics] Add multipart `/statics/refraction/apply-with-picks` endpoint
- #585 [services][statics] Load refraction pick NPZ directly from uploaded path without job lookup
- #586 [ui][viewer] Expose current viewer file metadata for Static Correction target resolution

Batch range: #583-#586
