### PR TITLE
Batch: address issues #587-#590

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1191,6 +1191,35 @@
       color: #475569;
     }
 
+    .static-correction-target-summary {
+      display: grid;
+      gap: 0.35em;
+      font-size: 0.86em;
+      color: #334155;
+    }
+
+    .static-correction-target-summary[hidden] {
+      display: none;
+    }
+
+    .static-correction-target-row {
+      display: grid;
+      grid-template-columns: minmax(7.5em, max-content) minmax(0, 1fr);
+      gap: 0.5em;
+      align-items: baseline;
+    }
+
+    .static-correction-target-label {
+      color: #64748b;
+      font-weight: 600;
+    }
+
+    .static-correction-target-value {
+      min-width: 0;
+      overflow-wrap: anywhere;
+      color: #111827;
+    }
+
     .static-correction-field {
       display: flex;
       flex-direction: column;
@@ -2073,27 +2102,38 @@
         <div class="static-correction-panel" data-testid="static-correction-panel">
           <h2 class="static-correction-title">Static Correction</h2>
           <form id="staticCorrectionForm" class="static-correction-form" data-testid="static-correction-form">
-            <section class="static-correction-section" aria-labelledby="staticCorrectionInputHeading">
-              <h3 id="staticCorrectionInputHeading">Input</h3>
-              <label class="static-correction-field" for="staticCorrectionFileId">File ID
-                <input id="staticCorrectionFileId" name="file_id" type="text" autocomplete="off"
-                  placeholder="SEG-Y or TraceStore file_id" data-testid="static-correction-file-id" />
-              </label>
-              <div class="static-correction-field-row">
-                <label class="static-correction-field" for="staticCorrectionKey1Byte">key1_byte
-                  <input id="staticCorrectionKey1Byte" name="key1_byte" type="number" min="1" step="1"
-                    value="189" data-testid="static-correction-key1-byte" />
-                </label>
-                <label class="static-correction-field" for="staticCorrectionKey2Byte">key2_byte
-                  <input id="staticCorrectionKey2Byte" name="key2_byte" type="number" min="1" step="1"
-                    value="193" data-testid="static-correction-key2-byte" />
-                </label>
+            <section class="static-correction-section" aria-labelledby="staticCorrectionTargetHeading">
+              <h3 id="staticCorrectionTargetHeading">Target</h3>
+              <div id="staticCorrectionTargetSummary" class="static-correction-target-summary"
+                data-testid="static-correction-target-summary">
+                <div id="staticCorrectionTargetEmpty" class="static-correction-help"
+                  data-testid="static-correction-target-empty">
+                  No active viewer file. Open an SGY/TraceStore in the viewer before running Static Correction.
+                </div>
+                <div id="staticCorrectionTargetDetails" class="static-correction-target-summary" hidden
+                  data-testid="static-correction-target-details">
+                  <div class="static-correction-target-row">
+                    <span class="static-correction-target-label">Current viewer file</span>
+                    <span id="staticCorrectionTargetFile" class="static-correction-target-value"
+                      data-testid="static-correction-target-file">-</span>
+                  </div>
+                  <div class="static-correction-target-row">
+                    <span class="static-correction-target-label">Sort keys</span>
+                    <span id="staticCorrectionTargetKeys" class="static-correction-target-value"
+                      data-testid="static-correction-target-keys">-</span>
+                  </div>
+                  <div class="static-correction-target-row">
+                    <span class="static-correction-target-label">Status</span>
+                    <span id="staticCorrectionTargetStatus" class="static-correction-target-value"
+                      data-testid="static-correction-target-status">-</span>
+                  </div>
+                </div>
               </div>
             </section>
             <section class="static-correction-section" aria-labelledby="staticCorrectionPresetHeading">
               <h3 id="staticCorrectionPresetHeading">Presets</h3>
               <p class="static-correction-help">
-                Presets store parameter fields only. Loading a preset keeps the current file_id and pick_source.job_id.
+                Presets store parameter fields only. Loading a preset keeps the current viewer target and pick_source.job_id.
               </p>
               <div class="static-correction-preset-grid">
                 <label class="static-correction-field" for="staticCorrectionPresetSelect">Saved preset

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1238,6 +1238,13 @@
       font: inherit;
     }
 
+    .static-correction-file-summary {
+      min-height: 1.4em;
+      color: #64748b;
+      font-size: 0.82em;
+      overflow-wrap: anywhere;
+    }
+
     .static-correction-field-row {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1298,57 +1305,6 @@
       color: #111827;
       font: inherit;
       font-size: 0.86em;
-    }
-
-    .static-correction-artifact-list {
-      display: flex;
-      flex-direction: column;
-      gap: 0.35em;
-      font-size: 0.82em;
-      color: #334155;
-    }
-
-    .static-correction-artifact-list[hidden] {
-      display: none;
-    }
-
-    .static-correction-artifact-list ul {
-      display: flex;
-      flex-direction: column;
-      gap: 0.3em;
-      margin: 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .static-correction-artifact-list li {
-      display: flex;
-      align-items: center;
-      gap: 0.4em;
-      min-width: 0;
-    }
-
-    .static-correction-artifact-list button {
-      min-width: 0;
-      overflow-wrap: anywhere;
-      padding: 0.3em 0.45em;
-      border: 1px solid #cbd5e1;
-      border-radius: 4px;
-      background: #fff;
-      color: #111827;
-      font: inherit;
-      text-align: left;
-    }
-
-    .static-correction-artifact-list button.is-likely {
-      border-color: #60a5fa;
-      background: #eff6ff;
-    }
-
-    .static-correction-artifact-tag {
-      flex: 0 0 auto;
-      color: #0369a1;
-      font-size: 0.9em;
     }
 
     .static-correction-job-panel {
@@ -2133,7 +2089,7 @@
             <section class="static-correction-section" aria-labelledby="staticCorrectionPresetHeading">
               <h3 id="staticCorrectionPresetHeading">Presets</h3>
               <p class="static-correction-help">
-                Presets store parameter fields only. Loading a preset keeps the current viewer target and pick_source.job_id.
+                Presets store parameter fields only. Loading a preset keeps the current viewer target and selected pick file.
               </p>
               <div class="static-correction-preset-grid">
                 <label class="static-correction-field" for="staticCorrectionPresetSelect">Saved preset
@@ -2160,33 +2116,15 @@
             <section class="static-correction-section" aria-labelledby="staticCorrectionPicksHeading">
               <h3 id="staticCorrectionPicksHeading">First-break picks</h3>
               <p class="static-correction-help">
-                Use a first-break pick artifact accepted by /statics/refraction/apply. The viewer first-break
-                probability cache is not a valid statics pick artifact.
+                Select a first-break pick NPZ for this static correction run. The viewer first-break probability
+                cache is not a valid statics pick file.
               </p>
-              <label class="static-correction-field" for="staticCorrectionPickKind">pick_source.kind
-                <select id="staticCorrectionPickKind" name="pick_source.kind"
-                  data-testid="static-correction-pick-kind">
-                  <option value="uploaded_npz">uploaded_npz</option>
-                  <option value="batch_predicted_npz" selected>batch_predicted_npz</option>
-                  <option value="manual_npz_artifact">manual_npz_artifact</option>
-                </select>
+              <label class="static-correction-field" for="staticCorrectionPickNpz">First-break pick NPZ
+                <input id="staticCorrectionPickNpz" name="pick_npz" type="file" accept=".npz"
+                  data-testid="static-correction-pick-npz" />
               </label>
-              <label class="static-correction-field" for="staticCorrectionPickJobId">pick_source.job_id
-                <input id="staticCorrectionPickJobId" name="pick_source.job_id" type="text" autocomplete="off"
-                  placeholder="Batch job ID containing pick artifact"
-                  data-testid="static-correction-pick-job-id" />
-              </label>
-              <label class="static-correction-field" for="staticCorrectionPickArtifactName">pick_source.artifact_name
-                <input id="staticCorrectionPickArtifactName" name="pick_source.artifact_name" type="text"
-                  autocomplete="off" value="predicted_picks_time_s.npz"
-                  data-testid="static-correction-pick-artifact-name" />
-              </label>
-              <div class="static-correction-actions">
-                <button id="staticCorrectionLoadPickArtifactsButton" type="button"
-                  data-testid="static-correction-load-pick-artifacts">Load pick artifacts</button>
-              </div>
-              <div id="staticCorrectionPickArtifactList" class="static-correction-artifact-list" hidden
-                data-testid="static-correction-pick-artifact-list"></div>
+              <div id="staticCorrectionPickNpzSummary" class="static-correction-file-summary"
+                data-testid="static-correction-pick-npz-summary">No NPZ file selected.</div>
             </section>
             <section class="static-correction-section" aria-labelledby="staticCorrectionGeometryHeading">
               <h3 id="staticCorrectionGeometryHeading">Geometry</h3>

--- a/app/static/refraction_static_run.js
+++ b/app/static/refraction_static_run.js
@@ -1,7 +1,5 @@
 (function () {
   const DEFAULTS = {
-    key1Byte: '189',
-    key2Byte: '193',
     modelPreset: 'one_layer_global',
     pickKind: 'batch_predicted_npz',
     pickArtifactName: 'predicted_picks_time_s.npz',
@@ -110,7 +108,7 @@
 
   const state = {
     ready: false,
-    message: 'Enter a SEG-Y/TraceStore file_id and a first-break pick artifact usable by refraction statics.',
+    message: 'Open a viewer file and choose a first-break pick artifact usable by refraction statics.',
     error: '',
     loadingPickArtifacts: false,
     pickArtifacts: [],
@@ -133,6 +131,7 @@
 
   let dom = null;
   let staticPollToken = 0;
+  let viewerTargetUnsubscribe = null;
 
   function trimValue(value) {
     return String(value || '').trim();
@@ -142,6 +141,30 @@
     if (element && trimValue(element.value) === '') {
       element.value = value;
     }
+  }
+
+  function getStaticCorrectionTarget() {
+    const viewerState = window.SeisViewerState;
+    if (!viewerState || typeof viewerState.getActiveFileTarget !== 'function') {
+      return null;
+    }
+    const target = viewerState.getActiveFileTarget();
+    if (!target || typeof target !== 'object') {
+      return null;
+    }
+    const fileId = trimValue(target.fileId);
+    const key1Byte = Number(target.key1Byte);
+    const key2Byte = Number(target.key2Byte);
+    if (!fileId || !Number.isInteger(key1Byte) || !Number.isInteger(key2Byte)) {
+      return null;
+    }
+    const displayName = trimValue(target.displayName) || fileId;
+    return {
+      file_id: fileId,
+      display_name: displayName,
+      key1_byte: key1Byte,
+      key2_byte: key2Byte,
+    };
   }
 
   function geometryValueElements(targetDom) {
@@ -210,10 +233,11 @@
 
   function collectInputs(targetDom = dom) {
     if (!targetDom) return null;
+    const target = getStaticCorrectionTarget();
     return {
-      file_id: trimValue(targetDom.fileId.value),
-      key1_byte: trimValue(targetDom.key1Byte.value),
-      key2_byte: trimValue(targetDom.key2Byte.value),
+      file_id: target ? target.file_id : '',
+      key1_byte: target ? String(target.key1_byte) : '',
+      key2_byte: target ? String(target.key2_byte) : '',
       pick_source: {
         kind: trimValue(targetDom.pickKind.value),
         job_id: trimValue(targetDom.pickJobId.value),
@@ -367,8 +391,6 @@
   function collectPresetInputs(targetDom = dom) {
     const inputValues = collectInputs(targetDom);
     return {
-      key1_byte: inputValues ? inputValues.key1_byte : '',
-      key2_byte: inputValues ? inputValues.key2_byte : '',
       pick_source: {
         kind: inputValues && inputValues.pick_source ? inputValues.pick_source.kind : '',
         artifact_name: inputValues && inputValues.pick_source
@@ -1408,10 +1430,14 @@
       throw validationError(['Static correction form is not available.']);
     }
     if (!values.file_id) {
-      errors.push('file_id is required.');
+      errors.push('No active viewer file. Open an SGY/TraceStore in the viewer before running Static Correction.');
     }
-    const key1Byte = parsePositiveInteger(values.key1_byte, 'key1_byte', errors);
-    const key2Byte = parsePositiveInteger(values.key2_byte, 'key2_byte', errors);
+    const key1Byte = values.file_id
+      ? parsePositiveInteger(values.key1_byte, 'key1_byte', errors)
+      : null;
+    const key2Byte = values.file_id
+      ? parsePositiveInteger(values.key2_byte, 'key2_byte', errors)
+      : null;
 
     let pickSource = null;
     try {
@@ -1462,10 +1488,14 @@
     }
 
     if (!values.file_id) {
-      errors.push('file_id is required.');
+      errors.push('No active viewer file. Open an SGY/TraceStore in the viewer before running Static Correction.');
     }
-    const key1Byte = parsePositiveInteger(values.key1_byte, 'key1_byte', errors);
-    const key2Byte = parsePositiveInteger(values.key2_byte, 'key2_byte', errors);
+    const key1Byte = values.file_id
+      ? parsePositiveInteger(values.key1_byte, 'key1_byte', errors)
+      : null;
+    const key2Byte = values.file_id
+      ? parsePositiveInteger(values.key2_byte, 'key2_byte', errors)
+      : null;
     let pickSource = null;
     try {
       pickSource = buildStaticCorrectionPickSource(dom);
@@ -1541,8 +1571,6 @@
   function applyPresetValues(values, targetDom = dom) {
     if (!targetDom || !values) return;
 
-    setElementValue(targetDom.key1Byte, values.key1_byte);
-    setElementValue(targetDom.key2Byte, values.key2_byte);
     if (values.pick_source) {
       setElementValue(targetDom.pickKind, values.pick_source.kind);
       setElementValue(targetDom.pickArtifactName, values.pick_source.artifact_name);
@@ -1681,7 +1709,7 @@
     state.error = '';
     state.showValidationSummary = false;
     state.validationErrors = [];
-    state.message = `Loaded preset ${preset.name}. Current file_id and pick_source.job_id were kept.`;
+    state.message = `Loaded preset ${preset.name}. Current viewer target and pick_source.job_id were kept.`;
     render();
   }
 
@@ -1971,18 +1999,41 @@
     }
   }
 
+  function renderTargetSummary() {
+    if (!dom || !dom.targetEmpty || !dom.targetDetails) return;
+    const target = getStaticCorrectionTarget();
+    dom.targetEmpty.hidden = Boolean(target);
+    dom.targetDetails.hidden = !target;
+    if (!target) {
+      dom.targetEmpty.textContent = 'No active viewer file. Open an SGY/TraceStore in the viewer before running Static Correction.';
+      return;
+    }
+    if (dom.targetFile) {
+      dom.targetFile.textContent = target.display_name;
+      dom.targetFile.title = target.file_id;
+    }
+    if (dom.targetKeys) {
+      dom.targetKeys.textContent = `key1=${target.key1_byte}, key2=${target.key2_byte}`;
+    }
+    if (dom.targetStatus) {
+      dom.targetStatus.textContent = 'Ready';
+    }
+  }
+
   function render() {
     if (!dom) return;
     const preview = getStaticCorrectionValidationSnapshot(dom);
+    const hasTarget = Boolean(getStaticCorrectionTarget());
     if (state.showValidationSummary) {
       state.validationErrors = preview.errors;
     }
     updateStaticCorrectionPickSourceControls(dom);
     updateStaticCorrectionLinkageOptions(dom);
+    renderTargetSummary();
     dom.status.textContent = state.message;
     dom.error.hidden = !state.error;
     dom.error.textContent = state.error;
-    dom.runButton.disabled = state.phase !== 'idle' || isStaticJobActive();
+    dom.runButton.disabled = !hasTarget || state.phase !== 'idle' || isStaticJobActive();
     if (dom.loadPickArtifactsButton) {
       dom.loadPickArtifactsButton.disabled = (
         state.loadingPickArtifacts
@@ -2347,6 +2398,15 @@
     runStaticCorrection();
   }
 
+  function subscribeToViewerTargetUpdates() {
+    if (viewerTargetUnsubscribe || !window.store || typeof window.store.subscribe !== 'function') {
+      return;
+    }
+    viewerTargetUnsubscribe = window.store.subscribe(() => {
+      render();
+    });
+  }
+
   async function cancelStaticCorrectionJob() {
     const jobId = trimValue(state.lastStaticCorrectionJobId);
     if (!jobId || !isStaticJobActive()) {
@@ -2384,9 +2444,11 @@
     const status = document.getElementById('staticCorrectionStatus');
     const error = document.getElementById('staticCorrectionError');
     const runButton = document.getElementById('staticCorrectionRunButton');
-    const fileId = document.getElementById('staticCorrectionFileId');
-    const key1Byte = document.getElementById('staticCorrectionKey1Byte');
-    const key2Byte = document.getElementById('staticCorrectionKey2Byte');
+    const targetEmpty = document.getElementById('staticCorrectionTargetEmpty');
+    const targetDetails = document.getElementById('staticCorrectionTargetDetails');
+    const targetFile = document.getElementById('staticCorrectionTargetFile');
+    const targetKeys = document.getElementById('staticCorrectionTargetKeys');
+    const targetStatus = document.getElementById('staticCorrectionTargetStatus');
     const presetSelect = document.getElementById('staticCorrectionPresetSelect');
     const presetName = document.getElementById('staticCorrectionPresetName');
     const savePresetButton = document.getElementById('staticCorrectionSavePresetButton');
@@ -2484,7 +2546,8 @@
     const staticArtifactBody = document.getElementById('staticCorrectionArtifactBody');
     const staticArtifactEmpty = document.getElementById('staticCorrectionArtifactEmpty');
     if (
-      !form || !status || !error || !runButton || !fileId || !key1Byte || !key2Byte
+      !form || !status || !error || !runButton || !targetEmpty || !targetDetails
+      || !targetFile || !targetKeys || !targetStatus
       || !presetSelect || !presetName || !savePresetButton || !loadPresetButton
       || !deletePresetButton
       || !pickKind || !pickJobId || !pickArtifactName || !loadPickArtifactsButton
@@ -2516,8 +2579,6 @@
       return;
     }
 
-    setDefaultValue(key1Byte, DEFAULTS.key1Byte);
-    setDefaultValue(key2Byte, DEFAULTS.key2Byte);
     setDefaultValue(pickKind, DEFAULTS.pickKind);
     setDefaultValue(pickArtifactName, DEFAULTS.pickArtifactName);
     setDefaultValue(linkageMode, DEFAULTS.linkageMode);
@@ -2552,9 +2613,11 @@
       status,
       error,
       runButton,
-      fileId,
-      key1Byte,
-      key2Byte,
+      targetEmpty,
+      targetDetails,
+      targetFile,
+      targetKeys,
+      targetStatus,
       presetSelect,
       presetName,
       savePresetButton,
@@ -2645,6 +2708,13 @@
       staticArtifactEmpty,
     };
     state.presets = readStoredPresets();
+    subscribeToViewerTargetUpdates();
+    if (window.viewerBootstrapReady && typeof window.viewerBootstrapReady.then === 'function') {
+      window.viewerBootstrapReady.then(() => {
+        subscribeToViewerTargetUpdates();
+        render();
+      });
+    }
     applyStaticCorrectionGeometryPreset(dom, trimValue(geometryPreset.value) || GEOMETRY_DEFAULTS.preset);
     updateModelPresetControls(dom);
     updateStaticCorrectionLinkageOptions(dom);

--- a/app/static/refraction_static_run.js
+++ b/app/static/refraction_static_run.js
@@ -1983,6 +1983,28 @@
     return response.json();
   }
 
+  function buildStaticCorrectionFormData(request, targetDom = dom) {
+    const pickFile = selectedPickNpzFile(targetDom);
+    if (!pickFile) {
+      throw validationError(['First-break pick NPZ is required.']);
+    }
+    const formData = new FormData();
+    formData.append('request_json', JSON.stringify(request));
+    formData.append('pick_npz', pickFile);
+    return formData;
+  }
+
+  async function postMultipart(url, formData, operation) {
+    const response = await fetch(url, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!response.ok) {
+      throw new Error(await readResponseError(response, operation));
+    }
+    return response.json();
+  }
+
   function delay(ms) {
     return new Promise((resolve) => window.setTimeout(resolve, ms));
   }
@@ -2154,10 +2176,11 @@
       ? `Linkage job ${state.lastLinkageJobId} is ready. Submitting static correction...`
       : 'Submitting static correction...';
     render();
-    const responsePayload = await postJson(
-      '/statics/refraction/apply',
-      payload,
-      'refraction static apply'
+    const formData = buildStaticCorrectionFormData(payload);
+    const responsePayload = await postMultipart(
+      '/statics/refraction/apply-with-picks',
+      formData,
+      'refraction static apply with picks'
     );
     state.lastStaticCorrectionJobId = trimValue(responsePayload && responsePayload.job_id);
     setStaticJobSnapshot(responsePayload);
@@ -2174,10 +2197,6 @@
       pollStaticCorrectionJobUntilTerminal(state.lastStaticCorrectionJobId);
     }
     return responsePayload;
-  }
-
-  function submitRefractionStaticApply(request) {
-    return postJson('/statics/refraction/apply', request, 'refraction static apply');
   }
 
   async function runStaticCorrection() {
@@ -2690,6 +2709,7 @@
     buildRefractionStaticApplyRequest,
     buildStaticCorrectionGeometry,
     buildStaticCorrectionGeometryRequest,
+    buildStaticCorrectionFormData,
     buildStaticCorrectionLinkage,
     buildStaticCorrectionLinkageRequest,
     buildStaticCorrectionPickSource,
@@ -2717,7 +2737,6 @@
     runStaticCorrection,
     saveCurrentPreset,
     stopStaticCorrectionPolling,
-    submitRefractionStaticApply,
     updateModelPresetControls,
     updateBedrockVelocityControls,
     updateStaticCorrectionFieldCorrectionOptions,

--- a/app/static/refraction_static_run.js
+++ b/app/static/refraction_static_run.js
@@ -1,8 +1,6 @@
 (function () {
   const DEFAULTS = {
     modelPreset: 'one_layer_global',
-    pickKind: 'batch_predicted_npz',
-    pickArtifactName: 'predicted_picks_time_s.npz',
     linkageMode: 'auto_threshold',
     linkageThresholdM: '25',
     weatheringVelocityMS: '800',
@@ -92,7 +90,6 @@
     },
   ];
   const UPLOADED_PICK_KIND = 'uploaded_npz';
-  const ARTIFACT_PICK_KINDS = new Set(['batch_predicted_npz', 'manual_npz_artifact']);
   const LINKAGE_THRESHOLD_MODES = new Set(['auto_threshold']);
   const LINKAGE_ARTIFACT_NAME = 'geometry_linkage.npz';
   const LINKAGE_READY_STATES = new Set(['done', 'ready']);
@@ -108,10 +105,8 @@
 
   const state = {
     ready: false,
-    message: 'Open a viewer file and choose a first-break pick artifact usable by refraction statics.',
+    message: 'Open a viewer file and choose a first-break pick NPZ for refraction statics.',
     error: '',
-    loadingPickArtifacts: false,
-    pickArtifacts: [],
     lastRequest: null,
     lastResponse: null,
     lastLinkageBuildRequest: null,
@@ -215,33 +210,45 @@
     }
   }
 
-  function isLikelyPickArtifact(name) {
-    const normalized = trimValue(name);
-    return (
-      normalized === DEFAULTS.pickArtifactName
-      || /^manual_picks_time.*\.npz$/i.test(normalized)
-    );
+  function hasNpzExtension(name) {
+    return trimValue(name).toLowerCase().endsWith('.npz');
   }
 
-  function pickArtifactRank(name) {
-    const normalized = trimValue(name);
-    if (normalized === DEFAULTS.pickArtifactName) {
-      return 0;
+  function selectedPickNpzFile(targetDom = dom) {
+    if (!targetDom || !targetDom.pickNpzFile || !targetDom.pickNpzFile.files) {
+      return null;
     }
-    return isLikelyPickArtifact(normalized) ? 1 : 2;
+    return targetDom.pickNpzFile.files[0] || null;
+  }
+
+  function formatFileSize(bytes) {
+    const size = Number(bytes);
+    if (!Number.isFinite(size) || size < 0) {
+      return '';
+    }
+    if (size < 1024) {
+      return `${size} B`;
+    }
+    if (size < 1024 * 1024) {
+      return `${(size / 1024).toFixed(1)} KiB`;
+    }
+    return `${(size / (1024 * 1024)).toFixed(1)} MiB`;
   }
 
   function collectInputs(targetDom = dom) {
     if (!targetDom) return null;
     const target = getStaticCorrectionTarget();
+    const pickFile = selectedPickNpzFile(targetDom);
     return {
       file_id: target ? target.file_id : '',
       key1_byte: target ? String(target.key1_byte) : '',
       key2_byte: target ? String(target.key2_byte) : '',
       pick_source: {
-        kind: trimValue(targetDom.pickKind.value),
-        job_id: trimValue(targetDom.pickJobId.value),
-        artifact_name: trimValue(targetDom.pickArtifactName.value),
+        kind: UPLOADED_PICK_KIND,
+      },
+      pick_npz: {
+        name: pickFile ? trimValue(pickFile.name) : '',
+        size: pickFile ? pickFile.size : null,
       },
     };
   }
@@ -389,14 +396,7 @@
   }
 
   function collectPresetInputs(targetDom = dom) {
-    const inputValues = collectInputs(targetDom);
     return {
-      pick_source: {
-        kind: inputValues && inputValues.pick_source ? inputValues.pick_source.kind : '',
-        artifact_name: inputValues && inputValues.pick_source
-          ? inputValues.pick_source.artifact_name
-          : '',
-      },
       geometry: collectGeometryInputs(targetDom),
       linkage: collectLinkageInputs(targetDom),
       model: collectModelInputs(targetDom),
@@ -552,43 +552,29 @@
     if (!values) {
       throw validationError(['Static correction form is not available.']);
     }
-    const pickSource = { ...values.pick_source };
-    const pickKind = pickSource.kind;
-    if (!pickKind) {
-      errors.push('pick_source.kind is required.');
-    }
-    if (pickKind === UPLOADED_PICK_KIND) {
-      if (errors.length) {
-        throw validationError(errors);
-      }
-      return { kind: UPLOADED_PICK_KIND };
-    }
-    if (ARTIFACT_PICK_KINDS.has(pickKind)) {
-      if (!pickSource.job_id) {
-        errors.push('pick_source.job_id is required for artifact-backed pick sources.');
-      }
-      if (!pickSource.artifact_name) {
-        errors.push('pick_source.artifact_name is required for artifact-backed pick sources.');
-      }
-    }
-    if (pickSource.artifact_name && !pickSource.artifact_name.toLowerCase().endsWith('.npz')) {
-      errors.push('pick_source.artifact_name must be an .npz artifact.');
+    const pickFile = selectedPickNpzFile(targetDom);
+    if (!pickFile) {
+      errors.push('First-break pick NPZ is required.');
+    } else if (!hasNpzExtension(pickFile.name)) {
+      errors.push('First-break pick file must use the .npz extension.');
     }
     if (errors.length) {
       throw validationError(errors);
     }
-    return pickSource;
+    return { kind: UPLOADED_PICK_KIND };
   }
 
-  function updateStaticCorrectionPickSourceControls(targetDom = dom) {
-    if (!targetDom) return;
-    const uploaded = trimValue(targetDom.pickKind && targetDom.pickKind.value) === UPLOADED_PICK_KIND;
-    if (targetDom.pickJobId) {
-      targetDom.pickJobId.disabled = uploaded;
+  function renderPickNpzSummary(targetDom = dom) {
+    if (!targetDom || !targetDom.pickNpzSummary) return;
+    const pickFile = selectedPickNpzFile(targetDom);
+    if (!pickFile) {
+      targetDom.pickNpzSummary.textContent = 'No NPZ file selected.';
+      return;
     }
-    if (targetDom.pickArtifactName) {
-      targetDom.pickArtifactName.disabled = uploaded;
-    }
+    const size = formatFileSize(pickFile.size);
+    targetDom.pickNpzSummary.textContent = size
+      ? `${pickFile.name} (${size})`
+      : pickFile.name;
   }
 
   function validateStaticCorrectionGeometryRequest(targetDom = dom) {
@@ -1571,11 +1557,6 @@
   function applyPresetValues(values, targetDom = dom) {
     if (!targetDom || !values) return;
 
-    if (values.pick_source) {
-      setElementValue(targetDom.pickKind, values.pick_source.kind);
-      setElementValue(targetDom.pickArtifactName, values.pick_source.artifact_name);
-    }
-
     const geometry = values.geometry || {};
     setElementValue(targetDom.geometryPreset, geometry.preset);
     setElementValue(targetDom.sourceIdByte, geometry.source_id_byte);
@@ -1709,7 +1690,7 @@
     state.error = '';
     state.showValidationSummary = false;
     state.validationErrors = [];
-    state.message = `Loaded preset ${preset.name}. Current viewer target and pick_source.job_id were kept.`;
+    state.message = `Loaded preset ${preset.name}. Current viewer target and selected pick file were kept.`;
     render();
   }
 
@@ -1750,16 +1731,8 @@
     return [...files].sort((left, right) => {
       const leftName = trimValue(left && left.name ? left.name : left);
       const rightName = trimValue(right && right.name ? right.name : right);
-      const rank = pickArtifactRank(leftName) - pickArtifactRank(rightName);
-      return rank || leftName.localeCompare(rightName);
+      return leftName.localeCompare(rightName);
     });
-  }
-
-  function pickArtifactListUrl(kind, jobId) {
-    if (kind === 'batch_predicted_npz') {
-      return `/batch/job/${encodeURIComponent(jobId)}/files`;
-    }
-    return '';
   }
 
   function normalizeStaticJobState(value) {
@@ -1811,60 +1784,6 @@
       detail = '';
     }
     return `${operation} ${response.status}${detail ? `: ${detail}` : ''}`;
-  }
-
-  function renderPickArtifactList() {
-    if (!dom || !dom.pickArtifactList) return;
-    dom.pickArtifactList.innerHTML = '';
-
-    if (state.loadingPickArtifacts) {
-      dom.pickArtifactList.hidden = false;
-      dom.pickArtifactList.textContent = 'Loading pick artifacts...';
-      return;
-    }
-
-    if (trimValue(dom.pickKind.value) === UPLOADED_PICK_KIND) {
-      dom.pickArtifactList.hidden = true;
-      return;
-    }
-
-    if (!state.pickArtifacts.length) {
-      dom.pickArtifactList.hidden = true;
-      return;
-    }
-
-    const list = document.createElement('ul');
-    for (const file of state.pickArtifacts) {
-      const name = trimValue(file && file.name ? file.name : file);
-      if (!name) continue;
-      const item = document.createElement('li');
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.textContent = name;
-      button.dataset.artifactName = name;
-      button.dataset.testid = `static-correction-pick-artifact-${name}`;
-      if (isLikelyPickArtifact(name)) {
-        button.classList.add('is-likely');
-      }
-      button.addEventListener('click', () => {
-        dom.pickArtifactName.value = name;
-        state.error = '';
-        state.message = `Selected pick artifact ${name}.`;
-        render();
-      });
-      item.appendChild(button);
-      if (isLikelyPickArtifact(name)) {
-        const tag = document.createElement('span');
-        tag.className = 'static-correction-artifact-tag';
-        tag.textContent = 'first-break candidate';
-        item.appendChild(tag);
-      }
-      list.appendChild(item);
-    }
-    dom.pickArtifactList.hidden = list.childNodes.length === 0;
-    if (!dom.pickArtifactList.hidden) {
-      dom.pickArtifactList.appendChild(list);
-    }
   }
 
   function renderStaticArtifacts() {
@@ -2027,19 +1946,18 @@
     if (state.showValidationSummary) {
       state.validationErrors = preview.errors;
     }
-    updateStaticCorrectionPickSourceControls(dom);
     updateStaticCorrectionLinkageOptions(dom);
     renderTargetSummary();
+    renderPickNpzSummary(dom);
     dom.status.textContent = state.message;
     dom.error.hidden = !state.error;
     dom.error.textContent = state.error;
-    dom.runButton.disabled = !hasTarget || state.phase !== 'idle' || isStaticJobActive();
-    if (dom.loadPickArtifactsButton) {
-      dom.loadPickArtifactsButton.disabled = (
-        state.loadingPickArtifacts
-        || trimValue(dom.pickKind.value) === UPLOADED_PICK_KIND
-      );
-    }
+    dom.runButton.disabled = (
+      !hasTarget
+      || preview.errors.length > 0
+      || state.phase !== 'idle'
+      || isStaticJobActive()
+    );
     if (dom.requestPreview) {
       dom.requestPreview.textContent = preview.payload
         ? JSON.stringify(preview.payload, null, 2)
@@ -2047,63 +1965,8 @@
     }
     renderValidationSummary();
     renderPresetSelect();
-    renderPickArtifactList();
     renderStaticJobPanel();
     renderStaticArtifacts();
-  }
-
-  async function loadPickArtifacts() {
-    if (!dom) return;
-    const pickKind = trimValue(dom.pickKind.value);
-    const jobId = trimValue(dom.pickJobId.value);
-    if (pickKind === UPLOADED_PICK_KIND) {
-      state.error = 'Artifact listing is not available for pick_source.kind uploaded_npz.';
-      state.message = 'Use the direct pick upload flow for uploaded_npz.';
-      state.pickArtifacts = [];
-      render();
-      return;
-    }
-    if (!jobId) {
-      state.error = 'pick_source.job_id is required before loading pick artifacts.';
-      state.message = 'Enter the batch job ID that produced the first-break pick artifact.';
-      state.pickArtifacts = [];
-      render();
-      return;
-    }
-    const listUrl = pickArtifactListUrl(pickKind, jobId);
-    if (!listUrl) {
-      state.error = `Artifact listing is not available for pick_source.kind ${pickKind || '(blank)'}.`;
-      state.message = 'Type the pick artifact name manually.';
-      state.pickArtifacts = [];
-      render();
-      return;
-    }
-
-    state.loadingPickArtifacts = true;
-    state.error = '';
-    state.message = 'Loading pick artifacts...';
-    state.pickArtifacts = [];
-    render();
-
-    try {
-      const response = await fetch(listUrl);
-      if (!response.ok) {
-        throw new Error(await readResponseError(response, 'batch job files'));
-      }
-      const payload = await response.json();
-      const files = Array.isArray(payload.files) ? payload.files : [];
-      state.pickArtifacts = sortedArtifactFiles(files);
-      state.message = files.length
-        ? `Loaded ${files.length} artifact file${files.length === 1 ? '' : 's'} for ${jobId}.`
-        : `No artifact files returned for ${jobId}.`;
-    } catch (error) {
-      state.pickArtifacts = [];
-      state.error = error instanceof Error ? error.message : String(error);
-      state.message = 'Unable to load pick artifacts.';
-    } finally {
-      state.loadingPickArtifacts = false;
-      render();
-    }
   }
 
   async function postJson(url, payload, operation) {
@@ -2454,11 +2317,8 @@
     const savePresetButton = document.getElementById('staticCorrectionSavePresetButton');
     const loadPresetButton = document.getElementById('staticCorrectionLoadPresetButton');
     const deletePresetButton = document.getElementById('staticCorrectionDeletePresetButton');
-    const pickKind = document.getElementById('staticCorrectionPickKind');
-    const pickJobId = document.getElementById('staticCorrectionPickJobId');
-    const pickArtifactName = document.getElementById('staticCorrectionPickArtifactName');
-    const loadPickArtifactsButton = document.getElementById('staticCorrectionLoadPickArtifactsButton');
-    const pickArtifactList = document.getElementById('staticCorrectionPickArtifactList');
+    const pickNpzFile = document.getElementById('staticCorrectionPickNpz');
+    const pickNpzSummary = document.getElementById('staticCorrectionPickNpzSummary');
     const geometryPreset = document.getElementById('staticCorrectionGeometryPreset');
     const sourceIdByte = document.getElementById('staticCorrectionSourceIdByte');
     const receiverIdByte = document.getElementById('staticCorrectionReceiverIdByte');
@@ -2550,8 +2410,7 @@
       || !targetFile || !targetKeys || !targetStatus
       || !presetSelect || !presetName || !savePresetButton || !loadPresetButton
       || !deletePresetButton
-      || !pickKind || !pickJobId || !pickArtifactName || !loadPickArtifactsButton
-      || !pickArtifactList || !geometryPreset || !sourceIdByte || !receiverIdByte
+      || !pickNpzFile || !pickNpzSummary || !geometryPreset || !sourceIdByte || !receiverIdByte
       || !sourceXByte || !sourceYByte || !receiverXByte || !receiverYByte
       || !sourceElevationByte || !receiverElevationByte || !coordinateScalarByte
       || !elevationScalarByte || !sourceDepthByte || !coordinateUnit || !elevationUnit
@@ -2579,8 +2438,6 @@
       return;
     }
 
-    setDefaultValue(pickKind, DEFAULTS.pickKind);
-    setDefaultValue(pickArtifactName, DEFAULTS.pickArtifactName);
     setDefaultValue(linkageMode, DEFAULTS.linkageMode);
     setDefaultValue(linkageThresholdM, DEFAULTS.linkageThresholdM);
     setDefaultValue(modelKind, DEFAULTS.modelPreset);
@@ -2623,11 +2480,8 @@
       savePresetButton,
       loadPresetButton,
       deletePresetButton,
-      pickKind,
-      pickJobId,
-      pickArtifactName,
-      loadPickArtifactsButton,
-      pickArtifactList,
+      pickNpzFile,
+      pickNpzSummary,
       geometryPreset,
       sourceIdByte,
       receiverIdByte,
@@ -2750,9 +2604,15 @@
       event.preventDefault();
       cancelStaticCorrectionJob();
     });
-    loadPickArtifactsButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      loadPickArtifacts();
+    pickNpzFile.addEventListener('change', () => {
+      const pickFile = selectedPickNpzFile(dom);
+      state.error = '';
+      state.showValidationSummary = false;
+      state.validationErrors = [];
+      state.message = pickFile
+        ? `Selected first-break pick NPZ ${pickFile.name}.`
+        : 'Choose a first-break pick NPZ before running refraction statics.';
+      render();
     });
     geometryPreset.addEventListener('change', () => {
       applyStaticCorrectionGeometryPreset(dom, geometryPreset.value);
@@ -2844,11 +2704,10 @@
     collectOutputInputs,
     collectPresetInputs,
     applyPresetValues,
-    isLikelyPickArtifact,
+    hasNpzExtension,
     deleteSelectedPreset,
     getStaticCorrectionValidationSnapshot,
     loadStaticArtifacts,
-    loadPickArtifacts,
     loadSelectedPreset,
     normalizeStaticJobState,
     pollStaticCorrectionJobUntilTerminal,

--- a/app/static/refraction_static_run.js
+++ b/app/static/refraction_static_run.js
@@ -1714,16 +1714,34 @@
     render();
   }
 
-  function buildStaticLinkageBuildRequest(staticCorrectionPayload) {
-    if (!staticCorrectionPayload) {
-      throw validationError(['Static correction payload is required before building linkage.']);
+  function buildStaticLinkageBuildRequest(targetDom = dom) {
+    const values = collectInputs(targetDom);
+    const errors = [];
+    if (!values) {
+      throw validationError(['Static correction form is not available.']);
+    }
+    if (!values.file_id) {
+      errors.push('No active viewer file. Open an SGY/TraceStore in the viewer before running Static Correction.');
+    }
+    const key1Byte = values.file_id
+      ? parsePositiveInteger(values.key1_byte, 'key1_byte', errors)
+      : null;
+    const key2Byte = values.file_id
+      ? parsePositiveInteger(values.key2_byte, 'key2_byte', errors)
+      : null;
+    const geometryResult = validateStaticCorrectionGeometryRequest(targetDom);
+    errors.push(...geometryResult.errors);
+    const linkageResult = validateStaticCorrectionLinkageRequest(targetDom);
+    errors.push(...linkageResult.errors);
+    if (errors.length) {
+      throw validationError(errors);
     }
     return {
-      file_id: staticCorrectionPayload.file_id,
-      key1_byte: staticCorrectionPayload.key1_byte,
-      key2_byte: staticCorrectionPayload.key2_byte,
-      geometry: { ...staticCorrectionPayload.geometry },
-      linkage: { ...staticCorrectionPayload.linkage },
+      file_id: values.file_id,
+      key1_byte: key1Byte,
+      key2_byte: key2Byte,
+      geometry: { ...geometryResult.payload.geometry },
+      linkage: { ...linkageResult.payload.linkage },
     };
   }
 
@@ -2232,11 +2250,11 @@
     try {
       let applyPayload = payload;
       if (dom.enableLinkage.checked) {
-        const linkageBuildPayload = buildStaticLinkageBuildRequest(payload);
-        state.lastLinkageBuildRequest = linkageBuildPayload;
         state.phase = 'building_linkage';
         state.message = 'Building endpoint geometry linkage...';
         render();
+        const linkageBuildPayload = buildStaticLinkageBuildRequest(dom);
+        state.lastLinkageBuildRequest = linkageBuildPayload;
 
         const linkageResponse = await postJson(
           '/statics/linkage/build',

--- a/app/tests/ui/refraction_static_geometry.test.js
+++ b/app/tests/ui/refraction_static_geometry.test.js
@@ -12,9 +12,12 @@ const INDEX_HTML = readFileSync(resolve(process.cwd(), 'static/index.html'), 'ut
 function renderStaticCorrectionForm() {
   document.body.innerHTML = `
     <form id="staticCorrectionForm">
-      <input id="staticCorrectionFileId" value="file-a" />
-      <input id="staticCorrectionKey1Byte" value="189" />
-      <input id="staticCorrectionKey2Byte" value="193" />
+      <div id="staticCorrectionTargetEmpty"></div>
+      <div id="staticCorrectionTargetDetails" hidden>
+        <span id="staticCorrectionTargetFile"></span>
+        <span id="staticCorrectionTargetKeys"></span>
+        <span id="staticCorrectionTargetStatus"></span>
+      </div>
       <select id="staticCorrectionPresetSelect">
         <option value="">No saved presets</option>
       </select>
@@ -22,15 +25,8 @@ function renderStaticCorrectionForm() {
       <button id="staticCorrectionSavePresetButton" type="button"></button>
       <button id="staticCorrectionLoadPresetButton" type="button"></button>
       <button id="staticCorrectionDeletePresetButton" type="button"></button>
-      <select id="staticCorrectionPickKind">
-        <option value="uploaded_npz">uploaded_npz</option>
-        <option value="batch_predicted_npz" selected>batch_predicted_npz</option>
-        <option value="manual_npz_artifact">manual_npz_artifact</option>
-      </select>
-      <input id="staticCorrectionPickJobId" value="pick-job-a" />
-      <input id="staticCorrectionPickArtifactName" value="predicted_picks_time_s.npz" />
-      <button id="staticCorrectionLoadPickArtifactsButton" type="button"></button>
-      <div id="staticCorrectionPickArtifactList"></div>
+      <input id="staticCorrectionPickNpz" type="file" accept=".npz" />
+      <div id="staticCorrectionPickNpzSummary"></div>
       <select id="staticCorrectionGeometryPreset">
         <option value="segy_default" selected>SEG-Y default</option>
         <option value="custom">custom</option>
@@ -192,6 +188,36 @@ function renderStaticCorrectionForm() {
   `;
 }
 
+let activeViewerTarget;
+
+function setViewerTarget(fileId = 'file-a', key1Byte = 189, key2Byte = 193) {
+  activeViewerTarget = fileId
+    ? {
+        fileId,
+        key1Byte,
+        key2Byte,
+        displayName: fileId,
+      }
+    : null;
+}
+
+function selectedPickFile(name = 'first-break-picks.npz', bytes = 'npz-bytes') {
+  const input = document.getElementById('staticCorrectionPickNpz');
+  const file = new File([bytes], name, { type: 'application/octet-stream' });
+  Object.defineProperty(input, 'files', {
+    value: [file],
+    configurable: true,
+  });
+  return file;
+}
+
+function clearSelectedPickFile() {
+  Object.defineProperty(document.getElementById('staticCorrectionPickNpz'), 'files', {
+    value: [],
+    configurable: true,
+  });
+}
+
 function loadStaticCorrectionScript() {
   window.eval(SCRIPT);
   document.dispatchEvent(new Event('DOMContentLoaded'));
@@ -208,8 +234,13 @@ beforeEach(() => {
   delete window.refractionStaticRunUI;
   delete window.refractionStaticRunState;
   delete window.RefractionQc;
+  setViewerTarget();
+  window.SeisViewerState = {
+    getActiveFileTarget: () => activeViewerTarget,
+  };
   window.localStorage.clear();
   renderStaticCorrectionForm();
+  selectedPickFile();
 });
 
 afterEach(() => {
@@ -217,6 +248,7 @@ afterEach(() => {
     window.refractionStaticRunUI.stopStaticCorrectionPolling();
   }
   delete window.RefractionQc;
+  delete window.SeisViewerState;
   vi.unstubAllGlobals();
   window.localStorage.clear();
 });
@@ -266,8 +298,16 @@ function createStaticCorrectionFetchMock(
   const linkageStatusQueue = [...linkageStatuses];
   const staticStatusQueue = [...staticStatuses];
   const fetchMock = vi.fn(async (url, options = {}) => {
-    const body = options.body ? JSON.parse(options.body) : null;
-    calls.push({ url: String(url), options, body });
+    let body = null;
+    let formData = null;
+    if (options.body instanceof FormData) {
+      formData = options.body;
+      const requestJson = formData.get('request_json');
+      body = requestJson ? JSON.parse(requestJson) : null;
+    } else if (options.body) {
+      body = JSON.parse(options.body);
+    }
+    calls.push({ url: String(url), options, body, formData });
 
     if (url === '/statics/linkage/build') {
       return jsonResponse({ job_id: 'linkage-job-a', state: 'queued' });
@@ -277,7 +317,7 @@ function createStaticCorrectionFetchMock(
         linkageStatusQueue.shift() || linkageStatuses[linkageStatuses.length - 1]
       );
     }
-    if (url === '/statics/refraction/apply') {
+    if (url === '/statics/refraction/apply-with-picks') {
       return jsonResponse({ job_id: 'static-job-a', state: 'queued' });
     }
     if (url === '/statics/job/static-job-a/status') {
@@ -306,92 +346,51 @@ function createStaticCorrectionFetchMock(
   return { calls, fetchMock };
 }
 
-test('load pick artifacts calls the batch files endpoint and sorts known pick artifacts first', async () => {
-  const ui = loadStaticCorrectionScript();
-  const calls = [];
-  vi.stubGlobal('fetch', vi.fn(async (url) => {
-    calls.push(String(url));
-    return jsonResponse({
-      files: [
-        { name: 'z_notes.txt', size_bytes: 10 },
-        { name: 'manual_picks_time_qc.npz', size_bytes: 20 },
-        { name: 'predicted_picks_time_s.npz', size_bytes: 30 },
-      ],
-    });
-  }));
+test('selected pick NPZ renders in the file summary', () => {
+  selectedPickFile('manual_picks_time_review.npz', 'abc');
+  loadStaticCorrectionScript();
 
-  await ui.loadPickArtifacts();
-  await flushAsyncWork();
-
-  expect(calls).toEqual(['/batch/job/pick-job-a/files']);
-  const buttons = [...document.querySelectorAll('#staticCorrectionPickArtifactList button')];
-  expect(buttons.map((button) => button.textContent)).toEqual([
-    'predicted_picks_time_s.npz',
-    'manual_picks_time_qc.npz',
-    'z_notes.txt',
-  ]);
-  expect(buttons[0].classList.contains('is-likely')).toBe(true);
-  expect(document.getElementById('staticCorrectionPickArtifactList').textContent).toContain(
-    'first-break candidate'
-  );
-});
-
-test('selecting a loaded pick artifact fills the artifact name input', async () => {
-  const ui = loadStaticCorrectionScript();
-  vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
-    files: [{ name: 'manual_picks_time_review.npz', size_bytes: 12 }],
-  })));
-
-  await ui.loadPickArtifacts();
-  await flushAsyncWork();
-  document.querySelector('#staticCorrectionPickArtifactList button').click();
-
-  expect(document.getElementById('staticCorrectionPickArtifactName').value).toBe(
+  expect(document.getElementById('staticCorrectionPickNpzSummary').textContent).toContain(
     'manual_picks_time_review.npz'
   );
-  expect(document.getElementById('staticCorrectionStatus').textContent).toContain(
-    'Selected pick artifact manual_picks_time_review.npz'
-  );
 });
 
-test('pick artifact listing 404 shows a warning and leaves manual input usable', async () => {
+test('missing pick NPZ blocks submit and shows validation', async () => {
   const ui = loadStaticCorrectionScript();
-  const artifactInput = document.getElementById('staticCorrectionPickArtifactName');
-  artifactInput.value = 'typed_picks.npz';
-  vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ detail: 'Job ID not found' }, 404)));
+  clearSelectedPickFile();
+  document.getElementById('staticCorrectionPickNpz').dispatchEvent(new Event('change'));
 
-  await ui.loadPickArtifacts();
+  await ui.runStaticCorrection();
   await flushAsyncWork();
 
   expect(document.getElementById('staticCorrectionError').hidden).toBe(false);
   expect(document.getElementById('staticCorrectionError').textContent).toContain(
-    'Job ID not found'
+    'First-break pick NPZ is required'
   );
-  expect(document.getElementById('staticCorrectionStatus').textContent).toBe(
-    'Unable to load pick artifacts.'
-  );
-  expect(artifactInput.value).toBe('typed_picks.npz');
+  expect(window.refractionStaticRunState.lastRequest).toBe(null);
 });
 
-test('unsupported pick artifact listing warns without fetching', async () => {
+test('non-NPZ pick upload blocks submit', async () => {
+  selectedPickFile('picks.txt', 'abc');
   const ui = loadStaticCorrectionScript();
-  document.getElementById('staticCorrectionPickKind').value = 'manual_npz_artifact';
-  const artifactInput = document.getElementById('staticCorrectionPickArtifactName');
-  artifactInput.value = 'manual_entry.npz';
-  const fetchMock = vi.fn();
-  vi.stubGlobal('fetch', fetchMock);
 
-  await ui.loadPickArtifacts();
+  await ui.runStaticCorrection();
   await flushAsyncWork();
 
-  expect(fetchMock).not.toHaveBeenCalled();
+  expect(document.getElementById('staticCorrectionError').hidden).toBe(false);
   expect(document.getElementById('staticCorrectionError').textContent).toContain(
-    'Artifact listing is not available for pick_source.kind manual_npz_artifact'
+    'First-break pick file must use the .npz extension'
   );
-  expect(document.getElementById('staticCorrectionStatus').textContent).toBe(
-    'Type the pick artifact name manually.'
-  );
-  expect(artifactInput.value).toBe('manual_entry.npz');
+  expect(window.refractionStaticRunState.lastRequest).toBe(null);
+});
+
+test('static correction request always uses uploaded NPZ pick source', () => {
+  const ui = loadStaticCorrectionScript();
+
+  const result = ui.buildStaticCorrectionRequest();
+
+  expect(result.errors).toEqual([]);
+  expect(result.payload.pick_source).toEqual({ kind: 'uploaded_npz' });
 });
 
 test('geometry defaults render from the SEG-Y preset', () => {
@@ -478,29 +477,25 @@ test('request preview renders valid JSON and updates when fields change', () => 
 
 test('request preview supports uploaded pick source without artifact fields', () => {
   loadStaticCorrectionScript();
-  const kind = document.getElementById('staticCorrectionPickKind');
-
-  kind.value = 'uploaded_npz';
-  kind.dispatchEvent(new Event('change', { bubbles: true }));
 
   const preview = JSON.parse(document.getElementById('staticCorrectionRequestPreview').textContent);
   expect(preview.pick_source).toEqual({ kind: 'uploaded_npz' });
-  expect(document.getElementById('staticCorrectionPickJobId').disabled).toBe(true);
-  expect(document.getElementById('staticCorrectionPickArtifactName').disabled).toBe(true);
-  expect(document.getElementById('staticCorrectionLoadPickArtifactsButton').disabled).toBe(true);
+  expect(INDEX_HTML).not.toContain('staticCorrectionPickJobId');
+  expect(INDEX_HTML).not.toContain('staticCorrectionPickArtifactName');
+  expect(INDEX_HTML).not.toContain('staticCorrectionLoadPickArtifactsButton');
 });
 
 test('validation summary lists invalid fields before submit', () => {
   loadStaticCorrectionScript();
-  document.getElementById('staticCorrectionFileId').value = '';
-  document.getElementById('staticCorrectionPickJobId').value = '';
+  setViewerTarget(null);
+  clearSelectedPickFile();
 
   document.getElementById('staticCorrectionRunButton').click();
 
   const summary = document.getElementById('staticCorrectionValidationSummary');
   expect(summary.hidden).toBe(false);
-  expect(summary.textContent).toContain('file_id is required');
-  expect(summary.textContent).toContain('pick_source.job_id is required');
+  expect(summary.textContent).toContain('No active viewer file');
+  expect(summary.textContent).toContain('First-break pick NPZ is required');
 });
 
 test('save preset writes localStorage without transient job state', () => {
@@ -512,7 +507,7 @@ test('save preset writes localStorage without transient job state', () => {
   expect(presets).toHaveLength(1);
   expect(presets[0].name).toBe('field layout');
   expect(presets[0].values).not.toHaveProperty('file_id');
-  expect(presets[0].values.pick_source).not.toHaveProperty('job_id');
+  expect(presets[0].values).not.toHaveProperty('pick_source');
   expect(presets[0].values).not.toHaveProperty('staticArtifacts');
 });
 
@@ -525,15 +520,15 @@ test('load preset restores model and header fields while keeping current ids', (
   document.getElementById('staticCorrectionPresetName').value = 'two-layer custom';
   document.getElementById('staticCorrectionSavePresetButton').click();
 
-  document.getElementById('staticCorrectionFileId').value = 'current-file';
-  document.getElementById('staticCorrectionPickJobId').value = 'current-picks';
+  setViewerTarget('current-file', 17, 21);
+  selectedPickFile('current-picks.npz');
   document.getElementById('staticCorrectionSourceIdByte').value = '9';
   selectModelPreset('one_layer_global');
   document.getElementById('staticCorrectionWeatheringVelocityMS').value = '700';
   document.getElementById('staticCorrectionLoadPresetButton').click();
 
-  expect(document.getElementById('staticCorrectionFileId').value).toBe('current-file');
-  expect(document.getElementById('staticCorrectionPickJobId').value).toBe('current-picks');
+  expect(window.SeisViewerState.getActiveFileTarget().fileId).toBe('current-file');
+  expect(document.getElementById('staticCorrectionPickNpz').files[0].name).toBe('current-picks.npz');
   expect(document.getElementById('staticCorrectionGeometryPreset').value).toBe('custom');
   expect(document.getElementById('staticCorrectionSourceIdByte').value).toBe('101');
   expect(document.getElementById('staticCorrectionModelKind').value).toBe('two_layer_global');
@@ -639,7 +634,8 @@ test('checked auto-threshold linkage validates threshold only when enabled', () 
 });
 
 test('field correction and export sections are collapsed details controls', () => {
-  expect(INDEX_HTML).toContain('<option value="uploaded_npz">uploaded_npz</option>');
+  expect(INDEX_HTML).toContain('id="staticCorrectionPickNpz"');
+  expect(INDEX_HTML).not.toContain('id="staticCorrectionPickKind"');
   expect(INDEX_HTML).toContain('<details id="staticCorrectionFieldCorrectionsSection"');
   expect(INDEX_HTML).toContain('<summary id="staticCorrectionFieldCorrectionsHeading">Field corrections</summary>');
   expect(INDEX_HTML).toContain('<details id="staticCorrectionExportSection"');
@@ -790,8 +786,8 @@ test('one-layer model preset is the default request shape', () => {
 
 test('two-layer preset builds public global V3/T2 request', () => {
   const ui = loadStaticCorrectionScript();
-  document.getElementById('staticCorrectionFileId').value = 'line-preserved';
-  document.getElementById('staticCorrectionPickJobId').value = 'pick-preserved';
+  setViewerTarget('line-preserved', 17, 21);
+  selectedPickFile('pick-preserved.npz');
 
   selectModelPreset('two_layer_global');
   document.getElementById('staticCorrectionV3MaxOffsetM').value = '';
@@ -801,7 +797,9 @@ test('two-layer preset builds public global V3/T2 request', () => {
   expect(document.getElementById('staticCorrectionV3LayerFields').hidden).toBe(false);
   expect(document.getElementById('staticCorrectionVsubLayerFields').hidden).toBe(true);
   expect(result.payload.file_id).toBe('line-preserved');
-  expect(result.payload.pick_source.job_id).toBe('pick-preserved');
+  expect(result.payload.key1_byte).toBe(17);
+  expect(result.payload.key2_byte).toBe(21);
+  expect(result.payload.pick_source).toEqual({ kind: 'uploaded_npz' });
   expect(result.payload.model).toMatchObject({
     method: 'multilayer_time_term',
     layers: [
@@ -941,11 +939,35 @@ test('unchecked linkage skips linkage build when running static correction', asy
   await flushAsyncWork();
 
   expect(calls.map((call) => call.url)).toEqual([
-    '/statics/refraction/apply',
+    '/statics/refraction/apply-with-picks',
     '/statics/job/static-job-a/status',
     '/statics/job/static-job-a/files',
   ]);
   expect(calls[0].body.linkage).toEqual({ mode: 'none' });
+  expect(calls.map((call) => call.url)).not.toContain('/statics/refraction/apply');
+  expect(calls[0].formData).toBeInstanceOf(FormData);
+  expect(calls[0].options.headers).toBeUndefined();
+});
+
+test('static correction multipart form data contains request JSON and pick NPZ', async () => {
+  const ui = loadStaticCorrectionScript();
+  const pickFile = selectedPickFile('uploaded-picks.npz', 'pick-data');
+  setViewerTarget('active-line', 9, 13);
+  const { calls } = createStaticCorrectionFetchMock();
+
+  await ui.runStaticCorrection();
+  await flushAsyncWork();
+
+  const applyCall = calls.find((call) => call.url === '/statics/refraction/apply-with-picks');
+  const request = JSON.parse(applyCall.formData.get('request_json'));
+  expect(request).toMatchObject({
+    file_id: 'active-line',
+    key1_byte: 9,
+    key2_byte: 13,
+    pick_source: { kind: 'uploaded_npz' },
+    linkage: { mode: 'none' },
+  });
+  expect(applyCall.formData.get('pick_npz')).toBe(pickFile);
 });
 
 test('static correction submit failure returns to a retryable idle state', async () => {
@@ -953,7 +975,7 @@ test('static correction submit failure returns to a retryable idle state', async
   const calls = [];
   vi.stubGlobal('fetch', vi.fn(async (url, options = {}) => {
     calls.push({ url: String(url), options });
-    if (url === '/statics/refraction/apply') {
+    if (url === '/statics/refraction/apply-with-picks') {
       return jsonResponse({ detail: 'apply failed' }, 400);
     }
     throw new Error(`unexpected fetch ${url}`);
@@ -962,12 +984,30 @@ test('static correction submit failure returns to a retryable idle state', async
   await ui.runStaticCorrection();
   await flushAsyncWork();
 
-  expect(calls.map((call) => call.url)).toEqual(['/statics/refraction/apply']);
+  expect(calls.map((call) => call.url)).toEqual(['/statics/refraction/apply-with-picks']);
   expect(window.refractionStaticRunState.phase).toBe('idle');
   expect(document.getElementById('staticCorrectionRunButton').disabled).toBe(false);
   expect(document.getElementById('staticCorrectionError').textContent).toContain('apply failed');
   expect(document.getElementById('staticCorrectionStatus').textContent).toContain(
     'Static correction submission failed'
+  );
+});
+
+test('static correction submit displays backend validation error', async () => {
+  const ui = loadStaticCorrectionScript();
+  vi.stubGlobal('fetch', vi.fn(async (url) => {
+    if (url === '/statics/refraction/apply-with-picks') {
+      return jsonResponse({ detail: 'request_json.file_id is invalid' }, 422);
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }));
+
+  await ui.runStaticCorrection();
+  await flushAsyncWork();
+
+  expect(document.getElementById('staticCorrectionError').hidden).toBe(false);
+  expect(document.getElementById('staticCorrectionError').textContent).toContain(
+    'request_json.file_id is invalid'
   );
 });
 
@@ -985,7 +1025,7 @@ test('checked linkage posts linkage build payload before static correction apply
   expect(calls.map((call) => call.url).slice(0, 3)).toEqual([
     '/statics/linkage/build',
     '/statics/job/linkage-job-a/status',
-    '/statics/refraction/apply',
+    '/statics/refraction/apply-with-picks',
   ]);
   expect(calls[0].body).toEqual({
     file_id: 'file-a',
@@ -1029,7 +1069,7 @@ test('checked linkage polls linkage status until ready', async () => {
   await flushAsyncWork();
 
   expect(calls.filter((call) => call.url === '/statics/job/linkage-job-a/status')).toHaveLength(3);
-  expect(calls.map((call) => call.url)).toContain('/statics/refraction/apply');
+  expect(calls.map((call) => call.url)).toContain('/statics/refraction/apply-with-picks');
 });
 
 test('failed linkage prevents refraction apply submit', async () => {
@@ -1042,7 +1082,7 @@ test('failed linkage prevents refraction apply submit', async () => {
   await ui.runStaticCorrection();
   await flushAsyncWork();
 
-  expect(calls.map((call) => call.url)).not.toContain('/statics/refraction/apply');
+  expect(calls.map((call) => call.url)).not.toContain('/statics/refraction/apply-with-picks');
   expect(document.getElementById('staticCorrectionError').hidden).toBe(false);
   expect(document.getElementById('staticCorrectionError').textContent).toContain(
     'linkage build failed'
@@ -1065,7 +1105,7 @@ test('successful linkage injects linkage job reference into refraction request',
   await ui.runStaticCorrection();
   await flushAsyncWork();
 
-  const applyCall = calls.find((call) => call.url === '/statics/refraction/apply');
+  const applyCall = calls.find((call) => call.url === '/statics/refraction/apply-with-picks');
   expect(applyCall.body.linkage).toEqual({
     mode: 'required',
     job_id: 'linkage-job-a',

--- a/tests/e2e/refraction_qc.spec.ts
+++ b/tests/e2e/refraction_qc.spec.ts
@@ -1060,13 +1060,24 @@ async function setStaticCorrectionViewerTarget(
 
 async function fillStaticCorrectionRunInputs(
 	page: Page,
-	{ fileId = 'fixture-line-a-store', pickJobId = 'fixture-first-break-job' } = {},
+	{ fileId = 'fixture-line-a-store', pickFileName = 'predicted_picks_time_s.npz' } = {},
 ) {
 	await setStaticCorrectionViewerTarget(page, { fileId });
-	await page.getByTestId('static-correction-pick-job-id').fill(pickJobId);
-	await page.getByTestId('static-correction-pick-artifact-name').fill('predicted_picks_time_s.npz');
+	await selectStaticCorrectionPickNpz(page, pickFileName);
 	await page.getByTestId('static-correction-model-kind').selectOption('one_layer_global');
 	await expect(page.getByTestId('static-correction-enable-linkage')).not.toBeChecked();
+}
+
+async function selectStaticCorrectionPickNpz(
+	page: Page,
+	name = 'predicted_picks_time_s.npz',
+	buffer = Buffer.from('npz'),
+) {
+	await page.getByTestId('static-correction-pick-npz').setInputFiles({
+		name,
+		mimeType: 'application/octet-stream',
+		buffer,
+	});
 }
 
 type StaticCorrectionRouteCall = {
@@ -1178,7 +1189,7 @@ test('static correction tab scaffold switches side panels', async ({ page }) => 
 	}
 	await expect(page.getByTestId('static-correction-form')).toBeVisible();
 	await expect(page.getByTestId('static-correction-status')).toContainText(
-		'Open a viewer file and choose a first-break pick artifact usable by refraction statics.',
+		'Open a viewer file and choose a first-break pick NPZ for refraction statics.',
 	);
 	await expect(page.getByTestId('static-correction-file-id')).toHaveCount(0);
 	await expect(page.getByTestId('static-correction-key1-byte')).toHaveCount(0);
@@ -1186,11 +1197,16 @@ test('static correction tab scaffold switches side panels', async ({ page }) => 
 	await expect(page.getByTestId('static-correction-target-empty')).toContainText(
 		'No active viewer file. Open an SGY/TraceStore in the viewer before running Static Correction.',
 	);
-	await expect(page.getByTestId('static-correction-pick-kind')).toHaveValue('batch_predicted_npz');
-	await expect(page.getByTestId('static-correction-pick-job-id')).toBeVisible();
-	await expect(page.getByTestId('static-correction-pick-artifact-name')).toHaveValue('predicted_picks_time_s.npz');
-	await expect(panel).toContainText('/statics/refraction/apply');
-	await expect(panel).toContainText('viewer first-break probability cache is not a valid statics pick artifact');
+	await expect(page.getByTestId('static-correction-pick-npz')).toBeVisible();
+	await expect(page.getByTestId('static-correction-pick-npz')).toHaveAttribute('accept', '.npz');
+	await expect(page.getByTestId('static-correction-pick-npz-summary')).toContainText('No NPZ file selected.');
+	await expect(page.getByTestId('static-correction-pick-kind')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-pick-job-id')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-pick-artifact-name')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-load-pick-artifacts')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-pick-artifact-list')).toHaveCount(0);
+	await expect(panel).toContainText('Select a first-break pick NPZ');
+	await expect(panel).toContainText('viewer first-break probability cache is not a valid statics pick file');
 	await expect(page.getByTestId('static-correction-error')).toBeHidden();
 	await expect(page.getByTestId('static-correction-run')).toBeVisible();
 	await expect(page.getByTestId('static-correction-run')).toBeDisabled();
@@ -1227,9 +1243,7 @@ test('static_correction_ui_runs_one_layer_without_linkage', async ({ page }) => 
 	expect(applyCall?.body).toMatchObject({
 		file_id: 'fixture-line-a-store',
 		pick_source: {
-			kind: 'batch_predicted_npz',
-			job_id: 'fixture-first-break-job',
-			artifact_name: 'predicted_picks_time_s.npz',
+			kind: 'uploaded_npz',
 		},
 		linkage: { mode: 'none' },
 		model: {
@@ -1382,14 +1396,83 @@ test('static_correction_target_summary_loaded_state', async ({ page }) => {
 	);
 	await expect(page.getByTestId('static-correction-target-keys')).toHaveText('key1=9, key2=13');
 	await expect(page.getByTestId('static-correction-target-status')).toHaveText('Ready');
+	await expect(page.getByTestId('static-correction-run')).toBeDisabled();
+	await selectStaticCorrectionPickNpz(page);
 	await expect(page.getByTestId('static-correction-run')).toBeEnabled();
+});
+
+test('static_correction_pick_npz_input_visible', async ({ page }) => {
+	await openStaticCorrectionTab(page);
+
+	await expect(page.getByTestId('static-correction-pick-npz')).toBeVisible();
+	await expect(page.getByTestId('static-correction-pick-npz')).toHaveAttribute('accept', '.npz');
+	await selectStaticCorrectionPickNpz(page, 'predicted_picks_time_s.npz', Buffer.from('abcd'));
+	await expect(page.getByTestId('static-correction-pick-npz-summary')).toContainText(
+		'predicted_picks_time_s.npz',
+	);
+	await expect(page.getByTestId('static-correction-pick-npz-summary')).toContainText('4 B');
+});
+
+test('static_correction_pick_job_fields_removed', async ({ page }) => {
+	await openStaticCorrectionTab(page);
+
+	await expect(page.getByTestId('static-correction-pick-kind')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-pick-job-id')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-pick-artifact-name')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-load-pick-artifacts')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-pick-artifact-list')).toHaveCount(0);
+});
+
+test('static_correction_request_preview_uses_uploaded_npz', async ({ page }) => {
+	await openStaticCorrectionTab(page);
+	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
+	await selectStaticCorrectionPickNpz(page);
+	await page.getByText('JSON request preview').click();
+
+	const requestPreview = page.getByTestId('static-correction-request-preview');
+	await expect(requestPreview).toContainText('"pick_source"');
+	await expect(requestPreview).toContainText('"kind": "uploaded_npz"');
+	await expect(requestPreview).not.toContainText('"job_id"');
+	await expect(requestPreview).not.toContainText('"artifact_name"');
+});
+
+test('static_correction_requires_pick_npz_before_run', async ({ page }) => {
+	const staticsRequests: string[] = [];
+	await page.route('**/statics/refraction/apply', async (route) => {
+		staticsRequests.push(route.request().url());
+		await route.abort();
+	});
+
+	await openStaticCorrectionTab(page);
+	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
+	await expect(page.getByTestId('static-correction-run')).toBeDisabled();
+	await page.getByText('JSON request preview').click();
+	await expect(page.getByTestId('static-correction-request-preview')).toContainText(
+		'First-break pick NPZ is required.',
+	);
+	expect(staticsRequests).toEqual([]);
+});
+
+test('static_correction_rejects_non_npz_pick_file', async ({ page }) => {
+	await openStaticCorrectionTab(page);
+	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
+	await selectStaticCorrectionPickNpz(page, 'predicted_picks_time_s.txt');
+
+	await expect(page.getByTestId('static-correction-pick-npz-summary')).toContainText(
+		'predicted_picks_time_s.txt',
+	);
+	await expect(page.getByTestId('static-correction-run')).toBeDisabled();
+	await page.getByText('JSON request preview').click();
+	await expect(page.getByTestId('static-correction-request-preview')).toContainText(
+		'First-break pick file must use the .npz extension.',
+	);
 });
 
 test('static correction one-layer builder defaults to no linkage and solved global V2', async ({ page }) => {
 	await page.goto('/');
 	await page.getByTestId('static-correction-tab').click();
 	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
-	await page.getByTestId('static-correction-pick-job-id').fill('pick-job');
+	await selectStaticCorrectionPickNpz(page);
 
 	const request = await page.evaluate(() => (
 		(window as any).refractionStaticRunUI.buildRefractionStaticApplyRequest()
@@ -1398,9 +1481,7 @@ test('static correction one-layer builder defaults to no linkage and solved glob
 	expect(request).toMatchObject({
 		file_id: 'line-a-store',
 		pick_source: {
-			kind: 'batch_predicted_npz',
-			job_id: 'pick-job',
-			artifact_name: 'predicted_picks_time_s.npz',
+			kind: 'uploaded_npz',
 		},
 		linkage: {
 			mode: 'none',
@@ -1475,7 +1556,7 @@ test('static correction run submits one-layer refraction apply request', async (
 	await page.goto('/');
 	await page.getByTestId('static-correction-tab').click();
 	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
-	await page.getByTestId('static-correction-pick-job-id').fill('pick-job');
+	await selectStaticCorrectionPickNpz(page);
 	await page.getByTestId('static-correction-run').click();
 
 	await expect(page.getByTestId('static-correction-job-id')).toHaveText('refraction-job-559');
@@ -1496,6 +1577,7 @@ test('static correction run submits one-layer refraction apply request', async (
 	await expect(requestPreview).not.toContainText('"time_term_spreadsheet"');
 	expect(applyRequest).toMatchObject({
 		file_id: 'line-a-store',
+		pick_source: { kind: 'uploaded_npz' },
 		linkage: { mode: 'none' },
 		model: {
 			first_layer: {
@@ -1525,7 +1607,7 @@ test('static correction submit errors keep user input visible', async ({ page })
 	await page.goto('/');
 	await page.getByTestId('static-correction-tab').click();
 	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
-	await page.getByTestId('static-correction-pick-job-id').fill('pick-job');
+	await selectStaticCorrectionPickNpz(page);
 	await page.getByTestId('static-correction-run').click();
 
 	await expect(page.getByTestId('static-correction-error')).toBeVisible();
@@ -1537,59 +1619,9 @@ test('static correction submit errors keep user input visible', async ({ page })
 	);
 	await expect(page.getByTestId('static-correction-target-file')).toContainText('fixture-line-a.sgy');
 	await expect(page.getByTestId('static-correction-target-keys')).toContainText('key1=9, key2=13');
-	await expect(page.getByTestId('static-correction-pick-job-id')).toHaveValue('pick-job');
-});
-
-test('static correction tab loads likely first-break pick artifacts', async ({ page }) => {
-	await page.route('**/batch/job/pick-job/files', async (route) => {
-		await route.fulfill({
-			status: 200,
-			contentType: 'application/json',
-			body: JSON.stringify({
-				files: [
-					{ name: 'job_meta.json', size_bytes: 12 },
-					{ name: 'predicted_picks_time_s.npz', size_bytes: 128 },
-					{ name: 'manual_picks_time_lineA.npz', size_bytes: 96 },
-				],
-			}),
-		});
-	});
-
-	await page.goto('/');
-	await page.getByTestId('static-correction-tab').click();
-	await page.getByTestId('static-correction-pick-job-id').fill('pick-job');
-	await page.getByTestId('static-correction-load-pick-artifacts').click();
-
-	const list = page.getByTestId('static-correction-pick-artifact-list');
-	await expect(list).toBeVisible();
-	await expect(list).toContainText('predicted_picks_time_s.npz');
-	await expect(list).toContainText('manual_picks_time_lineA.npz');
-	await expect(list).toContainText('first-break candidate');
-
-	await list.getByRole('button', { name: 'manual_picks_time_lineA.npz' }).click();
-	await expect(page.getByTestId('static-correction-pick-artifact-name')).toHaveValue(
-		'manual_picks_time_lineA.npz',
+	await expect(page.getByTestId('static-correction-pick-npz-summary')).toContainText(
+		'predicted_picks_time_s.npz',
 	);
-});
-
-test('static correction tab displays pick artifact load errors', async ({ page }) => {
-	await page.route('**/batch/job/missing-pick-job/files', async (route) => {
-		await route.fulfill({
-			status: 404,
-			contentType: 'application/json',
-			body: JSON.stringify({ detail: 'Job ID not found' }),
-		});
-	});
-
-	await page.goto('/');
-	await page.getByTestId('static-correction-tab').click();
-	await page.getByTestId('static-correction-pick-job-id').fill('missing-pick-job');
-	await page.getByTestId('static-correction-load-pick-artifacts').click();
-
-	await expect(page.getByTestId('static-correction-error')).toBeVisible();
-	await expect(page.getByTestId('static-correction-error')).toContainText('batch job files 404: Job ID not found');
-	await expect(page.getByTestId('static-correction-status')).toContainText('Unable to load pick artifacts.');
-	await expect(page.getByTestId('static-correction-pick-artifact-list')).toBeHidden();
 });
 
 test('refraction QC tab fetches bundle for job', async ({ page }) => {

--- a/tests/e2e/refraction_qc.spec.ts
+++ b/tests/e2e/refraction_qc.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Page, type Route } from '@playwright/test';
 
 function lineProfileRecords() {
 	return [
@@ -1085,6 +1085,22 @@ type StaticCorrectionRouteCall = {
 	body: Record<string, unknown>;
 };
 
+function multipartRequestJson(route: Route): Record<string, unknown> {
+	const contentType = route.request().headers()['content-type'] || '';
+	const boundaryMatch = /boundary=(?:"([^"]+)"|([^;]+))/i.exec(contentType);
+	const boundary = boundaryMatch?.[1] || boundaryMatch?.[2];
+	if (!boundary) {
+		throw new Error(`Expected multipart form data, got ${contentType || 'no content type'}`);
+	}
+	const postData = route.request().postData() || '';
+	for (const part of postData.split(`--${boundary}`)) {
+		if (!part.includes('name="request_json"')) continue;
+		const body = part.split(/\r?\n\r?\n/).slice(1).join('\n\n').trim();
+		return JSON.parse(body);
+	}
+	throw new Error('Multipart request_json field was not submitted');
+}
+
 async function routeCompletedStaticCorrectionFlow(
 	page: Page,
 	{
@@ -1093,10 +1109,10 @@ async function routeCompletedStaticCorrectionFlow(
 	}: { jobId?: string; statusMessage?: string } = {},
 ) {
 	const calls: StaticCorrectionRouteCall[] = [];
-	await page.route('**/statics/refraction/apply', async (route) => {
+	await page.route('**/statics/refraction/apply-with-picks', async (route) => {
 		calls.push({
 			endpoint: 'apply',
-			body: JSON.parse(route.request().postData() || '{}'),
+			body: multipartRequestJson(route),
 		});
 		await route.fulfill({
 			status: 200,
@@ -1279,6 +1295,12 @@ test('static_correction_ui_builds_linkage_when_checkbox_enabled', async ({ page 
 
 	await openStaticCorrectionTab(page);
 	await fillStaticCorrectionRunInputs(page);
+	await setStaticCorrectionViewerTarget(page, {
+		fileId: 'current-viewer-store',
+		displayName: 'current-viewer.sgy',
+		key1Byte: 17,
+		key2Byte: 21,
+	});
 	await page.getByTestId('static-correction-enable-linkage').check();
 	await expect(page.getByTestId('static-correction-linkage-options')).toBeVisible();
 	await page.getByTestId('static-correction-linkage-threshold-m').fill('12.5');
@@ -1295,14 +1317,65 @@ test('static_correction_ui_builds_linkage_when_checkbox_enabled', async ({ page 
 		'qc',
 	]);
 	expect(calls.find((call) => call.endpoint === 'linkage')?.body).toMatchObject({
-		file_id: 'fixture-line-a-store',
+		file_id: 'current-viewer-store',
+		key1_byte: 17,
+		key2_byte: 21,
 		linkage: { mode: 'auto_threshold', threshold_m: 12.5 },
+	});
+	expect(calls.find((call) => call.endpoint === 'apply')?.body).toMatchObject({
+		file_id: 'current-viewer-store',
+		key1_byte: 17,
+		key2_byte: 21,
 	});
 	expect(calls.find((call) => call.endpoint === 'apply')?.body.linkage).toEqual({
 		mode: 'required',
 		job_id: 'linkage-job-565',
 		artifact_name: 'geometry_linkage.npz',
 	});
+});
+
+test('static_correction_linkage_failure_blocks_static_submit', async ({ page }) => {
+	const calls: StaticCorrectionRouteCall[] = [];
+	await page.route('**/statics/linkage/build', async (route) => {
+		calls.push({
+			endpoint: 'linkage',
+			body: JSON.parse(route.request().postData() || '{}'),
+		});
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ job_id: 'linkage-job-failed', state: 'queued' }),
+		});
+	});
+	await page.route('**/statics/job/linkage-job-failed/status', async (route) => {
+		calls.push({ endpoint: 'linkage-status', body: {} });
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				job_id: 'linkage-job-failed',
+				state: 'error',
+				progress: 1,
+				message: 'no endpoint pairs matched',
+			}),
+		});
+	});
+	await page.route('**/statics/refraction/apply-with-picks', async (route) => {
+		calls.push({ endpoint: 'unexpected-apply', body: multipartRequestJson(route) });
+		await route.abort();
+	});
+
+	await openStaticCorrectionTab(page);
+	await fillStaticCorrectionRunInputs(page);
+	await page.getByTestId('static-correction-enable-linkage').check();
+	await page.getByTestId('static-correction-run').click();
+
+	await expect(page.getByTestId('static-correction-error')).toBeVisible();
+	await expect(page.getByTestId('static-correction-error')).toContainText('no endpoint pairs matched');
+	await expect(page.getByTestId('static-correction-status')).toContainText(
+		'Geometry linkage failed. Static correction was not submitted.',
+	);
+	expect(calls.map((call) => call.endpoint)).toEqual(['linkage', 'linkage-status']);
 });
 
 test('static_correction_ui_auto_loads_qc_after_ready_job', async ({ page }) => {
@@ -1326,10 +1399,10 @@ test('static_correction_ui_auto_loads_qc_after_ready_job', async ({ page }) => {
 
 test('static_correction_ui_shows_error_when_apply_fails', async ({ page }) => {
 	const calls: StaticCorrectionRouteCall[] = [];
-	await page.route('**/statics/refraction/apply', async (route) => {
+	await page.route('**/statics/refraction/apply-with-picks', async (route) => {
 		calls.push({
 			endpoint: 'apply',
-			body: JSON.parse(route.request().postData() || '{}'),
+			body: multipartRequestJson(route),
 		});
 		await route.fulfill({
 			status: 422,
@@ -1438,7 +1511,7 @@ test('static_correction_request_preview_uses_uploaded_npz', async ({ page }) => 
 
 test('static_correction_requires_pick_npz_before_run', async ({ page }) => {
 	const staticsRequests: string[] = [];
-	await page.route('**/statics/refraction/apply', async (route) => {
+	await page.route('**/statics/refraction/apply-with-picks', async (route) => {
 		staticsRequests.push(route.request().url());
 		await route.abort();
 	});
@@ -1517,8 +1590,8 @@ test('static correction one-layer builder defaults to no linkage and solved glob
 
 test('static correction run submits one-layer refraction apply request', async ({ page }) => {
 	let applyRequest: Record<string, unknown> | null = null;
-	await page.route('**/statics/refraction/apply', async (route) => {
-		applyRequest = JSON.parse(route.request().postData() || '{}');
+	await page.route('**/statics/refraction/apply-with-picks', async (route) => {
+		applyRequest = multipartRequestJson(route);
 		await route.fulfill({
 			status: 200,
 			contentType: 'application/json',
@@ -1596,7 +1669,7 @@ test('static correction run submits one-layer refraction apply request', async (
 });
 
 test('static correction submit errors keep user input visible', async ({ page }) => {
-	await page.route('**/statics/refraction/apply', async (route) => {
+	await page.route('**/statics/refraction/apply-with-picks', async (route) => {
 		await route.fulfill({
 			status: 422,
 			contentType: 'application/json',

--- a/tests/e2e/refraction_qc.spec.ts
+++ b/tests/e2e/refraction_qc.spec.ts
@@ -1034,11 +1034,35 @@ async function openStaticCorrectionTab(page: Page) {
 	await expect(page.getByTestId('static-correction-panel')).toBeVisible();
 }
 
+async function setStaticCorrectionViewerTarget(
+	page: Page,
+	{
+		fileId = 'fixture-line-a-store',
+		displayName = 'fixture-line-a.sgy',
+		key1Byte = 9,
+		key2Byte = 13,
+	} = {},
+) {
+	await page.evaluate((target) => {
+		(window as any).SeisViewerState.syncActiveFileTarget({
+			fileId: target.fileId,
+			displayName: target.displayName,
+			key1Byte: target.key1Byte,
+			key2Byte: target.key2Byte,
+			isFileLoaded: true,
+		});
+	}, { fileId, displayName, key1Byte, key2Byte });
+	await expect(page.getByTestId('static-correction-target-file')).toHaveText(displayName);
+	await expect(page.getByTestId('static-correction-target-keys')).toHaveText(
+		`key1=${key1Byte}, key2=${key2Byte}`,
+	);
+}
+
 async function fillStaticCorrectionRunInputs(
 	page: Page,
 	{ fileId = 'fixture-line-a-store', pickJobId = 'fixture-first-break-job' } = {},
 ) {
-	await page.getByTestId('static-correction-file-id').fill(fileId);
+	await setStaticCorrectionViewerTarget(page, { fileId });
 	await page.getByTestId('static-correction-pick-job-id').fill(pickJobId);
 	await page.getByTestId('static-correction-pick-artifact-name').fill('predicted_picks_time_s.npz');
 	await page.getByTestId('static-correction-model-kind').selectOption('one_layer_global');
@@ -1149,16 +1173,19 @@ test('static correction tab scaffold switches side panels', async ({ page }) => 
 	const panel = page.getByTestId('static-correction-panel');
 	await expect(panel).toBeVisible();
 	await expect(panel.getByRole('heading', { name: 'Static Correction' })).toBeVisible();
-	for (const heading of ['Input', 'First-break picks', 'Geometry', 'Linkage', 'Model', 'Output', 'Run']) {
+	for (const heading of ['Target', 'First-break picks', 'Geometry', 'Linkage', 'Model', 'Output', 'Run']) {
 		await expect(panel.getByRole('heading', { name: heading })).toBeVisible();
 	}
 	await expect(page.getByTestId('static-correction-form')).toBeVisible();
 	await expect(page.getByTestId('static-correction-status')).toContainText(
-		'Enter a SEG-Y/TraceStore file_id and a first-break pick artifact usable by refraction statics.',
+		'Open a viewer file and choose a first-break pick artifact usable by refraction statics.',
 	);
-	await expect(page.getByTestId('static-correction-file-id')).toBeVisible();
-	await expect(page.getByTestId('static-correction-key1-byte')).toHaveValue('189');
-	await expect(page.getByTestId('static-correction-key2-byte')).toHaveValue('193');
+	await expect(page.getByTestId('static-correction-file-id')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-key1-byte')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-key2-byte')).toHaveCount(0);
+	await expect(page.getByTestId('static-correction-target-empty')).toContainText(
+		'No active viewer file. Open an SGY/TraceStore in the viewer before running Static Correction.',
+	);
 	await expect(page.getByTestId('static-correction-pick-kind')).toHaveValue('batch_predicted_npz');
 	await expect(page.getByTestId('static-correction-pick-job-id')).toBeVisible();
 	await expect(page.getByTestId('static-correction-pick-artifact-name')).toHaveValue('predicted_picks_time_s.npz');
@@ -1166,7 +1193,7 @@ test('static correction tab scaffold switches side panels', async ({ page }) => 
 	await expect(panel).toContainText('viewer first-break probability cache is not a valid statics pick artifact');
 	await expect(page.getByTestId('static-correction-error')).toBeHidden();
 	await expect(page.getByTestId('static-correction-run')).toBeVisible();
-	await expect(page.getByTestId('static-correction-run')).toBeEnabled();
+	await expect(page.getByTestId('static-correction-run')).toBeDisabled();
 	await expect(page.getByTestId('pipeline-sidebar-tab')).toHaveAttribute('aria-selected', 'false');
 	await expect(page.getByTestId('refraction-qc-tab')).toHaveAttribute('aria-selected', 'false');
 	await expect(page.getByTestId('static-correction-tab')).toHaveAttribute('aria-selected', 'true');
@@ -1321,7 +1348,7 @@ test('static_correction_ui_shows_error_when_apply_fails', async ({ page }) => {
 	expect(calls.map((call) => call.endpoint)).toEqual(['apply']);
 });
 
-test('static correction tab validates required file and pick inputs without submitting', async ({ page }) => {
+test('static_correction_run_disabled_without_active_viewer_file', async ({ page }) => {
 	const staticsRequests: string[] = [];
 	await page.route('**/statics/refraction/**', async (route) => {
 		staticsRequests.push(route.request().url());
@@ -1330,21 +1357,38 @@ test('static correction tab validates required file and pick inputs without subm
 
 	await page.goto('/');
 	await page.getByTestId('static-correction-tab').click();
-	await page.getByTestId('static-correction-run').click();
 
-	await expect(page.getByTestId('static-correction-error')).toBeVisible();
-	await expect(page.getByTestId('static-correction-error')).toContainText('file_id is required');
-	await expect(page.getByTestId('static-correction-error')).toContainText('pick_source.job_id is required');
-	await expect(page.getByTestId('static-correction-status')).toContainText(
-		'Fix input errors before running refraction statics.',
+	await expect(page.getByTestId('static-correction-run')).toBeDisabled();
+	await expect(page.getByTestId('static-correction-target-empty')).toContainText(
+		'No active viewer file. Open an SGY/TraceStore in the viewer before running Static Correction.',
 	);
+	await expect(page.getByTestId('static-correction-target-details')).toBeHidden();
 	expect(staticsRequests).toEqual([]);
+});
+
+test('static_correction_target_summary_loaded_state', async ({ page }) => {
+	await openStaticCorrectionTab(page);
+	await setStaticCorrectionViewerTarget(page, {
+		fileId: 'target-file-id',
+		displayName: 'synthetic_static_2d_one_layer.sgy',
+		key1Byte: 9,
+		key2Byte: 13,
+	});
+
+	await expect(page.getByTestId('static-correction-target-empty')).toBeHidden();
+	await expect(page.getByTestId('static-correction-target-details')).toBeVisible();
+	await expect(page.getByTestId('static-correction-target-file')).toHaveText(
+		'synthetic_static_2d_one_layer.sgy',
+	);
+	await expect(page.getByTestId('static-correction-target-keys')).toHaveText('key1=9, key2=13');
+	await expect(page.getByTestId('static-correction-target-status')).toHaveText('Ready');
+	await expect(page.getByTestId('static-correction-run')).toBeEnabled();
 });
 
 test('static correction one-layer builder defaults to no linkage and solved global V2', async ({ page }) => {
 	await page.goto('/');
 	await page.getByTestId('static-correction-tab').click();
-	await page.getByTestId('static-correction-file-id').fill('line-a-store');
+	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
 	await page.getByTestId('static-correction-pick-job-id').fill('pick-job');
 
 	const request = await page.evaluate(() => (
@@ -1430,7 +1474,7 @@ test('static correction run submits one-layer refraction apply request', async (
 
 	await page.goto('/');
 	await page.getByTestId('static-correction-tab').click();
-	await page.getByTestId('static-correction-file-id').fill('line-a-store');
+	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
 	await page.getByTestId('static-correction-pick-job-id').fill('pick-job');
 	await page.getByTestId('static-correction-run').click();
 
@@ -1445,6 +1489,9 @@ test('static correction run submits one-layer refraction apply request', async (
 	await page.getByText('JSON request preview').click();
 	const requestPreview = page.getByTestId('static-correction-request-preview');
 	await expect(requestPreview).toBeVisible();
+	await expect(requestPreview).toContainText('"file_id": "line-a-store"');
+	await expect(requestPreview).toContainText('"key1_byte": 9');
+	await expect(requestPreview).toContainText('"key2_byte": 13');
 	await expect(requestPreview).toContainText('"lsst_plus"');
 	await expect(requestPreview).not.toContainText('"time_term_spreadsheet"');
 	expect(applyRequest).toMatchObject({
@@ -1477,7 +1524,7 @@ test('static correction submit errors keep user input visible', async ({ page })
 
 	await page.goto('/');
 	await page.getByTestId('static-correction-tab').click();
-	await page.getByTestId('static-correction-file-id').fill('line-a-store');
+	await setStaticCorrectionViewerTarget(page, { fileId: 'line-a-store' });
 	await page.getByTestId('static-correction-pick-job-id').fill('pick-job');
 	await page.getByTestId('static-correction-run').click();
 
@@ -1488,7 +1535,8 @@ test('static correction submit errors keep user input visible', async ({ page })
 	await expect(page.getByTestId('static-correction-status')).toContainText(
 		'Static correction submission failed.',
 	);
-	await expect(page.getByTestId('static-correction-file-id')).toHaveValue('line-a-store');
+	await expect(page.getByTestId('static-correction-target-file')).toContainText('fixture-line-a.sgy');
+	await expect(page.getByTestId('static-correction-target-keys')).toContainText('key1=9, key2=13');
 	await expect(page.getByTestId('static-correction-pick-job-id')).toHaveValue('pick-job');
 });
 


### PR DESCRIPTION
Closes #587
Closes #588
Closes #589
Closes #590

## Issues
- #587 [ui][statics] Remove `file_id`, `key1_byte`, and `key2_byte` inputs from Static Correction tab
- #588 [ui][statics] Replace pick job artifact selector with direct NPZ file input
- #589 [ui][statics] Submit Static Correction as multipart request with current viewer target and pick NPZ
- #590 [ui][statics] Keep optional endpoint linkage checkbox using current viewer target

Batch range: #587-#590
