### PR TITLE
[ui][refraction-qc] Add all-gather receiver-vs-pick map with pre-statics support

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -29,6 +29,8 @@ from app.api.schemas import (
     RefractionStaticQcBundleResponse,
     RefractionStaticQcDrilldownRequest,
     RefractionStaticQcDrilldownResponse,
+    RefractionStaticPickMapRequest,
+    RefractionStaticPickMapResponse,
     RefractionStaticTableApplyRequest,
     RefractionStaticTableApplyResponse,
     ResidualStaticApplyRequest,
@@ -70,6 +72,10 @@ from app.services.refraction_static_qc_drilldown import (
     RefractionStaticQcDrilldownError,
     RefractionStaticQcDrilldownNotFound,
     build_refraction_static_qc_drilldown,
+)
+from app.services.refraction_static_pick_map import (
+    RefractionStaticPickMapError,
+    build_refraction_static_pick_map,
 )
 from app.services.refraction_static_service import run_refraction_static_apply_job
 from app.services.refraction_static_table_apply_service import (
@@ -129,6 +135,18 @@ def _parse_refraction_apply_request_json(
 ) -> RefractionStaticApplyRequest:
     try:
         return RefractionStaticApplyRequest.model_validate_json(request_json)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=json.loads(exc.json()),
+        ) from exc
+
+
+def _parse_refraction_pick_map_request_json(
+    request_json: str,
+) -> RefractionStaticPickMapRequest:
+    try:
+        return RefractionStaticPickMapRequest.model_validate_json(request_json)
     except ValidationError as exc:
         raise HTTPException(
             status_code=422,
@@ -509,6 +527,69 @@ def refraction_static_qc_bundle(
         )
     except RefractionStaticQcBundleError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.post(
+    '/statics/refraction/qc/pick-map',
+    response_model=RefractionStaticPickMapResponse,
+    response_model_exclude_none=True,
+)
+async def refraction_static_qc_pick_map(
+    request: Request,
+) -> RefractionStaticPickMapResponse:
+    """Return all-gather before/after refraction pick-map arrays."""
+    content_type = request.headers.get('content-type', '').lower()
+    uploaded_pick_path: Path | None = None
+    temp_dir_handle: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        if content_type.startswith('multipart/form-data'):
+            form = await request.form()
+            request_json = form.get('request_json')
+            pick_npz = form.get('pick_npz')
+            if not isinstance(request_json, str):
+                raise HTTPException(
+                    status_code=422,
+                    detail='request_json form field is required',
+                )
+            if not hasattr(pick_npz, 'filename') or not hasattr(pick_npz, 'file'):
+                raise HTTPException(
+                    status_code=422,
+                    detail='pick_npz form file is required',
+                )
+            req = _parse_refraction_pick_map_request_json(request_json)
+            _validate_refraction_pick_upload(pick_npz)
+            temp_dir_handle = tempfile.TemporaryDirectory(prefix='refraction-pick-map-')
+            temp_dir = Path(temp_dir_handle.name)
+            uploaded_pick_path, _size_bytes = _store_refraction_pick_upload(
+                pick_npz=pick_npz,
+                job_dir=temp_dir,
+            )
+        else:
+            try:
+                req = RefractionStaticPickMapRequest.model_validate(
+                    await request.json()
+                )
+            except ValidationError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail=json.loads(exc.json()),
+                ) from exc
+
+        state = get_state(request.app)
+        cleanup_in_memory_state(state)
+        job = _get_static_job_or_404(state, req.job_id) if req.job_id else None
+        try:
+            return build_refraction_static_pick_map(
+                req=req,
+                state=state,
+                job=job,
+                uploaded_pick_npz_path=uploaded_pick_path,
+            )
+        except RefractionStaticPickMapError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+    finally:
+        if temp_dir_handle is not None:
+            temp_dir_handle.cleanup()
 
 
 @router.post(

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -3137,6 +3137,86 @@ class RefractionStaticQcBundleResponse(BaseModel):
     )
 
 
+class RefractionStaticPickMapGeometryRequest(RefractionStaticGeometryRequest):
+    """Geometry configuration for all-gather refraction pick-map QC."""
+
+    receiver_number_mode: Literal['global_sequential'] = 'global_sequential'
+
+
+class RefractionStaticPickMapRequest(BaseModel):
+    """Request model for all-gather refraction pick-map QC."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    job_id: str | None = None
+    file_id: str | None = None
+    key1_byte: int = 189
+    key2_byte: int = 193
+    pick_source: RefractionStaticPickSourceRequest | None = None
+    geometry: RefractionStaticPickMapGeometryRequest = Field(
+        default_factory=RefractionStaticPickMapGeometryRequest,
+    )
+
+    @field_validator('job_id', 'file_id')
+    @classmethod
+    def _check_optional_text(cls, value: str | None, info: Any) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value:
+            raise ValueError(f'{info.field_name} must be a non-empty string')
+        return value
+
+    @field_validator('key1_byte', 'key2_byte', mode='before')
+    @classmethod
+    def _check_key_header_byte(cls, value: object, info: Any) -> int:
+        return require_trace_header_byte(value, info.field_name)
+
+    @model_validator(mode='after')
+    def _check_source(self) -> 'RefractionStaticPickMapRequest':
+        if self.job_id is not None and self.pick_source is not None:
+            raise ValueError('pick_source must be omitted when job_id is provided')
+        if self.job_id is None:
+            if self.file_id is None:
+                raise ValueError('file_id is required when job_id is omitted')
+            if self.pick_source is None:
+                raise ValueError('pick_source is required when job_id is omitted')
+        return self
+
+
+class RefractionStaticPickMapData(BaseModel):
+    """Columnar arrays for all-gather pick-map plotting."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    gather_id: list[int | str | None]
+    receiver_number: list[int | float | None]
+    pick_before_ms: list[float]
+    trace_index: list[int | None] = Field(default_factory=list)
+    shot_id: list[int | str | None] = Field(default_factory=list)
+    source_id: list[int | str | None] = Field(default_factory=list)
+    receiver_id: list[int | str | None] = Field(default_factory=list)
+    offset_m: list[float | None] = Field(default_factory=list)
+    used_in_statics: list[bool | None] = Field(default_factory=list)
+    pick_after_ms: list[float | None] = Field(default_factory=list)
+    applied_shift_ms: list[float | None] = Field(default_factory=list)
+    offset_used: list[float | None] = Field(default_factory=list)
+
+
+class RefractionStaticPickMapResponse(BaseModel):
+    """All-gather refraction pick-map QC response."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    job_id: str | None = None
+    statics_kind: Literal['refraction']
+    mode: Literal['pre_statics', 'completed_job']
+    status_message: str
+    has_after_statics: bool
+    receiver_number_mode: Literal['global_sequential']
+    gather_range: dict[str, int | float | str | None]
+    pick_map: RefractionStaticPickMapData
+
+
 class RefractionStaticQcDrilldownEndpointTarget(BaseModel):
     """Endpoint target for detailed refraction QC drilldown."""
 

--- a/app/services/refraction_static_pick_map.py
+++ b/app/services/refraction_static_pick_map.py
@@ -1,0 +1,533 @@
+"""All-gather pick-map QC for refraction statics."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from app.api.schemas import RefractionStaticPickMapRequest
+from app.core.state import AppState
+from app.services.job_artifact_refs import resolve_job_artifact_path
+from app.services.job_manager import JobManager
+from app.services.reader import get_reader
+from app.services.refraction_static_artifacts import (
+    REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+    REFRACTION_FIRST_BREAK_FIT_QC_NPZ_NAME,
+    REFRACTION_STATIC_COMPONENT_QC_TRACE_CSV_NAME,
+    REFRACTION_STATIC_SOLUTION_NPZ_NAME,
+)
+from app.services.refraction_static_pick_source_loader import (
+    load_npz_refraction_pick_source_from_path,
+)
+from app.services.trace_store_index_validation import validate_sorted_to_original
+
+
+class RefractionStaticPickMapError(ValueError):
+    """Raised when a pick-map bundle cannot be assembled."""
+
+
+def build_refraction_static_pick_map(
+    *,
+    req: RefractionStaticPickMapRequest,
+    state: AppState,
+    job: dict[str, object] | None = None,
+    uploaded_pick_npz_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build a Plotly-ready all-gather pick-map response."""
+    if req.job_id is not None:
+        if job is None:
+            raise RefractionStaticPickMapError('job metadata is required')
+        return _build_completed_job_pick_map(req=req, job=job)
+    return _build_pre_statics_pick_map(
+        req=req,
+        state=state,
+        uploaded_pick_npz_path=uploaded_pick_npz_path,
+    )
+
+
+def _build_pre_statics_pick_map(
+    *,
+    req: RefractionStaticPickMapRequest,
+    state: AppState,
+    uploaded_pick_npz_path: Path | None,
+) -> dict[str, Any]:
+    if req.file_id is None or req.pick_source is None:
+        raise RefractionStaticPickMapError('file_id and pick_source are required')
+
+    reader = get_reader(req.file_id, req.key1_byte, req.key2_byte, state=state)
+    n_traces = _reader_n_traces(reader)
+    n_samples = _reader_n_samples(reader)
+    dt_s = _reader_dt(reader, state=state, file_id=req.file_id)
+    sorted_to_original = validate_sorted_to_original(
+        np.asarray(reader.get_sorted_to_original()),
+        expected_n_traces=n_traces,
+        role='reader',
+    )
+    pick_path = _resolve_pick_path(
+        req=req,
+        state=state,
+        uploaded_pick_npz_path=uploaded_pick_npz_path,
+    )
+    loaded = load_npz_refraction_pick_source_from_path(
+        pick_path,
+        n_traces=n_traces,
+        n_samples=n_samples,
+        dt_s=dt_s,
+        sorted_trace_index=sorted_to_original,
+        source_kind=req.pick_source.kind,
+    )
+
+    geometry = req.geometry
+    source_id = _header_as_python_values(
+        reader.ensure_header(geometry.source_id_byte),
+        n_traces=n_traces,
+        name='source_id',
+    )
+    receiver_id = _header_as_python_values(
+        reader.ensure_header(geometry.receiver_id_byte),
+        n_traces=n_traces,
+        name='receiver_id',
+    )
+    offset_m = _geometry_offset_m(reader=reader, req=req, n_traces=n_traces)
+
+    pick_s = np.asarray(loaded.picks_time_s_sorted, dtype=np.float64)
+    valid = np.isfinite(pick_s) & (pick_s >= 0.0)
+    records = _empty_pick_map()
+    for index in np.flatnonzero(valid):
+        pick_ms = float(pick_s[index] * 1000.0)
+        records['gather_id'].append(source_id[index])
+        records['receiver_number'].append(
+            _global_sequential_receiver_number(receiver_id[index])
+        )
+        records['pick_before_ms'].append(pick_ms)
+        records['trace_index'].append(int(index))
+        records['shot_id'].append(source_id[index])
+        records['source_id'].append(source_id[index])
+        records['receiver_id'].append(receiver_id[index])
+        records['offset_m'].append(_finite_float_or_none(offset_m[index]))
+        records['used_in_statics'].append(None)
+        records['pick_after_ms'].append(None)
+        records['applied_shift_ms'].append(None)
+        records['offset_used'].append(None)
+
+    return _response(
+        job_id=None,
+        mode='pre_statics',
+        status_message=(
+            'Pre-statics pick map loaded. Static Correction has not been run, '
+            'so After Statics is unavailable.'
+        ),
+        has_after_statics=False,
+        receiver_number_mode=req.geometry.receiver_number_mode,
+        pick_map=records,
+    )
+
+
+def _resolve_pick_path(
+    *,
+    req: RefractionStaticPickMapRequest,
+    state: AppState,
+    uploaded_pick_npz_path: Path | None,
+) -> Path:
+    pick_source = req.pick_source
+    if pick_source is None:
+        raise RefractionStaticPickMapError('pick_source is required')
+    if pick_source.kind == 'uploaded_npz':
+        if uploaded_pick_npz_path is None:
+            raise RefractionStaticPickMapError(
+                'pick_source.kind=uploaded_npz requires multipart pick_npz upload'
+            )
+        return Path(uploaded_pick_npz_path)
+    if req.file_id is None:
+        raise RefractionStaticPickMapError('file_id is required')
+    if pick_source.kind == 'manual_memmap':
+        raise RefractionStaticPickMapError(
+            'manual_memmap pick sources are not supported for pick-map QC'
+        )
+    allowed_job_types = (
+        {'batch_apply'} if pick_source.kind == 'batch_predicted_npz' else {'statics'}
+    )
+    return resolve_job_artifact_path(
+        state,
+        job_id=str(pick_source.job_id),
+        name=str(pick_source.artifact_name),
+        allowed_job_types=allowed_job_types,
+        expected_file_id=req.file_id,
+        expected_key1_byte=req.key1_byte,
+        expected_key2_byte=req.key2_byte,
+        reference_label='pick_source',
+    )
+
+
+def _build_completed_job_pick_map(
+    *,
+    req: RefractionStaticPickMapRequest,
+    job: dict[str, object],
+) -> dict[str, Any]:
+    job_id = str(req.job_id)
+    if job.get('statics_kind') != 'refraction':
+        raise RefractionStaticPickMapError(f'Job {job_id} is not a refraction statics job')
+    if not JobManager.is_ready_status_value(job.get('status')):
+        raise RefractionStaticPickMapError(
+            f'Job {job_id} is not complete; current state is '
+            f'{JobManager.normalize_status_value(job.get("status"))}'
+        )
+    artifacts_dir = _job_artifacts_dir(job, job_id)
+    pick_rows = _read_completed_pick_rows(artifacts_dir)
+    shifts_ms = _read_completed_trace_shifts_ms(artifacts_dir)
+
+    records = _empty_pick_map()
+    for row in pick_rows:
+        before_ms = _required_float(row.get('observed_first_break_time_s')) * 1000.0
+        trace_index = _optional_int(row.get('trace_index_sorted'))
+        if trace_index is None:
+            trace_index = _optional_int(row.get('sorted_trace_index'))
+        shift_ms = shifts_ms.get(trace_index) if trace_index is not None else None
+        used = _bool_value(row.get('used_in_solve', row.get('used_for_inversion')))
+        after_ms = before_ms + shift_ms if shift_ms is not None else None
+        offset = _optional_float(row.get('offset_m'))
+        source_id = _first_present(row, 'source_id', 'source_endpoint_key')
+        receiver_id = _first_present(row, 'receiver_id', 'receiver_endpoint_key')
+        receiver_number = _global_sequential_receiver_number(receiver_id)
+
+        records['gather_id'].append(source_id)
+        records['receiver_number'].append(receiver_number)
+        records['pick_before_ms'].append(before_ms)
+        records['trace_index'].append(trace_index)
+        records['shot_id'].append(source_id)
+        records['source_id'].append(source_id)
+        records['receiver_id'].append(receiver_id)
+        records['offset_m'].append(offset)
+        records['used_in_statics'].append(used)
+        records['pick_after_ms'].append(after_ms)
+        records['applied_shift_ms'].append(shift_ms)
+        records['offset_used'].append(offset if used else None)
+
+    return _response(
+        job_id=job_id,
+        mode='completed_job',
+        status_message='Static job loaded. Before/After pick comparison is available.',
+        has_after_statics=True,
+        receiver_number_mode=req.geometry.receiver_number_mode,
+        pick_map=records,
+    )
+
+
+def _read_completed_pick_rows(artifacts_dir: Path) -> list[dict[str, Any]]:
+    npz_path = artifacts_dir / REFRACTION_FIRST_BREAK_FIT_QC_NPZ_NAME
+    if npz_path.is_file():
+        return _read_pick_rows_from_npz(npz_path)
+    csv_path = artifacts_dir / REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME
+    if csv_path.is_file():
+        with csv_path.open(encoding='utf-8', newline='') as handle:
+            return [dict(row) for row in csv.DictReader(handle)]
+    raise RefractionStaticPickMapError(
+        f'Refraction pick map requires artifact {REFRACTION_FIRST_BREAK_FIT_QC_NPZ_NAME}'
+    )
+
+
+def _read_pick_rows_from_npz(path: Path) -> list[dict[str, Any]]:
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            required = ('observed_first_break_time_s',)
+            for key in required:
+                if key not in data.files:
+                    raise RefractionStaticPickMapError(
+                        f'Refraction pick map artifact is missing {key}'
+                    )
+            n_rows = int(np.asarray(data['observed_first_break_time_s']).shape[0])
+            rows: list[dict[str, Any]] = []
+            for index in range(n_rows):
+                row: dict[str, Any] = {}
+                for key in data.files:
+                    value = np.asarray(data[key])
+                    if value.ndim == 0:
+                        continue
+                    if value.shape[0] != n_rows:
+                        continue
+                    row[key] = _np_scalar_to_python(value[index])
+                rows.append(row)
+            return rows
+    except RefractionStaticPickMapError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise RefractionStaticPickMapError(
+            f'Could not read refraction pick map artifact {path.name}'
+        ) from exc
+
+
+def _read_completed_trace_shifts_ms(artifacts_dir: Path) -> dict[int, float]:
+    solution_path = artifacts_dir / REFRACTION_STATIC_SOLUTION_NPZ_NAME
+    if solution_path.is_file():
+        return _read_trace_shifts_from_solution_npz(solution_path)
+    csv_path = artifacts_dir / REFRACTION_STATIC_COMPONENT_QC_TRACE_CSV_NAME
+    if csv_path.is_file():
+        return _read_trace_shifts_from_component_csv(csv_path)
+    return {}
+
+
+def _read_trace_shifts_from_solution_npz(path: Path) -> dict[int, float]:
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            field = (
+                'final_trace_shift_s_sorted'
+                if 'final_trace_shift_s_sorted' in data.files
+                else 'refraction_trace_shift_s_sorted'
+            )
+            if field not in data.files:
+                return {}
+            shifts = np.asarray(data[field], dtype=np.float64)
+            return {
+                int(index): float(shift_s * 1000.0)
+                for index, shift_s in enumerate(shifts)
+                if np.isfinite(shift_s)
+            }
+    except Exception as exc:  # noqa: BLE001
+        raise RefractionStaticPickMapError(
+            f'Could not read refraction trace shifts from {path.name}'
+        ) from exc
+
+
+def _read_trace_shifts_from_component_csv(path: Path) -> dict[int, float]:
+    shifts: dict[int, float] = {}
+    with path.open(encoding='utf-8', newline='') as handle:
+        for row in csv.DictReader(handle):
+            trace_index = _optional_int(row.get('trace_index_sorted'))
+            shift_ms = _optional_float(
+                row.get('applied_trace_shift_ms', row.get('final_trace_shift_ms'))
+            )
+            if trace_index is not None and shift_ms is not None:
+                shifts[trace_index] = shift_ms
+    return shifts
+
+
+def _geometry_offset_m(
+    *,
+    reader: Any,
+    req: RefractionStaticPickMapRequest,
+    n_traces: int,
+) -> np.ndarray:
+    geometry = req.geometry
+    try:
+        source_x = _float_header(reader.ensure_header(geometry.source_x_byte), n_traces)
+        source_y = _float_header(reader.ensure_header(geometry.source_y_byte), n_traces)
+        receiver_x = _float_header(reader.ensure_header(geometry.receiver_x_byte), n_traces)
+        receiver_y = _float_header(reader.ensure_header(geometry.receiver_y_byte), n_traces)
+    except Exception:
+        return np.full(n_traces, np.nan, dtype=np.float64)
+    return np.ascontiguousarray(
+        np.hypot(source_x - receiver_x, source_y - receiver_y),
+        dtype=np.float64,
+    )
+
+
+def _response(
+    *,
+    job_id: str | None,
+    mode: str,
+    status_message: str,
+    has_after_statics: bool,
+    receiver_number_mode: str,
+    pick_map: dict[str, list[Any]],
+) -> dict[str, Any]:
+    return {
+        'job_id': job_id,
+        'statics_kind': 'refraction',
+        'mode': mode,
+        'status_message': status_message,
+        'has_after_statics': has_after_statics,
+        'receiver_number_mode': receiver_number_mode,
+        'gather_range': _gather_range(pick_map['gather_id']),
+        'pick_map': pick_map,
+    }
+
+
+def _empty_pick_map() -> dict[str, list[Any]]:
+    return {
+        'gather_id': [],
+        'receiver_number': [],
+        'pick_before_ms': [],
+        'trace_index': [],
+        'shot_id': [],
+        'source_id': [],
+        'receiver_id': [],
+        'offset_m': [],
+        'used_in_statics': [],
+        'pick_after_ms': [],
+        'applied_shift_ms': [],
+        'offset_used': [],
+    }
+
+
+def _gather_range(values: list[Any]) -> dict[str, int | float | str | None]:
+    numeric = [_numeric_or_none(value) for value in values]
+    finite = [float(value) for value in numeric if value is not None]
+    if finite:
+        start = min(finite)
+        end = max(finite)
+        if start.is_integer() and end.is_integer():
+            return {'min': int(start), 'max': int(end)}
+        return {'min': start, 'max': end}
+    text = [str(value) for value in values if value is not None and str(value)]
+    if text:
+        return {'min': min(text), 'max': max(text)}
+    return {'min': None, 'max': None}
+
+
+def _job_artifacts_dir(job: dict[str, object], job_id: str) -> Path:
+    raw = job.get('artifacts_dir')
+    if not isinstance(raw, str) or not raw:
+        raise RefractionStaticPickMapError(
+            f'Job {job_id} metadata is missing artifacts_dir'
+        )
+    path = Path(raw)
+    if not path.is_dir():
+        raise RefractionStaticPickMapError(
+            f'Job {job_id} artifacts directory is not available'
+        )
+    return path
+
+
+def _reader_n_traces(reader: Any) -> int:
+    shape = getattr(getattr(reader, 'traces', None), 'shape', ())
+    if shape:
+        value = int(shape[0])
+        if value > 0:
+            return value
+    meta = getattr(reader, 'meta', {})
+    value = int(meta.get('n_traces', 0)) if isinstance(meta, dict) else 0
+    if value <= 0:
+        raise RefractionStaticPickMapError('TraceStore metadata unavailable: n_traces')
+    return value
+
+
+def _reader_n_samples(reader: Any) -> int:
+    shape = getattr(getattr(reader, 'traces', None), 'shape', ())
+    if len(shape) >= 2 and int(shape[-1]) > 0:
+        return int(shape[-1])
+    raise RefractionStaticPickMapError('TraceStore metadata unavailable: n_samples')
+
+
+def _reader_dt(reader: Any, *, state: AppState, file_id: str) -> float:
+    meta = getattr(reader, 'meta', {})
+    if isinstance(meta, dict):
+        raw = meta.get('dt')
+        if isinstance(raw, (int, float)) and raw > 0:
+            return float(raw)
+    value = float(state.file_registry.get_dt(file_id))
+    if value <= 0.0:
+        raise RefractionStaticPickMapError('TraceStore metadata unavailable: dt')
+    return value
+
+
+def _header_as_python_values(values: object, *, n_traces: int, name: str) -> list[Any]:
+    arr = np.asarray(values)
+    if arr.shape != (n_traces,):
+        raise RefractionStaticPickMapError(
+            f'{name} header shape mismatch: expected {(n_traces,)}, got {arr.shape}'
+        )
+    return [_np_scalar_to_python(item) for item in arr]
+
+
+def _float_header(values: object, n_traces: int) -> np.ndarray:
+    arr = np.asarray(values, dtype=np.float64)
+    if arr.shape != (n_traces,):
+        raise RefractionStaticPickMapError(
+            f'header shape mismatch: expected {(n_traces,)}, got {arr.shape}'
+        )
+    return np.ascontiguousarray(arr, dtype=np.float64)
+
+
+def _required_float(value: object) -> float:
+    out = _optional_float(value)
+    if out is None:
+        raise RefractionStaticPickMapError('completed pick row has invalid pick time')
+    return out
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None or value == '':
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(out):
+        return None
+    return out
+
+
+def _finite_float_or_none(value: object) -> float | None:
+    return _optional_float(value)
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None or value == '':
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            out = float(value)
+        except (TypeError, ValueError):
+            return None
+        if not np.isfinite(out) or not out.is_integer():
+            return None
+        return int(out)
+
+
+def _numeric_or_none(value: object) -> int | float | None:
+    if isinstance(value, str):
+        raw = value.rsplit(':', 1)[-1]
+    else:
+        raw = value
+    out = _optional_float(raw)
+    if out is None:
+        return None
+    return int(out) if out.is_integer() else out
+
+
+def _global_sequential_receiver_number(receiver_id: object) -> int | float | None:
+    value = _optional_float(receiver_id)
+    if value is None and isinstance(receiver_id, str):
+        parts = receiver_id.split(':')
+        if len(parts) >= 2 and parts[0] == 'receiver':
+            value = _optional_float(parts[1])
+    if value is None:
+        return None
+    if value.is_integer():
+        return int(value)
+    return value
+
+
+def _bool_value(value: object) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'y'}
+    if isinstance(value, (int, np.integer)):
+        return bool(value)
+    return False
+
+
+def _first_present(row: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = row.get(key)
+        if value is not None and value != '':
+            return value
+    return None
+
+
+def _np_scalar_to_python(value: object) -> Any:
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+__all__ = [
+    'RefractionStaticPickMapError',
+    'build_refraction_static_pick_map',
+]

--- a/app/static/refraction_qc.html
+++ b/app/static/refraction_qc.html
@@ -117,6 +117,7 @@
 <button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-profiles-button" data-view="profiles_2d" role="tab" type="button">2D profiles</button>
 <button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-cells-button" data-view="cell_maps_3d" role="tab" type="button">3D cell maps</button>
 <button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-statics-button" data-view="static_components" role="tab" type="button">Static components</button>
+<button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-pick-map-button" data-view="pick_map" role="tab" type="button">Pick Map</button>
 <button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-gather-button" data-view="gather_preview" role="tab" type="button">Gather preview</button>
 </div>
 <div data-testid="refraction-qc-views" id="refractionQcViews">
@@ -143,6 +144,10 @@
 <section class="refraction-qc-view" data-testid="refraction-qc-view-statics" data-view-panel="static_components" hidden="">
 <h3>Static components</h3>
 <div class="refraction-qc-placeholder" data-view-content="static_components">No QC bundle loaded.</div>
+</section>
+<section class="refraction-qc-view" data-testid="refraction-qc-view-pick-map" data-view-panel="pick_map" hidden="">
+<h3>Pick Map</h3>
+<div class="refraction-qc-placeholder" data-view-content="pick_map">No Pick Map loaded.</div>
 </section>
 <section class="refraction-qc-view" data-testid="refraction-qc-view-gather" data-view-panel="gather_preview" hidden="">
 <h3>Gather preview</h3>

--- a/app/static/refraction_qc.js
+++ b/app/static/refraction_qc.js
@@ -1,5 +1,10 @@
 (function () {
   const RECENT_JOBS_KEY = 'sv.refraction_qc.recent_jobs';
+  const ACTIVE_VIEWER_TARGET_STORAGE_KEY = 'sv.active_viewer_target';
+  const STATIC_DRAFT_STORAGE_KEY = 'sv.static_correction.form_draft.v1';
+  const STATIC_PICK_DB_NAME = 'seisviewer2d-static-correction';
+  const STATIC_PICK_DB_VERSION = 1;
+  const STATIC_PICK_STORE = 'pick_npz_blobs';
   const MAX_RECENT_JOBS = 8;
   const DEFAULT_MAX_POINTS = 20000;
 
@@ -39,6 +44,12 @@
       include: 'static_components',
       viewKeys: ['static_components'],
       unavailableKeys: ['static_components'],
+    },
+    {
+      id: 'pick_map',
+      include: 'summary',
+      viewKeys: [],
+      unavailableKeys: [],
     },
     {
       id: 'gather_preview',
@@ -81,6 +92,15 @@
     gatherPreview: null,
     gatherLoading: false,
     gatherError: null,
+    pickMap: null,
+    pickMapLoading: false,
+    pickMapError: null,
+    pickMapDisplayMode: 'before',
+    pickMapGatherStart: '',
+    pickMapGatherEnd: '',
+    pickMapCachedFile: null,
+    pickMapCachedMeta: null,
+    pickMapCacheStatus: '',
     error: null,
     loading: false,
   };
@@ -88,12 +108,22 @@
   let dom = null;
   let requestSerial = 0;
   let gatherRequestSerial = 0;
+  let pickMapRequestSerial = 0;
 
   function safeLocalStorageValue(key) {
     try {
       return localStorage.getItem(key) || '';
     } catch (_) {
       return '';
+    }
+  }
+
+  function safeLocalStorageJson(key) {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    } catch (_) {
+      return null;
     }
   }
 
@@ -108,6 +138,141 @@
 
   function searchOrStorageValue(searchKey, storageKey, fallback = '') {
     return searchParamValue(searchKey) || safeLocalStorageValue(storageKey || searchKey) || fallback;
+  }
+
+  function normalizePickMapTargetCandidate(candidate, options = {}) {
+    if (!candidate || typeof candidate !== 'object') return null;
+    if (options.requireLoaded && candidate.isFileLoaded === false) return null;
+    const fileId = String(candidate.fileId ?? candidate.file_id ?? '').trim();
+    if (!fileId) return null;
+    const key1Byte = Number(candidate.key1Byte ?? candidate.key1_byte);
+    const key2Byte = Number(candidate.key2Byte ?? candidate.key2_byte);
+    if (!Number.isInteger(key1Byte) || key1Byte <= 0 || !Number.isInteger(key2Byte) || key2Byte <= 0) {
+      return null;
+    }
+    return { file_id: fileId, key1_byte: key1Byte, key2_byte: key2Byte };
+  }
+
+  function storedActivePickMapTarget() {
+    return normalizePickMapTargetCandidate(
+      safeLocalStorageJson(ACTIVE_VIEWER_TARGET_STORAGE_KEY),
+      { requireLoaded: true }
+    );
+  }
+
+  function standalonePickMapTarget() {
+    const storedTarget = storedActivePickMapTarget();
+    return normalizePickMapTargetCandidate({
+      fileId: searchParamValue('file_id'),
+      key1Byte: searchParamValue('key1_byte') || (storedTarget && storedTarget.key1_byte),
+      key2Byte: searchParamValue('key2_byte') || (storedTarget && storedTarget.key2_byte),
+      isFileLoaded: true,
+    })
+      || storedTarget
+      || normalizePickMapTargetCandidate({
+        fileId: searchOrStorageValue('file_id', 'file_id', ''),
+        key1Byte: searchOrStorageValue('key1_byte', 'key1_byte', safeLocalStorageValue('last_key1_byte') || '189'),
+        key2Byte: searchOrStorageValue('key2_byte', 'key2_byte', safeLocalStorageValue('last_key2_byte') || '193'),
+        isFileLoaded: true,
+      });
+  }
+
+  function activePickMapTarget() {
+    const viewerState = window.SeisViewerState;
+    if (viewerState && typeof viewerState.getActiveFileTarget === 'function') {
+      const active = normalizePickMapTargetCandidate(
+        viewerState.getActiveFileTarget(),
+        { requireLoaded: true }
+      );
+      if (active) return active;
+    }
+    if (viewerState && typeof viewerState.getActiveFileTargetState === 'function') {
+      const targetState = normalizePickMapTargetCandidate(viewerState.getActiveFileTargetState());
+      if (targetState) return targetState;
+    }
+    return standalonePickMapTarget();
+  }
+
+  function samePickMapTarget(left, right) {
+    if (!left || !right) return false;
+    return String(left.file_id || '') === String(right.file_id || '')
+      && Number(left.key1_byte) === Number(right.key1_byte)
+      && Number(left.key2_byte) === Number(right.key2_byte);
+  }
+
+  function openStaticPickDb() {
+    return new Promise((resolve, reject) => {
+      if (!window.indexedDB) {
+        reject(new Error('IndexedDB is not available in this browser.'));
+        return;
+      }
+      const request = window.indexedDB.open(STATIC_PICK_DB_NAME, STATIC_PICK_DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STATIC_PICK_STORE)) {
+          db.createObjectStore(STATIC_PICK_STORE, { keyPath: 'id' });
+        }
+      };
+      request.onerror = () => reject(request.error || new Error('Failed to open IndexedDB.'));
+      request.onsuccess = () => resolve(request.result);
+    });
+  }
+
+  function requestToPromise(request) {
+    return new Promise((resolve, reject) => {
+      request.onerror = () => reject(request.error || new Error('IndexedDB request failed.'));
+      request.onsuccess = () => resolve(request.result);
+    });
+  }
+
+  async function loadStaticPickRecord(recordId) {
+    if (!recordId) return null;
+    const db = await openStaticPickDb();
+    try {
+      const tx = db.transaction(STATIC_PICK_STORE, 'readonly');
+      const store = tx.objectStore(STATIC_PICK_STORE);
+      return await requestToPromise(store.get(recordId));
+    } finally {
+      db.close();
+    }
+  }
+
+  async function restoreCachedPickMapSource() {
+    const target = activePickMapTarget();
+    const draft = safeLocalStorageJson(STATIC_DRAFT_STORAGE_KEY);
+    const meta = draft?.pickNpz || null;
+    state.pickMapCachedFile = null;
+    state.pickMapCachedMeta = null;
+    state.pickMapCacheStatus = '';
+    if (!target || !draft || !meta) return;
+    if (!samePickMapTarget(draft.target, target) || !samePickMapTarget({
+      file_id: meta.fileId,
+      key1_byte: meta.key1Byte,
+      key2_byte: meta.key2Byte,
+    }, target)) {
+      state.pickMapCacheStatus = 'Saved Static Correction NPZ belongs to a different viewer target.';
+      render();
+      return;
+    }
+    try {
+      const record = await loadStaticPickRecord(meta.indexedDbRecordId);
+      if (!record || !record.blob) {
+        state.pickMapCacheStatus = 'Saved Static Correction NPZ is no longer available.';
+        render();
+        return;
+      }
+      state.pickMapCachedFile = record.blob instanceof File
+        ? record.blob
+        : new File([record.blob], record.filename || meta.filename || 'first_breaks.npz', {
+          type: record.type || meta.type || 'application/octet-stream',
+          lastModified: record.lastModified || meta.lastModified || Date.now(),
+        });
+      state.pickMapCachedMeta = meta;
+      state.pickMapCacheStatus = `Cached NPZ available: ${state.pickMapCachedFile.name}`;
+    } catch (error) {
+      state.pickMapCacheStatus = error instanceof Error ? error.message : String(error);
+    }
+    render();
   }
 
   function isStandaloneRefractionQcPage() {
@@ -3017,6 +3182,263 @@
     ]));
   }
 
+  function renderPickMap(content) {
+    const controls = document.createElement('div');
+    controls.className = 'refraction-qc-controls';
+
+    const beforeButton = document.createElement('button');
+    beforeButton.type = 'button';
+    beforeButton.textContent = 'Before Statics';
+    beforeButton.dataset.testid = 'refraction-qc-pick-map-before';
+    beforeButton.className = state.pickMapDisplayMode === 'before' ? 'is-active' : '';
+    beforeButton.addEventListener('click', () => {
+      state.pickMapDisplayMode = 'before';
+      render();
+    });
+
+    const afterButton = document.createElement('button');
+    afterButton.type = 'button';
+    afterButton.textContent = 'After Statics';
+    afterButton.dataset.testid = 'refraction-qc-pick-map-after';
+    afterButton.disabled = !state.pickMap?.has_after_statics;
+    afterButton.className = state.pickMapDisplayMode === 'after' ? 'is-active' : '';
+    afterButton.addEventListener('click', () => {
+      if (!state.pickMap?.has_after_statics) return;
+      state.pickMapDisplayMode = 'after';
+      render();
+    });
+
+    const gatherStart = document.createElement('input');
+    gatherStart.type = 'number';
+    gatherStart.placeholder = 'Gather start';
+    gatherStart.value = state.pickMapGatherStart;
+    gatherStart.dataset.testid = 'refraction-qc-pick-map-gather-start';
+    gatherStart.addEventListener('input', () => {
+      state.pickMapGatherStart = gatherStart.value;
+      render();
+    });
+
+    const gatherEnd = document.createElement('input');
+    gatherEnd.type = 'number';
+    gatherEnd.placeholder = 'Gather end';
+    gatherEnd.value = state.pickMapGatherEnd;
+    gatherEnd.dataset.testid = 'refraction-qc-pick-map-gather-end';
+    gatherEnd.addEventListener('input', () => {
+      state.pickMapGatherEnd = gatherEnd.value;
+      render();
+    });
+
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = '.npz,application/x-npz,application/zip';
+    fileInput.dataset.testid = 'refraction-qc-pick-map-npz';
+
+    const uploadButton = document.createElement('button');
+    uploadButton.type = 'button';
+    uploadButton.textContent = 'Load pre-statics Pick Map';
+    uploadButton.dataset.testid = 'refraction-qc-pick-map-load-upload';
+    uploadButton.addEventListener('click', () => {
+      loadPreStaticsPickMap(fileInput.files && fileInput.files[0]);
+    });
+
+    const cachedButton = document.createElement('button');
+    cachedButton.type = 'button';
+    cachedButton.textContent = 'Load pre-statics Pick Map from cached NPZ';
+    cachedButton.dataset.testid = 'refraction-qc-pick-map-load-cached';
+    cachedButton.disabled = !state.pickMapCachedFile;
+    cachedButton.addEventListener('click', () => {
+      loadPreStaticsPickMap(state.pickMapCachedFile);
+    });
+
+    const completedButton = document.createElement('button');
+    completedButton.type = 'button';
+    completedButton.textContent = 'Load completed-job Pick Map';
+    completedButton.dataset.testid = 'refraction-qc-pick-map-load-job';
+    completedButton.disabled = !(state.qcBundle?.job_id || state.selectedJobId);
+    completedButton.addEventListener('click', () => {
+      loadCompletedPickMap();
+    });
+
+    controls.append(beforeButton, afterButton, gatherStart, gatherEnd, fileInput, uploadButton, cachedButton, completedButton);
+    content.appendChild(controls);
+
+    if (state.pickMapCacheStatus) {
+      const cacheStatus = document.createElement('p');
+      cacheStatus.className = 'refraction-qc-note';
+      cacheStatus.dataset.testid = 'refraction-qc-pick-map-cache-status';
+      cacheStatus.textContent = state.pickMapCacheStatus;
+      content.appendChild(cacheStatus);
+    }
+    if (state.pickMapLoading) {
+      const loading = document.createElement('p');
+      loading.className = 'refraction-qc-placeholder';
+      loading.textContent = 'Loading Pick Map...';
+      content.appendChild(loading);
+      return;
+    }
+    if (state.pickMapError) {
+      const error = document.createElement('div');
+      error.className = 'refraction-qc-error';
+      error.dataset.testid = 'refraction-qc-pick-map-error';
+      error.textContent = state.pickMapError;
+      content.appendChild(error);
+    }
+    if (!state.pickMap) {
+      const empty = document.createElement('p');
+      empty.className = 'refraction-qc-placeholder';
+      empty.textContent = state.qcBundle
+        ? 'No Pick Map loaded for this static job.'
+        : 'Load a completed job or a pre-statics pick NPZ.';
+      content.appendChild(empty);
+      return;
+    }
+
+    const status = document.createElement('p');
+    status.className = 'refraction-qc-note';
+    status.dataset.testid = 'refraction-qc-pick-map-status';
+    status.textContent = state.pickMap.status_message || '';
+    content.appendChild(status);
+
+    const points = filteredPickMapPoints(state.pickMap);
+    content.appendChild(createKv([
+      ['Mode', state.pickMap.mode],
+      ['Receiver numbering', state.pickMap.receiver_number_mode],
+      ['Gather min', state.pickMap.gather_range?.min],
+      ['Gather max', state.pickMap.gather_range?.max],
+      ['Displayed points', points.length],
+    ]));
+
+    const plot = document.createElement('div');
+    plot.className = 'refraction-qc-plot';
+    plot.dataset.testid = 'refraction-qc-pick-map-plot';
+    plot.dataset.pointCount = String(points.length);
+    content.appendChild(plot);
+
+    if (!points.length) {
+      plot.textContent = 'No Pick Map records match the current gather range.';
+      return;
+    }
+    renderPickMapPlot(plot, points, state.pickMap);
+  }
+
+  function filteredPickMapPoints(payload) {
+    const data = payload?.pick_map || {};
+    const count = Array.isArray(data.pick_before_ms) ? data.pick_before_ms.length : 0;
+    const start = toFiniteNumber(state.pickMapGatherStart);
+    const end = toFiniteNumber(state.pickMapGatherEnd);
+    const hasStart = Number.isFinite(start);
+    const hasEnd = Number.isFinite(end);
+    const points = [];
+    for (let index = 0; index < count; index += 1) {
+      const gather = data.gather_id?.[index];
+      const gatherNumber = toFiniteNumber(gather);
+      if (hasStart && Number.isFinite(gatherNumber) && gatherNumber < start) continue;
+      if (hasEnd && Number.isFinite(gatherNumber) && gatherNumber > end) continue;
+      const beforeMs = toFiniteNumber(data.pick_before_ms?.[index]);
+      const afterMs = toFiniteNumber(data.pick_after_ms?.[index]);
+      const y = state.pickMapDisplayMode === 'after' && payload.has_after_statics ? afterMs : beforeMs;
+      const receiverNumber = toFiniteNumber(data.receiver_number?.[index]);
+      if (!Number.isFinite(receiverNumber) || !Number.isFinite(y)) continue;
+      const used = data.used_in_statics?.[index] === true;
+      points.push({
+        x: receiverNumber,
+        y,
+        gather,
+        sourceId: data.source_id?.[index],
+        receiverId: data.receiver_id?.[index],
+        beforeMs,
+        afterMs,
+        offsetM: toFiniteNumber(data.offset_m?.[index]),
+        offsetUsed: toFiniteNumber(data.offset_used?.[index]),
+        used,
+        appliedShiftMs: toFiniteNumber(data.applied_shift_ms?.[index]),
+      });
+    }
+    return points;
+  }
+
+  function renderPickMapPlot(plot, points, payload) {
+    if (!window.Plotly) {
+      plot.textContent = 'Plot library is unavailable.';
+      return;
+    }
+    const common = {
+      type: 'scattergl',
+      mode: 'markers',
+      hovertemplate: '%{text}<extra></extra>',
+    };
+    const traces = [];
+    if (payload.mode === 'completed_job') {
+      const used = points.filter((point) => point.used);
+      const unused = points.filter((point) => !point.used);
+      if (used.length) {
+        traces.push({
+          ...common,
+          name: 'Used in statics',
+          x: used.map((point) => point.x),
+          y: used.map((point) => point.y),
+          text: used.map((point) => pickMapHoverText(point, payload)),
+          marker: {
+            color: used.map((point) => Number.isFinite(point.offsetUsed) ? point.offsetUsed : point.offsetM),
+            colorscale: 'Viridis',
+            colorbar: { title: 'Offset used (m)' },
+            size: 6,
+            opacity: 0.9,
+          },
+        });
+      }
+      if (unused.length) {
+        traces.push({
+          ...common,
+          name: 'Unused',
+          x: unused.map((point) => point.x),
+          y: unused.map((point) => point.y),
+          text: unused.map((point) => pickMapHoverText(point, payload)),
+          marker: { color: '#94a3b8', size: 5, opacity: 0.35 },
+        });
+      }
+    } else {
+      traces.push({
+        ...common,
+        name: 'Before statics',
+        x: points.map((point) => point.x),
+        y: points.map((point) => point.y),
+        text: points.map((point) => pickMapHoverText(point, payload)),
+        marker: { color: '#2563eb', size: 5, opacity: 0.8 },
+      });
+    }
+    window.Plotly.newPlot(plot, traces, {
+      height: plotHeight(340, 560),
+      margin: { l: 64, r: 22, t: 34, b: 58 },
+      title: { text: state.pickMapDisplayMode === 'after' ? 'After Statics Pick Map' : 'Before Statics Pick Map', font: { size: 12 } },
+      font: { size: 10, color: '#334155' },
+      paper_bgcolor: '#ffffff',
+      plot_bgcolor: '#ffffff',
+      xaxis: { title: { text: 'Global receiver number' }, gridcolor: '#e5e7eb', zeroline: false },
+      yaxis: { title: { text: 'First-break pick time (ms)' }, gridcolor: '#e5e7eb', zeroline: false },
+      legend: { orientation: 'h', x: 0, y: 1.14, xanchor: 'left', yanchor: 'top', font: { size: 10 } },
+    }, { displayModeBar: false, responsive: true });
+  }
+
+  function pickMapHoverText(point, payload) {
+    const lines = [
+      `Gather / shot: ${textOrDash(point.gather)}`,
+      `Receiver number: ${formatNumber(point.x, 0)}`,
+      `Pick before statics: ${formatNumber(point.beforeMs, 2)} ms`,
+    ];
+    if (payload.has_after_statics) {
+      lines.push(`Pick after statics: ${formatNumber(point.afterMs, 2)} ms`);
+      lines.push(`Offset used: ${formatNumber(point.offsetUsed, 2)} m`);
+      lines.push(`Used in statics: ${point.used ? 'yes' : 'no'}`);
+      lines.push(`Applied shift: ${formatNumber(point.appliedShiftMs, 2)} ms`);
+    } else if (Number.isFinite(point.offsetM)) {
+      lines.push(`Offset: ${formatNumber(point.offsetM, 2)} m`);
+    }
+    lines.push(`Source: ${textOrDash(point.sourceId)}`);
+    lines.push(`Receiver: ${textOrDash(point.receiverId)}`);
+    return lines.join('<br>');
+  }
+
   function renderViewContent(viewDef) {
     if (!dom) return;
     const content = dom.viewContents.get(viewDef.id);
@@ -3026,6 +3448,11 @@
 
     if (state.loading) {
       appendText(content, 'Loading QC bundle...');
+      return;
+    }
+    if (viewDef.id === 'pick_map') {
+      content.className = '';
+      renderPickMap(content);
       return;
     }
     if (!state.qcBundle) {
@@ -3119,6 +3546,12 @@
     if (!VIEW_DEFS.some((view) => view.id === viewId)) return;
     state.selectedView = viewId;
     render();
+    if (viewId === 'pick_map') {
+      restoreCachedPickMapSource();
+      if (state.qcBundle?.job_id && !state.pickMap && !state.pickMapLoading) {
+        loadCompletedPickMap(state.qcBundle.job_id);
+      }
+    }
   }
 
   function activateSidebarTab(tabName) {
@@ -3152,6 +3585,83 @@
     } catch (_) {
     }
     return `${label} failed with status ${response.status}`;
+  }
+
+  function buildPickMapUploadRequest() {
+    const target = activePickMapTarget();
+    if (!target) return { payload: null, error: 'Open a viewer target before loading a pre-statics Pick Map.' };
+    return {
+      payload: {
+        file_id: target.file_id,
+        key1_byte: target.key1_byte,
+        key2_byte: target.key2_byte,
+        pick_source: { kind: 'uploaded_npz' },
+        geometry: { receiver_number_mode: 'global_sequential' },
+      },
+      error: '',
+    };
+  }
+
+  async function loadPreStaticsPickMap(file) {
+    if (!file) {
+      state.pickMapError = 'Select a first-break pick NPZ.';
+      render();
+      return;
+    }
+    const { payload, error } = buildPickMapUploadRequest();
+    if (error) {
+      state.pickMapError = error;
+      render();
+      return;
+    }
+    const formData = new FormData();
+    formData.append('request_json', JSON.stringify(payload));
+    formData.append('pick_npz', file, file.name || 'first_breaks.npz');
+    await loadPickMapRequest(() => fetch('/statics/refraction/qc/pick-map', {
+      method: 'POST',
+      body: formData,
+    }));
+  }
+
+  async function loadCompletedPickMap(jobId) {
+    const cleanJobId = String(jobId || state.qcBundle?.job_id || state.selectedJobId || '').trim();
+    if (!cleanJobId) {
+      state.pickMapError = 'Job ID is required for completed-job Pick Map.';
+      render();
+      return;
+    }
+    await loadPickMapRequest(() => fetch('/statics/refraction/qc/pick-map', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ job_id: cleanJobId }),
+    }));
+  }
+
+  async function loadPickMapRequest(requestFactory) {
+    const serial = ++pickMapRequestSerial;
+    state.pickMapLoading = true;
+    state.pickMapError = null;
+    render();
+    try {
+      const response = await requestFactory();
+      if (!response.ok) {
+        throw new Error(await readError(response, 'Pick Map request'));
+      }
+      const pickMap = await response.json();
+      if (serial !== pickMapRequestSerial) return;
+      state.pickMap = pickMap;
+      state.pickMapError = null;
+      if (!pickMap.has_after_statics) state.pickMapDisplayMode = 'before';
+    } catch (error) {
+      if (serial !== pickMapRequestSerial) return;
+      state.pickMap = null;
+      state.pickMapError = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (serial === pickMapRequestSerial) {
+        state.pickMapLoading = false;
+        render();
+      }
+    }
   }
 
   async function loadGatherPreview() {
@@ -3238,6 +3748,9 @@
       }
       const bundle = await response.json();
       if (serial !== requestSerial) return;
+      if (state.pickMap?.job_id && state.pickMap.job_id !== bundle.job_id) {
+        state.pickMap = null;
+      }
       state.qcBundle = bundle;
       if (state.gatherPreview && state.gatherPreview.job_id !== bundle.job_id) {
         state.gatherPreview = null;
@@ -3246,6 +3759,9 @@
       state.error = null;
       writeRecentJob(jobId);
       writeJobIdUrlParam(jobId);
+      if (state.selectedView === 'pick_map') {
+        loadCompletedPickMap(jobId);
+      }
       return bundle;
     } catch (error) {
       if (serial !== requestSerial) return;
@@ -3402,6 +3918,7 @@
 
     renderRecentJobs();
     render();
+    restoreCachedPickMapSource();
     if (jobId && isStandaloneRefractionQcPage()) {
       loadBundle();
     }

--- a/tests/e2e/refraction_qc.spec.ts
+++ b/tests/e2e/refraction_qc.spec.ts
@@ -1114,6 +1114,156 @@ function multipartRequestJson(route: Route): Record<string, unknown> {
 	throw new Error('Multipart request_json field was not submitted');
 }
 
+async function seedStaticCorrectionPickCache(
+	page: Page,
+	{
+		fileId = 'active-viewer-store',
+		key1Byte = 9,
+		key2Byte = 13,
+		filename = 'active-viewer-picks.npz',
+		recordId = 'target:active-viewer-store:9:13:latest',
+	} = {},
+) {
+	await page.evaluate(
+		async ({ fileId, key1Byte, key2Byte, filename, recordId }) => {
+			window.localStorage.removeItem('file_id');
+			window.localStorage.removeItem('key1_byte');
+			window.localStorage.removeItem('key2_byte');
+			window.localStorage.removeItem('last_key1_byte');
+			window.localStorage.removeItem('last_key2_byte');
+			window.localStorage.removeItem('sv.active_viewer_target');
+			if ((window as any).store?.patch) {
+				(window as any).store.patch({
+					fileId,
+					displayName: `${fileId}.sgy`,
+					key1Byte,
+					key2Byte,
+					isFileLoaded: true,
+				});
+			}
+			await new Promise<void>((resolve, reject) => {
+				const request = window.indexedDB.open('seisviewer2d-static-correction', 1);
+				request.onupgradeneeded = () => {
+					const db = request.result;
+					if (!db.objectStoreNames.contains('pick_npz_blobs')) {
+						db.createObjectStore('pick_npz_blobs', { keyPath: 'id' });
+					}
+				};
+				request.onerror = () => reject(request.error);
+				request.onsuccess = () => {
+					const db = request.result;
+					const tx = db.transaction('pick_npz_blobs', 'readwrite');
+					tx.objectStore('pick_npz_blobs').put({
+						id: recordId,
+						filename,
+						sizeBytes: 9,
+						type: 'application/octet-stream',
+						lastModified: 1700000000000,
+						savedAt: new Date(1700000000000).toISOString(),
+						fileId,
+						key1Byte,
+						key2Byte,
+						blob: new Blob(['npz-bytes'], { type: 'application/octet-stream' }),
+					});
+					tx.oncomplete = () => {
+						db.close();
+						resolve();
+					};
+					tx.onerror = () => {
+						db.close();
+						reject(tx.error);
+					};
+				};
+			});
+			window.localStorage.setItem(
+				'sv.static_correction.form_draft.v1',
+				JSON.stringify({
+					version: 1,
+					target: { file_id: fileId, key1_byte: key1Byte, key2_byte: key2Byte },
+					pickNpz: {
+						indexedDbRecordId: recordId,
+						filename,
+						sizeBytes: 9,
+						type: 'application/octet-stream',
+						lastModified: 1700000000000,
+						savedAt: new Date(1700000000000).toISOString(),
+						fileId,
+						key1Byte,
+						key2Byte,
+					},
+					form: {},
+				}),
+			);
+		},
+		{ fileId, key1Byte, key2Byte, filename, recordId },
+	);
+}
+
+test('Refraction QC Pick Map loads cached NPZ from active viewer target state', async ({ page }) => {
+	let pickMapRequest: Record<string, unknown> | null = null;
+	await page.addInitScript(() => {
+		(window as any).SeisViewerState = {
+			getActiveFileTarget: () => ({
+				fileId: 'active-viewer-store',
+				displayName: 'active-viewer-store.sgy',
+				key1Byte: 9,
+				key2Byte: 13,
+				isFileLoaded: true,
+			}),
+			getActiveFileTargetState: () => ({
+				fileId: 'active-viewer-store',
+				displayName: 'active-viewer-store.sgy',
+				key1Byte: 9,
+				key2Byte: 13,
+				isFileLoaded: true,
+			}),
+		};
+	});
+	await page.route('**/statics/refraction/qc/pick-map', async (route) => {
+		pickMapRequest = multipartRequestJson(route);
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				mode: 'pre_statics',
+				job_id: null,
+				has_after_statics: false,
+				receiver_number_mode: 'global_sequential',
+				gather_range: { min: 100, max: 100 },
+				status_message: 'Pre-statics pick map loaded. Static Correction has not been run, so After Statics is unavailable.',
+				pick_map: {
+					gather_id: [100],
+					receiver_number: [2000],
+					pick_before_ms: [84],
+					pick_after_ms: [null],
+					used_in_statics: [null],
+					offset_m: [120],
+				},
+			}),
+		});
+	});
+	await page.goto('/refraction-qc');
+	await page.addScriptTag({
+		content: 'window.Plotly = { newPlot: (element, traces) => { element.dataset.traceCount = String(traces.length); } };',
+	});
+	await seedStaticCorrectionPickCache(page);
+
+	await page.getByTestId('refraction-qc-view-pick-map-button').click();
+	await expect(page.getByTestId('refraction-qc-pick-map-cache-status')).toContainText(
+		'Cached NPZ available: active-viewer-picks.npz',
+	);
+	await page.getByTestId('refraction-qc-pick-map-load-cached').click();
+
+	await expect(page.getByTestId('refraction-qc-pick-map-status')).toContainText('Pre-statics pick map loaded');
+	expect(pickMapRequest).toMatchObject({
+		file_id: 'active-viewer-store',
+		key1_byte: 9,
+		key2_byte: 13,
+		pick_source: { kind: 'uploaded_npz' },
+		geometry: { receiver_number_mode: 'global_sequential' },
+	});
+});
+
 async function routeCompletedStaticCorrectionFlow(
 	page: Page,
 	{

--- a/tests/test_refraction_qc_pick_map.py
+++ b/tests/test_refraction_qc_pick_map.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.refraction_static_artifacts import (
+    REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+    REFRACTION_STATIC_COMPONENT_QC_TRACE_CSV_NAME,
+    REFRACTION_STATIC_QC_JSON_NAME,
+)
+from app.services.refraction_static_export_units import (
+    REFRACTION_STATIC_REPO_SIGN_CONVENTION,
+)
+
+KEY1 = 189
+KEY2 = 193
+FILE_ID = 'pick-map-file'
+
+
+@pytest.fixture()
+def pick_map_client(tmp_path: Path):
+    state = app.state.sv
+    with state.lock:
+        state.jobs.clear()
+        state.file_registry.clear()
+        state.cached_readers.clear()
+
+    store = tmp_path / 'store'
+    _write_trace_store(store)
+    with state.lock:
+        state.file_registry.update(FILE_ID, store_path=str(store), dt=0.004)
+
+    with TestClient(app) as client:
+        yield client, state, tmp_path
+
+    with state.lock:
+        state.jobs.clear()
+        state.file_registry.clear()
+        state.cached_readers.clear()
+
+
+def test_refraction_qc_pick_map_from_uploaded_npz_before_statics(pick_map_client):
+    client, _state, tmp_path = pick_map_client
+    pick_path = tmp_path / 'picks.npz'
+    np.savez(
+        pick_path,
+        first_break_time_s=np.asarray([0.084, -1.0, 0.091, 0.102]),
+        n_traces=np.asarray(4),
+        n_samples=np.asarray(10),
+        dt=np.asarray(0.004),
+        trace_order=np.asarray('trace_store_sorted'),
+    )
+
+    response = client.post(
+        '/statics/refraction/qc/pick-map',
+        data={
+            'request_json': json.dumps(
+                {
+                    'file_id': FILE_ID,
+                    'key1_byte': KEY1,
+                    'key2_byte': KEY2,
+                    'pick_source': {'kind': 'uploaded_npz'},
+                    'geometry': {'receiver_number_mode': 'global_sequential'},
+                }
+            ),
+        },
+        files={'pick_npz': ('picks.npz', pick_path.read_bytes(), 'application/x-npz')},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['mode'] == 'pre_statics'
+    assert body.get('job_id') is None
+    assert body['has_after_statics'] is False
+    assert 'After Statics is unavailable' in body['status_message']
+    assert body['gather_range'] == {'min': 100, 'max': 101}
+    pick_map = body['pick_map']
+    assert pick_map['gather_id'] == [100, 101, 101]
+    assert pick_map['receiver_number'] == [2000, 2000, 2001]
+    assert pick_map['pick_before_ms'] == pytest.approx([84.0, 91.0, 102.0])
+    assert pick_map['pick_after_ms'] == [None, None, None]
+    assert pick_map['used_in_statics'] == [None, None, None]
+    assert pick_map['offset_m'] == pytest.approx([100.0, 100.0, 100.0])
+
+
+def test_refraction_qc_pick_map_before_statics_does_not_require_job_id(
+    pick_map_client,
+):
+    client, _state, tmp_path = pick_map_client
+    pick_path = tmp_path / 'picks.npz'
+    np.savez(
+        pick_path,
+        first_break_time_s=np.asarray([0.084, 0.086, 0.091, 0.102]),
+        trace_order=np.asarray('trace_store_sorted'),
+    )
+
+    response = client.post(
+        '/statics/refraction/qc/pick-map',
+        data={
+            'request_json': json.dumps(
+                {
+                    'file_id': FILE_ID,
+                    'pick_source': {'kind': 'uploaded_npz'},
+                }
+            ),
+        },
+        files={'pick_npz': ('picks.npz', pick_path.read_bytes(), 'application/x-npz')},
+    )
+
+    assert response.status_code == 200
+    assert response.json()['mode'] == 'pre_statics'
+
+
+def test_refraction_qc_pick_map_completed_job_includes_before_and_after_picks(
+    pick_map_client,
+):
+    client, state, tmp_path = pick_map_client
+    artifacts_dir = tmp_path / 'artifacts'
+    artifacts_dir.mkdir()
+    _write_completed_pick_map_artifacts(artifacts_dir)
+    job_id = 'pick-map-static-job'
+    with state.lock:
+        state.jobs.create_static_job(
+            job_id,
+            file_id=FILE_ID,
+            key1_byte=KEY1,
+            key2_byte=KEY2,
+            statics_kind='refraction',
+            artifacts_dir=str(artifacts_dir),
+        )
+        state.jobs.mark_done(job_id, progress_1=True)
+
+    response = client.post(
+        '/statics/refraction/qc/pick-map',
+        json={'job_id': job_id},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['mode'] == 'completed_job'
+    assert body['has_after_statics'] is True
+    pick_map = body['pick_map']
+    assert pick_map['pick_before_ms'] == pytest.approx([84.0, 91.0, 102.0])
+    assert pick_map['receiver_number'] == [2000, 2001, 2000]
+    assert pick_map['applied_shift_ms'] == pytest.approx([-10.0, 5.0, 0.0])
+    assert pick_map['pick_after_ms'] == pytest.approx([74.0, 96.0, 102.0])
+    assert pick_map['used_in_statics'] == [True, False, True]
+    assert pick_map['offset_used'] == [120.0, None, 300.0]
+
+
+def _write_trace_store(store: Path) -> None:
+    store.mkdir(parents=True)
+    traces = np.zeros((4, 10), dtype=np.float32)
+    np.save(store / 'traces.npy', traces)
+    np.savez(
+        store / 'index.npz',
+        key1_values=np.asarray([100, 101], dtype=np.int64),
+        key1_offsets=np.asarray([0, 2], dtype=np.int64),
+        key1_counts=np.asarray([2, 2], dtype=np.int64),
+        sorted_to_original=np.arange(4, dtype=np.int64),
+    )
+    np.save(store / f'headers_byte_{KEY1}.npy', np.asarray([100, 100, 101, 101]))
+    np.save(store / f'headers_byte_{KEY2}.npy', np.asarray([1, 2, 1, 2]))
+    np.save(store / 'headers_byte_9.npy', np.asarray([100, 100, 101, 101]))
+    np.save(store / 'headers_byte_13.npy', np.asarray([2000, 2001, 2000, 2001]))
+    np.save(store / 'headers_byte_73.npy', np.asarray([0, 0, 1000, 1000]))
+    np.save(store / 'headers_byte_77.npy', np.asarray([0, 0, 0, 0]))
+    np.save(store / 'headers_byte_81.npy', np.asarray([100, 100, 1100, 1100]))
+    np.save(store / 'headers_byte_85.npy', np.asarray([0, 0, 0, 0]))
+    np.save(store / 'headers_byte_45.npy', np.asarray([10, 10, 10, 10]))
+    np.save(store / 'headers_byte_41.npy', np.asarray([20, 20, 20, 20]))
+    np.save(store / 'headers_byte_71.npy', np.ones(4, dtype=np.int32))
+    np.save(store / 'headers_byte_69.npy', np.ones(4, dtype=np.int32))
+    (store / 'meta.json').write_text(
+        json.dumps(
+            {
+                'schema_version': 1,
+                'dtype': 'float32',
+                'n_traces': 4,
+                'n_samples': 10,
+                'key_bytes': {'key1': KEY1, 'key2': KEY2},
+                'sorted_by': ['key1', 'key2'],
+                'dt': 0.004,
+            }
+        ),
+        encoding='utf-8',
+    )
+
+
+def _write_completed_pick_map_artifacts(artifacts_dir: Path) -> None:
+    (artifacts_dir / REFRACTION_STATIC_QC_JSON_NAME).write_text(
+        json.dumps({'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION}),
+        encoding='utf-8',
+    )
+    _write_csv(
+        artifacts_dir / REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+        [
+            {
+                'trace_index_sorted': '0',
+                'source_id': '100',
+                'receiver_endpoint_key': 'receiver:2000',
+                'offset_m': '120.0',
+                'observed_first_break_time_s': '0.084',
+                'used_in_solve': 'true',
+            },
+            {
+                'trace_index_sorted': '1',
+                'source_id': '100',
+                'receiver_endpoint_key': 'receiver:2001:10:0:20',
+                'offset_m': '220.0',
+                'observed_first_break_time_s': '0.091',
+                'used_in_solve': 'false',
+            },
+            {
+                'trace_index_sorted': '2',
+                'source_id': '101',
+                'receiver_endpoint_key': 'receiver:2000',
+                'offset_m': '300.0',
+                'observed_first_break_time_s': '0.102',
+                'used_in_solve': 'true',
+            },
+        ],
+    )
+    _write_csv(
+        artifacts_dir / REFRACTION_STATIC_COMPONENT_QC_TRACE_CSV_NAME,
+        [
+            {'trace_index_sorted': '0', 'applied_trace_shift_ms': '-10.0'},
+            {'trace_index_sorted': '1', 'applied_trace_shift_ms': '5.0'},
+            {'trace_index_sorted': '2', 'applied_trace_shift_ms': '0.0'},
+        ],
+    )
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open('w', encoding='utf-8', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)


### PR DESCRIPTION
Closes #645

## Summary
- [ui][refraction-qc] Add all-gather receiver-vs-pick map with pre-statics support

## Changed files
- `app/api/routers/statics.py`
- `app/api/schemas.py`
- `app/services/refraction_static_pick_map.py`
- `app/static/refraction_qc.html`
- `app/static/refraction_qc.js`
- `tests/e2e/refraction_qc.spec.ts`
- `tests/test_refraction_qc_pick_map.py`

## Checks
- `.work/codex/checks.log`: 2429 passed in 70.01s (0:01:10)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
