### PR TITLE
[ui][refraction-qc][pick-map] Fix Pick Map review findings: reversed time axis, robust gather filter, NaN-tolerant pre-statics loading

### DIFF
--- a/app/services/refraction_static_pick_map.py
+++ b/app/services/refraction_static_pick_map.py
@@ -23,6 +23,7 @@ from app.services.refraction_static_pick_source_loader import (
     load_npz_refraction_pick_source_from_path,
 )
 from app.services.trace_store_index_validation import validate_sorted_to_original
+from app.utils.segy_scalars import apply_segy_scalar, normalize_linear_unit
 
 
 class RefractionStaticPickMapError(ValueError):
@@ -78,6 +79,7 @@ def _build_pre_statics_pick_map(
         dt_s=dt_s,
         sorted_trace_index=sorted_to_original,
         source_kind=req.pick_source.kind,
+        allow_invalid_pick_values=True,
     )
 
     geometry = req.geometry
@@ -316,6 +318,29 @@ def _geometry_offset_m(
         source_y = _float_header(reader.ensure_header(geometry.source_y_byte), n_traces)
         receiver_x = _float_header(reader.ensure_header(geometry.receiver_x_byte), n_traces)
         receiver_y = _float_header(reader.ensure_header(geometry.receiver_y_byte), n_traces)
+        coordinate_scalar = _int_header(
+            reader.ensure_header(geometry.coordinate_scalar_byte),
+            n_traces,
+        )
+    except Exception:
+        return np.full(n_traces, np.nan, dtype=np.float64)
+    try:
+        source_x = normalize_linear_unit(
+            apply_segy_scalar(source_x, coordinate_scalar),
+            geometry.coordinate_unit,
+        )
+        source_y = normalize_linear_unit(
+            apply_segy_scalar(source_y, coordinate_scalar),
+            geometry.coordinate_unit,
+        )
+        receiver_x = normalize_linear_unit(
+            apply_segy_scalar(receiver_x, coordinate_scalar),
+            geometry.coordinate_unit,
+        )
+        receiver_y = normalize_linear_unit(
+            apply_segy_scalar(receiver_y, coordinate_scalar),
+            geometry.coordinate_unit,
+        )
     except Exception:
         return np.full(n_traces, np.nan, dtype=np.float64)
     return np.ascontiguousarray(
@@ -441,6 +466,17 @@ def _float_header(values: object, n_traces: int) -> np.ndarray:
     return np.ascontiguousarray(arr, dtype=np.float64)
 
 
+def _int_header(values: object, n_traces: int) -> np.ndarray:
+    arr = np.asarray(values)
+    if arr.shape != (n_traces,):
+        raise RefractionStaticPickMapError(
+            f'header shape mismatch: expected {(n_traces,)}, got {arr.shape}'
+        )
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise RefractionStaticPickMapError('header must have an integer dtype')
+    return np.ascontiguousarray(arr, dtype=np.int64)
+
+
 def _required_float(value: object) -> float:
     out = _optional_float(value)
     if out is None:
@@ -480,11 +516,12 @@ def _optional_int(value: object) -> int | None:
 
 
 def _numeric_or_none(value: object) -> int | float | None:
-    if isinstance(value, str):
-        raw = value.rsplit(':', 1)[-1]
-    else:
-        raw = value
-    out = _optional_float(raw)
+    out = _optional_float(value)
+    if out is None and isinstance(value, str):
+        for part in value.split(':')[1:]:
+            out = _optional_float(part)
+            if out is not None:
+                break
     if out is None:
         return None
     return int(out) if out.is_integer() else out

--- a/app/services/refraction_static_pick_source_loader.py
+++ b/app/services/refraction_static_pick_source_loader.py
@@ -68,6 +68,7 @@ def load_npz_refraction_pick_source_from_path(
     dt_s: float,
     sorted_trace_index: np.ndarray,
     source_kind: str,
+    allow_invalid_pick_values: bool = False,
 ) -> LoadedRefractionPickSource:
     """Load a refraction pick NPZ and normalize pick times to sorted order."""
     path = Path(npz_path)
@@ -93,7 +94,10 @@ def load_npz_refraction_pick_source_from_path(
                 path=path,
                 key=key,
             )
-            picks = _coerce_pick_array(np.asarray(npz[key]))
+            picks = _coerce_pick_array(
+                np.asarray(npz[key]),
+                allow_invalid_pick_values=allow_invalid_pick_values,
+            )
             metadata['pick_shape'] = tuple(int(dim) for dim in picks.shape)
             if picks.shape != (n_traces,):
                 msg = (
@@ -226,14 +230,18 @@ def _read_npz_order(npz: np.lib.npyio.NpzFile) -> str:
     return REFRACTION_PICK_ORDER_ORIGINAL_TRACE
 
 
-def _coerce_pick_array(values: np.ndarray) -> np.ndarray:
+def _coerce_pick_array(
+    values: np.ndarray,
+    *,
+    allow_invalid_pick_values: bool = False,
+) -> np.ndarray:
     arr = np.asarray(values)
     if arr.ndim != 1:
         raise ValueError('pick_time_s_sorted must be 1D')
     if np.issubdtype(arr.dtype, np.bool_) or not _is_real_numeric_dtype(arr.dtype):
         raise ValueError('pick_time_s_sorted must have a real numeric dtype')
     out = np.ascontiguousarray(arr, dtype=np.float64)
-    if not np.all(np.isfinite(out)):
+    if not allow_invalid_pick_values and not np.all(np.isfinite(out)):
         raise ValueError('pick_time_s_sorted must contain only finite values')
     return out
 

--- a/app/static/refraction_qc.js
+++ b/app/static/refraction_qc.js
@@ -7,6 +7,18 @@
   const STATIC_PICK_STORE = 'pick_npz_blobs';
   const MAX_RECENT_JOBS = 8;
   const DEFAULT_MAX_POINTS = 20000;
+  const PICK_MAP_DRAFT_GEOMETRY_HEADER_FIELDS = [
+    'source_id_byte',
+    'receiver_id_byte',
+    'source_x_byte',
+    'source_y_byte',
+    'receiver_x_byte',
+    'receiver_y_byte',
+    'source_elevation_byte',
+    'receiver_elevation_byte',
+    'coordinate_scalar_byte',
+    'elevation_scalar_byte',
+  ];
 
   const VIEW_DEFS = [
     {
@@ -198,6 +210,44 @@
     return String(left.file_id || '') === String(right.file_id || '')
       && Number(left.key1_byte) === Number(right.key1_byte)
       && Number(left.key2_byte) === Number(right.key2_byte);
+  }
+
+  function pickMapDraftHeaderByte(value, { optional = false } = {}) {
+    const text = String(value ?? '').trim();
+    if (optional && !text) return null;
+    if (!/^\d+$/.test(text)) return undefined;
+    const parsed = Number(text);
+    return parsed >= 1 && parsed <= 240 ? parsed : undefined;
+  }
+
+  function staticCorrectionDraftPickMapGeometry(target) {
+    const draft = safeLocalStorageJson(STATIC_DRAFT_STORAGE_KEY);
+    if (!draft || draft.version !== 1 || !samePickMapTarget(draft.target, target)) return null;
+    const values = draft.form?.geometry;
+    if (!values || typeof values !== 'object') return null;
+
+    const geometry = { receiver_number_mode: 'global_sequential' };
+    for (const key of PICK_MAP_DRAFT_GEOMETRY_HEADER_FIELDS) {
+      const parsed = pickMapDraftHeaderByte(values[key]);
+      if (parsed === undefined) return null;
+      geometry[key] = parsed;
+    }
+    const sourceDepthByte = pickMapDraftHeaderByte(values.source_depth_byte, { optional: true });
+    if (sourceDepthByte === undefined) return null;
+    geometry.source_depth_byte = sourceDepthByte;
+
+    const coordinateUnit = String(values.coordinate_unit ?? '').trim();
+    const elevationUnit = String(values.elevation_unit ?? '').trim();
+    if (!['m', 'ft'].includes(coordinateUnit) || !['m', 'ft'].includes(elevationUnit)) {
+      return null;
+    }
+    geometry.coordinate_unit = coordinateUnit;
+    geometry.elevation_unit = elevationUnit;
+    return geometry;
+  }
+
+  function pickMapGeometryRequest(target) {
+    return staticCorrectionDraftPickMapGeometry(target) || { receiver_number_mode: 'global_sequential' };
   }
 
   function openStaticPickDb() {
@@ -706,6 +756,17 @@
     if (typeof value !== 'string') return NaN;
     const parsed = Number.parseFloat(value.trim());
     return Number.isFinite(parsed) ? parsed : NaN;
+  }
+
+  function pickMapGatherNumber(value) {
+    if (value === null || value === undefined) return NaN;
+    const text = String(value).trim();
+    const direct = Number(text);
+    if (Number.isFinite(direct)) return direct;
+    const tail = text
+      .split(':')
+      .find((part, index) => index > 0 && Number.isFinite(Number(part)));
+    return tail === undefined ? NaN : Number(tail);
   }
 
   function normalizedText(value) {
@@ -3331,7 +3392,7 @@
     const points = [];
     for (let index = 0; index < count; index += 1) {
       const gather = data.gather_id?.[index];
-      const gatherNumber = toFiniteNumber(gather);
+      const gatherNumber = pickMapGatherNumber(gather);
       if (hasStart && Number.isFinite(gatherNumber) && gatherNumber < start) continue;
       if (hasEnd && Number.isFinite(gatherNumber) && gatherNumber > end) continue;
       const beforeMs = toFiniteNumber(data.pick_before_ms?.[index]);
@@ -3415,7 +3476,7 @@
       paper_bgcolor: '#ffffff',
       plot_bgcolor: '#ffffff',
       xaxis: { title: { text: 'Global receiver number' }, gridcolor: '#e5e7eb', zeroline: false },
-      yaxis: { title: { text: 'First-break pick time (ms)' }, gridcolor: '#e5e7eb', zeroline: false },
+      yaxis: { title: { text: 'First-break pick time (ms)' }, autorange: 'reversed', gridcolor: '#e5e7eb', zeroline: false },
       legend: { orientation: 'h', x: 0, y: 1.14, xanchor: 'left', yanchor: 'top', font: { size: 10 } },
     }, { displayModeBar: false, responsive: true });
   }
@@ -3596,7 +3657,7 @@
         key1_byte: target.key1_byte,
         key2_byte: target.key2_byte,
         pick_source: { kind: 'uploaded_npz' },
-        geometry: { receiver_number_mode: 'global_sequential' },
+        geometry: pickMapGeometryRequest(target),
       },
       error: '',
     };
@@ -3934,6 +3995,7 @@
     loadGatherPreview,
     setSelectedView,
     activateSidebarTab,
+    pickMapGatherNumber,
   };
 
   if (document.readyState === 'loading') {

--- a/tests/e2e/refraction_qc.spec.ts
+++ b/tests/e2e/refraction_qc.spec.ts
@@ -1122,10 +1122,11 @@ async function seedStaticCorrectionPickCache(
 		key2Byte = 13,
 		filename = 'active-viewer-picks.npz',
 		recordId = 'target:active-viewer-store:9:13:latest',
+		form = {},
 	} = {},
 ) {
 	await page.evaluate(
-		async ({ fileId, key1Byte, key2Byte, filename, recordId }) => {
+		async ({ fileId, key1Byte, key2Byte, filename, recordId, form }) => {
 			window.localStorage.removeItem('file_id');
 			window.localStorage.removeItem('key1_byte');
 			window.localStorage.removeItem('key2_byte');
@@ -1191,11 +1192,11 @@ async function seedStaticCorrectionPickCache(
 						key1Byte,
 						key2Byte,
 					},
-					form: {},
+					form,
 				}),
 			);
 		},
-		{ fileId, key1Byte, key2Byte, filename, recordId },
+		{ fileId, key1Byte, key2Byte, filename, recordId, form },
 	);
 }
 
@@ -1244,7 +1245,7 @@ test('Refraction QC Pick Map loads cached NPZ from active viewer target state', 
 	});
 	await page.goto('/refraction-qc');
 	await page.addScriptTag({
-		content: 'window.Plotly = { newPlot: (element, traces) => { element.dataset.traceCount = String(traces.length); } };',
+		content: 'window.Plotly = { newPlot: (element, traces, layout) => { element.dataset.traceCount = String(traces.length); element.dataset.yAxisAutorange = String(layout?.yaxis?.autorange || ""); } };',
 	});
 	await seedStaticCorrectionPickCache(page);
 
@@ -1255,6 +1256,7 @@ test('Refraction QC Pick Map loads cached NPZ from active viewer target state', 
 	await page.getByTestId('refraction-qc-pick-map-load-cached').click();
 
 	await expect(page.getByTestId('refraction-qc-pick-map-status')).toContainText('Pre-statics pick map loaded');
+	await expect(page.getByTestId('refraction-qc-pick-map-plot')).toHaveAttribute('data-y-axis-autorange', 'reversed');
 	expect(pickMapRequest).toMatchObject({
 		file_id: 'active-viewer-store',
 		key1_byte: 9,
@@ -1262,6 +1264,150 @@ test('Refraction QC Pick Map loads cached NPZ from active viewer target state', 
 		pick_source: { kind: 'uploaded_npz' },
 		geometry: { receiver_number_mode: 'global_sequential' },
 	});
+});
+
+test('Refraction QC Pick Map filters numeric and endpoint-key gather IDs', async ({ page }) => {
+	await page.addInitScript(() => {
+		(window as any).SeisViewerState = {
+			getActiveFileTarget: () => ({
+				fileId: 'active-viewer-store',
+				displayName: 'active-viewer-store.sgy',
+				key1Byte: 9,
+				key2Byte: 13,
+				isFileLoaded: true,
+			}),
+			getActiveFileTargetState: () => ({
+				fileId: 'active-viewer-store',
+				displayName: 'active-viewer-store.sgy',
+				key1Byte: 9,
+				key2Byte: 13,
+				isFileLoaded: true,
+			}),
+		};
+	});
+	await page.route('**/statics/refraction/qc/pick-map', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				mode: 'pre_statics',
+				job_id: null,
+				has_after_statics: false,
+				receiver_number_mode: 'global_sequential',
+				gather_range: { min: 99, max: 103 },
+				status_message: 'Pre-statics pick map loaded.',
+				pick_map: {
+					gather_id: [99, 100, 'source:101', 'source:102:10:20', 103],
+					receiver_number: [2000, 2001, 2002, 2003, 2004],
+					pick_before_ms: [80, 84, 91, 102, 110],
+					pick_after_ms: [null, null, null, null, null],
+					used_in_statics: [null, null, null, null, null],
+					offset_m: [100, 120, 140, 160, 180],
+				},
+			}),
+		});
+	});
+	await page.goto('/refraction-qc');
+	await page.addScriptTag({
+		content: 'window.Plotly = { newPlot: () => {} };',
+	});
+	await seedStaticCorrectionPickCache(page);
+
+	await page.getByTestId('refraction-qc-view-pick-map-button').click();
+	await page.getByTestId('refraction-qc-pick-map-load-cached').click();
+	await expect(page.getByTestId('refraction-qc-pick-map-plot')).toHaveAttribute('data-point-count', '5');
+
+	await page.getByTestId('refraction-qc-pick-map-gather-start').fill('100');
+	await page.getByTestId('refraction-qc-pick-map-gather-end').fill('101');
+	await expect(page.getByTestId('refraction-qc-pick-map-plot')).toHaveAttribute('data-point-count', '2');
+});
+
+test('Refraction QC pre-statics Pick Map uses Static Correction draft geometry', async ({ page }) => {
+	let pickMapRequest: Record<string, unknown> | null = null;
+	await page.addInitScript(() => {
+		(window as any).SeisViewerState = {
+			getActiveFileTarget: () => ({
+				fileId: 'active-viewer-store',
+				displayName: 'active-viewer-store.sgy',
+				key1Byte: 9,
+				key2Byte: 13,
+				isFileLoaded: true,
+			}),
+			getActiveFileTargetState: () => ({
+				fileId: 'active-viewer-store',
+				displayName: 'active-viewer-store.sgy',
+				key1Byte: 9,
+				key2Byte: 13,
+				isFileLoaded: true,
+			}),
+		};
+	});
+	await page.route('**/statics/refraction/qc/pick-map', async (route) => {
+		pickMapRequest = multipartRequestJson(route);
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				mode: 'pre_statics',
+				job_id: null,
+				has_after_statics: false,
+				receiver_number_mode: 'global_sequential',
+				gather_range: { min: 100, max: 100 },
+				status_message: 'Pre-statics pick map loaded.',
+				pick_map: {
+					gather_id: [100],
+					receiver_number: [2000],
+					pick_before_ms: [84],
+					pick_after_ms: [null],
+					used_in_statics: [null],
+					offset_m: [120],
+				},
+			}),
+		});
+	});
+	await page.goto('/refraction-qc');
+	await page.addScriptTag({ content: 'window.Plotly = { newPlot: () => {} };' });
+	await seedStaticCorrectionPickCache(page, {
+		form: {
+			geometry: {
+				source_id_byte: '21',
+				receiver_id_byte: '25',
+				source_x_byte: '101',
+				source_y_byte: '105',
+				receiver_x_byte: '109',
+				receiver_y_byte: '113',
+				source_elevation_byte: '117',
+				receiver_elevation_byte: '121',
+				coordinate_scalar_byte: '125',
+				elevation_scalar_byte: '129',
+				source_depth_byte: '',
+				coordinate_unit: 'ft',
+				elevation_unit: 'm',
+				offset_byte: '133',
+			},
+		},
+	});
+
+	await page.getByTestId('refraction-qc-view-pick-map-button').click();
+	await page.getByTestId('refraction-qc-pick-map-load-cached').click();
+	await expect(page.getByTestId('refraction-qc-pick-map-status')).toContainText('Pre-statics pick map loaded');
+
+	expect(pickMapRequest).toMatchObject({
+		geometry: {
+			receiver_number_mode: 'global_sequential',
+			source_id_byte: 21,
+			receiver_id_byte: 25,
+			source_x_byte: 101,
+			source_y_byte: 105,
+			receiver_x_byte: 109,
+			receiver_y_byte: 113,
+			coordinate_scalar_byte: 125,
+			coordinate_unit: 'ft',
+			elevation_unit: 'm',
+			source_depth_byte: null,
+		},
+	});
+	expect((pickMapRequest?.geometry as Record<string, unknown>).offset_byte).toBeUndefined();
 });
 
 async function routeCompletedStaticCorrectionFlow(

--- a/tests/test_refraction_qc_pick_map.py
+++ b/tests/test_refraction_qc_pick_map.py
@@ -117,6 +117,131 @@ def test_refraction_qc_pick_map_before_statics_does_not_require_job_id(
     assert response.json()['mode'] == 'pre_statics'
 
 
+def test_pick_map_pre_statics_accepts_nan_missing_picks_and_plots_valid_only(
+    pick_map_client,
+):
+    client, _state, tmp_path = pick_map_client
+    pick_path = tmp_path / 'picks-nan.npz'
+    np.savez(
+        pick_path,
+        first_break_time_s=np.asarray([0.084, np.nan, np.inf, 0.102]),
+        trace_order=np.asarray('trace_store_sorted'),
+    )
+
+    response = client.post(
+        '/statics/refraction/qc/pick-map',
+        data={
+            'request_json': json.dumps(
+                {
+                    'file_id': FILE_ID,
+                    'pick_source': {'kind': 'uploaded_npz'},
+                }
+            ),
+        },
+        files={'pick_npz': ('picks.npz', pick_path.read_bytes(), 'application/x-npz')},
+    )
+
+    assert response.status_code == 200
+    pick_map = response.json()['pick_map']
+    assert pick_map['trace_index'] == [0, 3]
+    assert pick_map['pick_before_ms'] == pytest.approx([84.0, 102.0])
+
+
+def test_pick_map_pre_statics_accepts_negative_sentinel_and_plots_valid_only(
+    pick_map_client,
+):
+    client, _state, tmp_path = pick_map_client
+    pick_path = tmp_path / 'picks-sentinel.npz'
+    np.savez(
+        pick_path,
+        first_break_time_s=np.asarray([0.084, -1.0, 0.091, -999.25]),
+        trace_order=np.asarray('trace_store_sorted'),
+    )
+
+    response = client.post(
+        '/statics/refraction/qc/pick-map',
+        data={
+            'request_json': json.dumps(
+                {
+                    'file_id': FILE_ID,
+                    'pick_source': {'kind': 'uploaded_npz'},
+                }
+            ),
+        },
+        files={'pick_npz': ('picks.npz', pick_path.read_bytes(), 'application/x-npz')},
+    )
+
+    assert response.status_code == 200
+    pick_map = response.json()['pick_map']
+    assert pick_map['trace_index'] == [0, 2]
+    assert pick_map['pick_before_ms'] == pytest.approx([84.0, 91.0])
+
+
+def test_pick_map_pre_statics_applies_negative_coordinate_scalar(
+    pick_map_client,
+):
+    client, _state, tmp_path = pick_map_client
+    np.save(tmp_path / 'store' / 'headers_byte_71.npy', np.full(4, -10, dtype=np.int32))
+    pick_path = tmp_path / 'picks-scaled.npz'
+    np.savez(
+        pick_path,
+        first_break_time_s=np.asarray([0.084, 0.086, 0.091, 0.102]),
+        trace_order=np.asarray('trace_store_sorted'),
+    )
+
+    response = client.post(
+        '/statics/refraction/qc/pick-map',
+        data={
+            'request_json': json.dumps(
+                {
+                    'file_id': FILE_ID,
+                    'pick_source': {'kind': 'uploaded_npz'},
+                    'geometry': {
+                        'receiver_number_mode': 'global_sequential',
+                        'coordinate_scalar_byte': 71,
+                    },
+                }
+            ),
+        },
+        files={'pick_npz': ('picks.npz', pick_path.read_bytes(), 'application/x-npz')},
+    )
+
+    assert response.status_code == 200
+    assert response.json()['pick_map']['offset_m'] == pytest.approx([10.0] * 4)
+
+
+def test_pick_map_pre_statics_converts_coordinate_feet_to_meters(
+    pick_map_client,
+):
+    client, _state, tmp_path = pick_map_client
+    pick_path = tmp_path / 'picks-feet.npz'
+    np.savez(
+        pick_path,
+        first_break_time_s=np.asarray([0.084, 0.086, 0.091, 0.102]),
+        trace_order=np.asarray('trace_store_sorted'),
+    )
+
+    response = client.post(
+        '/statics/refraction/qc/pick-map',
+        data={
+            'request_json': json.dumps(
+                {
+                    'file_id': FILE_ID,
+                    'pick_source': {'kind': 'uploaded_npz'},
+                    'geometry': {
+                        'receiver_number_mode': 'global_sequential',
+                        'coordinate_unit': 'ft',
+                    },
+                }
+            ),
+        },
+        files={'pick_npz': ('picks.npz', pick_path.read_bytes(), 'application/x-npz')},
+    )
+
+    assert response.status_code == 200
+    assert response.json()['pick_map']['offset_m'] == pytest.approx([30.48] * 4)
+
+
 def test_refraction_qc_pick_map_completed_job_includes_before_and_after_picks(
     pick_map_client,
 ):
@@ -152,6 +277,64 @@ def test_refraction_qc_pick_map_completed_job_includes_before_and_after_picks(
     assert pick_map['pick_after_ms'] == pytest.approx([74.0, 96.0, 102.0])
     assert pick_map['used_in_statics'] == [True, False, True]
     assert pick_map['offset_used'] == [120.0, None, 300.0]
+
+
+def test_pick_map_completed_job_gather_range_reports_endpoint_key_numeric_suffix(
+    pick_map_client,
+):
+    client, state, tmp_path = pick_map_client
+    artifacts_dir = tmp_path / 'endpoint-artifacts'
+    artifacts_dir.mkdir()
+    (artifacts_dir / REFRACTION_STATIC_QC_JSON_NAME).write_text(
+        json.dumps({'sign_convention': REFRACTION_STATIC_REPO_SIGN_CONVENTION}),
+        encoding='utf-8',
+    )
+    _write_csv(
+        artifacts_dir / REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+        [
+            {
+                'trace_index_sorted': '0',
+                'source_endpoint_key': 'source:100',
+                'receiver_endpoint_key': 'receiver:2000',
+                'offset_m': '120.0',
+                'observed_first_break_time_s': '0.084',
+                'used_in_solve': 'true',
+            },
+            {
+                'trace_index_sorted': '1',
+                'source_endpoint_key': 'source:101:10:20',
+                'receiver_endpoint_key': 'receiver:2001',
+                'offset_m': '220.0',
+                'observed_first_break_time_s': '0.091',
+                'used_in_solve': 'true',
+            },
+        ],
+    )
+    _write_csv(
+        artifacts_dir / REFRACTION_STATIC_COMPONENT_QC_TRACE_CSV_NAME,
+        [
+            {'trace_index_sorted': '0', 'applied_trace_shift_ms': '0.0'},
+            {'trace_index_sorted': '1', 'applied_trace_shift_ms': '0.0'},
+        ],
+    )
+    job_id = 'pick-map-endpoint-job'
+    with state.lock:
+        state.jobs.create_static_job(
+            job_id,
+            file_id=FILE_ID,
+            key1_byte=KEY1,
+            key2_byte=KEY2,
+            statics_kind='refraction',
+            artifacts_dir=str(artifacts_dir),
+        )
+        state.jobs.mark_done(job_id, progress_1=True)
+
+    response = client.post('/statics/refraction/qc/pick-map', json={'job_id': job_id})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['gather_range'] == {'min': 100, 'max': 101}
+    assert body['pick_map']['gather_id'] == ['source:100', 'source:101:10:20']
 
 
 def _write_trace_store(store: Path) -> None:


### PR DESCRIPTION
Closes #647

## Summary
- [ui][refraction-qc][pick-map] Fix Pick Map review findings: reversed time axis, robust gather filter, NaN-tolerant pre-statics loading

## Changed files
- `app/services/refraction_static_pick_map.py`
- `app/services/refraction_static_pick_source_loader.py`
- `app/static/refraction_qc.js`
- `tests/e2e/refraction_qc.spec.ts`
- `tests/test_refraction_qc_pick_map.py`

## Checks
- `.work/codex/checks.log`: 2434 passed in 69.96s (0:01:09)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
