### PR TITLE
[ui][navigation] Viewer / Static Correction / Refraction QC / Batch Apply のクリックでブラウザタブを増やさない

### DIFF
--- a/app/static/batch_apply.html
+++ b/app/static/batch_apply.html
@@ -352,7 +352,7 @@
   <header>
     <h1>Batch Apply</h1>
     <nav>
-      <a href="/">Viewer</a>
+      <a href="/" id="viewerLink">Viewer</a>
       <a href="/upload">Open SEG-Y</a>
     </nav>
   </header>

--- a/app/static/batch_apply.js
+++ b/app/static/batch_apply.js
@@ -187,10 +187,28 @@ function parseSearchOrStorage(paramKey, storageKey, fallback = '') {
   return fallback;
 }
 
+function buildViewerUrl(fileId, key1Byte, key2Byte) {
+  const url = new URL('/', window.location.origin);
+  if (fileId) url.searchParams.set('file_id', fileId);
+  if (key1Byte) url.searchParams.set('key1_byte', key1Byte);
+  if (key2Byte) url.searchParams.set('key2_byte', key2Byte);
+  return url.toString();
+}
+
+function refreshViewerLink(ui) {
+  if (!ui || !ui.viewerLink) return;
+  ui.viewerLink.href = buildViewerUrl(
+    ui.fileIdInput.value,
+    ui.key1ByteInput.value,
+    ui.key2ByteInput.value
+  );
+}
+
 function createUi() {
   return {
     form: document.getElementById('batchApplyForm'),
     formError: document.getElementById('formError'),
+    viewerLink: document.getElementById('viewerLink'),
     fileIdInput: document.getElementById('fileIdInput'),
     fileNameHint: document.getElementById('fileNameHint'),
     key1ByteInput: document.getElementById('key1ByteInput'),
@@ -558,6 +576,11 @@ function startBatchUi() {
   ui.fileIdInput.value = initialFileId;
   ui.key1ByteInput.value = initialKey1;
   ui.key2ByteInput.value = initialKey2;
+  refreshViewerLink(ui);
+  for (const input of [ui.fileIdInput, ui.key1ByteInput, ui.key2ByteInput]) {
+    input.addEventListener('input', () => refreshViewerLink(ui));
+    input.addEventListener('change', () => refreshViewerLink(ui));
+  }
 
   syncSavePicksControl(ui);
   setJobState(ui, {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1821,11 +1821,9 @@
     <span>Seismic Wiggle Viewer</span>
     <div class="headerLinks">
       <button type="button" id="viewerShortcutsButton" data-testid="viewer-shortcuts-button">Shortcuts</button>
-      <a id="staticCorrectionLink" href="/static-correction" target="_blank" rel="noopener"
-        onclick="openToolPage('/static-correction', event)" data-testid="static-correction-open-link">Static Correction</a>
-      <a id="refractionQcLink" href="/refraction-qc" target="_blank" rel="noopener"
-        onclick="openToolPage('/refraction-qc', event)" data-testid="refraction-qc-open-link">Refraction QC</a>
-      <a id="batchApplyLink" href="/batch" target="_blank" rel="noopener" onclick="openBatchApplyPage(event)">Batch Apply</a>
+      <a id="staticCorrectionLink" href="/static-correction" data-testid="static-correction-open-link">Static Correction</a>
+      <a id="refractionQcLink" href="/refraction-qc" data-testid="refraction-qc-open-link">Refraction QC</a>
+      <a id="batchApplyLink" href="/batch">Batch Apply</a>
       <a href="/upload">Open SEG-Y</a>
     </div>
   </header>
@@ -2327,18 +2325,6 @@
         if (link) link.href = buildViewerToolUrl(path).toString();
       }
     };
-
-    function openToolPage(path, event) {
-      if (event) event.preventDefault();
-      const opened = window.open(buildViewerToolUrl(path).toString(), '_blank', 'noopener,noreferrer');
-      if (opened) opened.opener = null;
-    }
-
-    function openBatchApplyPage(event) {
-      if (event) event.preventDefault();
-      const opened = window.open(buildViewerToolUrl('/batch').toString(), '_blank', 'noopener,noreferrer');
-      if (opened) opened.opener = null;
-    }
 
     window.addEventListener('DOMContentLoaded', () => {
       window.refreshViewerToolLinks();

--- a/app/static/refraction_qc.html
+++ b/app/static/refraction_qc.html
@@ -10,7 +10,7 @@
     <span>Refraction QC</span>
     <div class="headerLinks">
       <a href="/" data-tool-link>Viewer</a>
-      <a href="/static-correction" target="_blank" rel="noopener" data-tool-link onclick="openToolPage('/static-correction', event)">Static Correction</a>
+      <a href="/static-correction" data-tool-link>Static Correction</a>
       <a href="/upload">Open SEG-Y</a>
     </div>
   </header>
@@ -168,13 +168,6 @@
         target.searchParams.set('refraction_job_id', refractionJobId);
       }
       return target.toString();
-    }
-
-    function openToolPage(path, event) {
-      if (event) event.preventDefault();
-      const target = toolUrl(path);
-      const opened = window.open(target, '_blank', 'noopener,noreferrer');
-      if (opened) opened.opener = null;
     }
 
     window.addEventListener('DOMContentLoaded', () => {

--- a/app/static/static_correction.html
+++ b/app/static/static_correction.html
@@ -10,7 +10,7 @@
     <span>Static Correction</span>
     <div class="headerLinks">
       <a href="/" data-tool-link>Viewer</a>
-      <a href="/refraction-qc" target="_blank" rel="noopener" data-tool-link onclick="openToolPage('/refraction-qc', event)">Refraction QC</a>
+      <a href="/refraction-qc" data-tool-link>Refraction QC</a>
       <a href="/upload">Open SEG-Y</a>
     </div>
   </header>
@@ -442,7 +442,7 @@
 </div>
 </div><div class="static-correction-qc-link-row" data-testid="static-correction-qc-link-row" hidden="" id="staticCorrectionQcLinkRow">
 <span>Static Correction job is ready for visual QC.</span>
-<a data-testid="static-correction-open-qc-link" href="/refraction-qc" id="staticCorrectionQcLink" rel="noopener" target="_blank">Open Refraction QC</a>
+<a data-testid="static-correction-open-qc-link" href="/refraction-qc" id="staticCorrectionQcLink">Open Refraction QC</a>
 </div>
 <section aria-labelledby="staticCorrectionArtifactsHeading" class="static-correction-section">
 <h3 id="staticCorrectionArtifactsHeading">Artifacts</h3>
@@ -478,13 +478,6 @@
         target.searchParams.set('refraction_job_id', refractionJobId);
       }
       return target.toString();
-    }
-
-    function openToolPage(path, event) {
-      if (event) event.preventDefault();
-      const target = toolUrl(path);
-      const opened = window.open(target, '_blank', 'noopener,noreferrer');
-      if (opened) opened.opener = null;
     }
 
     window.addEventListener('DOMContentLoaded', () => {

--- a/app/tests/e2e/test_tool_navigation.py
+++ b/app/tests/e2e/test_tool_navigation.py
@@ -1,0 +1,93 @@
+from urllib.parse import parse_qs, urlparse
+
+
+def _query(url: str) -> dict[str, list[str]]:
+    return parse_qs(urlparse(url).query)
+
+
+def _assert_no_target_blank(page, selector: str) -> None:
+    link = page.locator(selector)
+    assert link.get_attribute("target") is None
+    assert link.get_attribute("rel") is None
+
+
+def test_playwright_tool_navigation_links_do_not_force_new_tabs(page, base_url):
+    page.goto(
+        f"{base_url}/static-correction?file_id=line-a&key1_byte=9&key2_byte=13",
+        wait_until="domcontentloaded",
+    )
+    _assert_no_target_blank(page, "header a:has-text('Viewer')")
+    _assert_no_target_blank(page, "header a:has-text('Refraction QC')")
+    _assert_no_target_blank(page, "[data-testid='static-correction-open-qc-link']")
+
+    page.goto(
+        f"{base_url}/refraction-qc?file_id=line-a&key1_byte=9&key2_byte=13",
+        wait_until="domcontentloaded",
+    )
+    _assert_no_target_blank(page, "header a:has-text('Viewer')")
+    _assert_no_target_blank(page, "header a:has-text('Static Correction')")
+
+    page.goto(f"{base_url}/?file_id=line-a&key1_byte=9&key2_byte=13", wait_until="domcontentloaded")
+    _assert_no_target_blank(page, "#staticCorrectionLink")
+    _assert_no_target_blank(page, "#refractionQcLink")
+    _assert_no_target_blank(page, "#batchApplyLink")
+
+
+def test_playwright_static_correction_to_refraction_qc_uses_same_tab(page, base_url):
+    page.goto(
+        f"{base_url}/static-correction?file_id=line-a&key1_byte=9&key2_byte=13",
+        wait_until="domcontentloaded",
+    )
+    before_pages = len(page.context.pages)
+
+    page.get_by_role("link", name="Refraction QC").click()
+    page.wait_for_url("**/refraction-qc?**")
+
+    assert len(page.context.pages) == before_pages
+    query = _query(page.url)
+    assert query["file_id"] == ["line-a"]
+    assert query["key1_byte"] == ["9"]
+    assert query["key2_byte"] == ["13"]
+
+
+def test_playwright_refraction_qc_to_static_correction_uses_same_tab(page, base_url):
+    page.goto(
+        f"{base_url}/refraction-qc?file_id=line-b&key1_byte=17&key2_byte=21",
+        wait_until="domcontentloaded",
+    )
+    before_pages = len(page.context.pages)
+
+    page.get_by_role("link", name="Static Correction").click()
+    page.wait_for_url("**/static-correction?**")
+
+    assert len(page.context.pages) == before_pages
+    query = _query(page.url)
+    assert query["file_id"] == ["line-b"]
+    assert query["key1_byte"] == ["17"]
+    assert query["key2_byte"] == ["21"]
+
+
+def test_playwright_viewer_batch_apply_viewer_roundtrip_uses_same_tab(page, base_url):
+    page.goto(f"{base_url}/?file_id=line-c&key1_byte=189&key2_byte=193", wait_until="domcontentloaded")
+    before_pages = len(page.context.pages)
+
+    page.locator("#batchApplyLink").click()
+    page.wait_for_url("**/batch?**")
+
+    assert len(page.context.pages) == before_pages
+    batch_query = _query(page.url)
+    assert batch_query["file_id"] == ["line-c"]
+    assert batch_query["key1_byte"] == ["189"]
+    assert batch_query["key2_byte"] == ["193"]
+
+    page.locator("#fileIdInput").fill("line-c-edited")
+    page.locator("#key1ByteInput").fill("101")
+    page.locator("#key2ByteInput").fill("202")
+    page.get_by_role("link", name="Viewer").click()
+    page.wait_for_url("**/?**")
+
+    assert len(page.context.pages) == before_pages
+    viewer_query = _query(page.url)
+    assert viewer_query["file_id"] == ["line-c-edited"]
+    assert viewer_query["key1_byte"] == ["101"]
+    assert viewer_query["key2_byte"] == ["202"]


### PR DESCRIPTION
Closes #641

## Summary
- [ui][navigation] Viewer / Static Correction / Refraction QC / Batch Apply のクリックでブラウザタブを増やさない

## Changed files
- `app/static/batch_apply.html`
- `app/static/batch_apply.js`
- `app/static/index.html`
- `app/static/refraction_qc.html`
- `app/static/static_correction.html`
- `app/tests/e2e/test_tool_navigation.py`

## Checks
- `.work/codex/checks.log`: 2426 passed in 70.78s (0:01:10)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
