### PR TITLE
[ui][refraction-qc] Add station structure QC panel for source/receiver time-term, velocity, and depth

### DIFF
--- a/app/api/routers/statics.py
+++ b/app/api/routers/statics.py
@@ -25,6 +25,8 @@ from app.api.schemas import (
     RefractionStaticExportJobResponse,
     RefractionStaticGatherPreviewRequest,
     RefractionStaticGatherPreviewResponse,
+    RefractionStaticStationStructureRequest,
+    RefractionStaticStationStructureResponse,
     RefractionStaticQcBundleRequest,
     RefractionStaticQcBundleResponse,
     RefractionStaticQcDrilldownRequest,
@@ -72,6 +74,10 @@ from app.services.refraction_static_qc_drilldown import (
     RefractionStaticQcDrilldownError,
     RefractionStaticQcDrilldownNotFound,
     build_refraction_static_qc_drilldown,
+)
+from app.services.refraction_static_station_structure import (
+    RefractionStaticStationStructureError,
+    build_refraction_static_station_structure,
 )
 from app.services.refraction_static_pick_map import (
     RefractionStaticPickMapError,
@@ -614,6 +620,28 @@ def refraction_static_qc_drilldown(
     except RefractionStaticQcDrilldownNotFound as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except RefractionStaticQcDrilldownError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.post(
+    '/statics/refraction/qc/station-structure',
+    response_model=RefractionStaticStationStructureResponse,
+)
+def refraction_static_qc_station_structure(
+    req: RefractionStaticStationStructureRequest,
+    request: Request,
+) -> RefractionStaticStationStructureResponse:
+    """Return source/receiver station-structure QC series."""
+    state = get_state(request.app)
+    cleanup_in_memory_state(state)
+    job = _get_static_job_or_404(state, req.job_id)
+    try:
+        return build_refraction_static_station_structure(
+            job_id=req.job_id,
+            job=job,
+            req=req,
+        )
+    except RefractionStaticStationStructureError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -31,6 +31,29 @@ RefractionStaticQcBundleCoordinateMode = Literal[
     'line_2d_projected',
     'grid_3d',
 ]
+RefractionStaticStationStructureXAxis = Literal[
+    'auto',
+    'global_receiver_number',
+    'station_number',
+    'inline_m',
+]
+RefractionStaticStationStructureVelocityField = Literal[
+    'auto',
+    'v1',
+    'v2',
+    'v3',
+    'vsub',
+]
+RefractionStaticStationStructureDepthField = Literal[
+    'auto',
+    'sh1',
+    'sh2',
+    'sh3',
+    'refractor_depth',
+    'refractor_elevation',
+    'layer1_base_elevation',
+    'layer2_base_elevation',
+]
 RefractionStaticGatherPreviewAxis = Literal['section', 'source', 'receiver']
 RefractionStaticGatherPreviewOverlayLayer = Literal[
     'observed_first_break',
@@ -3224,6 +3247,75 @@ class RefractionStaticPickMapResponse(BaseModel):
     receiver_number_mode: Literal['global_sequential']
     gather_range: dict[str, int | float | str | None]
     pick_map: RefractionStaticPickMapData
+
+
+class RefractionStaticStationStructureRequest(BaseModel):
+    """Request model for station-structure refraction QC."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    job_id: str
+    gather_start: float | None = None
+    gather_end: float | None = None
+    x_axis: RefractionStaticStationStructureXAxis = 'auto'
+    velocity_field: RefractionStaticStationStructureVelocityField = 'auto'
+    depth_field: RefractionStaticStationStructureDepthField = 'auto'
+
+    @field_validator('job_id')
+    @classmethod
+    def _check_job_id(cls, value: str) -> str:
+        if not isinstance(value, str) or not value:
+            raise ValueError('job_id must be a non-empty string')
+        return value
+
+    @field_validator('gather_start', 'gather_end', mode='before')
+    @classmethod
+    def _check_optional_gather_bound(cls, value: object, info: Any) -> float | None:
+        if value is None or value == '':
+            return None
+        return _require_finite_float(value, info.field_name)
+
+
+class RefractionStaticStationStructureSeries(BaseModel):
+    """Columnar series for one endpoint side in station-structure QC."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    x: list[float | int]
+    y: list[float]
+    endpoint_key: list[str]
+    status: list[str]
+
+
+class RefractionStaticStationStructurePanel(BaseModel):
+    """One station-structure QC plot payload."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    field: str
+    label: str
+    unit: str
+    source: RefractionStaticStationStructureSeries
+    receiver: RefractionStaticStationStructureSeries
+
+
+class RefractionStaticStationStructureResponse(BaseModel):
+    """Station-structure QC payload for completed refraction static jobs."""
+
+    model_config = ConfigDict(extra='forbid')
+
+    job_id: str
+    statics_kind: Literal['refraction']
+    view_kind: Literal['station_structure']
+    x_axis: str
+    x_axis_label: str
+    filter_status: str
+    gather_range: dict[str, int | float | str | None]
+    colors: dict[Literal['source', 'receiver'], str]
+    time_term: RefractionStaticStationStructurePanel
+    velocity: RefractionStaticStationStructurePanel
+    depth: RefractionStaticStationStructurePanel
+    warnings: list[str] = Field(default_factory=list)
 
 
 class RefractionStaticQcDrilldownEndpointTarget(BaseModel):

--- a/app/services/refraction_static_station_structure.py
+++ b/app/services/refraction_static_station_structure.py
@@ -1,0 +1,682 @@
+"""Station-structure QC assembly for completed refraction static jobs."""
+
+from __future__ import annotations
+
+import csv
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from app.api.schemas import RefractionStaticStationStructureRequest
+from app.services.job_manager import JobManager
+from app.services.refraction_static_artifacts import (
+    RECEIVER_STATIC_TABLE_CSV_NAME,
+    REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+    REFRACTION_FIRST_BREAK_FIT_QC_NPZ_NAME,
+    REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+    SOURCE_STATIC_TABLE_CSV_NAME,
+)
+
+
+class RefractionStaticStationStructureError(ValueError):
+    """Raised when station-structure QC cannot be assembled."""
+
+
+_NUMERIC_SUFFIX_RE = re.compile(r'([-+]?\d+(?:\.\d+)?)\s*$')
+
+_VELOCITY_FIELDS = ('v2', 'v1', 'v3', 'vsub')
+_DEPTH_FIELDS = (
+    'sh1',
+    'sh2',
+    'sh3',
+    'refractor_depth',
+    'refractor_elevation',
+    'layer1_base_elevation',
+    'layer2_base_elevation',
+)
+
+_DEPTH_LABELS = {
+    'sh1': 'Weathering thickness SH1',
+    'sh2': 'Weathering thickness SH2',
+    'sh3': 'Weathering thickness SH3',
+    'refractor_depth': 'Refractor depth',
+    'refractor_elevation': 'Refractor elevation',
+    'layer1_base_elevation': 'Layer 1 base elevation',
+    'layer2_base_elevation': 'Layer 2 base elevation',
+}
+
+
+def build_refraction_static_station_structure(
+    *,
+    job_id: str,
+    job: dict[str, object],
+    req: RefractionStaticStationStructureRequest,
+) -> dict[str, Any]:
+    """Build columnar station-structure QC data from completed artifacts."""
+    if job.get('statics_kind') != 'refraction':
+        raise RefractionStaticStationStructureError(
+            f'Job {job_id} is not a refraction statics job'
+        )
+    if not JobManager.is_ready_status_value(job.get('status')):
+        raise RefractionStaticStationStructureError(
+            f'Job {job_id} is not complete; current state is '
+            f'{JobManager.normalize_status_value(job.get("status"))}'
+        )
+
+    artifacts_dir = _job_artifacts_dir(job, job_id)
+    rows = _read_endpoint_rows(artifacts_dir)
+    if not rows:
+        raise RefractionStaticStationStructureError(
+            'Station-structure QC requires endpoint static artifacts'
+        )
+
+    warnings: list[str] = []
+    source_rows, receiver_rows, filter_status = _apply_gather_filter(
+        rows,
+        artifacts_dir=artifacts_dir,
+        req=req,
+        warnings=warnings,
+    )
+    x_axis, x_axis_label = _resolve_x_axis(source_rows + receiver_rows, req.x_axis)
+    velocity_field = _resolve_velocity_field(source_rows, receiver_rows, req.velocity_field)
+    depth_field = _resolve_depth_field(source_rows, receiver_rows, req.depth_field)
+    _append_linked_node_velocity_warning(
+        source_rows,
+        receiver_rows,
+        x_axis,
+        velocity_field,
+        warnings,
+    )
+
+    return {
+        'job_id': job_id,
+        'statics_kind': 'refraction',
+        'view_kind': 'station_structure',
+        'x_axis': x_axis,
+        'x_axis_label': x_axis_label,
+        'filter_status': filter_status,
+        'gather_range': {
+            'start': req.gather_start,
+            'end': req.gather_end,
+        },
+        'colors': {
+            'source': 'cyan',
+            'receiver': 'red',
+        },
+        'time_term': {
+            'field': _time_term_field_for_velocity(velocity_field),
+            'label': 'Time-term distribution',
+            'unit': 'ms',
+            'source': _series(
+                source_rows,
+                'source',
+                x_axis,
+                lambda kind, row: _time_term_candidates(kind, row, velocity_field),
+            ),
+            'receiver': _series(
+                receiver_rows,
+                'receiver',
+                x_axis,
+                lambda kind, row: _time_term_candidates(kind, row, velocity_field),
+            ),
+        },
+        'velocity': {
+            'field': velocity_field,
+            'label': f'Velocity structure: {velocity_field.upper()}',
+            'unit': 'm/s',
+            'source': _series(
+                source_rows,
+                'source',
+                x_axis,
+                lambda kind, row: _velocity_candidates(kind, row, velocity_field),
+            ),
+            'receiver': _series(
+                receiver_rows,
+                'receiver',
+                x_axis,
+                lambda kind, row: _velocity_candidates(kind, row, velocity_field),
+            ),
+        },
+        'depth': {
+            'field': depth_field,
+            'label': _DEPTH_LABELS[depth_field],
+            'unit': 'm',
+            'source': _series(
+                source_rows,
+                'source',
+                x_axis,
+                lambda kind, row: _depth_candidates(kind, row, depth_field),
+            ),
+            'receiver': _series(
+                receiver_rows,
+                'receiver',
+                x_axis,
+                lambda kind, row: _depth_candidates(kind, row, depth_field),
+            ),
+        },
+        'warnings': warnings,
+    }
+
+
+def _job_artifacts_dir(job: dict[str, object], job_id: str) -> Path:
+    raw = job.get('artifacts_dir')
+    if not isinstance(raw, str) or not raw:
+        raise RefractionStaticStationStructureError(
+            f'Job {job_id} metadata is missing artifacts_dir'
+        )
+    path = Path(raw)
+    if not path.is_dir():
+        raise RefractionStaticStationStructureError(
+            f'Job {job_id} artifacts directory is not available'
+        )
+    return path
+
+
+def _read_endpoint_rows(artifacts_dir: Path) -> list[dict[str, Any]]:
+    combined = artifacts_dir / REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME
+    if combined.is_file():
+        rows = _read_csv(combined)
+        if rows:
+            return rows
+
+    rows: list[dict[str, Any]] = []
+    source_path = artifacts_dir / SOURCE_STATIC_TABLE_CSV_NAME
+    if source_path.is_file():
+        for row in _read_csv(source_path):
+            row.setdefault('endpoint_kind', 'source')
+            if not row.get('endpoint_key') and row.get('source_endpoint_key'):
+                row['endpoint_key'] = row['source_endpoint_key']
+            rows.append(row)
+    receiver_path = artifacts_dir / RECEIVER_STATIC_TABLE_CSV_NAME
+    if receiver_path.is_file():
+        for row in _read_csv(receiver_path):
+            row.setdefault('endpoint_kind', 'receiver')
+            if not row.get('endpoint_key') and row.get('receiver_endpoint_key'):
+                row['endpoint_key'] = row['receiver_endpoint_key']
+            rows.append(row)
+    return rows
+
+
+def _read_csv(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding='utf-8', newline='') as handle:
+        return [dict(row) for row in csv.DictReader(handle)]
+
+
+def _apply_gather_filter(
+    rows: list[dict[str, Any]],
+    *,
+    artifacts_dir: Path,
+    req: RefractionStaticStationStructureRequest,
+    warnings: list[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str]:
+    source_rows = [row for row in rows if _endpoint_kind(row) == 'source']
+    receiver_rows = [row for row in rows if _endpoint_kind(row) == 'receiver']
+    if req.gather_start is None and req.gather_end is None:
+        return source_rows, receiver_rows, 'unfiltered'
+
+    filtered_sources = [
+        row for row in source_rows if _include_gather_number(_source_gather_number(row), req)
+    ]
+    observations = _read_observation_rows(artifacts_dir)
+    if observations is None:
+        warnings.append(
+            'Receiver participation for the selected shot-gather range could not '
+            'be determined from available first-break QC artifacts; receiver '
+            'series is unfiltered.'
+        )
+        return filtered_sources, receiver_rows, 'receiver_participation_unavailable'
+
+    receiver_keys: set[str] = set()
+    receiver_numbers: set[float] = set()
+    has_filterable_observation = False
+    for row in observations:
+        gather_number = _observation_source_gather_number(row)
+        if gather_number is None:
+            continue
+        has_filterable_observation = True
+        if not _include_gather_number(gather_number, req):
+            continue
+        receiver_key = _first_text(
+            row,
+            'receiver_endpoint_key',
+            'receiver_key',
+            'endpoint_key',
+        )
+        if receiver_key:
+            receiver_keys.add(receiver_key)
+        receiver_number = _numeric_or_none(
+            _first_present(
+                row,
+                'receiver_id',
+                'endpoint_id',
+                'global_receiver_number',
+                'station_number',
+                'receiver_number',
+            )
+        )
+        if receiver_number is not None:
+            receiver_numbers.add(receiver_number)
+
+    if not has_filterable_observation:
+        warnings.append(
+            'Receiver participation for the selected shot-gather range could not '
+            'be determined because available first-break QC artifacts do not '
+            'include usable source gather identifiers; receiver series is '
+            'unfiltered.'
+        )
+        return filtered_sources, receiver_rows, 'receiver_participation_unavailable'
+
+    filtered_receivers = [
+        row
+        for row in receiver_rows
+        if _endpoint_identity_matches(row, receiver_keys, receiver_numbers)
+    ]
+    return filtered_sources, filtered_receivers, 'ok'
+
+
+def _read_observation_rows(artifacts_dir: Path) -> list[dict[str, Any]] | None:
+    npz_path = artifacts_dir / REFRACTION_FIRST_BREAK_FIT_QC_NPZ_NAME
+    if npz_path.is_file():
+        return _read_observation_rows_from_npz(npz_path)
+    csv_path = artifacts_dir / REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME
+    if csv_path.is_file():
+        return _read_csv(csv_path)
+    return None
+
+
+def _read_observation_rows_from_npz(path: Path) -> list[dict[str, Any]]:
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            n_rows = 0
+            for key in data.files:
+                value = np.asarray(data[key])
+                if value.ndim > 0:
+                    n_rows = int(value.shape[0])
+                    break
+            rows: list[dict[str, Any]] = []
+            for index in range(n_rows):
+                row: dict[str, Any] = {}
+                for key in data.files:
+                    value = np.asarray(data[key])
+                    if value.ndim == 0 or value.shape[0] != n_rows:
+                        continue
+                    row[key] = _np_scalar_to_python(value[index])
+                rows.append(row)
+            return rows
+    except Exception as exc:  # noqa: BLE001
+        raise RefractionStaticStationStructureError(
+            f'Could not read refraction observation artifact {path.name}'
+        ) from exc
+
+
+def _np_scalar_to_python(value: object) -> object:
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, bytes):
+        return value.decode('utf-8', errors='replace')
+    return value
+
+
+def _resolve_x_axis(
+    rows: list[dict[str, Any]],
+    requested: str,
+) -> tuple[str, str]:
+    if requested != 'auto':
+        if requested == 'inline_m':
+            return 'inline_m', 'Inline distance (m)'
+        return requested, _x_axis_label(requested)
+    for field in ('global_receiver_number', 'station_number', 'receiver_number'):
+        if any(_numeric_or_none(row.get(field)) is not None for row in rows):
+            return field, _x_axis_label(field)
+    for field in ('endpoint_id', 'source_id', 'receiver_id'):
+        if any(_numeric_or_none(row.get(field)) is not None for row in rows):
+            return field, _x_axis_label(field)
+    if any(_numeric_suffix(_endpoint_key(row)) is not None for row in rows):
+        return 'endpoint_key_numeric_suffix', 'Station number'
+    if any(_numeric_or_none(row.get('inline_m')) is not None for row in rows):
+        return 'inline_m', 'Inline distance (m)'
+    raise RefractionStaticStationStructureError(
+        'Station-structure QC requires a station-like x-axis field'
+    )
+
+
+def _x_axis_label(field: str) -> str:
+    if field == 'global_receiver_number':
+        return 'Global receiver number'
+    if field in {'station_number', 'receiver_number', 'endpoint_id', 'source_id', 'receiver_id'}:
+        return 'Station number'
+    if field == 'inline_m':
+        return 'Inline distance (m)'
+    return field.replace('_', ' ').title()
+
+
+def _resolve_velocity_field(
+    source_rows: list[dict[str, Any]],
+    receiver_rows: list[dict[str, Any]],
+    requested: str,
+) -> str:
+    if requested != 'auto':
+        return requested
+    for field in _VELOCITY_FIELDS:
+        if _has_series_values(source_rows, receiver_rows, lambda kind, row: _velocity_candidates(kind, row, field)):
+            return field
+    return 'v2'
+
+
+def _resolve_depth_field(
+    source_rows: list[dict[str, Any]],
+    receiver_rows: list[dict[str, Any]],
+    requested: str,
+) -> str:
+    if requested != 'auto':
+        return requested
+    for field in _DEPTH_FIELDS:
+        if _has_series_values(source_rows, receiver_rows, lambda kind, row: _depth_candidates(kind, row, field)):
+            return field
+    return 'sh1'
+
+
+def _has_series_values(
+    source_rows: list[dict[str, Any]],
+    receiver_rows: list[dict[str, Any]],
+    candidates_for: Any,
+) -> bool:
+    for kind, rows in (('source', source_rows), ('receiver', receiver_rows)):
+        for row in rows:
+            if _candidate_value(row, candidates_for(kind, row)) is not None:
+                return True
+    return False
+
+
+def _append_linked_node_velocity_warning(
+    source_rows: list[dict[str, Any]],
+    receiver_rows: list[dict[str, Any]],
+    x_axis: str,
+    velocity_field: str,
+    warnings: list[str],
+) -> None:
+    for kind, rows in (('source', source_rows), ('receiver', receiver_rows)):
+        for row in rows:
+            if _x_value(row, kind, x_axis) is None:
+                continue
+            field, value = _candidate_value_with_field(
+                row,
+                _velocity_candidates(kind, row, velocity_field),
+            )
+            if field == 'linked_node_velocity_m_s' and value is not None:
+                warnings.append(
+                    'Velocity structure uses linked_node_velocity_m_s for one or '
+                    'more endpoints because endpoint-side velocity fields are '
+                    'unavailable; linked source and receiver endpoints may share '
+                    'the same velocity value.'
+                )
+                return
+
+
+def _series(
+    rows: list[dict[str, Any]],
+    endpoint_kind: str,
+    x_axis: str,
+    candidates_for: Any,
+) -> dict[str, list[Any]]:
+    points: list[tuple[float, float, str, str]] = []
+    for row in rows:
+        x_value = _x_value(row, endpoint_kind, x_axis)
+        y_value = _candidate_value(row, candidates_for(endpoint_kind, row))
+        if x_value is None or y_value is None:
+            continue
+        points.append((x_value, y_value, _endpoint_key(row), _status(row)))
+    points.sort(key=lambda point: (point[0], point[2]))
+    return {
+        'x': [_json_number(point[0]) for point in points],
+        'y': [float(point[1]) for point in points],
+        'endpoint_key': [point[2] for point in points],
+        'status': [point[3] for point in points],
+    }
+
+
+def _x_value(row: dict[str, Any], endpoint_kind: str, x_axis: str) -> float | None:
+    if x_axis == 'endpoint_key_numeric_suffix':
+        return _numeric_suffix(_endpoint_key(row))
+    if x_axis == 'source_id' and endpoint_kind != 'source':
+        return _numeric_or_none(row.get('receiver_id')) or _numeric_or_none(row.get('source_id'))
+    if x_axis == 'receiver_id' and endpoint_kind != 'receiver':
+        return _numeric_or_none(row.get('source_id')) or _numeric_or_none(row.get('receiver_id'))
+    value = _numeric_or_none(row.get(x_axis))
+    if value is not None:
+        return value
+    if x_axis in {'endpoint_id', 'source_id', 'receiver_id'}:
+        return _numeric_suffix(_endpoint_key(row))
+    return None
+
+
+def _json_number(value: float) -> int | float:
+    if float(value).is_integer():
+        return int(value)
+    return float(value)
+
+
+def _time_term_field_for_velocity(velocity_field: str) -> str:
+    if velocity_field == 'v3':
+        return 't2'
+    if velocity_field == 'vsub':
+        return 't3'
+    return 't1'
+
+
+def _time_term_candidates(
+    endpoint_kind: str,
+    row: dict[str, Any],
+    velocity_field: str,
+) -> tuple[str, ...]:
+    layer_field = _time_term_field_for_velocity(velocity_field)
+    if endpoint_kind == 'source':
+        return (
+            'source_time_term_ms',
+            'source_half_intercept_time_ms',
+            f'source_{layer_field}_ms',
+            'half_intercept_time_ms',
+            f'{layer_field}_ms',
+        )
+    return (
+        'receiver_time_term_ms',
+        'receiver_half_intercept_time_ms',
+        f'receiver_{layer_field}_ms',
+        'half_intercept_time_ms',
+        f'{layer_field}_ms',
+    )
+
+
+def _velocity_candidates(
+    endpoint_kind: str,
+    row: dict[str, Any],
+    field: str,
+) -> tuple[str, ...]:
+    return (
+        f'{endpoint_kind}_{field}_m_s',
+        f'{endpoint_kind}_velocity_m_s',
+        f'{field}_m_s',
+        'linked_node_velocity_m_s',
+    )
+
+
+def _depth_candidates(
+    endpoint_kind: str,
+    row: dict[str, Any],
+    field: str,
+) -> tuple[str, ...]:
+    if field in {'sh1', 'sh2', 'sh3'}:
+        return (
+            f'{endpoint_kind}_{field}_m',
+            f'{endpoint_kind}_weathering_thickness_m',
+            f'{field}_m',
+            f'{field}_weathering_thickness_m',
+            'weathering_thickness_m',
+        )
+    if field == 'refractor_depth':
+        return (
+            f'{endpoint_kind}_refractor_depth_m',
+            'refractor_depth_m',
+        )
+    if field == 'refractor_elevation':
+        return (
+            f'{endpoint_kind}_refractor_elevation_m',
+            'final_refractor_elevation_m',
+            'refractor_elevation_m',
+        )
+    return (
+        f'{endpoint_kind}_{field}_m',
+        f'{field}_m',
+    )
+
+
+def _candidate_value(row: dict[str, Any], candidates: tuple[str, ...]) -> float | None:
+    return _candidate_value_with_field(row, candidates)[1]
+
+
+def _candidate_value_with_field(
+    row: dict[str, Any],
+    candidates: tuple[str, ...],
+) -> tuple[str | None, float | None]:
+    for field in candidates:
+        value = _numeric_or_none(row.get(field))
+        if value is not None:
+            return field, value
+    return None, None
+
+
+def _endpoint_kind(row: dict[str, Any]) -> str:
+    return str(row.get('endpoint_kind') or '').strip().lower()
+
+
+def _endpoint_key(row: dict[str, Any]) -> str:
+    return _first_text(
+        row,
+        'endpoint_key',
+        'source_endpoint_key',
+        'receiver_endpoint_key',
+    ) or ''
+
+
+def _status(row: dict[str, Any]) -> str:
+    return _first_text(
+        row,
+        'static_status',
+        'solution_status',
+        'weathering_status',
+        'v2_status',
+        'status',
+    ) or 'ok'
+
+
+def _source_gather_number(row: dict[str, Any]) -> float | None:
+    value = _numeric_or_none(
+        _first_present(
+            row,
+            'source_id',
+            'source_number',
+            'shot_id',
+            'gather_id',
+            'source_endpoint_key',
+        )
+    )
+    if value is not None:
+        return value
+    return _numeric_suffix(_first_text(row, 'source_endpoint_key', 'endpoint_key') or '')
+
+
+def _observation_source_gather_number(row: dict[str, Any]) -> float | None:
+    value = _numeric_or_none(
+        _first_present(
+            row,
+            'source_id',
+            'source_number',
+            'shot_id',
+            'gather_id',
+            'source_endpoint_key',
+        )
+    )
+    if value is not None:
+        return value
+    return _numeric_suffix(_first_text(row, 'source_endpoint_key') or '')
+
+
+def _include_gather_number(
+    gather_number: float | None,
+    req: RefractionStaticStationStructureRequest,
+) -> bool:
+    if gather_number is None:
+        return True
+    if req.gather_start is not None and gather_number < req.gather_start:
+        return False
+    if req.gather_end is not None and gather_number > req.gather_end:
+        return False
+    return True
+
+
+def _endpoint_identity_matches(
+    row: dict[str, Any],
+    keys: set[str],
+    numbers: set[float],
+) -> bool:
+    endpoint_key = _endpoint_key(row)
+    if endpoint_key and endpoint_key in keys:
+        return True
+    endpoint_number = _numeric_or_none(
+        _first_present(
+            row,
+            'receiver_id',
+            'endpoint_id',
+            'global_receiver_number',
+            'station_number',
+            'receiver_number',
+        )
+    )
+    if endpoint_number is None:
+        endpoint_number = _numeric_suffix(endpoint_key)
+    return endpoint_number in numbers if endpoint_number is not None else False
+
+
+def _first_present(row: dict[str, Any], *keys: str) -> object:
+    for key in keys:
+        value = row.get(key)
+        if value is not None and value != '':
+            return value
+    return None
+
+
+def _first_text(row: dict[str, Any], *keys: str) -> str | None:
+    value = _first_present(row, *keys)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _numeric_or_none(value: object) -> float | None:
+    if value is None or value == '':
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return _numeric_suffix(str(value))
+    return number if np.isfinite(number) else None
+
+
+def _numeric_suffix(value: str) -> float | None:
+    match = _NUMERIC_SUFFIX_RE.search(str(value).strip())
+    if not match:
+        return None
+    try:
+        number = float(match.group(1))
+    except ValueError:
+        return None
+    return number if np.isfinite(number) else None
+
+
+__all__ = [
+    'RefractionStaticStationStructureError',
+    'build_refraction_static_station_structure',
+]

--- a/app/static/refraction_qc.html
+++ b/app/static/refraction_qc.html
@@ -119,6 +119,7 @@
 <button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-statics-button" data-view="static_components" role="tab" type="button">Static components</button>
 <button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-pick-map-button" data-view="pick_map" role="tab" type="button">RecNo-time</button>
 <button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-offset-time-button" data-view="offset_time" role="tab" type="button">Offset-time</button>
+<button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-station-structure-button" data-view="station_structure" role="tab" type="button">Structure QC</button>
 <button aria-selected="false" class="refraction-qc-view-button" data-testid="refraction-qc-view-gather-button" data-view="gather_preview" role="tab" type="button">Gather preview</button>
 </div>
 <div data-testid="refraction-qc-views" id="refractionQcViews">
@@ -153,6 +154,10 @@
 <section class="refraction-qc-view" data-testid="refraction-qc-view-offset-time" data-view-panel="offset_time" hidden="">
 <h3>Offset-time</h3>
 <div class="refraction-qc-placeholder" data-view-content="offset_time">No Pick Map loaded.</div>
+</section>
+<section class="refraction-qc-view" data-testid="refraction-qc-view-station-structure" data-view-panel="station_structure" hidden="">
+<h3>Structure QC</h3>
+<div class="refraction-qc-placeholder" data-view-content="station_structure">No station-structure QC loaded.</div>
 </section>
 <section class="refraction-qc-view" data-testid="refraction-qc-view-gather" data-view-panel="gather_preview" hidden="">
 <h3>Gather preview</h3>

--- a/app/static/refraction_qc.js
+++ b/app/static/refraction_qc.js
@@ -70,6 +70,12 @@
       unavailableKeys: [],
     },
     {
+      id: 'station_structure',
+      include: 'summary',
+      viewKeys: [],
+      unavailableKeys: [],
+    },
+    {
       id: 'gather_preview',
       include: 'gather_preview',
       viewKeys: [],
@@ -119,6 +125,13 @@
     pickMapCachedFile: null,
     pickMapCachedMeta: null,
     pickMapCacheStatus: '',
+    stationStructure: null,
+    stationStructureLoading: false,
+    stationStructureError: null,
+    stationStructureGatherStart: '',
+    stationStructureGatherEnd: '',
+    stationStructureVelocityField: 'auto',
+    stationStructureDepthField: 'auto',
     error: null,
     loading: false,
   };
@@ -127,7 +140,9 @@
   let requestSerial = 0;
   let gatherRequestSerial = 0;
   let pickMapRequestSerial = 0;
+  let stationStructureRequestSerial = 0;
   let pickMapCanvasCleanup = null;
+  let stationStructureCanvasCleanup = null;
 
   const PICK_MAP_VIEWS = {
     pick_map: {
@@ -3680,6 +3695,352 @@
     context.globalAlpha = 1;
   }
 
+  function renderStationStructure(content) {
+    cleanupStationStructureCanvasRenderer();
+    content.appendChild(createStationStructureControls());
+
+    if (state.stationStructureLoading) {
+      const loading = document.createElement('p');
+      loading.className = 'refraction-qc-placeholder';
+      loading.textContent = 'Loading station-structure QC...';
+      content.appendChild(loading);
+      return;
+    }
+    if (state.stationStructureError) {
+      const error = document.createElement('div');
+      error.className = 'refraction-qc-error';
+      error.dataset.testid = 'refraction-qc-station-structure-error';
+      error.textContent = state.stationStructureError;
+      content.appendChild(error);
+    }
+    if (!state.stationStructure) {
+      const empty = document.createElement('p');
+      empty.className = 'refraction-qc-placeholder';
+      empty.textContent = state.qcBundle
+        ? 'Load station-structure QC for this completed refraction job.'
+        : 'Load a completed job before requesting station-structure QC.';
+      content.appendChild(empty);
+      return;
+    }
+
+    const payload = state.stationStructure;
+    const status = document.createElement('p');
+    status.className = 'refraction-qc-note';
+    status.dataset.testid = 'refraction-qc-station-structure-filter-status';
+    status.textContent = stationStructureFilterNote(payload);
+    content.appendChild(status);
+
+    const warnings = Array.isArray(payload.warnings) ? payload.warnings : [];
+    for (const warningText of warnings) {
+      const warning = document.createElement('p');
+      warning.className = 'refraction-qc-note';
+      warning.textContent = warningText;
+      content.appendChild(warning);
+    }
+
+    content.appendChild(createKv([
+      ['X axis', payload.x_axis_label || payload.x_axis],
+      ['Velocity', String(payload.velocity?.field || '').toUpperCase()],
+      ['Depth / structure', payload.depth?.label || payload.depth?.field],
+      ['Source color', payload.colors?.source || 'cyan'],
+      ['Receiver color', payload.colors?.receiver || 'red'],
+    ]));
+
+    const grid = document.createElement('div');
+    grid.className = 'refraction-qc-plot-grid refraction-qc-station-structure-grid';
+    content.appendChild(grid);
+
+    const panels = [
+      {
+        key: 'time_term',
+        title: 'Time-term distribution',
+        yAxisTitle: 'Time term (ms)',
+        testId: 'refraction-qc-station-structure-time-term',
+      },
+      {
+        key: 'velocity',
+        title: payload.velocity?.label || 'Velocity structure',
+        yAxisTitle: 'Velocity (m/s)',
+        testId: 'refraction-qc-station-structure-velocity',
+      },
+      {
+        key: 'depth',
+        title: payload.depth?.label || 'Depth / structure',
+        yAxisTitle: stationStructureDepthYAxisTitle(payload.depth),
+        testId: 'refraction-qc-station-structure-depth',
+      },
+    ];
+
+    const cleanups = [];
+    for (const panelConfig of panels) {
+      const plot = document.createElement('div');
+      plot.className = 'refraction-qc-plot refraction-qc-station-structure-plot';
+      plot.dataset.testid = `${panelConfig.testId}-plot`;
+      plot.dataset.renderer = 'canvas';
+      plot.dataset.xAxisTitle = payload.x_axis_label || payload.x_axis || '';
+      plot.dataset.yAxisTitle = panelConfig.yAxisTitle;
+      const panel = payload[panelConfig.key] || {};
+      const pointCount = stationStructurePointCount(panel);
+      plot.dataset.pointCount = String(pointCount);
+      grid.appendChild(plot);
+      if (!pointCount) {
+        plot.textContent = `No finite ${panelConfig.title.toLowerCase()} values are available for the selected range.`;
+        continue;
+      }
+      cleanups.push(renderStationStructureCanvas(plot, payload, panel, panelConfig));
+    }
+    stationStructureCanvasCleanup = () => {
+      for (const cleanup of cleanups) cleanup();
+    };
+  }
+
+  function createStationStructureControls() {
+    const controls = document.createElement('div');
+    controls.className = 'refraction-qc-controls';
+
+    const gatherStart = document.createElement('input');
+    gatherStart.type = 'number';
+    gatherStart.placeholder = 'Shot gather start';
+    gatherStart.value = state.stationStructureGatherStart;
+    gatherStart.dataset.testid = 'refraction-qc-station-structure-gather-start';
+    gatherStart.addEventListener('input', () => {
+      state.stationStructureGatherStart = gatherStart.value;
+    });
+
+    const gatherEnd = document.createElement('input');
+    gatherEnd.type = 'number';
+    gatherEnd.placeholder = 'Shot gather end';
+    gatherEnd.value = state.stationStructureGatherEnd;
+    gatherEnd.dataset.testid = 'refraction-qc-station-structure-gather-end';
+    gatherEnd.addEventListener('input', () => {
+      state.stationStructureGatherEnd = gatherEnd.value;
+    });
+
+    const velocity = document.createElement('select');
+    velocity.dataset.testid = 'refraction-qc-station-structure-velocity-field';
+    for (const [value, label] of [
+      ['auto', 'Auto'],
+      ['v1', 'V1'],
+      ['v2', 'V2'],
+      ['v3', 'V3'],
+      ['vsub', 'Vsub'],
+    ]) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = label;
+      velocity.appendChild(option);
+    }
+    velocity.value = state.stationStructureVelocityField;
+    velocity.addEventListener('change', () => {
+      state.stationStructureVelocityField = velocity.value;
+    });
+
+    const depth = document.createElement('select');
+    depth.dataset.testid = 'refraction-qc-station-structure-depth-field';
+    for (const [value, label] of [
+      ['auto', 'Auto'],
+      ['sh1', 'Weathering thickness SH1'],
+      ['sh2', 'Weathering thickness SH2'],
+      ['sh3', 'Weathering thickness SH3'],
+      ['refractor_depth', 'Refractor depth'],
+      ['refractor_elevation', 'Refractor elevation'],
+      ['layer1_base_elevation', 'Layer 1 base elevation'],
+      ['layer2_base_elevation', 'Layer 2 base elevation'],
+    ]) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = label;
+      depth.appendChild(option);
+    }
+    depth.value = state.stationStructureDepthField;
+    depth.addEventListener('change', () => {
+      state.stationStructureDepthField = depth.value;
+    });
+
+    const loadButton = document.createElement('button');
+    loadButton.type = 'button';
+    loadButton.textContent = 'Load / Refresh';
+    loadButton.dataset.testid = 'refraction-qc-station-structure-load';
+    loadButton.disabled = !(state.qcBundle?.job_id || state.selectedJobId);
+    loadButton.addEventListener('click', () => {
+      loadStationStructureQc();
+    });
+
+    controls.append(gatherStart, gatherEnd, velocity, depth, loadButton);
+    return controls;
+  }
+
+  function stationStructureFilterNote(payload) {
+    const status = payload.filter_status || 'unknown';
+    const start = payload.gather_range?.start ?? '';
+    const end = payload.gather_range?.end ?? '';
+    const rangeText = start === '' && end === '' ? 'all gathers' : `shot gathers ${start || 'min'} to ${end || 'max'}`;
+    if (status === 'ok') return `Filter: ${rangeText}.`;
+    if (status === 'unfiltered') return 'Filter: all available source and receiver endpoints.';
+    if (status === 'receiver_participation_unavailable') {
+      return `Filter: source endpoints use ${rangeText}; receiver participation is unavailable from artifacts.`;
+    }
+    return `Filter status: ${status}.`;
+  }
+
+  function stationStructureDepthYAxisTitle(panel) {
+    const field = panel?.field || '';
+    if (field === 'refractor_elevation' || field === 'layer1_base_elevation' || field === 'layer2_base_elevation') {
+      return 'Elevation (m)';
+    }
+    return 'Depth / structure (m)';
+  }
+
+  function stationStructurePointCount(panel) {
+    const source = Array.isArray(panel?.source?.x) ? panel.source.x.length : 0;
+    const receiver = Array.isArray(panel?.receiver?.x) ? panel.receiver.x.length : 0;
+    return source + receiver;
+  }
+
+  function cleanupStationStructureCanvasRenderer() {
+    if (!stationStructureCanvasCleanup) return;
+    stationStructureCanvasCleanup();
+    stationStructureCanvasCleanup = null;
+  }
+
+  function renderStationStructureCanvas(plot, payload, panel, panelConfig) {
+    clearNode(plot);
+    const canvas = document.createElement('canvas');
+    canvas.className = 'refraction-qc-station-structure-canvas';
+    canvas.dataset.testid = `${panelConfig.testId}-canvas`;
+    canvas.setAttribute('role', 'img');
+    canvas.setAttribute('aria-label', `${panelConfig.title} station-structure scatter plot.`);
+    plot.appendChild(canvas);
+
+    const draw = () => drawStationStructureCanvas(plot, canvas, payload, panel, panelConfig);
+    draw();
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(draw);
+      observer.observe(plot);
+      return () => observer.disconnect();
+    }
+    window.addEventListener('resize', draw);
+    return () => window.removeEventListener('resize', draw);
+  }
+
+  function drawStationStructureCanvas(plot, canvas, payload, panel, panelConfig) {
+    let context = null;
+    try {
+      context = canvas.getContext('2d');
+    } catch (_) {
+      context = null;
+    }
+    if (!context) {
+      plot.textContent = 'Canvas rendering is unavailable.';
+      return;
+    }
+
+    const points = stationStructurePoints(panel, payload.colors || {});
+    const rect = plot.getBoundingClientRect();
+    const cssWidth = Math.max(1, Math.floor(rect.width || plot.clientWidth || plot.offsetWidth || 640));
+    const cssHeight = Math.max(plotHeight(250, 300), Math.floor(rect.height || plot.clientHeight || plot.offsetHeight || 0));
+    const pixelRatio = Math.max(1, window.devicePixelRatio || 1);
+    const pixelWidth = Math.max(1, Math.floor(cssWidth * pixelRatio));
+    const pixelHeight = Math.max(1, Math.floor(cssHeight * pixelRatio));
+    if (canvas.width !== pixelWidth) canvas.width = pixelWidth;
+    if (canvas.height !== pixelHeight) canvas.height = pixelHeight;
+    canvas.style.width = `${cssWidth}px`;
+    canvas.style.height = `${cssHeight}px`;
+
+    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    context.clearRect(0, 0, cssWidth, cssHeight);
+    context.fillStyle = '#ffffff';
+    context.fillRect(0, 0, cssWidth, cssHeight);
+
+    const margin = { left: 68, right: 22, top: 34, bottom: 52 };
+    const plotWidth = Math.max(1, cssWidth - margin.left - margin.right);
+    const plotHeightCss = Math.max(1, cssHeight - margin.top - margin.bottom);
+    const xRange = paddedRange(points, (point) => point.x);
+    const yRange = paddedRange(points, (point) => point.y);
+    const xScale = (value) => margin.left + ((value - xRange.min) / (xRange.max - xRange.min)) * plotWidth;
+    const yScale = (value) => margin.top + plotHeightCss - ((value - yRange.min) / (yRange.max - yRange.min)) * plotHeightCss;
+
+    drawStationStructureGrid(context, margin, plotWidth, plotHeightCss, xRange, yRange, xScale, yScale, payload, panelConfig);
+    for (const point of points) {
+      context.beginPath();
+      context.arc(xScale(point.x), yScale(point.y), point.status === 'ok' ? 3 : 2.5, 0, Math.PI * 2);
+      context.globalAlpha = point.status === 'ok' ? 0.85 : 0.35;
+      context.fillStyle = point.color;
+      context.fill();
+    }
+    context.globalAlpha = 1;
+  }
+
+  function stationStructurePoints(panel, colors) {
+    const points = [];
+    for (const side of ['source', 'receiver']) {
+      const series = panel?.[side] || {};
+      const count = Array.isArray(series.x) ? series.x.length : 0;
+      for (let index = 0; index < count; index += 1) {
+        const x = toFiniteNumber(series.x[index]);
+        const y = toFiniteNumber(series.y?.[index]);
+        if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+        points.push({
+          x,
+          y,
+          side,
+          color: side === 'source' ? (colors.source || 'cyan') : (colors.receiver || 'red'),
+          status: String(series.status?.[index] || 'ok'),
+        });
+      }
+    }
+    return points;
+  }
+
+  function drawStationStructureGrid(context, margin, plotWidth, plotHeightCss, xRange, yRange, xScale, yScale, payload, panelConfig) {
+    const right = margin.left + plotWidth;
+    const bottom = margin.top + plotHeightCss;
+    context.save();
+    context.strokeStyle = '#e5e7eb';
+    context.lineWidth = 1;
+    context.font = '10px sans-serif';
+    context.fillStyle = '#334155';
+    context.textBaseline = 'middle';
+    for (const tick of pickMapTicks(xRange)) {
+      const x = xScale(tick);
+      context.beginPath();
+      context.moveTo(x, margin.top);
+      context.lineTo(x, bottom);
+      context.stroke();
+      context.textAlign = 'center';
+      context.fillText(formatNumber(tick, 0), x, bottom + 16);
+    }
+    for (const tick of pickMapTicks(yRange)) {
+      const y = yScale(tick);
+      context.beginPath();
+      context.moveTo(margin.left, y);
+      context.lineTo(right, y);
+      context.stroke();
+      context.textAlign = 'right';
+      context.fillText(formatNumber(tick, 1), margin.left - 8, y);
+    }
+    context.strokeStyle = '#94a3b8';
+    context.strokeRect(margin.left, margin.top, plotWidth, plotHeightCss);
+    context.textAlign = 'left';
+    context.textBaseline = 'top';
+    context.fillText(panelConfig.title, margin.left, 10);
+    context.fillStyle = payload.colors?.source || 'cyan';
+    context.fillText('source', right - 90, 10);
+    context.fillStyle = payload.colors?.receiver || 'red';
+    context.fillText('receiver', right - 48, 10);
+    context.fillStyle = '#334155';
+    context.textAlign = 'center';
+    context.textBaseline = 'bottom';
+    context.fillText(payload.x_axis_label || payload.x_axis || 'Station', margin.left + plotWidth / 2, bottom + 42);
+    context.save();
+    context.translate(14, margin.top + plotHeightCss / 2);
+    context.rotate(-Math.PI / 2);
+    context.textBaseline = 'top';
+    context.fillText(panelConfig.yAxisTitle, 0, 0);
+    context.restore();
+    context.restore();
+  }
+
   function pickMapColorValue(point) {
     return Number.isFinite(point.offsetUsed) ? point.offsetUsed : point.offsetM;
   }
@@ -3742,6 +4103,8 @@
       renderCellMapPlot(content, state.qcBundle, viewDef);
     } else if (viewDef.id === 'static_components') {
       renderStaticComponents(content, state.qcBundle, viewDef);
+    } else if (viewDef.id === 'station_structure') {
+      renderStationStructure(content);
     } else if (viewDef.id === 'gather_preview') {
       renderGatherPreview(content, state.qcBundle);
     } else {
@@ -3762,6 +4125,7 @@
   function render() {
     if (!dom) return;
     if (!PICK_MAP_VIEWS[state.selectedView]) cleanupPickMapCanvasRenderer();
+    if (state.selectedView !== 'station_structure') cleanupStationStructureCanvasRenderer();
 
     dom.loadButton.disabled = state.loading;
     dom.maxPoints.value = String(state.maxPoints);
@@ -3820,6 +4184,10 @@
       restoreCachedPickMapSource();
       if (state.qcBundle?.job_id && !state.pickMap && !state.pickMapLoading) {
         loadCompletedPickMap(state.qcBundle.job_id);
+      }
+    } else if (viewId === 'station_structure') {
+      if (state.qcBundle?.job_id && !state.stationStructure && !state.stationStructureLoading) {
+        loadStationStructureQc(state.qcBundle.job_id);
       }
     }
   }
@@ -3934,6 +4302,58 @@
     }
   }
 
+  function buildStationStructureRequest(jobId) {
+    return {
+      job_id: jobId,
+      gather_start: stationStructureOptionalNumber(state.stationStructureGatherStart),
+      gather_end: stationStructureOptionalNumber(state.stationStructureGatherEnd),
+      x_axis: 'auto',
+      velocity_field: state.stationStructureVelocityField,
+      depth_field: state.stationStructureDepthField,
+    };
+  }
+
+  function stationStructureOptionalNumber(value) {
+    const number = toFiniteNumber(value);
+    return Number.isFinite(number) ? number : null;
+  }
+
+  async function loadStationStructureQc(jobId) {
+    const cleanJobId = String(jobId || state.qcBundle?.job_id || state.selectedJobId || '').trim();
+    if (!cleanJobId) {
+      state.stationStructureError = 'Job ID is required for station-structure QC.';
+      render();
+      return;
+    }
+    const serial = ++stationStructureRequestSerial;
+    state.stationStructureLoading = true;
+    state.stationStructureError = null;
+    render();
+    try {
+      const response = await fetch('/statics/refraction/qc/station-structure', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildStationStructureRequest(cleanJobId)),
+      });
+      if (!response.ok) {
+        throw new Error(await readError(response, 'Station-structure QC request'));
+      }
+      const payload = await response.json();
+      if (serial !== stationStructureRequestSerial) return;
+      state.stationStructure = payload;
+      state.stationStructureError = null;
+    } catch (error) {
+      if (serial !== stationStructureRequestSerial) return;
+      state.stationStructure = null;
+      state.stationStructureError = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (serial === stationStructureRequestSerial) {
+        state.stationStructureLoading = false;
+        render();
+      }
+    }
+  }
+
   async function loadGatherPreview() {
     const { payload, errors } = buildGatherPreviewRequest();
     if (errors.length) {
@@ -4036,12 +4456,21 @@
       if (state.gatherPreview && state.gatherPreview.job_id !== bundle.job_id) {
         state.gatherPreview = null;
       }
+      if (state.stationStructure && state.stationStructure.job_id !== bundle.job_id) {
+        stationStructureRequestSerial += 1;
+        state.stationStructure = null;
+        state.stationStructureLoading = false;
+        state.stationStructureError = null;
+      }
       state.gatherError = null;
       state.error = null;
       writeRecentJob(jobId);
       writeJobIdUrlParam(jobId);
       if (PICK_MAP_VIEWS[state.selectedView] && !state.pickMap) {
         loadCompletedPickMap(bundleJobId);
+      }
+      if (state.selectedView === 'station_structure' && !state.stationStructure) {
+        loadStationStructureQc(bundleJobId);
       }
       return bundle;
     } catch (error) {
@@ -4213,6 +4642,7 @@
     loadBundle,
     loadJob,
     loadGatherPreview,
+    loadStationStructureQc,
     setSelectedView,
     activateSidebarTab,
     pickMapGatherNumber,

--- a/app/static/tool_pages.css
+++ b/app/static/tool_pages.css
@@ -667,6 +667,17 @@ select {
       height: 100%;
     }
 
+    .refraction-qc-station-structure-plot {
+      height: 250px;
+      overflow: hidden;
+    }
+
+    .refraction-qc-station-structure-canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
     .refraction-qc-cell-map-plot {
       height: 340px;
     }
@@ -870,12 +881,20 @@ select {
   gap: 1rem;
 }
 
+.refraction-qc-page .refraction-qc-station-structure-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .refraction-qc-page .refraction-qc-plot {
   height: 440px;
 }
 
 .refraction-qc-page .refraction-qc-pick-map-plot {
   height: 560px;
+}
+
+.refraction-qc-page .refraction-qc-station-structure-plot {
+  height: 300px;
 }
 
 .refraction-qc-page .refraction-qc-cell-map-plot {

--- a/app/tests/test_refraction_static_qc_bundle.py
+++ b/app/tests/test_refraction_static_qc_bundle.py
@@ -25,6 +25,8 @@ from app.services.refraction_static_artifacts import (
     REFRACTION_STATIC_COMPONENT_QC_TRACE_CSV_NAME,
     REFRACTION_STATIC_QC_JSON_NAME,
     REFRACTION_STATIC_REQUEST_JSON_NAME,
+    SOURCE_STATIC_TABLE_CSV_NAME,
+    RECEIVER_STATIC_TABLE_CSV_NAME,
 )
 
 
@@ -463,6 +465,411 @@ def test_refraction_static_qc_bundle_uses_static_component_qc_artifacts(
         REFRACTION_STATIC_COMPONENT_QC_TRACE_CSV_NAME
     )
     assert payload['views']['static_component_qc_trace']['records'] == trace_rows
+
+
+def test_refraction_static_station_structure_uses_endpoint_side_fields(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'refraction-job'
+    _write_refraction_qc_artifacts(
+        job_dir,
+        rows=[{'trace': '0', 'first_break_residual_ms': '1.25'}],
+        extra_artifact_names=[
+            REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+            REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+        ],
+    )
+    endpoint_rows = [
+        {
+            'endpoint_kind': 'source',
+            'endpoint_key': 'source:100',
+            'source_id': '100',
+            'receiver_id': '',
+            'global_receiver_number': '100',
+            't1_ms': '8.0',
+            'v2_m_s': '2400',
+            'sh1_m': '12.5',
+            'static_status': 'ok',
+        },
+        {
+            'endpoint_kind': 'source',
+            'endpoint_key': 'source:101',
+            'source_id': '101',
+            'receiver_id': '',
+            'global_receiver_number': '101',
+            't1_ms': '8.5',
+            'v2_m_s': '2450',
+            'sh1_m': '13.5',
+            'static_status': 'ok',
+        },
+        {
+            'endpoint_kind': 'receiver',
+            'endpoint_key': 'receiver:200',
+            'source_id': '',
+            'receiver_id': '200',
+            'global_receiver_number': '200',
+            't1_ms': '18.0',
+            'v2_m_s': '2600',
+            'sh1_m': '22.5',
+            'static_status': 'ok',
+        },
+        {
+            'endpoint_kind': 'receiver',
+            'endpoint_key': 'receiver:201',
+            'source_id': '',
+            'receiver_id': '201',
+            'global_receiver_number': '201',
+            't1_ms': '19.0',
+            'v2_m_s': '2650',
+            'sh1_m': '23.5',
+            'static_status': 'ok',
+        },
+    ]
+    _write_csv(job_dir / REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME, endpoint_rows)
+    _write_csv(
+        job_dir / REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+        [
+            {'source_id': '100', 'receiver_id': '200'},
+            {'source_id': '101', 'receiver_id': '201'},
+        ],
+    )
+    _create_static_job(client, job_id='refraction-job', job_dir=job_dir)
+
+    response = client.post(
+        '/statics/refraction/qc/station-structure',
+        json={
+            'job_id': 'refraction-job',
+            'gather_start': 101,
+            'gather_end': 101,
+            'velocity_field': 'v2',
+            'depth_field': 'sh1',
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['view_kind'] == 'station_structure'
+    assert payload['x_axis'] == 'global_receiver_number'
+    assert payload['x_axis_label'] == 'Global receiver number'
+    assert payload['filter_status'] == 'ok'
+    assert payload['colors'] == {'source': 'cyan', 'receiver': 'red'}
+    assert payload['time_term']['source']['endpoint_key'] == ['source:101']
+    assert payload['time_term']['source']['y'] == [8.5]
+    assert payload['velocity']['field'] == 'v2'
+    assert payload['velocity']['receiver']['endpoint_key'] == ['receiver:201']
+    assert payload['velocity']['receiver']['y'] == [2650.0]
+    assert payload['depth']['field'] == 'sh1'
+    assert payload['depth']['receiver']['y'] == [23.5]
+
+
+def test_refraction_static_station_structure_warns_on_linked_velocity_fallback(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'refraction-job'
+    _write_refraction_qc_artifacts(
+        job_dir,
+        rows=[{'trace': '0', 'first_break_residual_ms': '1.25'}],
+        extra_artifact_names=[REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME],
+    )
+    _write_csv(
+        job_dir / REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+        [
+            {
+                'endpoint_kind': 'source',
+                'endpoint_key': 'source:100',
+                'source_id': '100',
+                'receiver_id': '',
+                'global_receiver_number': '100',
+                't1_ms': '8.0',
+                'linked_node_velocity_m_s': '2400',
+                'sh1_m': '12.5',
+            },
+            {
+                'endpoint_kind': 'receiver',
+                'endpoint_key': 'receiver:100',
+                'source_id': '',
+                'receiver_id': '100',
+                'global_receiver_number': '100',
+                't1_ms': '18.0',
+                'linked_node_velocity_m_s': '2400',
+                'sh1_m': '22.5',
+            },
+        ],
+    )
+    _create_static_job(client, job_id='refraction-job', job_dir=job_dir)
+
+    response = client.post(
+        '/statics/refraction/qc/station-structure',
+        json={'job_id': 'refraction-job', 'velocity_field': 'v2'},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['velocity']['source']['endpoint_key'] == ['source:100']
+    assert payload['velocity']['receiver']['endpoint_key'] == ['receiver:100']
+    assert payload['velocity']['source']['y'] == [2400.0]
+    assert payload['velocity']['receiver']['y'] == [2400.0]
+    assert any('linked_node_velocity_m_s' in warning for warning in payload['warnings'])
+
+
+def test_refraction_static_station_structure_filters_receivers_by_station_fields(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'refraction-job'
+    _write_refraction_qc_artifacts(
+        job_dir,
+        rows=[{'trace': '0', 'first_break_residual_ms': '1.25'}],
+        extra_artifact_names=[
+            REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+            REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+        ],
+    )
+    _write_csv(
+        job_dir / REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+        [
+            {
+                'endpoint_kind': 'source',
+                'endpoint_key': 'source:10',
+                'source_id': '10',
+                'receiver_id': '',
+                'global_receiver_number': '10',
+                'station_number': '10',
+                'receiver_number': '10',
+                't1_ms': '7.5',
+                'v2_m_s': '2300',
+                'sh1_m': '10.0',
+            },
+            {
+                'endpoint_kind': 'receiver',
+                'endpoint_key': 'receiver:A',
+                'receiver_id': '',
+                'global_receiver_number': '500',
+                'station_number': '1500',
+                'receiver_number': '2500',
+                't1_ms': '17.0',
+                'v2_m_s': '2550',
+                'sh1_m': '20.0',
+            },
+            {
+                'endpoint_kind': 'receiver',
+                'endpoint_key': 'receiver:B',
+                'receiver_id': '',
+                'global_receiver_number': '501',
+                'station_number': '1501',
+                'receiver_number': '2501',
+                't1_ms': '18.0',
+                'v2_m_s': '2650',
+                'sh1_m': '21.0',
+            },
+        ],
+    )
+    _write_csv(
+        job_dir / REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+        [
+            {
+                'source_id': '10',
+                'global_receiver_number': '501',
+            }
+        ],
+    )
+    _create_static_job(client, job_id='refraction-job', job_dir=job_dir)
+
+    response = client.post(
+        '/statics/refraction/qc/station-structure',
+        json={'job_id': 'refraction-job', 'gather_start': 10, 'gather_end': 10},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['filter_status'] == 'ok'
+    assert payload['time_term']['receiver']['endpoint_key'] == ['receiver:B']
+    assert payload['velocity']['receiver']['x'] == [501]
+
+
+def test_refraction_static_station_structure_reports_unavailable_receiver_filter(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'refraction-job'
+    _write_refraction_qc_artifacts(
+        job_dir,
+        rows=[{'trace': '0', 'first_break_residual_ms': '1.25'}],
+        extra_artifact_names=[
+            SOURCE_STATIC_TABLE_CSV_NAME,
+            RECEIVER_STATIC_TABLE_CSV_NAME,
+        ],
+    )
+    _write_csv(
+        job_dir / SOURCE_STATIC_TABLE_CSV_NAME,
+        [
+            {
+                'endpoint_kind': 'source',
+                'source_endpoint_key': 'source:100',
+                'source_id': '100',
+                't1_ms': '8.0',
+                'v2_m_s': '2400',
+                'sh1_weathering_thickness_m': '12.5',
+                'static_status': 'ok',
+            }
+        ],
+    )
+    _write_csv(
+        job_dir / RECEIVER_STATIC_TABLE_CSV_NAME,
+        [
+            {
+                'endpoint_kind': 'receiver',
+                'receiver_endpoint_key': 'receiver:200',
+                'receiver_id': '200',
+                't1_ms': '18.0',
+                'v2_m_s': '2600',
+                'sh1_weathering_thickness_m': '22.5',
+                'static_status': 'ok',
+            }
+        ],
+    )
+    _create_static_job(client, job_id='refraction-job', job_dir=job_dir)
+
+    response = client.post(
+        '/statics/refraction/qc/station-structure',
+        json={'job_id': 'refraction-job', 'gather_start': 100, 'gather_end': 100},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['filter_status'] == 'receiver_participation_unavailable'
+    assert 'receiver series is unfiltered' in payload['warnings'][0]
+    assert payload['velocity']['source']['x'] == [100]
+    assert payload['velocity']['receiver']['x'] == [200]
+
+
+def test_refraction_static_station_structure_reports_unfilterable_observations(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'refraction-job'
+    _write_refraction_qc_artifacts(
+        job_dir,
+        rows=[{'trace': '0', 'first_break_residual_ms': '1.25'}],
+        extra_artifact_names=[
+            REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+            REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+        ],
+    )
+    _write_csv(
+        job_dir / REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+        [
+            {
+                'endpoint_kind': 'source',
+                'endpoint_key': 'source:100',
+                'source_id': '100',
+                'receiver_id': '',
+                'global_receiver_number': '100',
+                't1_ms': '8.0',
+                'v2_m_s': '2400',
+                'sh1_m': '12.5',
+            },
+            {
+                'endpoint_kind': 'receiver',
+                'endpoint_key': 'receiver:200',
+                'source_id': '',
+                'receiver_id': '200',
+                'global_receiver_number': '200',
+                't1_ms': '18.0',
+                'v2_m_s': '2600',
+                'sh1_m': '22.5',
+            },
+        ],
+    )
+    _write_csv(
+        job_dir / REFRACTION_FIRST_BREAK_FIT_QC_CSV_NAME,
+        [
+            {
+                'endpoint_key': 'receiver:200',
+                'receiver_id': '200',
+            }
+        ],
+    )
+    _create_static_job(client, job_id='refraction-job', job_dir=job_dir)
+
+    response = client.post(
+        '/statics/refraction/qc/station-structure',
+        json={'job_id': 'refraction-job', 'gather_start': 100, 'gather_end': 100},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['filter_status'] == 'receiver_participation_unavailable'
+    assert 'do not include usable source gather identifiers' in payload['warnings'][0]
+    assert payload['time_term']['receiver']['endpoint_key'] == ['receiver:200']
+
+
+def test_refraction_static_station_structure_falls_back_from_empty_line_profile(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    job_dir = tmp_path / 'refraction-job'
+    _write_refraction_qc_artifacts(
+        job_dir,
+        rows=[{'trace': '0', 'first_break_residual_ms': '1.25'}],
+        extra_artifact_names=[
+            REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+            SOURCE_STATIC_TABLE_CSV_NAME,
+            RECEIVER_STATIC_TABLE_CSV_NAME,
+        ],
+    )
+    _write_empty_csv(
+        job_dir / REFRACTION_LINE_PROFILE_QC_COMBINED_CSV_NAME,
+        [
+            'endpoint_kind',
+            'endpoint_key',
+            'global_receiver_number',
+            't1_ms',
+            'v2_m_s',
+            'sh1_m',
+        ],
+    )
+    _write_csv(
+        job_dir / SOURCE_STATIC_TABLE_CSV_NAME,
+        [
+            {
+                'source_endpoint_key': 'source:100',
+                'source_id': '100',
+                't1_ms': '8.0',
+                'v2_m_s': '2400',
+                'sh1_weathering_thickness_m': '12.5',
+                'static_status': 'ok',
+            }
+        ],
+    )
+    _write_csv(
+        job_dir / RECEIVER_STATIC_TABLE_CSV_NAME,
+        [
+            {
+                'receiver_endpoint_key': 'receiver:200',
+                'receiver_id': '200',
+                't1_ms': '18.0',
+                'v2_m_s': '2600',
+                'sh1_weathering_thickness_m': '22.5',
+                'static_status': 'ok',
+            }
+        ],
+    )
+    _create_static_job(client, job_id='refraction-job', job_dir=job_dir)
+
+    response = client.post(
+        '/statics/refraction/qc/station-structure',
+        json={'job_id': 'refraction-job'},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['time_term']['source']['endpoint_key'] == ['source:100']
+    assert payload['time_term']['receiver']['endpoint_key'] == ['receiver:200']
+    assert payload['velocity']['source']['y'] == [2400.0]
+    assert payload['depth']['receiver']['y'] == [22.5]
 
 
 def _create_static_job(

--- a/app/tests/ui/refraction_qc_auto_load.test.js
+++ b/app/tests/ui/refraction_qc_auto_load.test.js
@@ -41,6 +41,7 @@ function renderRefractionQcPanel() {
       <button type="button" class="refraction-qc-view-button" data-view="summary"></button>
       <button type="button" class="refraction-qc-view-button" data-view="pick_map"></button>
       <button type="button" class="refraction-qc-view-button" data-view="offset_time"></button>
+      <button type="button" class="refraction-qc-view-button" data-view="station_structure"></button>
       <section class="refraction-qc-view" data-view-panel="summary">
         <div data-view-content="summary"></div>
       </section>
@@ -49,6 +50,9 @@ function renderRefractionQcPanel() {
       </section>
       <section class="refraction-qc-view" data-testid="refraction-qc-view-offset-time" data-view-panel="offset_time" hidden>
         <div data-view-content="offset_time"></div>
+      </section>
+      <section class="refraction-qc-view" data-testid="refraction-qc-view-station-structure" data-view-panel="station_structure" hidden>
+        <div data-view-content="station_structure"></div>
       </section>
     </section>
   `;
@@ -204,6 +208,53 @@ function qcBundle(jobId) {
     available_views: ['summary'],
     unavailable_views: [],
     coordinate_mode: 'auto',
+  };
+}
+
+function stationStructurePayload(jobId = 'completed-job-structure') {
+  const source = {
+    x: [100, 101],
+    y: [8, 9],
+    endpoint_key: ['source:100', 'source:101'],
+    status: ['ok', 'ok'],
+  };
+  const receiver = {
+    x: [200, 201],
+    y: [18, 19],
+    endpoint_key: ['receiver:200', 'receiver:201'],
+    status: ['ok', 'low_fold'],
+  };
+  return {
+    job_id: jobId,
+    statics_kind: 'refraction',
+    view_kind: 'station_structure',
+    x_axis: 'global_receiver_number',
+    x_axis_label: 'Global receiver number',
+    filter_status: 'ok',
+    gather_range: { start: 100, end: 101 },
+    colors: { source: 'cyan', receiver: 'red' },
+    time_term: {
+      field: 't1',
+      label: 'Time-term distribution',
+      unit: 'ms',
+      source,
+      receiver,
+    },
+    velocity: {
+      field: 'v2',
+      label: 'Velocity structure: V2',
+      unit: 'm/s',
+      source: { ...source, y: [2400, 2450] },
+      receiver: { ...receiver, y: [2600, 2650] },
+    },
+    depth: {
+      field: 'sh1',
+      label: 'Weathering thickness SH1',
+      unit: 'm',
+      source: { ...source, y: [12, 13] },
+      receiver: { ...receiver, y: [22, 23] },
+    },
+    warnings: [],
   };
 }
 
@@ -568,6 +619,72 @@ test('Offset-time shows a clear message when selected records have no finite off
   expect(plot.textContent).toBe(
     'No Offset-time records are available because offset_m is missing or non-finite for the selected gather range.'
   );
+});
+
+test('Structure QC uses canvas renderer without Plotly', () => {
+  const plotly = {
+    newPlot: vi.fn(() => {
+      throw new Error('Structure QC must not call Plotly.newPlot');
+    }),
+    react: vi.fn(() => {
+      throw new Error('Structure QC must not call Plotly.react');
+    }),
+  };
+  window.Plotly = plotly;
+  loadRefractionQcScript();
+
+  window.refractionQcState.qcBundle = qcBundle('completed-job-structure');
+  window.refractionQcState.stationStructure = stationStructurePayload();
+  window.refractionQcUI.setSelectedView('station_structure');
+
+  const timePlot = document.querySelector('[data-testid="refraction-qc-station-structure-time-term-plot"]');
+  expect(document.querySelector('[data-testid="refraction-qc-station-structure-time-term-canvas"]')).not.toBeNull();
+  expect(document.querySelector('[data-testid="refraction-qc-station-structure-velocity-canvas"]')).not.toBeNull();
+  expect(document.querySelector('[data-testid="refraction-qc-station-structure-depth-canvas"]')).not.toBeNull();
+  expect(timePlot.parentElement.classList.contains('refraction-qc-station-structure-grid')).toBe(true);
+  expect(timePlot.dataset.renderer).toBe('canvas');
+  expect(timePlot.dataset.xAxisTitle).toBe('Global receiver number');
+  expect(timePlot.dataset.pointCount).toBe('4');
+  expect(plotly.newPlot).not.toHaveBeenCalled();
+  expect(plotly.react).not.toHaveBeenCalled();
+});
+
+test('Structure QC sends gather range and selectors to station endpoint', async () => {
+  const fetch = vi.fn(async () => jsonResponse(stationStructurePayload('completed-job-structure')));
+  vi.stubGlobal('fetch', fetch);
+  loadRefractionQcScript();
+
+  window.refractionQcState.qcBundle = qcBundle('completed-job-structure');
+  window.refractionQcUI.setSelectedView('station_structure');
+  document.querySelector('[data-testid="refraction-qc-station-structure-gather-start"]').value = '101';
+  document.querySelector('[data-testid="refraction-qc-station-structure-gather-start"]')
+    .dispatchEvent(new Event('input', { bubbles: true }));
+  document.querySelector('[data-testid="refraction-qc-station-structure-gather-end"]').value = '120';
+  document.querySelector('[data-testid="refraction-qc-station-structure-gather-end"]')
+    .dispatchEvent(new Event('input', { bubbles: true }));
+  document.querySelector('[data-testid="refraction-qc-station-structure-velocity-field"]').value = 'v2';
+  document.querySelector('[data-testid="refraction-qc-station-structure-velocity-field"]')
+    .dispatchEvent(new Event('change', { bubbles: true }));
+  document.querySelector('[data-testid="refraction-qc-station-structure-depth-field"]').value = 'refractor_elevation';
+  document.querySelector('[data-testid="refraction-qc-station-structure-depth-field"]')
+    .dispatchEvent(new Event('change', { bubbles: true }));
+
+  await window.refractionQcUI.loadStationStructureQc();
+
+  expect(fetch).toHaveBeenCalledWith('/statics/refraction/qc/station-structure', expect.objectContaining({
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  }));
+  const body = JSON.parse(fetch.mock.calls.at(-1)[1].body);
+  expect(body).toMatchObject({
+    job_id: 'completed-job-structure',
+    gather_start: 101,
+    gather_end: 120,
+    x_axis: 'auto',
+    velocity_field: 'v2',
+    depth_field: 'refractor_elevation',
+  });
+  expect(document.querySelector('[data-testid="refraction-qc-station-structure-time-term-canvas"]')).not.toBeNull();
 });
 
 test('Pick Map does not render manual NPZ file input or upload button', () => {


### PR DESCRIPTION
Closes #659

## Summary
- [ui][refraction-qc] Add station structure QC panel for source/receiver time-term, velocity, and depth

## Changed files
- `app/api/routers/statics.py`
- `app/api/schemas.py`
- `app/services/refraction_static_station_structure.py`
- `app/static/refraction_qc.html`
- `app/static/refraction_qc.js`
- `app/static/tool_pages.css`
- `app/tests/test_refraction_static_qc_bundle.py`
- `app/tests/ui/refraction_qc_auto_load.test.js`

## Checks
- `.work/codex/checks.log`: 2445 passed in 70.17s (0:01:10)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 1
