### PR TITLE
[P1] multi-layer 実行時の design matrix diagnostics の layer 識別を明確化する

### DIFF
--- a/app/services/refraction_static_artifacts/registry.py
+++ b/app/services/refraction_static_artifacts/registry.py
@@ -13,6 +13,9 @@ from app.services.refraction_static_layer_config import (
 from app.services.refraction_static_design_matrix import (
     REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
     REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
+    all_refraction_design_matrix_layer_artifact_names,
+    refraction_design_matrix_layer_node_diagnostics_csv_name,
+    refraction_design_matrix_layer_qc_json_name,
 )
 from app.services.refraction_static_preflight_diagnostics import (
     REFRACTION_STATIC_PREFLIGHT_OBSERVATIONS_CSV_NAME,
@@ -468,7 +471,7 @@ REFRACTION_STATIC_REGISTERED_ARTIFACT_NAMES = frozenset(
     REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
     REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
     UPLOADED_REFRACTION_PICKS_NPZ_NAME,
-}
+} | frozenset(all_refraction_design_matrix_layer_artifact_names())
 
 
 def registered_artifact_names() -> frozenset[str]:
@@ -549,6 +552,7 @@ def artifact_entries_for_request(
         _ARTIFACTS
         + _grid_map_qc_artifact_entries(req)
         + _refractor_cell_velocity_artifact_entries(req)
+        + _design_matrix_diagnostics_artifact_entries(req)
         + _t1lsst_artifact_entries(req)
         + _upstream_artifact_entries(
             _validate_upstream_artifact_names(
@@ -574,6 +578,37 @@ def _refractor_cell_velocity_artifact_entries(
     entries: list[dict[str, str | bool]] = []
     for layer_kind in _request_cell_velocity_layer_kinds(req):
         entries.extend(_cell_velocity_artifact_entries_for_layer(layer_kind))
+    return tuple(entries)
+
+
+def _design_matrix_diagnostics_artifact_entries(
+    req: RefractionStaticApplyRequest,
+) -> tuple[dict[str, str | bool], ...]:
+    if req.model.method != 'multilayer_time_term':
+        return ()
+    entries: list[dict[str, str | bool]] = []
+    for config in normalize_refraction_static_layers(req.model):
+        label = _CELL_VELOCITY_LABEL_BY_LAYER[config.kind]
+        entries.extend(
+            (
+                {
+                    'name': refraction_design_matrix_layer_qc_json_name(config.kind),
+                    'kind': 'json',
+                    'required': True,
+                    'description': f'{label} design-matrix QC summary',
+                },
+                {
+                    'name': (
+                        refraction_design_matrix_layer_node_diagnostics_csv_name(
+                            config.kind
+                        )
+                    ),
+                    'kind': 'csv',
+                    'required': True,
+                    'description': f'{label} design-matrix node diagnostics',
+                },
+            )
+        )
     return tuple(entries)
 
 
@@ -759,6 +794,7 @@ __all__ = [
     '_cell_velocity_artifact_names_for_request',
     '_cell_velocity_artifact_paths_for_request',
     '_cell_velocity_layer_kind',
+    '_design_matrix_diagnostics_artifact_entries',
     '_grid_map_qc_artifact_entries',
     '_refractor_cell_velocity_artifact_entries',
     '_request_cell_velocity_layer_kinds',

--- a/app/services/refraction_static_artifacts/writer.py
+++ b/app/services/refraction_static_artifacts/writer.py
@@ -6,6 +6,9 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from app.api.schemas import RefractionStaticApplyRequest
+from app.services.refraction_static_design_matrix import (
+    all_refraction_design_matrix_layer_artifact_names,
+)
 from app.services.refraction_static_artifacts.cell_velocity import (
     build_refraction_cell_solver_history_rows,
     build_refraction_refractor_velocity_grid_arrays,
@@ -120,6 +123,7 @@ from app.services.refraction_static_artifacts.qc import (
 from app.services.refraction_static_artifacts.registry import (
     REFRACTION_STATIC_REGISTERED_ARTIFACT_NAMES,
     _artifact_entries_for_request,
+    _artifact_list_for_qc,
     _build_manifest_payload,
     _cell_velocity_artifact_paths_for_request,
     _validate_declared_upstream_artifacts,
@@ -193,12 +197,17 @@ def write_refraction_static_artifacts(
         first_layer,
         upstream_artifact_names=upstream_names,
     )
+    artifact_entries = _filter_present_design_matrix_diagnostics(
+        root,
+        artifact_entries,
+    )
     qc = build_refraction_static_qc_payload(
         result=values.result,
         req=request,
         resolved_first_layer=first_layer,
         upstream_artifact_names=upstream_names,
     )
+    qc['artifacts'] = _artifact_list_for_qc(artifact_entries)
     manifest = _build_manifest_payload(artifact_entries)
     _assert_strict_json(manifest, artifact_name=REFRACTION_STATIC_ARTIFACTS_JSON_NAME)
     t1lsst_components_path = (
@@ -526,6 +535,21 @@ def write_refraction_static_artifacts(
             )
     _validate_declared_upstream_artifacts(root, upstream_names)
     return paths
+
+
+def _filter_present_design_matrix_diagnostics(
+    root: Path,
+    artifact_entries: tuple[dict[str, str | bool], ...],
+) -> tuple[dict[str, str | bool], ...]:
+    design_matrix_names = set(all_refraction_design_matrix_layer_artifact_names())
+    if not design_matrix_names:
+        return artifact_entries
+    return tuple(
+        entry
+        for entry in artifact_entries
+        if str(entry['name']) not in design_matrix_names
+        or (root / str(entry['name'])).is_file()
+    )
 
 
 __all__ = [

--- a/app/services/refraction_static_design_matrix.py
+++ b/app/services/refraction_static_design_matrix.py
@@ -24,6 +24,7 @@ from app.services.refraction_static_cell_grid import (
 from app.services.refraction_static_first_layer import resolve_weathering_velocity_m_s
 from app.services.refraction_static_types import (
     RefractionDesignMatrixNodeDiagnostics,
+    RefractionLayerKind,
     RefractionStaticDesignMatrix,
     RefractionStaticInputModel,
     ResolvedRefractionFirstLayer,
@@ -37,6 +38,11 @@ LOW_FOLD_CELL_VELOCITY_STATUS = 'low_fold'
 REFRACTION_DESIGN_MATRIX_QC_JSON_NAME = 'refraction_design_matrix_qc.json'
 REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME = (
     'refraction_design_matrix_node_diagnostics.csv'
+)
+_REFRACTION_DESIGN_MATRIX_LAYER_KINDS: tuple[RefractionLayerKind, ...] = (
+    'v2_t1',
+    'v3_t2',
+    'vsub_t3',
 )
 _NODE_DIAGNOSTIC_COLUMNS = (
     'node_id',
@@ -53,6 +59,47 @@ _NODE_DIAGNOSTIC_COLUMNS = (
     'reason',
     'first_trace_indices_pre_filter',
 )
+
+
+def refraction_design_matrix_layer_qc_json_name(
+    layer_kind: RefractionLayerKind,
+) -> str:
+    """Return the root artifact name for layer-specific design-matrix QC."""
+    _validate_design_matrix_layer_kind(layer_kind)
+    return f'refraction_design_matrix_{layer_kind}_qc.json'
+
+
+def refraction_design_matrix_layer_node_diagnostics_csv_name(
+    layer_kind: RefractionLayerKind,
+) -> str:
+    """Return the root artifact name for layer-specific node diagnostics."""
+    _validate_design_matrix_layer_kind(layer_kind)
+    return f'refraction_design_matrix_{layer_kind}_node_diagnostics.csv'
+
+
+def refraction_design_matrix_layer_artifact_names(
+    layer_kind: RefractionLayerKind,
+) -> tuple[str, str]:
+    """Return layer-specific root artifact names for design-matrix diagnostics."""
+    return (
+        refraction_design_matrix_layer_qc_json_name(layer_kind),
+        refraction_design_matrix_layer_node_diagnostics_csv_name(layer_kind),
+    )
+
+
+def all_refraction_design_matrix_layer_artifact_names() -> tuple[str, ...]:
+    """Return all registered layer-specific design-matrix diagnostic names."""
+    names: list[str] = []
+    for layer_kind in _REFRACTION_DESIGN_MATRIX_LAYER_KINDS:
+        names.extend(refraction_design_matrix_layer_artifact_names(layer_kind))
+    return tuple(names)
+
+
+def _validate_design_matrix_layer_kind(layer_kind: RefractionLayerKind) -> None:
+    if layer_kind not in _REFRACTION_DESIGN_MATRIX_LAYER_KINDS:
+        raise RefractionStaticDesignMatrixError(
+            f'unsupported design-matrix diagnostics layer kind: {layer_kind}'
+        )
 
 
 class RefractionStaticDesignMatrixError(ValueError):
@@ -1718,8 +1765,12 @@ __all__ = [
     'RefractionStaticDesignMatrixError',
     'REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME',
     'REFRACTION_DESIGN_MATRIX_QC_JSON_NAME',
+    'all_refraction_design_matrix_layer_artifact_names',
     'build_refraction_static_cell_design_matrix',
     'build_refraction_static_design_matrix',
     'build_refraction_static_design_matrix_from_arrays',
+    'refraction_design_matrix_layer_artifact_names',
+    'refraction_design_matrix_layer_node_diagnostics_csv_name',
+    'refraction_design_matrix_layer_qc_json_name',
     'write_refraction_design_matrix_diagnostics_artifacts',
 ]

--- a/app/services/refraction_static_multilayer_service.py
+++ b/app/services/refraction_static_multilayer_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
+import json
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +42,8 @@ from app.services.refraction_static_design_matrix import (
     OUTSIDE_REFRACTOR_CELL_GRID_REASON,
     REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
     REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
+    refraction_design_matrix_layer_node_diagnostics_csv_name,
+    refraction_design_matrix_layer_qc_json_name,
 )
 from app.services.refraction_static_half_intercept import (
     estimate_refraction_half_intercept_times_from_first_breaks,
@@ -179,14 +182,18 @@ def solve_refraction_multilayer_time_terms(
         try:
             result = layer_solver(context)
         except Exception:  # noqa: BLE001
-            _copy_layer_design_matrix_diagnostics_to_root(
+            _copy_layer_design_matrix_diagnostics_to_root_artifacts(
                 root=job_dir,
                 layer_dir=layer_job_dir,
+                layer_kind=config.kind,
+                layer_index=_layer_index(config.kind),
             )
             raise
-        _copy_layer_design_matrix_diagnostics_to_root(
+        _copy_layer_design_matrix_diagnostics_to_root_artifacts(
             root=job_dir,
             layer_dir=layer_job_dir,
+            layer_kind=config.kind,
+            layer_index=_layer_index(config.kind),
         )
         _validate_layer_result(result=result, config=config)
         result = _validate_layer_velocity_sequence(
@@ -2328,25 +2335,46 @@ def _layer_design_matrix_artifact_dir(
     return Path(root) / f'{_DESIGN_MATRIX_ARTIFACT_DIR_PREFIX}_{config.kind}'
 
 
-def _copy_layer_design_matrix_diagnostics_to_root(
+def _copy_layer_design_matrix_diagnostics_to_root_artifacts(
     *,
     root: Path | None,
     layer_dir: Path | None,
+    layer_kind: RefractionLayerKind,
+    layer_index: int,
 ) -> None:
-    """Expose the latest layer diagnostics through root-level job artifacts."""
+    """Expose layer diagnostics through disambiguated root-level artifacts."""
     if root is None or layer_dir is None:
         return
     root_path = Path(root)
     layer_path = Path(layer_dir)
-    for name in (
-        REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
-        REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
-    ):
-        source = layer_path / name
-        if not source.is_file():
-            continue
+    qc_source = layer_path / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME
+    if qc_source.is_file():
         root_path.mkdir(parents=True, exist_ok=True)
-        (root_path / name).write_bytes(source.read_bytes())
+        qc_payload = json.loads(qc_source.read_text(encoding='utf-8'))
+        if not isinstance(qc_payload, dict):
+            raise RefractionMultiLayerSolveError(
+                'design matrix diagnostics QC artifact must contain a JSON object'
+            )
+        qc_payload = {
+            **qc_payload,
+            'layer_kind': layer_kind,
+            'layer_index': int(layer_index),
+            'source_artifact_dir': layer_path.name,
+        }
+        (
+            root_path / refraction_design_matrix_layer_qc_json_name(layer_kind)
+        ).write_text(
+            json.dumps(qc_payload, indent=2, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+
+    csv_source = layer_path / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME
+    if csv_source.is_file():
+        root_path.mkdir(parents=True, exist_ok=True)
+        (
+            root_path
+            / refraction_design_matrix_layer_node_diagnostics_csv_name(layer_kind)
+        ).write_bytes(csv_source.read_bytes())
 
 
 def _layer_result_from_half_intercept(

--- a/app/services/refraction_static_service.py
+++ b/app/services/refraction_static_service.py
@@ -32,6 +32,7 @@ from app.services.refraction_static_artifacts import (
 from app.services.refraction_static_design_matrix import (
     REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
     REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
+    all_refraction_design_matrix_layer_artifact_names,
 )
 from app.services.refraction_static_datum import (
     build_refraction_datum_statics,
@@ -107,7 +108,7 @@ _FAILURE_DIAGNOSTIC_ARTIFACT_NAMES = (
     REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
     REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
     REFRACTION_STATIC_FAILURE_DIAGNOSTICS_JSON_NAME,
-)
+) + all_refraction_design_matrix_layer_artifact_names()
 _PUBLIC_MULTILAYER_APPLY_CONTRACT = (
     'public multi-layer refraction apply requires '
     'model.method=multilayer_time_term, '
@@ -1424,6 +1425,10 @@ def _failed_refraction_static_stage(exc: Exception, job_dir: Path) -> str:
     if (
         (job_dir / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME).is_file()
         or (job_dir / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME).is_file()
+        or any(
+            (job_dir / name).is_file()
+            for name in all_refraction_design_matrix_layer_artifact_names()
+        )
     ):
         return 'design_matrix'
     return 'unknown'

--- a/app/tests/_refraction_multilayer_3layer_helpers.py
+++ b/app/tests/_refraction_multilayer_3layer_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import json
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +20,12 @@ from app.services.refraction_static_artifacts import write_refraction_static_art
 from app.services.refraction_static_datum import (
     build_refraction_datum_statics,
     write_refraction_datum_statics_artifacts,
+)
+from app.services.refraction_static_design_matrix import (
+    REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
+    REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
+    refraction_design_matrix_layer_node_diagnostics_csv_name,
+    refraction_design_matrix_layer_qc_json_name,
 )
 from app.services.refraction_static_multilayer_service import (
     RefractionMultiLayerStaticsWorkflowResult,
@@ -270,7 +277,9 @@ def compute_three_layer_workflow(
         datum_result=datum_result,
     )
     if job_dir is not None:
-        write_refraction_datum_statics_artifacts(Path(job_dir), datum_result)
+        root = Path(job_dir)
+        write_refraction_datum_statics_artifacts(root, datum_result)
+        _write_fixture_design_matrix_diagnostics(root, solve_result)
         write_refraction_static_artifacts(
             result=datum_result,
             req=_artifact_request(
@@ -280,10 +289,49 @@ def compute_three_layer_workflow(
                 datum=active_datum,
                 apply_options=apply_options,
             ),
-            job_dir=Path(job_dir),
+            job_dir=root,
             resolved_first_layer=resolved_first_layer(),
         )
     return dataset, input_model, model, workflow
+
+
+def _write_fixture_design_matrix_diagnostics(
+    root: Path,
+    solve_result: RefractionMultiLayerSolveResult,
+) -> None:
+    for layer in solve_result.layer_results:
+        layer_dir = root / f'refraction_design_matrix_{layer.layer_kind}'
+        layer_dir.mkdir(parents=True, exist_ok=True)
+        layer_qc = {
+            'n_active_nodes': int(layer.node_time_term_s.shape[0]),
+            'n_rows': int(np.count_nonzero(layer.used_observation_mask_sorted)),
+        }
+        (layer_dir / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME).write_text(
+            json.dumps(layer_qc, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+        (
+            layer_dir / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME
+        ).write_text('node_id,status\n1,ok\n', encoding='utf-8')
+        root_qc = {
+            **layer_qc,
+            'layer_kind': layer.layer_kind,
+            'layer_index': int(layer.layer_index),
+            'source_artifact_dir': layer_dir.name,
+        }
+        root_qc_path = root / refraction_design_matrix_layer_qc_json_name(
+            layer.layer_kind
+        )
+        root_qc_path.write_text(
+            json.dumps(root_qc, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+        (
+            root
+            / refraction_design_matrix_layer_node_diagnostics_csv_name(
+                layer.layer_kind
+            )
+        ).write_text('node_id,status\n1,ok\n', encoding='utf-8')
 
 
 def make_three_layer_solve_result(

--- a/app/tests/test_job_artifact_refs.py
+++ b/app/tests/test_job_artifact_refs.py
@@ -40,6 +40,8 @@ from app.services.refraction_static_artifacts import (
 from app.services.refraction_static_design_matrix import (
     REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
     REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
+    refraction_design_matrix_layer_node_diagnostics_csv_name,
+    refraction_design_matrix_layer_qc_json_name,
 )
 from app.services.refraction_static_preflight_diagnostics import (
     REFRACTION_STATIC_PREFLIGHT_OBSERVATIONS_CSV_NAME,
@@ -191,6 +193,12 @@ def test_resolve_job_artifact_path_rejects_wrong_statics_kind(
         REFRACTION_STATIC_PREFLIGHT_OBSERVATIONS_CSV_NAME,
         REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
         REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
+        refraction_design_matrix_layer_qc_json_name('v2_t1'),
+        refraction_design_matrix_layer_node_diagnostics_csv_name('v2_t1'),
+        refraction_design_matrix_layer_qc_json_name('v3_t2'),
+        refraction_design_matrix_layer_node_diagnostics_csv_name('v3_t2'),
+        refraction_design_matrix_layer_qc_json_name('vsub_t3'),
+        refraction_design_matrix_layer_node_diagnostics_csv_name('vsub_t3'),
         UPLOADED_REFRACTION_PICKS_NPZ_NAME,
         SOURCE_STATIC_TABLE_CSV_NAME,
         RECEIVER_STATIC_TABLE_CSV_NAME,

--- a/app/tests/test_refraction_static_artifacts.py
+++ b/app/tests/test_refraction_static_artifacts.py
@@ -22,6 +22,10 @@ from app.services.refraction_static_artifacts.io import (
     _write_json_atomic,
     _write_npz_atomic,
 )
+from app.services.refraction_static_design_matrix import (
+    refraction_design_matrix_layer_node_diagnostics_csv_name,
+    refraction_design_matrix_layer_qc_json_name,
+)
 from app.services.refraction_static_artifacts import (
     FIRST_BREAK_RESIDUALS_CSV_NAME,
     NEAR_SURFACE_MODEL_CSV_NAME,
@@ -483,6 +487,9 @@ def test_refraction_static_registry_manifest_entry_contract() -> None:
     t1lsst_manifest = artifact_registry.build_manifest_payload(
         artifact_registry.artifact_entries_for_request(_t1lsst_request())
     )
+    multilayer_manifest = artifact_registry.build_manifest_payload(
+        artifact_registry.artifact_entries_for_request(_v3_solve_cell_request())
+    )
     upstream_manifest = artifact_registry.build_manifest_payload(
         artifact_registry.artifact_entries_for_request(
             _estimated_v1_request(),
@@ -496,6 +503,7 @@ def test_refraction_static_registry_manifest_entry_contract() -> None:
             base_manifest,
             solve_cell_manifest,
             t1lsst_manifest,
+            multilayer_manifest,
             upstream_manifest,
         )
         for item in manifest['artifacts']
@@ -526,6 +534,16 @@ def test_refraction_static_registry_manifest_entry_contract() -> None:
             'json',
             True,
             'Direct-arrival V1 estimation QC summary',
+        ),
+        refraction_design_matrix_layer_qc_json_name('v3_t2'): (
+            'json',
+            True,
+            'V3/T2 design-matrix QC summary',
+        ),
+        refraction_design_matrix_layer_node_diagnostics_csv_name('v3_t2'): (
+            'csv',
+            True,
+            'V3/T2 design-matrix node diagnostics',
         ),
     }
     for artifact_name, (kind, required, description) in expected.items():

--- a/app/tests/test_refraction_static_multilayer_artifacts.py
+++ b/app/tests/test_refraction_static_multilayer_artifacts.py
@@ -43,6 +43,10 @@ from app.services.refraction_static_artifacts import (
     write_refraction_static_artifacts,
 )
 from app.services.refraction_static_datum import build_refraction_datum_statics
+from app.services.refraction_static_design_matrix import (
+    refraction_design_matrix_layer_node_diagnostics_csv_name,
+    refraction_design_matrix_layer_qc_json_name,
+)
 from app.services.refraction_static_multilayer_service import (
     _artifact_request_for_multilayer_workflow,
     build_refraction_multilayer_weathering_replacement_statics,
@@ -97,6 +101,18 @@ _CELL_VELOCITY_ARTIFACT_NAMES = {
 }
 
 
+def _design_matrix_diagnostic_artifact_names(
+    layer_kinds: tuple[str, ...],
+) -> set[str]:
+    names: set[str] = set()
+    for layer_kind in layer_kinds:
+        names.add(refraction_design_matrix_layer_qc_json_name(layer_kind))
+        names.add(
+            refraction_design_matrix_layer_node_diagnostics_csv_name(layer_kind)
+        )
+    return names
+
+
 def test_three_layer_job_manifest_lists_multilayer_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -111,6 +127,9 @@ def test_three_layer_job_manifest_lists_multilayer_artifacts(
     manifest_names = {item['name'] for item in manifest['artifacts']}
 
     assert _CORE_FINAL_ARTIFACT_NAMES <= manifest_names
+    assert _design_matrix_diagnostic_artifact_names(
+        ('v2_t1', 'v3_t2', 'vsub_t3')
+    ) <= manifest_names
     assert _CELL_VELOCITY_ARTIFACT_NAMES.isdisjoint(manifest_names)
     for artifact_name in manifest_names:
         assert (job_dir / artifact_name).is_file()
@@ -253,6 +272,9 @@ def test_two_layer_artifact_manifest_regression_still_passes(
     )
     manifest_names = {item['name'] for item in manifest['artifacts']}
     assert _CORE_FINAL_ARTIFACT_NAMES <= manifest_names
+    assert _design_matrix_diagnostic_artifact_names(('v2_t1', 'v3_t2')) <= (
+        manifest_names
+    )
     assert _CELL_VELOCITY_ARTIFACT_NAMES.isdisjoint(manifest_names)
 
     qc = json.loads(

--- a/app/tests/test_refraction_static_multilayer_orchestration.py
+++ b/app/tests/test_refraction_static_multilayer_orchestration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import numpy as np
@@ -9,6 +10,8 @@ from app.api.schemas import RefractionStaticModelRequest, RefractionStaticSolver
 from app.services.refraction_static_design_matrix import (
     REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME,
     REFRACTION_DESIGN_MATRIX_QC_JSON_NAME,
+    refraction_design_matrix_layer_node_diagnostics_csv_name,
+    refraction_design_matrix_layer_qc_json_name,
 )
 from app.services.refraction_static_layer_config import (
     normalize_refraction_static_layers,
@@ -95,8 +98,20 @@ def test_multilayer_orchestrator_runs_normalized_one_layer_v2_solve(
     assert (
         layer_artifact_dir / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME
     ).is_file()
-    assert (tmp_path / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME).is_file()
-    assert (tmp_path / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME).is_file()
+    assert not (tmp_path / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME).exists()
+    assert not (
+        tmp_path / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME
+    ).exists()
+    root_qc_path = tmp_path / refraction_design_matrix_layer_qc_json_name('v2_t1')
+    root_csv_path = (
+        tmp_path / refraction_design_matrix_layer_node_diagnostics_csv_name('v2_t1')
+    )
+    assert root_qc_path.is_file()
+    assert root_csv_path.is_file()
+    root_qc = json.loads(root_qc_path.read_text(encoding='utf-8'))
+    assert root_qc['layer_kind'] == 'v2_t1'
+    assert root_qc['layer_index'] == 1
+    assert root_qc['source_artifact_dir'] == 'refraction_design_matrix_v2_t1'
 
 
 def test_multilayer_orchestrator_exposes_failed_layer_design_matrix_artifacts(
@@ -148,8 +163,19 @@ def test_multilayer_orchestrator_exposes_failed_layer_design_matrix_artifacts(
             solver_dispatch={('v2_t1', 'solve_global'): _failing_solver},
         )
 
-    assert (tmp_path / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME).is_file()
-    assert (tmp_path / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME).is_file()
+    assert not (tmp_path / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME).exists()
+    assert not (
+        tmp_path / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME
+    ).exists()
+    root_qc_path = tmp_path / refraction_design_matrix_layer_qc_json_name('v2_t1')
+    assert root_qc_path.is_file()
+    root_qc = json.loads(root_qc_path.read_text(encoding='utf-8'))
+    assert root_qc['layer_kind'] == 'v2_t1'
+    assert root_qc['layer_index'] == 1
+    assert root_qc['source_artifact_dir'] == 'refraction_design_matrix_v2_t1'
+    assert (
+        tmp_path / refraction_design_matrix_layer_node_diagnostics_csv_name('v2_t1')
+    ).is_file()
 
 
 def test_multilayer_orchestrator_dispatches_enabled_layers_in_order() -> None:
@@ -219,6 +245,95 @@ def test_multilayer_orchestrator_dispatches_enabled_layers_in_order() -> None:
     assert [layer.layer_index for layer in result.layer_results] == [1, 2, 3]
     assert result.qc['layers']['v3_t2']['layer_kind'] == 'v3_t2'
     assert result.qc['observation_gates']['vsub_t3']['max_offset_m'] is None
+
+
+def test_multilayer_design_matrix_diagnostics_are_layer_disambiguated(
+    tmp_path: Path,
+) -> None:
+    dataset = make_2d_straight_three_layer_refraction_dataset()
+    model = _model(
+        [
+            _layer(
+                'v2_t1',
+                min_offset_m=300.0,
+                max_offset_m=800.0,
+                velocity_mode='fixed_global',
+                fixed_velocity_m_s=SYNTHETIC_MULTILAYER_V2_M_S,
+                min_velocity_m_s=1600.0,
+                max_velocity_m_s=3200.0,
+            ),
+            _layer(
+                'v3_t2',
+                min_offset_m=1000.0,
+                max_offset_m=1900.0,
+                velocity_mode='fixed_global',
+                fixed_velocity_m_s=SYNTHETIC_MULTILAYER_V3_M_S,
+                min_velocity_m_s=2600.0,
+                max_velocity_m_s=4800.0,
+            ),
+            _layer(
+                'vsub_t3',
+                min_offset_m=2200.0,
+                max_offset_m=None,
+                velocity_mode='fixed_global',
+                fixed_velocity_m_s=SYNTHETIC_MULTILAYER_VSUB_M_S,
+                min_velocity_m_s=3800.0,
+                max_velocity_m_s=6200.0,
+            ),
+        ]
+    )
+    input_model = _input_model(dataset)
+    masks = build_refraction_layer_observation_masks(
+        input_model=input_model,
+        model=model,
+    )
+
+    def fake_solver(context: RefractionLayerSolverContext) -> RefractionLayerSolveResult:
+        assert context.job_dir is not None
+        context.job_dir.mkdir(parents=True, exist_ok=True)
+        (context.job_dir / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME).write_text(
+            '{"n_active_nodes": 2}',
+            encoding='utf-8',
+        )
+        (
+            context.job_dir / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME
+        ).write_text('node_id,status\n1,ok\n', encoding='utf-8')
+        return _fake_layer_result(context)
+
+    solve_refraction_multilayer_time_terms(
+        input_model=input_model,
+        resolved_first_layer=_resolved_first_layer(),
+        normalized_layers=normalize_refraction_static_layers(model),
+        layer_masks=masks,
+        model=model,
+        solver=RefractionStaticSolverRequest(),
+        job_dir=tmp_path,
+        solver_dispatch={
+            ('v2_t1', 'fixed_global'): fake_solver,
+            ('v3_t2', 'fixed_global'): fake_solver,
+            ('vsub_t3', 'fixed_global'): fake_solver,
+        },
+    )
+
+    assert not (tmp_path / REFRACTION_DESIGN_MATRIX_QC_JSON_NAME).exists()
+    assert not (
+        tmp_path / REFRACTION_DESIGN_MATRIX_NODE_DIAGNOSTICS_CSV_NAME
+    ).exists()
+    for layer_kind, layer_index in (
+        ('v2_t1', 1),
+        ('v3_t2', 2),
+        ('vsub_t3', 3),
+    ):
+        qc_path = tmp_path / refraction_design_matrix_layer_qc_json_name(layer_kind)
+        csv_path = (
+            tmp_path
+            / refraction_design_matrix_layer_node_diagnostics_csv_name(layer_kind)
+        )
+        qc = json.loads(qc_path.read_text(encoding='utf-8'))
+        assert qc['layer_kind'] == layer_kind
+        assert qc['layer_index'] == layer_index
+        assert qc['source_artifact_dir'] == f'refraction_design_matrix_{layer_kind}'
+        assert csv_path.is_file()
 
 
 def test_multilayer_orchestrator_applies_layer_cell_settings_to_layer_model() -> None:


### PR DESCRIPTION
Closes #630

## Summary
- [P1] multi-layer 実行時の design matrix diagnostics の layer 識別を明確化する

## Changed files
- `app/services/refraction_static_artifacts/registry.py`
- `app/services/refraction_static_artifacts/writer.py`
- `app/services/refraction_static_design_matrix.py`
- `app/services/refraction_static_multilayer_service.py`
- `app/services/refraction_static_service.py`
- `app/tests/_refraction_multilayer_3layer_helpers.py`
- `app/tests/test_job_artifact_refs.py`
- `app/tests/test_refraction_static_artifacts.py`
- `app/tests/test_refraction_static_multilayer_artifacts.py`
- `app/tests/test_refraction_static_multilayer_orchestration.py`

## Checks
- `.work/codex/checks.log`: 2422 passed in 68.15s (0:01:08)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
