### PR TITLE
P0: Gather Preview side-by-side の panel size / residual colorbar / shared legend を修正する

### DIFF
--- a/app/static/refraction_qc.js
+++ b/app/static/refraction_qc.js
@@ -1083,6 +1083,19 @@
     return value.toFixed(digits);
   }
 
+  function formatAsciiTick(value, digits) {
+    const normalized = Math.abs(value) < Number.EPSILON ? 0 : value;
+    const text = normalized.toFixed(digits).replace(/\.?0+$/, '');
+    return text === '-0' ? '0' : text;
+  }
+
+  function residualTickDigits(maxAbs) {
+    if (maxAbs >= 10) return 1;
+    if (maxAbs >= 1) return 2;
+    if (maxAbs >= 0.1) return 3;
+    return 4;
+  }
+
   function layerLabel(layerKind) {
     return LAYER_LABELS[layerKind] || (layerKind ? String(layerKind) : 'Unlayered');
   }
@@ -4500,6 +4513,28 @@
     return banner;
   }
 
+  function createGatherOverlayLegendItem(symbol, label) {
+    const item = document.createElement('span');
+    item.className = 'refraction-qc-gather-shared-legend-item';
+    const marker = document.createElement('span');
+    marker.className = `refraction-qc-gather-shared-legend-marker refraction-qc-gather-shared-legend-marker-${symbol}`;
+    marker.setAttribute('aria-hidden', 'true');
+    const text = document.createElement('span');
+    text.textContent = label;
+    item.appendChild(marker);
+    item.appendChild(text);
+    return item;
+  }
+
+  function createGatherOverlayLegend() {
+    const legend = document.createElement('div');
+    legend.className = 'refraction-qc-gather-shared-legend';
+    legend.dataset.testid = 'refraction-qc-gather-shared-legend';
+    legend.appendChild(createGatherOverlayLegendItem('observed', 'Observed first break'));
+    legend.appendChild(createGatherOverlayLegendItem('modeled', 'Modeled first break'));
+    return legend;
+  }
+
   function finitePairPoints(xValues, yValues) {
     const x = [];
     const y = [];
@@ -4515,6 +4550,49 @@
     return { x, y, indices };
   }
 
+  function finiteResidualMs(preview) {
+    const residuals = Array.isArray(preview?.residual_s) ? preview.residual_s : [];
+    return residuals
+      .map((value) => Number(value) * 1000.0)
+      .filter((value) => Number.isFinite(value));
+  }
+
+  function gatherHasResidualScale(preview) {
+    return finiteResidualMs(preview).length > 0;
+  }
+
+  function residualColorScale(residualMs) {
+    const finite = residualMs.filter((value) => Number.isFinite(value));
+    if (!finite.length) return null;
+    const maxAbs = finite.reduce((current, value) => Math.max(current, Math.abs(value)), 0);
+    if (maxAbs === 0) {
+      return {
+        colorbar: {
+          title: { text: 'Residual (ms)' },
+          tickmode: 'array',
+          tickvals: [0],
+          ticktext: ['0'],
+          x: 1.02,
+          xanchor: 'left',
+        },
+      };
+    }
+    const tickvals = [-maxAbs, -maxAbs / 2, 0, maxAbs / 2, maxAbs];
+    const digits = residualTickDigits(maxAbs);
+    return {
+      cmin: -maxAbs,
+      cmax: maxAbs,
+      colorbar: {
+        title: { text: 'Residual (ms)' },
+        tickmode: 'array',
+        tickvals,
+        ticktext: tickvals.map((value) => formatAsciiTick(value, digits)),
+        x: 1.02,
+        xanchor: 'left',
+      },
+    };
+  }
+
   function gatherOverlayTrace(preview, xValues, options) {
     const times = Array.isArray(preview[options.field]) ? preview[options.field] : [];
     const points = finitePairPoints(xValues, times);
@@ -4526,8 +4604,10 @@
     });
     const hasResidual = options.residual && residualMs.some((value) => Number.isFinite(value));
     const showResidualScale = Boolean(hasResidual && options.showResidualScale);
+    const residualScale = showResidualScale ? residualColorScale(residualMs) : null;
     return {
       name: options.name,
+      showlegend: options.showlegend !== false,
       type: 'scatter',
       mode: 'markers',
       x: points.x,
@@ -4538,10 +4618,10 @@
         colorscale: hasResidual ? 'RdBu' : undefined,
         reversescale: hasResidual ? true : undefined,
         cmid: hasResidual ? 0 : undefined,
+        cmin: residualScale?.cmin,
+        cmax: residualScale?.cmax,
         showscale: showResidualScale,
-        colorbar: showResidualScale
-          ? { title: { text: 'Residual (ms)' }, x: 1.02, xanchor: 'left' }
-          : undefined,
+        colorbar: residualScale?.colorbar,
         symbol: options.symbol,
         size: options.size || 8,
         line: { color: '#0f172a', width: 0.5 },
@@ -4580,6 +4660,7 @@
     const sideBySide = Boolean(options.sideBySide);
     const showAmplitudeScale = !sideBySide;
     const showResidualScale = !sideBySide || Boolean(options.corrected);
+    const showOverlayLegend = !sideBySide;
     const observedField = options.corrected
       ? 'corrected_observed_pick_time_s'
       : 'observed_pick_time_s';
@@ -4588,11 +4669,12 @@
       : 'modeled_pick_time_s';
     const observedTrace = gatherOverlayTrace(preview, xAxis.x, {
       field: observedField,
-      name: options.corrected ? 'Corrected observed first break' : 'Observed first break',
+      name: 'Observed first break',
       color: '#2563eb',
       symbol: 'circle',
       residual: true,
       showResidualScale,
+      showlegend: showOverlayLegend,
     });
     const hasResidualColorbar = Boolean(observedTrace?.marker?.showscale);
     const splitColorbars = showAmplitudeScale && hasResidualColorbar;
@@ -4611,7 +4693,10 @@
       };
     }
     const showAnyColorbar = showAmplitudeScale || hasResidualColorbar;
-    const marginRight = splitColorbars ? 96 : showAnyColorbar ? 86 : 24;
+    const sideBySideRightMargin = gatherHasResidualScale(preview) ? 86 : 24;
+    const marginRight = sideBySide
+      ? sideBySideRightMargin
+      : splitColorbars ? 96 : showAnyColorbar ? 86 : 24;
     const traces = [
       {
         name: options.title,
@@ -4628,10 +4713,11 @@
     ];
     const modeledTrace = gatherOverlayTrace(preview, xAxis.x, {
       field: modeledField,
-      name: options.corrected ? 'Corrected modeled first break' : 'Modeled first break',
+      name: 'Modeled first break',
       color: '#f97316',
       symbol: 'x',
       size: 9,
+      showlegend: showOverlayLegend,
     });
     if (observedTrace) traces.push(observedTrace);
     if (modeledTrace) traces.push(modeledTrace);
@@ -4642,6 +4728,7 @@
       font: { size: 10, color: '#334155' },
       paper_bgcolor: '#ffffff',
       plot_bgcolor: '#ffffff',
+      showlegend: showOverlayLegend,
       title: { text: options.title, font: { size: 12 } },
       xaxis: {
         title: { text: xAxis.label },
@@ -4778,6 +4865,9 @@
     const axisContext = gatherPreviewAxisContext(preview);
     const plotGrid = document.createElement('div');
     const sideBySide = state.gatherDisplayMode === 'side_by_side';
+    if (sideBySide) {
+      content.appendChild(createGatherOverlayLegend());
+    }
     plotGrid.className = sideBySide
       ? 'refraction-qc-gather-grid refraction-qc-gather-grid-side-by-side'
       : 'refraction-qc-plot-grid';

--- a/app/static/tool_pages.css
+++ b/app/static/tool_pages.css
@@ -1075,6 +1075,49 @@ select {
       overflow-x: auto;
     }
 
+    .refraction-qc-gather-shared-legend {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.85rem;
+      margin: 0.5rem 0 0.35rem;
+      color: #334155;
+      font-size: 0.9em;
+    }
+
+    .refraction-qc-gather-shared-legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      white-space: nowrap;
+    }
+
+    .refraction-qc-gather-shared-legend-marker {
+      display: inline-flex;
+      width: 0.85rem;
+      height: 0.85rem;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+      flex: 0 0 auto;
+    }
+
+    .refraction-qc-gather-shared-legend-marker-observed {
+      border: 1px solid #0f172a;
+      border-radius: 50%;
+      background: #2563eb;
+    }
+
+    .refraction-qc-gather-shared-legend-marker-modeled {
+      color: #f97316;
+      font-size: 1rem;
+      font-weight: 800;
+    }
+
+    .refraction-qc-gather-shared-legend-marker-modeled::before {
+      content: "x";
+    }
+
     .refraction-qc-gather-plot {
       height: 320px;
     }
@@ -1277,6 +1320,49 @@ select {
   gap: 1rem;
   align-items: start;
   overflow-x: auto;
+}
+
+.refraction-qc-page .refraction-qc-gather-shared-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.85rem;
+  margin: 0.5rem 0 0.35rem;
+  color: #334155;
+  font-size: 0.9em;
+}
+
+.refraction-qc-page .refraction-qc-gather-shared-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+}
+
+.refraction-qc-page .refraction-qc-gather-shared-legend-marker {
+  display: inline-flex;
+  width: 0.85rem;
+  height: 0.85rem;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.refraction-qc-page .refraction-qc-gather-shared-legend-marker-observed {
+  border: 1px solid #0f172a;
+  border-radius: 50%;
+  background: #2563eb;
+}
+
+.refraction-qc-page .refraction-qc-gather-shared-legend-marker-modeled {
+  color: #f97316;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.refraction-qc-page .refraction-qc-gather-shared-legend-marker-modeled::before {
+  content: "x";
 }
 
 .refraction-qc-page .refraction-qc-gather-plot {

--- a/tests/e2e/refraction_qc.spec.ts
+++ b/tests/e2e/refraction_qc.spec.ts
@@ -1137,8 +1137,16 @@ async function gatherPlotSummary(page: Page, testId: string) {
 				x?: number[];
 				y?: number[];
 				z?: number[][];
+				showlegend?: boolean;
+				marker?: {
+					colorbar?: {
+						ticktext?: string[];
+					};
+				};
 			}>;
 			layout?: {
+				margin?: { r?: number };
+				showlegend?: boolean;
 				xaxis?: { title?: { text?: string } };
 				yaxis?: { title?: { text?: string } };
 			};
@@ -1152,7 +1160,11 @@ async function gatherPlotSummary(page: Page, testId: string) {
 				x: Array.isArray(trace.x) ? trace.x : [],
 				y: Array.isArray(trace.y) ? trace.y : [],
 				z: Array.isArray(trace.z) ? trace.z : [],
+				showlegend: trace.showlegend,
+				residualTickText: trace.marker?.colorbar?.ticktext ?? [],
 			})),
+			marginRight: plot.layout?.margin?.r ?? null,
+			showlegend: plot.layout?.showlegend,
 		};
 	});
 }
@@ -2787,10 +2799,16 @@ test('refraction gather preview UI raw corrected side by side renders overlays',
 		});
 	});
 	await page.route('**/statics/refraction/qc', async (route) => {
+		const bundle = qcBundlePayload('refraction-gather-side-by-side') as any;
+		bundle.summary.request = {
+			file_id: 'raw-preview-file',
+			key1_byte: 9,
+			key2_byte: 13,
+		};
 		await route.fulfill({
 			status: 200,
 			contentType: 'application/json',
-			body: JSON.stringify(qcBundlePayload('refraction-gather-side-by-side')),
+			body: JSON.stringify(bundle),
 		});
 	});
 
@@ -2801,22 +2819,37 @@ test('refraction gather preview UI raw corrected side by side renders overlays',
 	await expect(page.getByTestId('refraction-qc-gather-raw-plot')).toBeVisible();
 	await expect(page.getByTestId('refraction-qc-gather-corrected-plot')).toBeVisible();
 	await expect(page.getByTestId('refraction-qc-gather-corrected-status')).toContainText('corrected_tracestore');
+	await expect(page.getByTestId('refraction-qc-gather-shared-legend')).toHaveText(
+		'Observed first breakModeled first break',
+	);
 	await expect.poll(async () => gatherPlotSummary(page, 'refraction-qc-gather-raw-plot')).toMatchObject({
 		xAxisTitle: 'Offset (m)',
 		yAxisTitle: 'Time (s)',
+		marginRight: 86,
+		showlegend: false,
 		traces: [
 			expect.objectContaining({ name: 'Raw gather', type: 'heatmap' }),
-			expect.objectContaining({ name: 'Observed first break', x: [100, 200], y: [0.1, 0.2] }),
-			expect.objectContaining({ name: 'Modeled first break', x: [100, 200], y: [0.11, 0.19] }),
+			expect.objectContaining({ name: 'Observed first break', x: [100, 200], y: [0.1, 0.2], showlegend: false }),
+			expect.objectContaining({ name: 'Modeled first break', x: [100, 200], y: [0.11, 0.19], showlegend: false }),
 		],
 	});
 	await expect.poll(async () => gatherPlotSummary(page, 'refraction-qc-gather-corrected-plot')).toMatchObject({
+		marginRight: 86,
+		showlegend: false,
 		traces: [
 			expect.objectContaining({ name: 'Corrected gather', type: 'heatmap' }),
-			expect.objectContaining({ name: 'Corrected observed first break', x: [100, 200], y: [0.12, 0.19] }),
-			expect.objectContaining({ name: 'Corrected modeled first break', x: [100, 200], y: [0.13, 0.18] }),
+			expect.objectContaining({
+				name: 'Observed first break',
+				x: [100, 200],
+				y: [0.12, 0.19],
+				showlegend: false,
+				residualTickText: ['-10', '-5', '0', '5', '10'],
+			}),
+			expect.objectContaining({ name: 'Modeled first break', x: [100, 200], y: [0.13, 0.18], showlegend: false }),
 		],
 	});
+	await expect(page.getByTestId('refraction-qc-view-gather')).not.toContainText('Corrected observed first break');
+	await expect(page.getByTestId('refraction-qc-view-gather')).not.toContainText('Corrected modeled first break');
 });
 
 test('refraction gather preview UI missing corrected status is clear', async ({ page }) => {


### PR DESCRIPTION
Closes #678

## Summary
- P0: Gather Preview side-by-side の panel size / residual colorbar / shared legend を修正する

## Changed files
- `app/static/refraction_qc.js`
- `app/static/tool_pages.css`
- `tests/e2e/refraction_qc.spec.ts`

## Checks
- `.work/codex/checks.log`: 2460 passed in 73.94s (0:01:13)

## Review
- `.work/codex/review.txt`: accept: yes
- findings: blocker 0, major 0, minor 0
